### PR TITLE
chore: configure git-lfs for binary assets (PNG, MP3, etc.)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,35 @@
+# Git LFS configuration.
+#
+# Why: research/front-page/*.png (~30MB across 32 files) and
+# research/audio/*.mp3 (~11MB across 20 files) grow ~3MB/week. Git stores
+# binaries as full snapshots per revision (no delta compression on these
+# formats), so without LFS the .git pack balloons indefinitely.
+#
+# Scope: This config affects FUTURE commits only. Existing committed binaries
+# stay as regular git objects until the maintainer runs `git lfs migrate
+# import` (see PR runbook). The .gitattributes file IS the LFS contract —
+# `git lfs install` configures local filter hooks but the routing decision
+# lives here.
+#
+# Patterns kept narrow to actual + plausibly-incoming binary formats. Add
+# more here (don't pre-register every extension) if the pipeline starts
+# producing new media types.
+
+# Images (newspaper front pages today; logos / generated diagrams plausibly tomorrow)
+*.png  filter=lfs diff=lfs merge=lfs -text
+*.jpg  filter=lfs diff=lfs merge=lfs -text
+*.jpeg filter=lfs diff=lfs merge=lfs -text
+*.gif  filter=lfs diff=lfs merge=lfs -text
+*.webp filter=lfs diff=lfs merge=lfs -text
+
+# Audio (daily digest MP3s today; OGG/WAV plausibly if TTS pipeline changes)
+*.mp3 filter=lfs diff=lfs merge=lfs -text
+*.wav filter=lfs diff=lfs merge=lfs -text
+*.ogg filter=lfs diff=lfs merge=lfs -text
+
+# Video (none today; covered for forward-compat — silent video pipeline change)
+*.mp4 filter=lfs diff=lfs merge=lfs -text
+*.webm filter=lfs diff=lfs merge=lfs -text
+
+# Large documents (none today; covered for forward-compat)
+*.pdf filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/ai-news-research.yml
+++ b/.github/workflows/ai-news-research.yml
@@ -169,8 +169,10 @@ jobs:
             Full report on GitHub.
             ```
 
-            After writing both files, commit:
-            git add research/
+            After writing both files, commit (stage ONLY today's two files;
+            do NOT `git add research/`, the LFS clean filter would convert
+            historical PNGs/MP3s to LFS pointers in one commit):
+            git add research/${{ steps.date.outputs.date }}-ai-news.md research/summaries/${{ steps.date.outputs.date }}-summary.txt
             git commit -m "Add AI news research for ${{ steps.date.outputs.date }}"
 
             CRITICAL: Write REAL news with actual sources. No placeholder content. NO DUPLICATES from previous reports.
@@ -275,8 +277,10 @@ jobs:
             Full report on GitHub.
             ```
 
-            After writing both files, commit:
-            git add research/
+            After writing both files, commit (stage ONLY today's two files;
+            do NOT `git add research/`, the LFS clean filter would convert
+            historical PNGs/MP3s to LFS pointers in one commit):
+            git add research/${{ steps.date.outputs.date }}-ai-news.md research/summaries/${{ steps.date.outputs.date }}-summary.txt
             git commit -m "Add AI news research for ${{ steps.date.outputs.date }}"
 
             CRITICAL: You MUST write a real file with actual news. Do not write placeholder content. NO DUPLICATES from previous reports.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # lfs: true is REQUIRED because dashboard/scripts/prebuild.mjs runs
+          # cpSync over research/front-page/*.png and research/audio/*.mp3
+          # into public/research/. Without LFS hydration, those would be
+          # 135-byte pointer files — the build wouldn't fail but the deployed
+          # dashboard would serve pointer text instead of images/audio.
+          lfs: true
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,22 @@ jobs:
       run:
         working-directory: dashboard
     steps:
