### PR TITLE
Deduplicate news items in Jan 17 AI news report

### DIFF
--- a/.github/workflows/ai-news-research.yml
+++ b/.github/workflows/ai-news-research.yml
@@ -28,7 +28,9 @@ jobs:
 
       - name: Get current date
         id: date
-        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+        run: |
+          echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+          echo "yesterday=$(date -d 'yesterday' +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: Check for MCP API keys
         id: check-keys
@@ -101,8 +103,17 @@ jobs:
             You are an AI news research agent. Find BREAKING NEWS and RECENT ANNOUNCEMENTS only.
 
             TODAY: ${{ steps.date.outputs.date }}
+            YESTERDAY: ${{ steps.date.outputs.yesterday }}
             REPO: ${{ github.repository }}
 
+            STEP 1 - DEDUPLICATION CHECK:
+            First, read the previous report(s) to avoid duplicating news:
+            - Read: research/${{ steps.date.outputs.yesterday }}-ai-news.md (if exists)
+            - Read: research/${{ steps.date.outputs.date }}-ai-news.md (if exists, to append new items)
+
+            Make a mental note of ALL stories already covered. DO NOT include any story that was already reported.
+
+            STEP 2 - SEARCH FOR NEW NEWS:
             Use MCP search tools (Exa, Perplexity) to search for REAL NEWS from last 24-48 hours:
             - Perplexity provides real-time web search with citations
             - Use whichever tools are available to find:
@@ -118,10 +129,14 @@ jobs:
             - Is from a CREDIBLE source (TechCrunch, VentureBeat, The Verge, official company blogs, Reuters)
             - Contains CONCRETE information (not speculation)
             - Has REAL URLs
+            - WAS NOT ALREADY COVERED in previous reports
 
-            DO NOT include: generic AI explanations, old news, speculation without sources.
+            DO NOT include: generic AI explanations, old news, speculation without sources, OR DUPLICATE STORIES from previous reports.
 
-            REPORT FORMAT - Use Write tool to create: research/${{ steps.date.outputs.date }}-ai-news.md
+            STEP 3 - WRITE REPORT:
+            Use Write tool to create: research/${{ steps.date.outputs.date }}-ai-news.md
+
+            Include at the top: "**Note:** For earlier news coverage, see previous reports in this directory."
 
             Sections: Breaking News, New Model Releases, Funding & Acquisitions, Research Papers, Industry Moves, Regulatory Updates
 
@@ -129,7 +144,7 @@ jobs:
             git add research/
             git commit -m "Add AI news research for ${{ steps.date.outputs.date }}"
 
-            CRITICAL: Write REAL news with actual sources. No placeholder content.
+            CRITICAL: Write REAL news with actual sources. No placeholder content. NO DUPLICATES from previous reports.
 
       - name: Run AI News Research with Claude (without MCP)
         if: steps.check-keys.outputs.has_exa != 'true' && steps.check-keys.outputs.has_perplexity != 'true'
@@ -142,9 +157,17 @@ jobs:
             You are an AI news research agent. Find BREAKING NEWS and RECENT ANNOUNCEMENTS only.
 
             TODAY: ${{ steps.date.outputs.date }}
+            YESTERDAY: ${{ steps.date.outputs.yesterday }}
             REPO: ${{ github.repository }}
 
-            SEARCH REQUIREMENTS:
+            STEP 1 - DEDUPLICATION CHECK:
+            First, read the previous report(s) to avoid duplicating news:
+            - Read: research/${{ steps.date.outputs.yesterday }}-ai-news.md (if exists)
+            - Read: research/${{ steps.date.outputs.date }}-ai-news.md (if exists, to append new items)
+
+            Make a mental note of ALL stories already covered. DO NOT include any story that was already reported.
+
+            STEP 2 - SEARCH FOR NEW NEWS:
             Do multiple specific searches to find REAL NEWS from the last 24-48 hours:
             - "OpenAI announcement January 2026"
             - "Anthropic Claude new release 2026"
@@ -158,20 +181,25 @@ jobs:
             - Is from a CREDIBLE source (TechCrunch, VentureBeat, The Verge, official company blogs, Reuters, etc.)
             - Contains CONCRETE information (not speculation or opinion)
             - Has REAL URLs that can be verified
+            - WAS NOT ALREADY COVERED in previous reports
 
             DO NOT include:
             - Generic explanations of what AI is
             - Old news or evergreen content
             - Speculation without sources
             - Information without specific dates
