### PR TITLE
fix: pipeline bugs — daily-improve PRs, model-timeline handles, front-page trigger, liveness check

### DIFF
--- a/.github/workflows/24h-model-timeline.yml
+++ b/.github/workflows/24h-model-timeline.yml
@@ -46,7 +46,7 @@ jobs:
           mkdir -p /tmp/bird
 
           # Company accounts
-          companies="OpenAI AnthropicAI GoogleDeepMind GoogleAI MistralAI MetaAI xaboratory NVIDIAAIDev awscloud Apple CohereAI Azure"
+          companies="OpenAI AnthropicAI GoogleDeepMind GoogleAI MistralAI MetaAI xai NVIDIAAIDev awscloud Apple CohereAI Azure"
 
           for handle in $companies; do
             echo "Fetching @${handle}..."
@@ -59,7 +59,7 @@ jobs:
           CT0: ${{ secrets.BIRD_CT0 }}
         run: |
           # Key execs and insiders
-          execs="sama demishassabis sataboratory DrJimFan tszzl OfficialLoganK alexalbert__ mustafasuleyman"
+          execs="sama demishassabis satyanadella DrJimFan tszzl OfficialLoganK alexalbert__ mustafasuleyman"
 
           for handle in $execs; do
             echo "Fetching @${handle}..."

--- a/.github/workflows/daily-front-page.yml
+++ b/.github/workflows/daily-front-page.yml
@@ -1,9 +1,17 @@
 name: Daily Front Page
 
+# Triggered when the Daily AI Digest workflow finishes successfully on main.
+# Previously this ran on a 30-minute-delayed cron (`30 0 * * *`), which
+# silently no-op'd whenever the Opus-driven digest run exceeded 30 min on
+# the self-hosted runner (it gates on the digest file existing — see
+# `Check digest exists` below). The workflow_run trigger removes the
+# clock-based race entirely. `workflow_dispatch` is retained as a manual
+# fallback for backfills.
 on:
-  schedule:
-    # Run at 00:30 UTC, 30 minutes after digest
-    - cron: '30 0 * * *'
+  workflow_run:
+    workflows: ["Daily AI Digest (All Sources)"]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
 
 concurrency:
@@ -13,6 +21,10 @@ concurrency:
 jobs:
   front-page:
     runs-on: [self-hosted, Linux]
+    # Only run when the digest succeeded, OR when a human dispatched us.
+    # `workflow_run.conclusion` is empty on workflow_dispatch, so we must
+    # explicitly allow that event or the manual fallback silently no-ops.
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/daily-improve.yml
+++ b/.github/workflows/daily-improve.yml
@@ -31,12 +31,26 @@ jobs:
           echo "yesterday=$(date -d 'yesterday' +'%Y-%m-%d' 2>/dev/null || date -v-1d +'%Y-%m-%d')" >> $GITHUB_OUTPUT
           echo "branch=improve/$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
+      # Set authenticated remote URL so Claude's `git push` (inside the
+      # sandboxed Bash(git:*) tool) can reach the origin without re-running
+      # `git remote set-url` from inside the agent prompt.
+      - name: Configure authenticated git remote
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git
+
       - name: Analyze and Improve Methodology
         uses: anthropics/claude-code-action@v1
+        env:
+          # `gh pr create` invoked from the agent prompt needs GH_TOKEN.
+          # Without this the agent silently fails at the PR-create step
+          # even when Bash(gh:*) is in the allowlist.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
-            --model opus --allowedTools "Glob,Read,Write,Edit,Bash(git:*),WebSearch"
+            --model opus --allowedTools "Glob,Read,Write,Edit,Bash(git:*),Bash(gh:*),WebSearch"
           prompt: |
             You are an AI research methodology optimizer. Analyze yesterday's output quality and propose improvements.
 

--- a/.github/workflows/daily-improve.yml
+++ b/.github/workflows/daily-improve.yml
@@ -105,10 +105,11 @@ jobs:
                - Add new data sources
                - Fix any bugs found
 
-            3. Create an IMPROVEMENTS.md file documenting:
+            3. Create a dated improvement note at docs/archive/${{ steps.dates.outputs.today }}-improvements.md documenting:
                - What issues were found
                - What improvements were made
                - Expected impact