+      # Provision git-lfs BEFORE checkout — `actions/checkout@v4` with
+      # `lfs: true` shells out to `git lfs` during the checkout phase, so
+      # if the runner image doesn't already have it the checkout fails
+      # before any later install step gets to run. apt-get install needs
+      # no repo content, so it's safe to run pre-checkout. Job-level
+      # `defaults.run.working-directory: dashboard` doesn't exist yet (no
+      # checkout), so override with `working-directory: .`.
+      - name: Ensure git-lfs is installed
+        working-directory: .
+        run: |
+          if ! command -v git-lfs >/dev/null 2>&1; then
+            echo "git-lfs not found on runner — installing..."
+            sudo apt-get update -qq && sudo apt-get install -y -qq git-lfs
+          fi
+          git lfs version
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/daily-arxiv.yml
+++ b/.github/workflows/daily-arxiv.yml
@@ -137,8 +137,10 @@ jobs:
             Full report on GitHub.
             ```
 
-            After writing both files, commit:
-            git add research/
+            After writing both files, commit (stage ONLY today's two files;
+            do NOT `git add research/`, the LFS clean filter would convert
+            historical PNGs/MP3s to LFS pointers in one commit):
+            git add research/arxiv/${{ steps.date.outputs.date }}-papers.md research/summaries/${{ steps.date.outputs.date }}-arxiv-summary.txt
             git commit -m "arXiv papers ${{ steps.date.outputs.date }}"
 
       - name: Push changes

--- a/.github/workflows/daily-digest.yml
+++ b/.github/workflows/daily-digest.yml
@@ -18,12 +18,9 @@ jobs:
       id-token: write
 
     steps:
-      # Provision git-lfs on the runner BEFORE checkout in case the runner
-      # image doesn't ship with it. This workflow doesn't use `lfs: true` on
-      # checkout (it only writes its own fresh MP3 — no existing LFS objects
-      # to hydrate), but downstream `git pull --rebase` may pull LFS-routed
-      # commits from other workflows, so the smudge filter needs git-lfs
-      # available. apt-get install needs no repo content; safe pre-checkout.
+      # Provision git-lfs on the runner BEFORE checkout — `actions/checkout@v4`
+      # with `lfs: true` shells out to `git lfs` during the checkout phase
+      # and fails if it's missing. apt-get install needs no repo content.
       - name: Ensure git-lfs is installed
         run: |
           if ! command -v git-lfs >/dev/null 2>&1; then
@@ -36,6 +33,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # lfs: true REQUIRED for safe re-runs. The TTS step has
+          # `continue-on-error: true` and `exit 0`s without writing a fresh
+          # MP3 if GEMINI_API_KEY is missing or the API fails. The downstream
+          # Telegram + Hooker steps then test `[ -f $AUDIO_FILE ]` — a
+          # 135-byte LFS pointer passes that check and gets uploaded as
+          # "audio". Hydrating on checkout means the on-disk file is always
+          # a real MP3 (either the previously-committed one, or the fresh
+          # one written by ffmpeg this run).
+          lfs: true
 
       # Wire git-lfs smudge/clean filters into THIS worktree's git config so
       # the MP3 produced by the TTS step below routes through LFS on commit

--- a/.github/workflows/daily-digest.yml
+++ b/.github/workflows/daily-digest.yml
@@ -18,23 +18,30 @@ jobs:
       id-token: write
 
     steps:
+      # Provision git-lfs on the runner BEFORE checkout in case the runner
+      # image doesn't ship with it. This workflow doesn't use `lfs: true` on
+      # checkout (it only writes its own fresh MP3 — no existing LFS objects
+      # to hydrate), but downstream `git pull --rebase` may pull LFS-routed
+      # commits from other workflows, so the smudge filter needs git-lfs
+      # available. apt-get install needs no repo content; safe pre-checkout.
+      - name: Ensure git-lfs is installed
+        run: |
+          if ! command -v git-lfs >/dev/null 2>&1; then
+            echo "git-lfs not found on runner — installing..."
+            sudo apt-get update -qq && sudo apt-get install -y -qq git-lfs
+          fi
+          git lfs version
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      # Ensure git-lfs filter hooks are wired in. Self-hosted runner may
-      # already have it installed; `git lfs install` is idempotent. The MP3
-      # produced by the TTS step below matches `*.mp3` in .gitattributes, so
-      # this step is what routes the commit through LFS instead of fat-storing
-      # the blob in git history.
+      # Wire git-lfs smudge/clean filters into THIS worktree's git config so
+      # the MP3 produced by the TTS step below routes through LFS on commit
+      # (matches `*.mp3` in .gitattributes). `git lfs install` is idempotent.
       - name: Install git-lfs hooks
-        run: |
-          if ! command -v git-lfs >/dev/null 2>&1; then
-            echo "git-lfs not found on runner — attempting install..."
-            sudo apt-get update -qq && sudo apt-get install -y -qq git-lfs
-          fi
-          git lfs install --local
+        run: git lfs install --local
 
       - name: Pull latest changes
         run: git pull origin main || true

--- a/.github/workflows/daily-digest.yml
+++ b/.github/workflows/daily-digest.yml
@@ -23,6 +23,19 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Ensure git-lfs filter hooks are wired in. Self-hosted runner may
+      # already have it installed; `git lfs install` is idempotent. The MP3
+      # produced by the TTS step below matches `*.mp3` in .gitattributes, so
+      # this step is what routes the commit through LFS instead of fat-storing
+      # the blob in git history.
+      - name: Install git-lfs hooks
+        run: |
+          if ! command -v git-lfs >/dev/null 2>&1; then
+            echo "git-lfs not found on runner — attempting install..."
+            sudo apt-get update -qq && sudo apt-get install -y -qq git-lfs
+          fi
+          git lfs install --local
+
       - name: Pull latest changes
         run: git pull origin main || true
 

--- a/.github/workflows/daily-digest.yml
+++ b/.github/workflows/daily-digest.yml
@@ -210,8 +210,11 @@ jobs:
             Full digest on GitHub.
             ```
 
