### PR TITLE
chore: pin all dependency versions, add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,10 @@
 # Scope notes:
 # - github-actions: scans .github/workflows/*.yml for `uses:` action refs.
 #   Bumps things like actions/checkout@v4, anthropics/claude-code-action@v1.
-# - pip: scans requirements.txt at repo root. Bumps yfinance, pyyaml.
+# - pip: scans requirements*.txt at repo root. Bumps pyyaml
+#   (requirements.txt, hard-required) and yfinance (requirements-optional.txt,
+#   best-effort). Split so a flaky optional install can't take down the
+#   hard-required path.
 # - npm (/dashboard): scans dashboard/package.json. Bumps dompurify, marked,
 #   typescript, vite. The dashboard has its own lockfile lifecycle separate
 #   from workflow deps.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,50 @@
+# Dependabot configuration — weekly automated dependency bump PRs.
+#
+# Scope notes:
+# - github-actions: scans .github/workflows/*.yml for `uses:` action refs.
+#   Bumps things like actions/checkout@v4, anthropics/claude-code-action@v1.
+# - pip: scans requirements.txt at repo root. Bumps yfinance, pyyaml.
+# - npm (/dashboard): scans dashboard/package.json. Bumps dompurify, marked,
+#   typescript, vite. The dashboard has its own lockfile lifecycle separate
+#   from workflow deps.
+#
+# What Dependabot CAN'T see and must be bumped manually:
+# - Inline `npm install -g <pkg>` in workflow run: blocks (bird, pi-coding-agent).
+# - Inline `npm install <pkg>` in workflow run: blocks (puppeteer in
+#   daily-front-page.yml).
+# These are version-pinned in the workflow YAML — re-check the pins monthly
+# and bump in the same PR you'd merge a Dependabot suggestion in.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: UTC
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(actions)"
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: UTC
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(pip)"
+
+  - package-ecosystem: npm
+    directory: /dashboard
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: UTC
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(npm)"

--- a/.github/workflows/24h-model-timeline.yml
+++ b/.github/workflows/24h-model-timeline.yml
@@ -36,7 +36,8 @@ jobs:
           node-version: '22'
 
       - name: Install bird CLI
-        run: npm install -g @steipete/bird
+        # pinned 2026-05-17; bump manually (Dependabot can't track inline npm -g installs)
+        run: npm install -g @steipete/bird@0.8.0
 
       - name: Fetch tweets from company accounts
         env:

--- a/.github/workflows/daily-front-page.yml
+++ b/.github/workflows/daily-front-page.yml
@@ -67,7 +67,8 @@ jobs:
 
       - name: Install puppeteer
         if: steps.check.outputs.exists == 'true'
-        run: cd /tmp && npm install puppeteer
+        # pinned 2026-05-17; bump manually (Dependabot can't track inline npm installs)
+        run: cd /tmp && npm install puppeteer@25.0.2
 
       # Claude reads digest and generates newspaper-style HTML
       - name: Generate front page HTML

--- a/.github/workflows/generative-research.yml
+++ b/.github/workflows/generative-research.yml
@@ -248,30 +248,34 @@ jobs:
           fi
           echo "curl:      $(command -v curl || echo MISSING) $(curl --version 2>/dev/null | head -1)"
           echo "pdftotext: $(command -v pdftotext || echo MISSING) $(pdftotext -v 2>&1 | head -1)"
-          # yfinance for scripts/stock_prices.py. Yahoo's chart API blocks
-          # bare-urllib clients; yfinance handles the crumb-cookie dance and
-          # retries, which is the difference between working and 429ing from
-          # the runner. --break-system-packages is required because the
-          # runner's Python ships with PEP-668 enabled — even --user installs
-          # are blocked otherwise. Safe here because this runner is dedicated
-          # to this workflow; we're not contending with a host package manager.
-          if ! python3 -c "import yfinance" 2>/dev/null; then
-            echo "Installing yfinance"
-            python3 -m pip install --quiet --user --upgrade --break-system-packages yfinance \
-              || echo "WARN: pip install yfinance failed; stock_prices.py will fall back to urllib/stooq" >&2
+          # yfinance + PyYAML: Python deps for this workflow. Versions live in
+          # requirements.txt at the repo root so Dependabot's pip ecosystem can
+          # propose bumps via PR (see .github/dependabot.yml). yfinance handles
+          # Yahoo's chart-API crumb-cookie dance for scripts/stock_prices.py;
+          # PyYAML drives the .ara.md compiler in scripts/compile_ara.py.
+          # --break-system-packages is required because the runner's Python
+          # ships with PEP-668 enabled — even --user installs are blocked
+          # otherwise. Safe here because this runner is dedicated to this
+          # workflow; we're not contending with a host package manager.
+          # Skip the install if both are already importable to keep warm runs
+          # fast; if either is missing, install the full pinned set so
+          # versions stay consistent.
+          if ! python3 -c "import yfinance, yaml" 2>/dev/null; then
+            echo "Installing pinned Python deps from requirements.txt"
+            # Soft-tolerate install failures here — per-package fail modes
+            # are enforced by the verification steps below (yfinance soft,
+            # pyyaml hard). A bulk hard-fail would regress today's behavior
+            # where a flaky yfinance install drops back to stooq/urllib.
+            python3 -m pip install --quiet --user --break-system-packages \
+              -r requirements.txt \
+              || echo "WARN: pip install -r requirements.txt failed; verifying per-package fallbacks below" >&2
           fi