+               (Do NOT write to repo-root IMPROVEMENTS.md — that path is archived. See CLAUDE.md load-bearing rule #7.)
 
             4. Commit changes:
                git add -A

--- a/.github/workflows/liveness-check.yml
+++ b/.github/workflows/liveness-check.yml
@@ -45,7 +45,11 @@ jobs:
           # measuring pipeline output freshness.
 
           today_epoch=$(date -u +%s)
-          max_age_days=2
+          # Threshold in seconds, not days, to avoid the truncation bug where
+          # `(now - newest) / 86400` reports `2` for anything in the 48h..72h
+          # window — which would silently let a 60h-stale subdir pass an
+          # "alert above 48h" check until it crossed 72h.
+          max_age_seconds=$(( 48 * 3600 ))
           fail=0
           report=""
 
@@ -83,13 +87,14 @@ jobs:
               continue
             fi
 
-            age_days=$(( (today_epoch - newest_epoch) / 86400 ))
+            age_seconds=$(( today_epoch - newest_epoch ))
+            age_hours=$(( age_seconds / 3600 ))
 
-            if [ "$age_days" -gt "$max_age_days" ]; then
-              report="${report}STALE: $dir -- newest file dated $newest_date (${age_days}d old, max ${max_age_days}d)\n"
+            if [ "$age_seconds" -gt "$max_age_seconds" ]; then
+              report="${report}STALE: $dir -- newest file dated $newest_date (${age_hours}h old, max 48h)\n"
               fail=1
             else
-              echo "OK: $dir -- newest $newest_date (${age_days}d old)"
+              echo "OK: $dir -- newest $newest_date (${age_hours}h old)"
             fi
           done
 

--- a/.github/workflows/liveness-check.yml
+++ b/.github/workflows/liveness-check.yml
@@ -1,0 +1,107 @@
+name: Pipeline Liveness Check
+
+# Daily heartbeat that verifies each research subdirectory has produced a
+# file within the last 48h. Designed to make silent pipeline outages loud:
+# audit found research/rss/ went 20 days stale with zero alarm.
+#
+# Uses GitHub-hosted ubuntu-latest (not the self-hosted runner) so this
+# check still fires even when the self-hosted runner is down — which is
+# precisely the failure mode we need to catch.
+#
+# Failure surface: on staleness this workflow exits non-zero. GitHub's
+# native workflow-failure email/notification is the alert. Deliberately
+# NOT using `gh issue create` to avoid spamming the repo with duplicate
+# issues every day until the underlying pipeline is fixed.
+
+on:
+  schedule:
+    # Daily at 12:00 UTC (12 hours after midnight pipelines run, giving
+    # them plenty of room to publish before we check).
+    - cron: '0 12 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: liveness-check
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check freshness of each research subdir
+        run: |
+          set -uo pipefail
+
+          # Filenames carry the canonical date as a YYYY-MM-DD prefix
+          # (e.g. 2026-05-17.md, 2026-05-17-reddit.md, 2026-05-17-papers.md).
+          # We parse the filename, not the file mtime, because git checkout
+          # rewrites mtimes to the checkout time — making mtime useless for
+          # measuring pipeline output freshness.
+
+          today_epoch=$(date -u +%s)
+          max_age_days=2
+          fail=0
+          report=""
+
+          subdirs="rss twitter bluesky community arxiv digest"
+
+          for sub in $subdirs; do
+            dir="research/$sub"
+            if [ ! -d "$dir" ]; then
+              report="${report}MISSING DIR: $dir\n"
+              fail=1
+              continue
+            fi
+
+            # Extract YYYY-MM-DD prefix from each filename, take the max.
+            # `grep -oE '^[0-9]{4}-[0-9]{2}-[0-9]{2}'` skips files that
+            # don't start with a date (subdirs, READMEs, etc.).
+            newest_date=$(
+              ls -1 "$dir" 2>/dev/null \
+                | grep -oE '^[0-9]{4}-[0-9]{2}-[0-9]{2}' \
+                | sort -u \
+                | tail -1
+            )
+
+            if [ -z "$newest_date" ]; then
+              report="${report}EMPTY: $dir (no date-prefixed files found)\n"
+              fail=1
+              continue
+            fi
+
+            # GNU date on ubuntu-latest. Convert YYYY-MM-DD to epoch.
+            newest_epoch=$(date -u -d "${newest_date}T00:00:00Z" +%s 2>/dev/null || echo 0)
+            if [ "$newest_epoch" -eq 0 ]; then
+              report="${report}PARSE ERROR: $dir (newest=$newest_date)\n"
+              fail=1
+              continue
+            fi
+
+            age_days=$(( (today_epoch - newest_epoch) / 86400 ))
+
+            if [ "$age_days" -gt "$max_age_days" ]; then
+              report="${report}STALE: $dir -- newest file dated $newest_date (${age_days}d old, max ${max_age_days}d)\n"
+              fail=1
+            else
+              echo "OK: $dir -- newest $newest_date (${age_days}d old)"
+            fi
+          done
+
+          if [ "$fail" -ne 0 ]; then
+            echo ""
+            echo "::error::Pipeline liveness check FAILED -- one or more research subdirs are stale."
+            echo ""
+            printf "%b" "$report"
+            echo ""
+            echo "Investigate the corresponding workflow(s) on the self-hosted runner."
+            exit 1
+          fi
+
+          echo ""
+          echo "All research subdirs are fresh."


### PR DESCRIPTION
## Summary

Four targeted fixes for silent pipeline failures surfaced by recent audit.

- **`daily-improve.yml`** — Add `Bash(gh:*)` to allowedTools and `GH_TOKEN` env on the Claude step so `gh pr create` in the prompt actually runs. Previously the sandbox rejected it silently. Also hoists `git remote set-url` to a pre-step so Claude's `git push` (inside `Bash(git:*)`) can reach origin without re-running the URL set inside the agent prompt.
- **`24h-model-timeline.yml`** — Fix two typo'd X handles that returned empty every run: `xaboratory` -> `xai` (xAI company account), `sataboratory` -> `satyanadella` (Microsoft CEO, alongside other execs in the list).
- **`daily-front-page.yml`** — Replace clock-based cron (`30 0 * * *`) with a `workflow_run` trigger on the `Daily AI Digest (All Sources)` workflow. The 30-minute delay was too tight — Opus-driven digests routinely overran, causing the front-page job to silently no-op via its digest-exists gate. The job-level `if` allows both `workflow_run.conclusion == 'success'` and `workflow_dispatch` so manual backfills still work.
- **`liveness-check.yml`** (new) — Daily heartbeat on `ubuntu-latest` at 12:00 UTC that parses `YYYY-MM-DD` filename prefixes in each research subdir and exits non-zero if any is >48h stale. Catches the silent-outage class of bug that let `research/rss/` go 20 days stale with no alarm. Uses GitHub-hosted runner so it fires even when the self-hosted runner is down. Compares elapsed seconds (not truncated days — fix applied per codex review feedback).

## Test plan

- [ ] Validate YAML on all four files: `python3 -c "import yaml; yaml.safe_load(open('<file>'))"` — done locally, all four parse
- [ ] Local self-test of liveness-check bash logic against current repo state — done: catches `rss/` at 480h, passes the other 5 subdirs at 0h
- [ ] After merge: trigger `Daily Self-Improvement` manually via `workflow_dispatch` and confirm `gh pr create` succeeds
- [ ] After merge: confirm `24h Model Timeline` JSON files for `xai.json` and `satyanadella.json` populate (no more empty `[]`)
- [ ] After merge: verify next-day digest at 00:00 UTC triggers `Daily Front Page` via `workflow_run` rather than waiting for cron
- [ ] After merge: confirm `Pipeline Liveness Check` fires at next 12:00 UTC and flags the stale `rss/` subdir until the underlying RSS workflow is fixed

## Codex review

Ran `codex review --base main` (model_reasoning_effort=high). One [P2] finding: integer-day truncation in the liveness check would miss the 48h-72h window the workflow advertised. Fixed in commit `e831fb05` — now compares elapsed seconds directly. No other findings. Gate: PASS.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>