-            After writing both files, commit:
-            git add research/
+            After writing both files, commit (ONLY today's two files — do
+            NOT `git add research/`, because the LFS clean filter would
+            silently convert all existing historical PNGs/MP3s to LFS
+            pointers in one commit):
+            git add research/digest/${{ steps.date.outputs.date }}-digest.md research/summaries/${{ steps.date.outputs.date }}-digest-summary.txt
             git commit -m "Daily digest ${{ steps.date.outputs.date }}"
 
       - name: Synthesize Daily Digest (WebSearch fallback)
@@ -301,8 +304,11 @@ jobs:
             Full digest on GitHub.
             ```
 
-            After writing both files, commit:
-            git add research/
+            After writing both files, commit (ONLY today's two files — do
+            NOT `git add research/`, because the LFS clean filter would
+            silently convert all existing historical PNGs/MP3s to LFS
+            pointers in one commit):
+            git add research/digest/${{ steps.date.outputs.date }}-digest.md research/summaries/${{ steps.date.outputs.date }}-digest-summary.txt
             git commit -m "Daily digest ${{ steps.date.outputs.date }}"
 
       - name: Rewrite summary as ARA spoken script (Claude Sonnet)

--- a/.github/workflows/daily-front-page.yml
+++ b/.github/workflows/daily-front-page.yml
@@ -249,10 +249,18 @@ jobs:
         if: steps.check.outputs.exists == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TODAY: ${{ steps.date.outputs.date }}
         run: |
-          git add research/front-page/ README.md
-          git commit -m "Front page ${{ steps.date.outputs.date }}" || echo "Nothing to commit"
-          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git
+          # Stage ONLY today's PNG, not the entire research/front-page/ dir.
+          # If we staged the whole dir, the LFS clean filter could detect
+          # "modifications" on historical PNGs (regular git blobs that now
+          # match the *.png filter=lfs rule) and silently convert all 32
+          # existing PNGs into LFS pointers in one commit — exactly the
+          # "Phase 1 only" violation this PR promises to defer to a manual
+          # `git lfs migrate import` runbook.
+          git add "research/front-page/${TODAY}-front-page.png" README.md
+          git commit -m "Front page ${TODAY}" || echo "Nothing to commit"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
           git pull --rebase || true
           git push || echo "Nothing to push"
 

--- a/.github/workflows/daily-front-page.yml
+++ b/.github/workflows/daily-front-page.yml
@@ -22,6 +22,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # lfs: true is REQUIRED here because this workflow runs 30 min after
+          # daily-digest.yml, which commits today's MP3 through git-lfs. The
+          # "Publish digest audio via hooker" step below reads that MP3 and
+          # feeds it to ffmpeg — without lfs: true, checkout would hand it a
+          # 135-byte pointer file that `[ -f ]` passes but ffmpeg can't decode.
+          lfs: true
 
       # Ensure git-lfs filter hooks are wired in. Self-hosted runner may
       # already have it installed; `git lfs install` is idempotent. The PNG
@@ -36,6 +42,10 @@ jobs:
           git lfs install --local
 
       - name: Pull latest changes
+        # `git pull` after merge will fetch LFS objects automatically because
+        # `git lfs install --local` wired the smudge filter. The earlier
+        # `lfs: true` on checkout is what guarantees the initial checkout
+        # state already has the MP3 hydrated for the publish step below.
         run: git pull origin main || true
 
       - name: Get current date

--- a/.github/workflows/daily-front-page.yml
+++ b/.github/workflows/daily-front-page.yml
@@ -18,6 +18,19 @@ jobs:
       id-token: write
 
     steps:
+      # Provision git-lfs on the runner BEFORE checkout. `actions/checkout@v4`
+      # with `lfs: true` shells out to `git lfs` during the checkout phase,
+      # so if git-lfs isn't already on PATH the checkout itself fails before
+      # any later install step can run. apt-get install doesn't need repo
+      # content, so this is safe to run pre-checkout.
+      - name: Ensure git-lfs is installed
+        run: |
+          if ! command -v git-lfs >/dev/null 2>&1; then
+            echo "git-lfs not found on runner — installing..."
+            sudo apt-get update -qq && sudo apt-get install -y -qq git-lfs
+          fi
+          git lfs version
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -29,17 +42,11 @@ jobs:
           # 135-byte pointer file that `[ -f ]` passes but ffmpeg can't decode.
           lfs: true
 
-      # Ensure git-lfs filter hooks are wired in. Self-hosted runner may
-      # already have it installed; `git lfs install` is idempotent. The PNG
-      # produced below matches `*.png` in .gitattributes, so this step is
-      # what routes the commit through LFS instead of fat-storing the blob.
+      # Wire git-lfs smudge/clean filters into THIS worktree's git config so
+      # the PNG produced below routes through LFS on commit. `git lfs install`
+      # is idempotent; safe to run on every workflow invocation.
       - name: Install git-lfs hooks
-        run: |
-          if ! command -v git-lfs >/dev/null 2>&1; then
-            echo "git-lfs not found on runner — attempting install..."
-            sudo apt-get update -qq && sudo apt-get install -y -qq git-lfs
-          fi
-          git lfs install --local
+        run: git lfs install --local
 
       - name: Pull latest changes
         # `git pull` after merge will fetch LFS objects automatically because

--- a/.github/workflows/daily-front-page.yml
+++ b/.github/workflows/daily-front-page.yml
@@ -23,6 +23,18 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Ensure git-lfs filter hooks are wired in. Self-hosted runner may
+      # already have it installed; `git lfs install` is idempotent. The PNG
+      # produced below matches `*.png` in .gitattributes, so this step is
+      # what routes the commit through LFS instead of fat-storing the blob.
+      - name: Install git-lfs hooks
+        run: |
+          if ! command -v git-lfs >/dev/null 2>&1; then
+            echo "git-lfs not found on runner — attempting install..."
+            sudo apt-get update -qq && sudo apt-get install -y -qq git-lfs
+          fi
+          git lfs install --local
+
       - name: Pull latest changes
         run: git pull origin main || true
 

--- a/.github/workflows/daily-improve.yml
+++ b/.github/workflows/daily-improve.yml
@@ -96,8 +96,13 @@ jobs:
                - What improvements were made
                - Expected impact
 
-            4. Commit changes:
-               git add -A
+            4. Commit changes (DO NOT use `git add -A`. The repo uses git-lfs
+               for *.png and *.mp3 — `git add -A` would also stage all
+               existing historical binaries as LFS pointers, contradicting
+               the deferred history-migration plan. Stage only the workflow
+               and doc files you actually changed, e.g.:
+                 git add .github/workflows/*.yml IMPROVEMENTS.md
+               Or: `git add` with explicit paths for each modified file.):
                git commit -m "Methodology improvements for ${{ steps.dates.outputs.today }}"
 
             5. Push and create PR:

--- a/dashboard/scripts/prebuild.mjs
+++ b/dashboard/scripts/prebuild.mjs
@@ -9,7 +9,7 @@
 // the GH Pages workflow can call this same script too if you simplify it
 // later.
 
-import { existsSync, readdirSync, mkdirSync, readFileSync, writeFileSync, cpSync } from 'node:fs';
+import { existsSync, readdirSync, mkdirSync, readFileSync, writeFileSync, cpSync, statSync, openSync, readSync, closeSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -33,8 +33,71 @@ const DATE_PATTERNS = {
   audio:     { dir: 'audio',      re: /^(\d{4}-\d{2}-\d{2})-digest\.mp3$/ },
 };
 
+// Binary file extensions that are routed through git-lfs (see .gitattributes
+// at repo root). Anything else can be skipped — pointer-file detection is
+// only meaningful for files that COULD be LFS-routed.
+const LFS_EXT_RE = /\.(png|jpg|jpeg|gif|webp|mp3|wav|ogg|mp4|webm|pdf)$/i;
+
+// LFS pointer files are tiny (~135 bytes) and start with this prefix. If the
+// build runs on a checkout that didn't hydrate LFS objects, cpSync happily
+// copies the pointer text and the deployed dashboard serves it as if it were
+// the real binary — silent breakage. We'd rather fail the build loudly.
+function isLfsPointer(filePath) {
+  let stats;
+  try {
+    stats = statSync(filePath);
+  } catch {
+    return false;
+  }
+  // Real binaries are always larger than the largest plausible pointer file.
+  // LFS pointer spec is 3 lines, well under 1KB; cap at 1024 to be safe.
+  if (!stats.isFile() || stats.size > 1024) return false;
+  const fd = openSync(filePath, 'r');
+  const buf = Buffer.alloc(64);
+  try {
+    readSync(fd, buf, 0, 64, 0);
+  } finally {
+    closeSync(fd);
+  }
+  return buf.toString('utf8').startsWith('version https://git-lfs.github.com/spec/v1');
+}
+
+function findLfsPointers(dir) {
+  const pointers = [];
+  if (!existsSync(dir)) return pointers;
+  for (const name of readdirSync(dir)) {
+    if (!LFS_EXT_RE.test(name)) continue;
+    const full = join(dir, name);
+    if (isLfsPointer(full)) pointers.push(full);
+  }
+  return pointers;
+}
+
 function copyData() {
   mkdirSync(publicResearch, { recursive: true });
+
+  // Pre-flight: scan for LFS pointer files in the source tree. If any are
+  // found, the build environment didn't hydrate LFS objects — usually
+  // because Vercel's "Git LFS" toggle is OFF in project settings, or a
+  // GitHub Actions checkout is missing `lfs: true`. Fail loudly here instead
+  // of silently shipping pointer text to production.
+  const allPointers = [];
+  for (const sub of COPY_DIRS) {
+    allPointers.push(...findLfsPointers(join(researchSrc, sub)));
+  }
+  if (allPointers.length > 0) {
+    console.error(
+      `prebuild: ERROR — found ${allPointers.length} git-lfs pointer file(s) ` +
+      'in the source tree. The build environment did not hydrate LFS objects. ' +
+      'On Vercel: enable "Git LFS" in Project Settings > Git, then redeploy. ' +
+      'On GitHub Actions: add `lfs: true` to actions/checkout. ' +
+      'On local dev: run `git lfs install && git lfs pull`.\n' +
+      'Sample pointer files:\n' +
+      allPointers.slice(0, 5).map((p) => `  - ${p}`).join('\n'),
+    );
+    process.exit(1);
+  }
+
   for (const sub of COPY_DIRS) {
     const src = join(researchSrc, sub);
     if (!existsSync(src)) continue;

--- a/dashboard/vercel.json
+++ b/dashboard/vercel.json
@@ -4,7 +4,7 @@
   "installCommand": "bun install --frozen-lockfile",
   "buildCommand": "bun run build",
   "outputDirectory": "dist",
-  "ignoreCommand": "git rev-parse HEAD^ >/dev/null 2>&1 || exit 1; git diff --quiet HEAD^ HEAD -- ./ ../research/twitter/ ../research/models/ ../research/front-page/ ../research/digest/ ../research/audio/ ../research/generative/",
+  "ignoreCommand": "if [ -z \"$VERCEL_GIT_PREVIOUS_SHA\" ]; then exit 1; fi; git diff --quiet \"$VERCEL_GIT_PREVIOUS_SHA\" HEAD -- ./ ../research/twitter/ ../research/models/ ../research/front-page/ ../research/digest/ ../research/audio/ ../research/generative/ || exit 1; exit 0",
   "rewrites": [
     {
       "source": "/((?!research/.+|.*\\.[a-zA-Z0-9]+$).*)",

--- a/dashboard/vercel.json
+++ b/dashboard/vercel.json
@@ -4,6 +4,7 @@
   "installCommand": "bun install --frozen-lockfile",
   "buildCommand": "bun run build",
   "outputDirectory": "dist",
+  "ignoreCommand": "git rev-parse HEAD^ >/dev/null 2>&1 || exit 1; git diff --quiet HEAD^ HEAD -- ./ ../research/twitter/ ../research/models/ ../research/front-page/ ../research/digest/ ../research/audio/ ../research/generative/",
   "rewrites": [
     {
       "source": "/((?!research/.+|.*\\.[a-zA-Z0-9]+$).*)",


### PR DESCRIPTION
## Summary

Configure git-lfs for binary assets (PNG, MP3, +forward-compat extensions) going forward. The repo currently stores 41MB of binaries as fat git blobs (32 PNGs in `research/front-page/` + 20 MP3s in `research/audio/`) growing ~3MB/week with no useful delta compression. Without LFS, `.git` would balloon over the year.

**This PR is forward-only — existing committed binaries stay as regular git objects.** History rewrite is deferred to a manual runbook (below). Eight commits:

1. `.gitattributes` routes `*.png`, `*.mp3`, and forward-compat extensions through LFS filters
2. Three workflows install git-lfs on the runner, hydrate LFS objects on checkout (`daily-front-page.yml`, `daily-digest.yml`, `ci.yml`)
3. `dashboard/scripts/prebuild.mjs` fails the build loudly if it ever finds LFS pointer files in `research/` (defense against Vercel LFS toggle being off)
4. `dashboard/vercel.json` adds `ignoreCommand` to skip Vercel deploys when the diff against the last deploy doesn't touch any dashboard-consumed paths (saves ~70-80% of Vercel bandwidth)
5. Five workflows narrow their `git add` calls so the LFS clean filter doesn't silently bulk-migrate historical binaries (would violate the "Phase 1 only" promise)

## LFS inventory (today)

| Path | Count | Size | Growth |
|---|---|---|---|
| `research/front-page/*.png` | 32 | 30 MB | ~1 PNG/day, ~2 MB/week |
| `research/audio/*.mp3` | 20 | 11 MB | ~1 MP3/day, ~1 MB/week |
| `.gitattributes` also pre-registers `.jpg/.jpeg/.gif/.webp/.wav/.ogg/.mp4/.webm/.pdf` for forward-compat | 0 today | 0 MB | — |

**GitHub LFS storage quota**: free tier is 1 GB storage + 1 GB bandwidth/month. Current 41 MB is 4% of quota; ~3 MB/week growth = ~150 MB/year, so this fits comfortably for ~5-6 years on free tier without paying.

**LFS bandwidth quota**: this was the close call. The repo has ~40 pushes/day to main (hourly twitter, hourly rss, 4h community, etc.). Vercel deploys on every push and now pulls LFS objects on each checkout. Without optimization, that's ~40 × (cumulative LFS size) per day = burn through 1 GB/month quota in days once LFS storage crosses a few MB. **Fix**: `dashboard/vercel.json` `ignoreCommand` skips Vercel deploys for commits whose diff doesn't touch `dashboard/**` or any dashboard-consumed `research/` subdir (twitter, models, front-page, digest, audio, generative). Excludes rss/, community/, arxiv/, bluesky/, summaries/ — verified locally each of those would skip. Cuts deploys ~70-80%.

## Local install (one-time, before pulling this branch)

```bash
brew install git-lfs   # macOS
# or: apt-get install git-lfs (Debian/Ubuntu); dnf install git-lfs (Fedora)
git lfs install        # wires global filter hooks
```

After install + pull, run `git lfs pull` once to hydrate any LFS objects produced by workflows after merge.

## Vercel deploy implications (MANUAL STEP REQUIRED)

**Vercel's git checkout leaves LFS pointer files by default.** After merge, enable Git LFS in the Vercel project settings:

1. https://vercel.com/dashboard → open this project
2. Project Settings > Git > **Git Large File Storage (LFS)**
3. Toggle ON
4. Redeploy (push any commit, or click "Redeploy" on the latest deployment)

[Vercel docs](https://vercel.com/docs/project-configuration/git-settings): "When Git LFS support is enabled, Vercel will pull LFS objects used in your repository. You must redeploy your project after turning Git LFS on for the changes to take effect."

**Grace window**: existing pre-merge binaries are regular git objects, so the dashboard keeps working immediately after merge. The first day Vercel would break is when `daily-digest.yml` / `daily-front-page.yml` commits a new LFS-routed binary.

**Defense in depth**: `dashboard/scripts/prebuild.mjs` now exits non-zero if it sees a pointer file in `research/`, so a misconfigured deploy fails the build loudly instead of silently shipping 135-byte pointer text as PNG/MP3.

## Verification after merge

```bash
git lfs ls-files                           # should show today's PNG + MP3
git lfs status                             # confirms LFS routing
du -sh .git                                # baseline; will stay flat over time
```

On Vercel: deployment logs should mention "Git LFS objects pulled" near the checkout step.

## Phase 2 (deferred, optional) - history rewrite runbook

To retroactively migrate the existing 41 MB of binaries out of git history and into LFS, run these commands MANUALLY on `main` from a regular checkout. **This is destructive — it rewrites every commit hash on `main` and requires a force-push.**

```bash
# 1. Make sure you have a backup
git clone --mirror git@github.com:guzus/ai-research-arm.git /tmp/aira-backup.git

# 2. From a regular clone of main (NOT this worktree):
cd ~/some/clean/checkout/of/main
git pull origin main
git lfs migrate import --include="*.png,*.jpg,*.jpeg,*.gif,*.webp,*.mp3,*.wav,*.ogg,*.mp4,*.webm,*.pdf" --everything

# 3. Inspect: .git should shrink dramatically, LFS objects should appear
du -sh .git                # before: ~60 MB, after: should be ~20 MB
git lfs ls-files | wc -l   # should be 52 (32 PNG + 20 MP3)

# 4. Force-push (destructive on main):
git push --force origin main

# 5. Anyone with a clone after this needs to re-clone, OR:
git fetch origin
git reset --hard origin/main
git lfs install
git lfs pull
```

After the rewrite, LFS storage usage jumps from ~3 MB (just future objects) to ~41 MB (all history). Still well under the 1 GB free tier.

## Codex review verdict

Iterated `/codex review` 7 passes. Each pass surfaced a real issue that got fixed:

| Pass | Finding | Fix |
|---|---|---|
| 1 | `daily-front-page.yml` reads MP3 daily-digest committed 30 min earlier | `lfs: true` on checkout |
| 2 | `actions/checkout@v4` with `lfs: true` shells out to `git lfs` DURING checkout (chicken-and-egg) | Hoist install step BEFORE checkout |
| 3 | Vercel ships pointer files when LFS toggle is off | Prebuild detector + PR doc |
| 4 | `daily-digest.yml` re-runs upload pointer text when TTS step `exit 0`s | `lfs: true` on its checkout too |
| 5 | Workflows running `git add research/` would mass-convert historical binaries to LFS pointers (silent Phase-1 violation) | Narrow `git add` to specific files in 5 workflows |
| 6 | Vercel `ignoreCommand` using `HEAD^ HEAD` misses multi-commit pushes | Use `VERCEL_GIT_PREVIOUS_SHA` instead |
| 7 (FINAL) | "I did not identify any discrete correctness issues introduced by the diff." | GATE: PASS |

## Test plan

- [ ] Local: `brew install git-lfs && git lfs install && git pull origin chore/binaries-lfs && git lfs pull` — verify clone works
- [ ] Merge to main
- [ ] Manually toggle Git LFS ON in Vercel project settings + redeploy
- [ ] Wait for next nightly run of `daily-digest.yml` (00:00 UTC) and `daily-front-page.yml` (00:30 UTC)
- [ ] Verify `git lfs ls-files` on main shows the new PNG + MP3 as LFS objects (not the 52 historical ones)
- [ ] Verify dashboard at https://ara.guzus.xyz/ still shows today's front-page image and plays the audio digest
- [ ] Check Vercel deployment log: should mention "ignoreCommand" skipping deploys for hourly twitter/rss commits
- [ ] (Later, when ready) Run the Phase 2 history-rewrite runbook

🤖 Generated with [Claude Code](https://claude.com/claude-code)