-          python3 -c "import yfinance; print('yfinance:', yfinance.__version__)" 2>&1 || true
-          # PyYAML for scripts/compile_ara.py (the .ara.md frontmatter +
-          # block-body parser). Without it the compiler can't run and the
-          # writer falls back to its raw-HTML path, which means
-          # section-writer agents must hand-write HTML — the whole point
-          # of the DSL is undone. Hard-fail if install fails.
-          if ! python3 -c "import yaml" 2>/dev/null; then
-            echo "Installing PyYAML"
-            python3 -m pip install --quiet --user --upgrade --break-system-packages pyyaml \
-              || { echo "ERROR: pip install pyyaml failed; compile_ara cannot run"; exit 1; }
-          fi
-          python3 -c "import yaml; print('yaml:', yaml.__version__)" 2>&1 || true
+          # yfinance is best-effort — stock_prices.py falls back to urllib/stooq.
+          python3 -c "import yfinance; print('yfinance:', yfinance.__version__)" 2>&1 \
+            || echo "WARN: yfinance unavailable; stock_prices.py will fall back to urllib/stooq" >&2
+          # PyYAML is load-bearing — compile_ara cannot run without it.
+          python3 -c "import yaml; print('yaml:', yaml.__version__)" 2>&1 \
+            || { echo "ERROR: pyyaml unavailable; compile_ara cannot run"; exit 1; }
 
       # Snapshot HEAD before the model runs so we can later identify the file
       # THIS run produced (rather than guessing by `ls -t`, which would point

--- a/.github/workflows/generative-research.yml
+++ b/.github/workflows/generative-research.yml
@@ -248,34 +248,35 @@ jobs:
           fi
           echo "curl:      $(command -v curl || echo MISSING) $(curl --version 2>/dev/null | head -1)"
           echo "pdftotext: $(command -v pdftotext || echo MISSING) $(pdftotext -v 2>&1 | head -1)"
-          # yfinance + PyYAML: Python deps for this workflow. Versions live in
-          # requirements.txt at the repo root so Dependabot's pip ecosystem can
-          # propose bumps via PR (see .github/dependabot.yml). yfinance handles
-          # Yahoo's chart-API crumb-cookie dance for scripts/stock_prices.py;
-          # PyYAML drives the .ara.md compiler in scripts/compile_ara.py.
+          # Python deps split into two manifests so failure modes stay
+          # per-package (Dependabot's pip ecosystem watches both via the
+          # `requirements*.txt` glob — see .github/dependabot.yml):
+          #   requirements.txt          — required, hard-fail (pyyaml)
+          #   requirements-optional.txt — best-effort, soft-fail (yfinance)
           # --break-system-packages is required because the runner's Python
           # ships with PEP-668 enabled — even --user installs are blocked
           # otherwise. Safe here because this runner is dedicated to this
           # workflow; we're not contending with a host package manager.
-          # Skip the install if both are already importable to keep warm runs
-          # fast; if either is missing, install the full pinned set so
-          # versions stay consistent.
-          if ! python3 -c "import yfinance, yaml" 2>/dev/null; then
-            echo "Installing pinned Python deps from requirements.txt"
-            # Soft-tolerate install failures here — per-package fail modes
-            # are enforced by the verification steps below (yfinance soft,
-            # pyyaml hard). A bulk hard-fail would regress today's behavior
-            # where a flaky yfinance install drops back to stooq/urllib.
+          # PyYAML: drives .ara.md compiler in scripts/compile_ara.py.
+          if ! python3 -c "import yaml" 2>/dev/null; then
+            echo "Installing required Python deps from requirements.txt"
             python3 -m pip install --quiet --user --break-system-packages \
               -r requirements.txt \
-              || echo "WARN: pip install -r requirements.txt failed; verifying per-package fallbacks below" >&2
+              || { echo "ERROR: required pip install failed; compile_ara cannot run"; exit 1; }
           fi
