### PR TITLE
Fix auth failure in hourly-twitter Prepare step

### DIFF
--- a/.github/workflows/hourly-twitter.yml
+++ b/.github/workflows/hourly-twitter.yml
@@ -417,7 +417,6 @@ jobs:
           FILTERED_FILE: /tmp/${{ steps.datetime.outputs.date }}-twitter-${{ steps.datetime.outputs.hour }}h-headlines-to-send.json
           HISTORY_FILE: research/summaries/twitter-announced-history.json
           TIMESTAMP: ${{ steps.datetime.outputs.timestamp }}
-          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run == true }}
         run: |
           set -euo pipefail
 
@@ -426,11 +425,15 @@ jobs:
           [ -f "$HEADLINES_FILE" ] || echo '[]' > "$HEADLINES_FILE"
           [ -f "$HISTORY_FILE" ] || echo '[]' > "$HISTORY_FILE"
 
-          # Rebase before filtering so the delivered-alert ledger is current.
-          # Dry-run fixtures are intentionally uncommitted, so skip rebase there.
-          if [ "$DRY_RUN" != "true" ]; then
-            git pull --rebase
-          fi
+          # No `git pull --rebase` here: the only writer for
+          # twitter-announced-history.json is this workflow's own
+          # hooker-send step (later in this same job), and concurrency
+          # cancel-in-progress guarantees no parallel instance. The
+          # checked-out tree is already authoritative for our dedupe
+          # input. Doing a pull here would also fail on the self-hosted
+          # runner because this step has no GITHUB_TOKEN in env and
+          # the actions/checkout extraheader doesn't reliably survive
+          # mid-job.
 
           python3 scripts/dedupe_headline_alerts.py filter \
             --headlines-file "$HEADLINES_FILE" \
@@ -445,6 +448,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git
+          # Other workflows commit to main on different paths between
+          # our checkout and now; rebase so this push is fast-forward.
+          # Token is already on the remote URL above so auth works.
+          git pull --rebase || { git rebase --abort 2>/dev/null || true; exit 1; }
           git push
           echo "pushed=true" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Problem
Every scheduled run of the hourly-twitter workflow has failed since PR #26 was merged (7 consecutive failures). The new "Prepare headline alerts for delivery" step calls \`git pull --rebase\` but has no \`GITHUB_TOKEN\` in env and doesn't rewrite the remote URL. On the self-hosted runner, the actions/checkout-installed extraheader doesn't reliably carry the token mid-job:

\`\`\`
remote: Invalid username or token. Password authentication is not supported for Git operations.
fatal: Authentication failed for 'https://github.com/guzus/ai-research-arm.git/'
\`\`\`

## Fix
Two changes:

1. **Drop the rebase from Prepare entirely.** The only writer for \`twitter-announced-history.json\` is this same workflow's hooker-send step, gated by \`concurrency: cancel-in-progress\`. The checked-out tree is already authoritative for the dedupe input — there's nothing to rebase against.
2. **Restore \`git pull --rebase\` in the Push step**, where the token is already on the remote URL so auth works. This was the pre-PR-26 pattern (\`git pull --rebase || true\`); without it, a concurrent commit from another workflow makes our push non-fast-forward and fails. Use a strict variant that aborts on conflict.

## Test plan
- [x] YAML parses
- [ ] Trigger \`workflow_dispatch\` on the branch (real run, no \`dry_run=true\`) — must complete without auth error
- [ ] After merge: confirm next scheduled run goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)