### PR TITLE
Expand Twitter feed: add 13 high-signal AI accounts

### DIFF
--- a/.github/workflows/hourly-twitter.yml
+++ b/.github/workflows/hourly-twitter.yml
@@ -105,13 +105,21 @@ jobs:
           mkdir -p /tmp/bird
 
           # AI Labs & Company accounts
-          labs="OpenAI AnthropicAI GoogleAI GoogleDeepMind MistralAI MetaAI CohereAI AI21Labs StabilityAI HuggingFace NVIDIAAIDev"
+          # Added 2026-05-01: AIatMeta (real Meta AI account; @MetaAI is largely
+          # inactive), ClaudeDevs (official Anthropic developer announcements).
+          labs="OpenAI AnthropicAI GoogleAI GoogleDeepMind MistralAI MetaAI AIatMeta CohereAI AI21Labs StabilityAI HuggingFace NVIDIAAIDev ClaudeDevs"
 
           # Hyperscalers — top execs and key insiders
-          hyperscalers="elonmusk sama demishassabis OfficialLoganK alexalbert__ DrJimFan tszzl"
+          # Added 2026-05-01: ilyasut (SSI/OpenAI cofounder), alexandr_wang
+          # (Meta CAIO ex-Scale), OriolVinyalsML (Gemini co-lead),
+          # woj_zaremba (OpenAI cofounder, AI resilience).
+          hyperscalers="elonmusk sama demishassabis OfficialLoganK alexalbert__ DrJimFan tszzl ilyasut alexandr_wang OriolVinyalsML woj_zaremba"
 
           # Others — researchers, analysts, specialists, media
-          others="karpathy iruletheworldmo AndrewCurran_ fi56622380 jukan05 vitrupo dejavucoder jiratickets SemiAnalysis_ benthompson theinformation GavinSBaker mark_k ns123abc kimmonismus _akhaliq simonw emollick testingcatalog rasbt skirano jackclarkSF ylecun hardmaru JeffDean AravSrinivas deedydas swyx TheAITimeline levelsio steipete mckaywrigley nutlope rauchg amasad geoffreylitt jxnlco danshipper andreasklinger nikitabier tibo_maker marclou shl dharmesh"
+          # Added 2026-05-01 from anchor-following discovery (≥3 anchors):
+          # jeremyphoward, soumithchintala, giffmana, arankomatsuzaki,
+          # percyliang, JonathanRoss321, hendrycks.
+          others="karpathy iruletheworldmo AndrewCurran_ fi56622380 jukan05 vitrupo dejavucoder jiratickets SemiAnalysis_ benthompson theinformation GavinSBaker mark_k ns123abc kimmonismus _akhaliq simonw emollick testingcatalog rasbt skirano jackclarkSF ylecun hardmaru JeffDean AravSrinivas deedydas swyx TheAITimeline levelsio steipete mckaywrigley nutlope rauchg amasad geoffreylitt jxnlco danshipper andreasklinger nikitabier tibo_maker marclou shl dharmesh jeremyphoward soumithchintala giffmana arankomatsuzaki percyliang JonathanRoss321 hendrycks"
 
           # Build the manifest via Python (avoids jq's multi-line quoting
           # issues inside YAML literal blocks): 50+ user-tweets ops + 7


### PR DESCRIPTION
## Summary
Adds 13 high-signal AI accounts to the hourly Twitter feed (62 → 75 handles). Discovery used **anchor-following overlap**: pulled who 9 high-signal accounts already in our feed (`karpathy`, `sama`, `demishassabis`, `ylecun`, `simonw`, `swyx`, `alexalbert__`, `DrJimFan`, `jackclarkSF`) follow, aggregated 515 candidates, ranked by how many anchors follow each, filtered out the existing 62.

## Why this method
Anchor-overlap ≥3 is a strong quality filter — it requires multiple independent curators to validate the account. Search-based discovery (recent topical tweets) was tried but mostly surfaced bots and aggregator accounts.

## Additions

**Tier 1 — followed by ≥3 anchors:**

| handle | role |
|---|---|
| `ilyasut` | SSI founder, OpenAI cofounder. Rare but market-moving posts. |
| `alexandr_wang` | Meta CAIO (ex-Scale AI). Strategy + Meta Superintelligence signal. |
| `OriolVinyalsML` | Google DeepMind VP, Gemini co-lead. |
| `woj_zaremba` | OpenAI cofounder, AI resilience lead. |
| `jeremyphoward` | Answer.AI / fast.ai. Open-source + education. |
| `soumithchintala` | PyTorch cofounder, Thinking Machines. |
| `giffmana` | Lucas Beyer (Meta, ex OpenAI/DeepMind). Sharp research takes. |
| `arankomatsuzaki` | Daily AI-research roundup poster. |
| `percyliang` | Stanford NLP, Together AI cofounder. Eval/benchmark angle. |
| `JonathanRoss321` | Groq founder. Inference-chip angle. |

**Tier 2 — coverage gaps (≥2 anchors):**

| handle | gap filled |
|---|---|
| `AIatMeta` | Real active Meta AI org account. (`@MetaAI` is largely inactive — kept in case it gets re-activated.) |
| `ClaudeDevs` | Official Anthropic developer announcements. |
| `hendrycks` | Dan Hendrycks — MMLU/HLE creator. AI safety voice the list lacked. |

## Skipped on purpose
- General-tech investors with low AI focus: `levie`, `friedberg`, `garrytan`, `tobi`
- Pure academic/quiet posters: `sirbayes`, `YiMaTweets`, `ZeyuanAllenZhu`
- Video-format / low text-news signal: `ykilcher`
- Adjacent but not AI-news-primary: `mitsuhiko`, `jarredsumner`, `nearcyan`

## Test plan
- [x] YAML parses; 75 unique handles, no duplicates
- [ ] Next scheduled run includes the new handles in the manifest (verifiable in `Fetch tweets...` log step)
- [ ] No rate-limit regression — current cycle had ~30 successful fetches; adding 13 more should still fit comfortably under birdy's per-account ceiling

🤖 Generated with [Claude Code](https://claude.com/claude-code)