-          # yfinance is best-effort — stock_prices.py falls back to urllib/stooq.
-          python3 -c "import yfinance; print('yfinance:', yfinance.__version__)" 2>&1 \
-            || echo "WARN: yfinance unavailable; stock_prices.py will fall back to urllib/stooq" >&2
-          # PyYAML is load-bearing — compile_ara cannot run without it.
           python3 -c "import yaml; print('yaml:', yaml.__version__)" 2>&1 \
             || { echo "ERROR: pyyaml unavailable; compile_ara cannot run"; exit 1; }
+          # yfinance: best-effort; stock_prices.py falls back to urllib/stooq.
+          # Installed separately so a yfinance install/network flake never
+          # blocks the workflow.
+          if ! python3 -c "import yfinance" 2>/dev/null; then
+            echo "Installing optional Python deps from requirements-optional.txt"
+            python3 -m pip install --quiet --user --break-system-packages \
+              -r requirements-optional.txt \
+              || echo "WARN: optional pip install failed; stock_prices.py will fall back to urllib/stooq" >&2
+          fi
+          python3 -c "import yfinance; print('yfinance:', yfinance.__version__)" 2>&1 \
+            || echo "WARN: yfinance unavailable; stock_prices.py will fall back to urllib/stooq" >&2
 
       # Snapshot HEAD before the model runs so we can later identify the file
       # THIS run produced (rather than guessing by `ls -t`, which would point

--- a/.github/workflows/hourly-twitter-deepseek-agentic.yml
+++ b/.github/workflows/hourly-twitter-deepseek-agentic.yml
@@ -61,7 +61,8 @@ jobs:
           sudo journalctl --vacuum-time=2d >/dev/null 2>&1 || true
 
       - name: Install bird CLI
-        run: npm install -g @steipete/bird
+        # pinned 2026-05-17; bump manually (Dependabot can't track inline npm -g installs)
+        run: npm install -g @steipete/bird@0.8.0
 
       - name: Install birdy from GitHub release
         env:

--- a/.github/workflows/hourly-twitter-deepseek-pi.yml
+++ b/.github/workflows/hourly-twitter-deepseek-pi.yml
@@ -50,10 +50,12 @@ jobs:
           node-version: '22'
 
       - name: Install bird CLI
-        run: npm install -g @steipete/bird
+        # pinned 2026-05-17; bump manually (Dependabot can't track inline npm -g installs)
+        run: npm install -g @steipete/bird@0.8.0
 
       - name: Install pi coding agent
-        run: npm install -g @mariozechner/pi-coding-agent
+        # pinned 2026-05-17; bump manually (Dependabot can't track inline npm -g installs)
+        run: npm install -g @mariozechner/pi-coding-agent@0.73.1
 
       - name: Configure git identity
         run: |

--- a/.github/workflows/hourly-twitter.yml
+++ b/.github/workflows/hourly-twitter.yml
@@ -62,7 +62,8 @@ jobs:
           df -h / 2>&1 | tail -2
 
       - name: Install bird CLI
-        run: npm install -g @steipete/bird
+        # pinned 2026-05-17; bump manually (Dependabot can't track inline npm -g installs)
+        run: npm install -g @steipete/bird@0.8.0
 
       - name: Install birdy from GitHub release
         env:

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,0 +1,8 @@
+# Optional Python deps for ai-research-arm workflows. Soft-fail tolerated —
+# downstream scripts have urllib/stooq fallbacks when these are missing.
+# Dependabot's pip ecosystem watches this file (see .github/dependabot.yml).
+#
+# yfinance: Yahoo's chart API blocks bare-urllib clients; yfinance handles
+# the crumb-cookie dance and retries. Used by scripts/stock_prices.py.
+# Falls back to urllib/stooq when missing.
+yfinance==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+# Python dependencies for ai-research-arm workflows.
+# Single source of truth — Dependabot pip ecosystem watches this file.
+# Installed in .github/workflows/generative-research.yml via:
+#   python3 -m pip install --user --break-system-packages -r requirements.txt
+#
+# yfinance: Yahoo's chart API blocks bare-urllib clients; yfinance handles
+# the crumb-cookie dance and retries. Used by scripts/stock_prices.py.
+yfinance==1.3.0
+# PyYAML: scripts/compile_ara.py parses .ara.md frontmatter + block bodies.
+# Hard dependency for the .ara.md compiler; without it the writer falls back
+# to its raw-HTML path and the DSL benefits are undone.
+pyyaml==6.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,8 @@
-# Python dependencies for ai-research-arm workflows.
-# Single source of truth — Dependabot pip ecosystem watches this file.
-# Installed in .github/workflows/generative-research.yml via:
-#   python3 -m pip install --user --break-system-packages -r requirements.txt
+# Required Python deps for ai-research-arm workflows. Hard-fail if install
+# breaks — these are load-bearing for generative-research.yml.
+# Dependabot's pip ecosystem watches this file (see .github/dependabot.yml).
 #
