### PR TITLE
fix: tier down model selection on aggregation workflows, tighten gen-research turn cap

### DIFF
--- a/.github/workflows/2h-bluesky.yml
+++ b/.github/workflows/2h-bluesky.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
-            --model opus --allowedTools "Read,Write,Edit,Bash(git:*)"
+            --model sonnet --allowedTools "Read,Write,Edit,Bash(git:*)"
           prompt: |
             You are a Bluesky AI feed curator. Process REAL-TIME posts from Bluesky.
 

--- a/.github/workflows/4h-community.yml
+++ b/.github/workflows/4h-community.yml
@@ -93,7 +93,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
-            --model opus --mcp-config /tmp/mcp-config.json
+            --model sonnet --mcp-config /tmp/mcp-config.json
             --allowedTools "Read,Write,Edit,Bash(git:*),mcp__hackernews__*"
           prompt: |
             You are a community AI news curator. Process REAL-TIME data from HN and Reddit.

--- a/.github/workflows/generative-research.yml
+++ b/.github/workflows/generative-research.yml
@@ -336,7 +336,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
-            --model opus --max-turns 240 --allowedTools "Read,Write,Edit,Bash(git:*),Bash(python3:*),Bash(cat:*),Bash(ls:*),Bash(printenv:*),Bash(curl:*),Bash(pdftotext:*),Bash(bird:*),Bash(bird-fast:*),Bash(jq:*),WebSearch,WebFetch,Task,TodoWrite"
+            --model opus --max-turns 120 --allowedTools "Read,Write,Edit,Bash(git:*),Bash(python3:*),Bash(cat:*),Bash(ls:*),Bash(printenv:*),Bash(curl:*),Bash(pdftotext:*),Bash(bird:*),Bash(bird-fast:*),Bash(jq:*),WebSearch,WebFetch,Task,TodoWrite"
           prompt: |
             You are a deep-research analyst writing a COMPREHENSIVE,
             analyst-grade HTML article on the topic supplied by the user.
@@ -841,7 +841,7 @@ jobs:
           # ANTHROPIC_AUTH_TOKEN because ANTHROPIC_BASE_URL is set.
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
-            --model opus --max-turns 240 --allowedTools "Read,Write,Edit,Bash(git:*),Bash(python3:*),Bash(cat:*),Bash(ls:*),Bash(printenv:*),Bash(curl:*),Bash(pdftotext:*),Bash(bird:*),Bash(bird-fast:*),Bash(jq:*),WebSearch,WebFetch,Task,TodoWrite"
+            --model opus --max-turns 120 --allowedTools "Read,Write,Edit,Bash(git:*),Bash(python3:*),Bash(cat:*),Bash(ls:*),Bash(printenv:*),Bash(curl:*),Bash(pdftotext:*),Bash(bird:*),Bash(bird-fast:*),Bash(jq:*),WebSearch,WebFetch,Task,TodoWrite"
           prompt: |
             You are a deep-research analyst running on DeepSeek v4 Pro,
             writing a COMPREHENSIVE, analyst-grade HTML article on the

--- a/.github/workflows/hourly-rss.yml
+++ b/.github/workflows/hourly-rss.yml
@@ -98,7 +98,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
-            --model opus --allowedTools "Read,Write,Edit,Bash(git:*)"
+            --model haiku --allowedTools "Read,Write,Edit,Bash(git:*)"
           prompt: |
             You are an RSS feed processor for AI news. Extract NEW articles from official sources.
 


### PR DESCRIPTION
## Summary

Cost optimization based on first-principles task analysis. Model tier should match task character, not be uniformly maxed.

- **`hourly-rss.yml`**: opus → **haiku**. Pure XML → markdown templating. Read RSS feeds, filter by pubDate (last 24h), dedupe against existing file, append into a fixed template. No ranking, no significance judgment, no analysis. Textbook Haiku case. **~720 runs/month — biggest single cost line item.**
- **`2h-bluesky.yml`**: opus → **sonnet**. Categorize posts into 4 buckets with mechanical filters (>5 likes, skip generic). Light pattern-matching. Daily.
- **`4h-community.yml`**: opus → **sonnet**. HN + Reddit aggregation into tables with light editorial judgment over score-and-content filters. 6 runs/day.
- **`generative-research.yml`**: `--max-turns 240` → **120** (both Claude and DeepSeek backends). 240 was a runaway-cost cap, not a real guardrail. The pipeline is 16-32 evidence collectors (waves of 8) + 5-10 writers (waves of 4) + verifier + bounded revision = ~40-60 turn worst case; 120 leaves ~2x headroom and stays well above any floor the orchestration genuinely needs.

## What's NOT in this PR (analytical work — left alone per audit guidance)

- `daily-arxiv.yml` — judging research paper novelty is real intellectual work
- `24h-model-timeline.yml` — cross-source intelligence synthesis, status classification, day-over-day diff narration
- `daily-front-page.yml` HTML step — creative editorial + visual design (story selection, image search, drop-cap layout)
- `hourly-twitter.yml` analyst brief (per audit)
- `daily-digest.yml` (per audit)
- `generative-research.yml` writer steps (per audit)

These are candidates for a separate follow-up after observing if the current downgrades hold quality.

## Review

Codex review (gpt-5.5, reasoning=high): **GATE PASS** — "The changes only adjust Claude model aliases and max-turn limits in workflow invocations. I did not find a discrete introduced defect that would clearly break existing behavior."

## Test plan

- [ ] Watch next `hourly-rss` run — verify output format unchanged and dedupe still works on Haiku
- [ ] Watch next `2h-bluesky` and `4h-community` runs — verify categorization quality on Sonnet
- [ ] On next manually-dispatched `generative-research` run, confirm pipeline completes within 120 turns (look at action logs for turn count)
- [ ] If any workflow now produces noticeably worse output, revert that specific file and tier back up one step (haiku → sonnet, sonnet → opus)

🤖 Generated with [Claude Code](https://claude.com/claude-code)