+            - DUPLICATE STORIES from previous reports
 
-            REPORT FORMAT - Use the Write tool to create: research/${{ steps.date.outputs.date }}-ai-news.md
+            STEP 3 - WRITE REPORT:
+            Use the Write tool to create: research/${{ steps.date.outputs.date }}-ai-news.md
 
             ```markdown
             # AI News Report - ${{ steps.date.outputs.date }}
 
+            **Note:** For earlier news coverage, see previous reports in this directory.
+
             ## Breaking News
-            [Most important announcements from last 24 hours]
+            [Most important NEW announcements from last 24 hours - not in previous reports]
 
             ## New Model Releases
             [Specific model launches with version numbers, capabilities, pricing]
@@ -196,7 +224,7 @@ jobs:
             git add research/
             git commit -m "Add AI news research for ${{ steps.date.outputs.date }}"
 
-            CRITICAL: You MUST write a real file with actual news. Do not write placeholder content.
+            CRITICAL: You MUST write a real file with actual news. Do not write placeholder content. NO DUPLICATES from previous reports.
 
       - name: Push changes
         env:

--- a/research/2026-01-17-ai-news.md
+++ b/research/2026-01-17-ai-news.md
@@ -1,34 +1,24 @@
 # AI News Research - January 17, 2026
 
-Research conducted on 2026-01-17 covering breaking news from January 16-17, 2026 and recent developments.
+Research conducted on 2026-01-17 covering breaking news from January 16-17, 2026.
+
+**Note:** For comprehensive coverage of earlier news (January 5-16), see [2026-01-16-ai-news.md](2026-01-16-ai-news.md).
 
 ---
 
 ## Breaking News
 
-### xAI Raises Record $20 Billion
-**Date:** January 6, 2026
-Elon Musk's xAI secured $20 billion in funding, exceeding its prior target of $15 billion. The financing values the AI startup at approximately $230 billion. Major investors include Nvidia, Cisco Investments, Valor Equity Partners, Stepstone Group, Fidelity, Qatar Investment Authority, Abu Dhabi's MGX, and Baron Capital Group.
+### OpenAI ChatGPT Go Launch
+**Date:** January 16, 2026
+OpenAI introduced ChatGPT Go, now available worldwide. This $8/month subscription offers GPT-5.2 Instant access, higher usage limits, and longer memory—making advanced AI more affordable globally.
 
-**Source:** [CNBC](https://www.cnbc.com/2026/01/06/elon-musk-xai-raises-20-billion-from-nvidia-cisco-investors.html)
+**Source:** [OpenAI News](https://openai.com/news/)
 
 ### Replit Nears $9 Billion Valuation
 **Date:** January 15, 2026
 AI coding startup Replit is in advanced discussions to raise approximately $400 million, which would roughly triple its valuation to $9 billion.
 
 **Source:** [Bloomberg](https://www.bloomberg.com/news/articles/2026-01-15/ai-coding-startup-replit-nears-funding-at-9-billion-valuation)
-
-### OpenAI Invests in Merge Labs
-**Date:** January 15, 2026
-OpenAI announced an investment in Merge Labs as part of its expanding portfolio of strategic partnerships.
-
-**Source:** [OpenAI News](https://openai.com/news/)
-
-### OpenAI ChatGPT Go Launch
-**Date:** January 16, 2026
-OpenAI introduced ChatGPT Go, now available worldwide. This represents OpenAI's latest consumer product expansion beyond the existing ChatGPT offerings.
-
-**Source:** [OpenAI News](https://openai.com/news/)
 
 ### Anthropic Claude Cowork Launch
 **Date:** January 16, 2026
@@ -42,59 +32,15 @@ Anthropic released Claude Cowork, a preview feature extending Claude's computer 
 
 ## New Model Releases
 
-### NVIDIA Alpamayo and Physical AI Models
-**Date:** January 5, 2026 (CES 2026)
-NVIDIA launched Alpamayo, a new family of open-source AI models for training physical robots and autonomous vehicles. Key releases include:
-
-- **Alpamayo 1:** A 10 billion-parameter chain-of-thought, reason-based vision language action (VLA) model for autonomous vehicles
-- **Cosmos Reason 2:** A new leaderboard-topping reasoning VLM for robots and AI agents
-- **GR00T open models:** For robot learning and reasoning
-- **Isaac Lab-Arena:** For robot evaluation
-- **OSMO edge-to-cloud compute framework**
-- **Nemotron models:** For speech recognition, multimodal RAG, and safety
-
-**Sources:**
-- [NVIDIA Investor Relations](https://investor.nvidia.com/news/press-release-details/2026/NVIDIA-Releases-New-Physical-AI-Models-as-Global-Partners-Unveil-Next-Generation-Robots/default.aspx)
-- [TechCrunch](https://techcrunch.com/2026/01/05/nvidia-launches-alpamayo-open-ai-models-that-allow-autonomous-vehicles-to-think-like-a-human/)
-- [NVIDIA Blog](https://blogs.nvidia.com/blog/open-models-data-tools-accelerate-ai/)
-
-### DeepSeek R1
-**Date:** January 2026
-DeepSeek released R1, an open-source reasoning model that demonstrated competitive performance despite being developed by a relatively small Chinese firm with limited resources.
-
-**Source:** [LLM News](https://llm-stats.com/ai-news)
-
 ### IQuest Coder V1
 **Date:** January 1, 2026
 Chinese quantitative hedge fund's AI research arm released an open-source coding AI that reportedly outperforms Claude Sonnet 4.5 and GPT models with only 40 billion parameters.
 
 **Source:** [DEV Community](https://dev.to/yakhilesh/china-just-released-the-first-coding-ai-of-2026-and-its-crushing-everything-we-know-3bbj)
 
-### Google Gemini 3 Pro and Deep Think
-**Date:** January 2026
-Google rolled out Gemini 3 Pro to all users in the Gemini app, featuring state-of-the-art reasoning capabilities. Google AI Ultra subscribers gained access to Gemini 3 Deep Think, the most advanced reasoning mode using iterative rounds of reasoning for complex tasks.
-
-Additionally, Google released:
-- **gemini-2.5-flash-lite:** A fast, low-cost, high-performance Gemini 2.5 model
-- **veo-3.0-generate-preview:** Video with audio generation
-
-**Source:** [Gemini Release Notes](https://gemini.google/release-notes/)
-
-### Stanford SleepFM
-**Date:** January 6, 2026
-Stanford Medicine announced SleepFM, an AI model trained on nearly 600,000 hours of sleep data from 65,000 participants. The model can predict a person's risk of developing more than 100 health conditions using physiological recordings from one night's sleep.
-
-**Source:** [Stanford Medicine](https://med.stanford.edu/news/all-news/2026/01/ai-sleep-disease.html)
-
 ---
 
 ## Funding & Acquisitions
-
-### Skild AI Triples Valuation to $14 Billion
-**Date:** January 14, 2026
-Robotics startup Skild AI raised $1.4 billion in a Series C round, tripling its valuation to over $14 billion just seven months after raising a $135 million Series B at $4.5 billion valuation. SoftBank Group led the financing round, with participation from Nvidia, Macquarie Group, and 1789 Capital.
-
-**Source:** [TechCrunch](https://techcrunch.com/2026/01/14/robotic-software-maker-skild-ai-hits-14b-valuation/)
 
 ### Deepgram Raises $130M at $1.3B Valuation
 **Date:** January 13, 2026
@@ -114,56 +60,19 @@ Spangle, an AI e-commerce startup founded by former Bolt CEO Maju Kuruvilla, rai
 
 **Source:** [TechCrunch](https://techcrunch.com/2026/01/08/former-bolt-ceo-maju-kuruvillas-startup-triples-to-100m-valuation/)
 
-### OpenAI Strategic Partnerships
-**Date:** January 14-15, 2026
-- OpenAI partnered with Cerebras (January 15, 2026)
-- OpenAI and SoftBank Group partnered with SB Energy (January 14, 2026)
-- OpenAI announced strengthening US AI supply chain through domestic manufacturing (January 15, 2026)
-
-**Source:** [OpenAI News](https://openai.com/news/)
-
 ---
 
 ## Product Launches & Updates
 
-### OpenAI ChatGPT Health
+### OpenAI ChatGPT Advertising Approach
+**Date:** January 16, 2026
+OpenAI announced its approach to advertising and expanding access to ChatGPT. The company plans to test clearly-labeled ads in the US for free and Go tiers, starting with shopping links while maintaining conversation privacy.
+
+**Source:** [OpenAI News](https://openai.com/news/)
+
+### OpenAI ChatGPT Images
 **Date:** January 7, 2026
-OpenAI unveiled ChatGPT Health, offering users a dedicated space for health-related conversations. Key features:
-- Securely connect medical records and wellness apps
-- Over 230 million users globally ask health questions weekly on the platform
-- Not intended for diagnosis/treatment or to replace medical care
-- Launched alongside ChatGPT for Healthcare and HIPAA-compliant API (January 9, 2026)
-
-**Sources:**
-- [TechCrunch](https://techcrunch.com/2026/01/07/openai-unveils-chatgpt-health-says-230-million-users-ask-about-health-each-week/)
-- [OpenAI](https://openai.com/index/introducing-chatgpt-health/)
-- [CNBC](https://www.cnbc.com/2026/01/07/openai-chatgpt-health-medical-records.html)
-
-### Anthropic Claude for Healthcare
-**Date:** January 12, 2026
-Following OpenAI's ChatGPT Health reveal, Anthropic announced Claude for Healthcare with:
-- Partnership with HealthEx to let patients query electronic health records
-- Apple Health and Android Health Connect integrations rolling out to beta testers
-- Available to Claude Pro and Max subscribers in the U.S.
-
-**Sources:**
-- [TechCrunch](https://techcrunch.com/2026/01/12/anthropic-announces-claude-for-healthcare-following-openais-chatgpt-health-reveal/)
-- [Fortune](https://fortune.com/2026/01/11/anthropic-unveils-claude-for-healthcare-and-expands-life-science-features-partners-with-healthex-to-let-users-connect-medical-records/)
-
-### Anthropic Claude Code 2.1.0
-**Date:** January 14, 2026
-Anthropic released Claude Code v2.1.0 with 1,096 commits, featuring:
-- Hot reload for skills
-- Merged slash commands and skills
-- Release channel toggle (stable or latest)
-- Security fixes for sensitive data exposure in debug logs
-- Fixes for session persistence and API context overflow
-
-**Source:** [VentureBeat](https://venturebeat.com/orchestration/claude-code-2-1-0-arrives-with-smoother-workflows-and-smarter-agents)
-
-### OpenAI ChatGPT Images & Advertising
-**Date:** January 7, 2026
-OpenAI launched ChatGPT Images and announced its approach to advertising and expanding access to ChatGPT (January 16, 2026).
+OpenAI launched ChatGPT Images, a new feature for image generation within ChatGPT.
 
 **Source:** [OpenAI News](https://openai.com/news/)
 
@@ -191,40 +100,9 @@ Gemini began rolling out in Chrome to Google AI Pro or Ultra subscribers in the 
 
 **Source:** [9to5Google](https://9to5google.com/2026/01/02/gemini-model-switch/)
 
-### Google Gemini Personal Intelligence Feature
-**Date:** January 14, 2026
-Google launched a new beta feature in the Gemini app called Personal Intelligence that allows the AI assistant to tailor responses by connecting across Gmail, Photos, Search, and YouTube history. Gemini 3 can now reason across user data to surface proactive insights. The feature is off by default for privacy protection and challenges Apple Intelligence.
-
-**Sources:**
-- [TechCrunch](https://techcrunch.com/2026/01/14/geminis-new-beta-feature-provides-proactive-responses-based-on-your-photos-emails-and-more/)
-- [CNBC](https://www.cnbc.com/2026/01/14/google-launches-personal-intelligence-in-gemini-app-challenging-apple.html)
-
-### Apple-Google Gemini Partnership
-**Date:** January 12, 2026
-Apple announced a multiyear partnership with Google to power AI features in Siri using Google's Gemini technology and cloud infrastructure. The integration will bring 7 new AI-powered capabilities to Siri.
-
-**Source:** [CNBC](https://www.cnbc.com/2026/01/12/apple-google-ai-siri-gemini.html)
-
 ---
 
 ## Industry Moves
-
-### Anthropic Leadership Changes
-**Date:** January 2026
-Anthropic announced significant leadership changes:
-- **Mike Krieger** is stepping away from his chief product officer role to co-lead Anthropic's Labs team
-- **Ami Vora** is taking over as head of product
-- **Rahul Patil** has been appointed as CTO
-
-**Sources:**
-- [eWEEK](https://www.eweek.com/news/anthropic-labs-expansion/)
-- [VentureBeat](https://venturebeat.com/technology/the-creator-of-claude-code-just-revealed-his-workflow-and-developers-are)
-
-### Anthropic Expands to India
-**Date:** January 16, 2026
-Anthropic appointed Irina Ghose as Managing Director of India ahead of opening Bengaluru office.
-
-**Source:** [Releasebot](https://releasebot.io/updates/anthropic)
 
 ### ElevenLabs Revenue Milestone
 **Date:** January 13, 2026
@@ -238,57 +116,8 @@ The Anthropic Console transitioned from console.anthropic.com to platform.claude
 
 **Source:** [Claude Documentation](https://platform.claude.com/docs/en/release-notes/overview)
 
-### OpenAI Grove Applications
-**Date:** Closed January 12, 2026
-OpenAI closed applications for the next cohort of OpenAI Grove, a program for technical talent at the start of their company-building journey.
-
-**Source:** [OpenAI](https://openai.com/index/openai-grove/)
-
----
-
-## Regulatory Updates
-
-### State AI Laws Take Effect
-**Date:** January 1, 2026
-Multiple state AI laws became effective:
-
-**California:**
-- Transparency in Frontier Artificial Intelligence Act (TFAIA)
-- AI Safety Act (employee protections for reporting AI-related risks)
-- AB 489 (prohibits AI chatbots from impersonating licensed professionals)
-- SB 524 (requires law enforcement disclosure of AI use in police reports)
-
-**Texas:**
-- Responsible Artificial Intelligence Governance Act (RAIGA)
-
-38 states total passed AI legislation covering election misuse prevention and medical information regulation.
-
-**Sources:**
-- [King & Spalding](https://www.kslaw.com/news-and-insights/new-state-ai-laws-are-effective-on-january-1-2026-but-a-new-executive-order-signals-disruption)
-- [NBC News](https://www.nbcnews.com/politics/politics-news/2026-new-laws-states-elections-midterms-ai-obamacare-aca-paid-leave-rcna247602)
-- [California Governor](https://www.gov.ca.gov/2025/12/31/new-in-2026-california-laws-taking-effect-in-the-new-year/)
-
-### Federal AI Executive Order
-**Date:** December 11, 2025 (Impacting January 2026)
-President Trump signed executive order "Ensuring a National Policy Framework for Artificial Intelligence" proposing to establish uniform Federal policy that preempts inconsistent state AI laws. Key provisions:
-
-- Attorney General must establish AI litigation task force within 30 days to contest state AI laws on constitutional grounds
-- Secretary of Commerce must publish by March 11, 2026, an evaluation of burdensome state AI laws conflicting with federal policy
-- Does not currently invalidate existing state/local AI laws pending court action or Congressional legislation
-
-**Sources:**
-- [White House](https://www.whitehouse.gov/presidential-actions/2025/12/eliminating-state-law-obstruction-of-national-artificial-intelligence-policy/)
-- [Buchanan Ingersoll & Rooney](https://www.bipc.com/new-executive-order-signals-federal-preemption-strategy-for-state-laws-on-artificial-intelligence)
-
----
-
-## Market Trends
-
-### Q4 2025 Funding Totals
-Startups raised $91.6 billion in Q4 2025, with funding rounds from Anthropic and three other San Francisco companies accounting for 30% of total. Industry observers predict continued AI investment momentum in 2026.
-
-**Source:** [SF Examiner](https://www.sfexaminer.com/news/technology/ai-startups-reap-rewards-of-massive-venture-funding-boom/article_8814499b-184e-43de-bb54-3ce360d5311e.html)
-
 ---
 
 *Research compiled using web search tools on 2026-01-17*
+
+*For earlier news coverage (xAI $20B funding, NVIDIA Alpamayo, DeepSeek R1, Stanford SleepFM, Skild AI $1.4B, OpenAI ChatGPT Health, Anthropic Claude for Healthcare, Apple-Google Gemini Partnership, State AI Laws, etc.), see the [January 16, 2026 report](2026-01-16-ai-news.md).*


### PR DESCRIPTION
Remove 19 duplicate items that were already covered in the Jan 16 report:
- xAI $20B funding, OpenAI Merge Labs investment
- NVIDIA Alpamayo, DeepSeek R1, Google Gemini 3
- Stanford SleepFM, Skild AI $1.4B funding
- OpenAI ChatGPT Health, Anthropic Claude for Healthcare
- Google Personal Intelligence, Apple-Google partnership
- Anthropic leadership changes and India expansion
- State AI laws and Federal AI Executive Order
- OpenAI Strategic Partnerships

Added cross-reference to Jan 16 report for comprehensive coverage.