-# yfinance: Yahoo's chart API blocks bare-urllib clients; yfinance handles
-# the crumb-cookie dance and retries. Used by scripts/stock_prices.py.
-yfinance==1.3.0
 # PyYAML: scripts/compile_ara.py parses .ara.md frontmatter + block bodies.
-# Hard dependency for the .ara.md compiler; without it the writer falls back
-# to its raw-HTML path and the DSL benefits are undone.
+# Without it the compiler can't run and the writer falls back to raw HTML,
+# defeating the .ara.md DSL.
 pyyaml==6.0.3


### PR DESCRIPTION
## Summary

Every workflow install was floating to "latest", which on a self-hosted runner with persistent secrets is a Shai-Hulud-class supply-chain vector — any compromised upstream release runs as the runner the next time a workflow fires. This PR pins every install to an exact version and wires Dependabot so the pins stay current without becoming a maintenance liability.

### Per-package pin table (latest stable as of 2026-05-17)

| Package | Pinned | Where | Strategy |
|---|---|---|---|
| `@steipete/bird` | `0.8.0` | inline `npm install -g` in 4 workflows | A (inline pin) |
| `@mariozechner/pi-coding-agent` | `0.73.1` | inline `npm install -g` in `hourly-twitter-deepseek-pi.yml` | A (inline pin) |
| `puppeteer` | `25.0.2` | inline `npm install` in `daily-front-page.yml` | A (inline pin) |
| `pyyaml` | `6.0.3` | new `requirements.txt` (hard-required) | B (manifest) |
| `yfinance` | `1.3.0` | new `requirements-optional.txt` (best-effort) | B (manifest) |

### Strategy rationale (hybrid A + B)

- **pip → Strategy B (manifest-driven):** added `requirements.txt` + `requirements-optional.txt` at repo root. `generative-research.yml` now runs `pip install -r requirements*.txt`. Dependabot's pip ecosystem watches both files and proposes PRs automatically — Strategy B pays for itself here because the pin actually becomes self-maintaining.
- **npm → Strategy A (inline pins):** the npm CLI tools are global installs (`npm install -g <pkg>@<ver>`) and `puppeteer` is a one-off into `/tmp`. Refactoring all three workflows to use a repo-root `package.json` + `npm ci` is invasive and would conflict with the existing `dashboard/package.json`. Inline pins are minimal-blast-radius and honest; the trade-off is documented in `.github/dependabot.yml` as "bump manually."

### Two-file split for pip (post-Codex-review fix)

First pass used a single `requirements.txt`. Codex review flagged: bulk install couples optional `yfinance` to required `pyyaml` — a transient yfinance install failure would abort pip before reaching pyyaml, then the subsequent hard `import yaml` check would fail the whole workflow. Previously yfinance failures were tolerated.

Fix: split into two manifests + two independent `pip install` calls. Required deps hard-fail, optional deps soft-fail to existing `scripts/stock_prices.py` urllib/stooq fallback.

### Dependabot

New `.github/dependabot.yml` runs weekly (Mon 09:00 UTC) across three ecosystems:
- `github-actions` — bumps `uses:` refs in workflows
- `pip` — bumps `requirements*.txt` at repo root
- `npm` — bumps `dashboard/package.json`

Inline npm CLI installs in workflows can't be tracked — flagged in the dependabot.yml header comment with the "bump manually" instruction.

### Recent activity flag (per task brief)

Recent commits touched yfinance integration: `5b658c7d` (gen-research telemetry + yfinance fix) and `53384cac` (gen-research: yfinance backend + real BE chart). Reviewer should confirm `yfinance==1.3.0` doesn't break the current `scripts/stock_prices.py` integration before merging — that's the package most likely to have a churn risk here.

### Codex review

```
GATE: PASS (1 P2 advisory, 0 P1 critical)

[P2] Install required PyYAML independently of optional yfinance —
generative-research.yml:269-271
```

Addressed by the second commit (split into required vs optional manifests).

## Test plan

- [ ] Trigger `generative-research.yml` once on the self-hosted runner — verify pyyaml + yfinance install cleanly with the pinned versions, and the `import` verification lines print expected versions.
- [ ] Trigger `hourly-twitter.yml` once — verify `@steipete/bird@0.8.0` installs cleanly on the runner.
- [ ] Trigger `daily-front-page.yml` once when a digest exists — verify `puppeteer@25.0.2` installs cleanly into `/tmp`.
- [ ] Trigger `hourly-twitter-deepseek-pi.yml` once — verify both `@steipete/bird@0.8.0` and `@mariozechner/pi-coding-agent@0.73.1` install cleanly.
- [ ] Confirm Dependabot picks up the new `dependabot.yml` after merge (check `Insights > Dependency graph > Dependabot` tab within 24h).
- [ ] Simulate yfinance install failure (e.g., temporarily pin to a nonexistent version on a branch) and confirm the workflow continues with the urllib/stooq fallback warning, rather than hard-failing.