### PR TITLE
feat: enforce generative-research quality targets as build gates

### DIFF
--- a/.github/workflows/generative-research.yml
+++ b/.github/workflows/generative-research.yml
@@ -285,6 +285,13 @@ jobs:
       # Keep model recovery drafts scoped to this workflow run. Self-hosted
       # runners can retain /tmp between jobs, so a fixed draft path can cause
       # a retry to publish a stale article from a different backend/run.
+      # Also remove any stale verifier-findings JSON from a previous run.
+      # The audit step trusts whatever JSON file exists, so a stale one
+      # left behind by an earlier failed attempt would be applied to this
+      # run's (different) article body — wrong claims audited against the
+      # wrong text. Idempotent rm at job start guarantees this run's
+      # audit either sees this run's verifier output or no file at all
+      # (in which case the audit takes its documented soft-skip path).
       - name: Prepare run-scoped draft path
         id: draft
         run: |
@@ -293,6 +300,11 @@ jobs:
           path="${base}/gen-research-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.ara.md"
           rm -f "$path"
           echo "path=$path" >> "$GITHUB_OUTPUT"
+          # Delete stale verifier findings from a prior workflow attempt
+          # on this self-hosted runner. The Claude / DeepSeek retry loops
+          # already reset research/generative; this is the matching
+          # cleanup for the verifier artifact.
+          rm -f "$GITHUB_WORKSPACE/.gen-verifier-findings.json"
 
       # Acknowledge the user on the issue path so they know the job started.
       # The workflow_dispatch path has no comment surface; skip.
@@ -1454,6 +1466,9 @@ jobs:
             echo "Cleaning tracked and untracked repository artifacts from the failed attempt before retry."
             git reset --hard "$PRE_SHA"
             git clean -fd -- research/generative
+            # Drop stale verifier-findings JSON so the retry's audit
+            # can't compare new article body against old verifier claims.
+            rm -f "$GITHUB_WORKSPACE/.gen-verifier-findings.json"
           elif [ "$OUTCOME" = "failure" ]; then
             echo "::warning::DeepSeek attempt 1 reported failure, but an article commit exists; continuing to publish that output."
           else
@@ -1499,6 +1514,10 @@ jobs:
             echo "Cleaning tracked and untracked repository artifacts from the failed retry before the final retry."
             git reset --hard "$PRE_SHA"
             git clean -fd -- research/generative
+            # Drop stale verifier-findings JSON so the final retry's
+            # audit can't compare new article body against old verifier
+            # claims.
+            rm -f "$GITHUB_WORKSPACE/.gen-verifier-findings.json"
           elif [ "$OUTCOME" = "failure" ]; then
             echo "::warning::DeepSeek retry 1 reported failure, but an article commit exists; continuing to publish that output."
           else
@@ -1581,6 +1600,8 @@ jobs:
             # could leak into a subsequent run's `git diff` window.
             git reset --hard "$PRE_SHA"
             git clean -fd -- research/generative || true
+            # Same verifier-findings cleanup as the retry paths above.
+            rm -f "$GITHUB_WORKSPACE/.gen-verifier-findings.json"
             exit 1
           fi
 
@@ -1627,6 +1648,8 @@ jobs:
             echo "::error::Verifier-findings audit FAILED for $article"
             git reset --hard "$PRE_SHA"
             git clean -fd -- research/generative || true
+            # Same verifier-findings cleanup as the retry paths above.
+            rm -f "$GITHUB_WORKSPACE/.gen-verifier-findings.json"
             exit 1
           fi
 

--- a/.github/workflows/generative-research.yml
+++ b/.github/workflows/generative-research.yml
@@ -616,6 +616,35 @@ jobs:
 
                   - additionally flag any factual claim WITHOUT a cite
 
+               THEN the verifier MUST ALSO write a structured JSON
+               artifact to:
+
+                      $GITHUB_WORKSPACE/.gen-verifier-findings.json
+
+               The JSON's shape MUST be:
+
+                      {
+                        "claims": [
+                          {
+                            "id": "c1",
+                            "text": "<verbatim claim sentence from the body — full sentence or first 80+ chars>",
+                            "verdict": "supported" | "weak" | "unsupported",
+                            "citation": "<url or null>"
+                          },
+                          ...
+                        ]
+                      }
+
+               Every claim_id in the findings table MUST have a
+               matching entry in `claims[]`. The `text` field is the
+               sentence text as it appears in the .ara.md body — used
+               by the post-revision audit step to verify which
+               unsupported claims were actually addressed. A
+               deterministic workflow step reads this file after
+               bounded revision and FAILS the build if any
+               `unsupported` claim survives in the body without being
+               demoted (`==…==` / `<mark>`) or removed.
+
             7. BOUNDED REVISION. Address ONLY the verifier's findings.
                Each unsupported claim must be either: (a) replaced with
                a supported variant from the ledger, (b) demoted by
@@ -623,7 +652,15 @@ jobs:
                `<mark class="ara-mark">`), or (c) deleted. Do NOT
                generically expand or pad. ONE revision pass maximum.
 
-            QUALITY TARGETS — these, not word count, are the bar:
+               After revising, you do NOT need to re-run the verifier
+               or regenerate the JSON — the post-revision audit step
+               re-reads `.gen-verifier-findings.json` and checks each
+               `unsupported` claim against the FINAL committed body.
+
+            QUALITY TARGETS — these, not word count, are the bar
+               (cite-density and refs are now ENFORCED in step 7.5;
+               primary-share and cited-claim-share are tracked as
+               metrics but not yet hard-gated):
                - Research questions answered: ≥ 85% of your plan
                - Substantive factual claims with cite: ≥ 90%
                - Primary-source share among cited sources: ≥ 50%
@@ -1151,6 +1188,35 @@ jobs:
 
                   - additionally flag any factual claim WITHOUT a cite
 
+               THEN the verifier MUST ALSO write a structured JSON
+               artifact to:
+
+                      $GITHUB_WORKSPACE/.gen-verifier-findings.json
+
+               The JSON's shape MUST be:
+
+                      {
+                        "claims": [
+                          {
+                            "id": "c1",
+                            "text": "<verbatim claim sentence from the body — full sentence or first 80+ chars>",
+                            "verdict": "supported" | "weak" | "unsupported",
+                            "citation": "<url or null>"
+                          },
+                          ...
+                        ]
+                      }
+
+               Every claim_id in the findings table MUST have a
+               matching entry in `claims[]`. The `text` field is the
+               sentence text as it appears in the .ara.md body — used
+               by the post-revision audit step to verify which
+               unsupported claims were actually addressed. A
+               deterministic workflow step reads this file after
+               bounded revision and FAILS the build if any
+               `unsupported` claim survives in the body without being
+               demoted (`==…==` / `<mark>`) or removed.
+
             7. BOUNDED REVISION. Address ONLY the verifier's findings.
                Each unsupported claim must be either: (a) replaced with
                a supported variant from the ledger, (b) demoted by
@@ -1158,7 +1224,15 @@ jobs:
                `<mark class="ara-mark">`), or (c) deleted. Do NOT
                generically expand or pad. ONE revision pass maximum.
 
-            QUALITY TARGETS — these, not word count, are the bar:
+               After revising, you do NOT need to re-run the verifier
+               or regenerate the JSON — the post-revision audit step
+               re-reads `.gen-verifier-findings.json` and checks each
+               `unsupported` claim against the FINAL committed body.
+
+            QUALITY TARGETS — these, not word count, are the bar
+               (cite-density and refs are now ENFORCED in step 7.5;
+               primary-share and cited-claim-share are tracked as
+               metrics but not yet hard-gated):
                - Research questions answered: ≥ 85% of your plan
                - Substantive factual claims with cite: ≥ 90%
                - Primary-source share among cited sources: ≥ 50%
@@ -1500,6 +1574,42 @@ jobs:
             echo "passed=false" >> "$GITHUB_OUTPUT"
             exit 1
           fi
+
+      # Deterministic verifier-findings audit. The verifier sub-agent
+      # (step 6 of the model prompt) writes a structured JSON list of
+      # every claim it inspected, including its verdict. The agent's
+      # "bounded revision" (step 7) addresses unsupported claims inline.
+      # Previously that pass was faith-based — no audit. Now we read
+      # the JSON back here and FAIL the build if any `unsupported`
+      # claim survives in the final committed body without being
+      # demoted (`<mark>` / `==…==`) or removed.
+      #
+      # Logic lives in scripts/check_generative_research.py under
+      # --audit-verifier-findings so it's unit-tested. See
+      # audit_verifier_findings() for the matching heuristic.
+      #
+      # Soft-fail mode: if the verifier didn't write the JSON file at
+      # all (older runs, model-side failure), we WARN but do not block.
+      # Once the verifier consistently emits JSON, tighten to hard-fail
+      # by removing the `if [ ! -f "$findings" ]` early-return.
+      - name: Verifier-findings audit
+        id: verifier-audit
+        if: steps.outfile.outputs.has_file == 'true'
+        env:
+          FILE: ${{ steps.outfile.outputs.file }}
+        run: |
+          set -euo pipefail
+          findings="$GITHUB_WORKSPACE/.gen-verifier-findings.json"
+          article="research/generative/$FILE"
+          if [ ! -f "$findings" ]; then
+            echo "::warning::No verifier findings JSON at $findings — the model verifier sub-agent did not write one. The bounded-revision audit cannot run. Build continues; tighten to hard-fail once the verifier consistently emits."
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          python3 scripts/check_generative_research.py \
+            "$article" \
+            --audit-verifier-findings "$findings"
+          echo "skipped=false" >> "$GITHUB_OUTPUT"
 
       # Per-run quality report — corpus-audit metrics on the article
       # this run produced. We can't see the agent's compile-check

--- a/.github/workflows/generative-research.yml
+++ b/.github/workflows/generative-research.yml
@@ -736,14 +736,20 @@ jobs:
 
             7.5. COMPILE CHECK (deterministic; before commit).
                  a. Write the draft `.ara.md` to $GEN_DRAFT.
-                 b. Run with design gates active (corpus audit shows
-                    real articles emit 0–3 viz primitives and 5–10
-                    callouts; we hold this run to ≥ 3 viz + ≤ 5
-                    callouts and warn on percentages-without-viz):
+                 b. Run with design AND research-quality gates active.
+                    Corpus audit shows real articles emit 0–3 viz
+                    primitives and 5–10 callouts; we hold this run
+                    to ≥ 3 viz + ≤ 5 callouts. cite-density-min and
+                    refs-min encode the QUALITY TARGETS as build gates
+                    (previously prose-only; corpus audit found 4
+                    historical articles shipped with zero citations).
+                    --strict-shape adds soft warnings on percentages-
+                    without-viz (advisory, doesn't block):
 
                       python3 scripts/check_generative_research.py \
                         "$GEN_DRAFT" \
                         --diversity-min 3 --callout-max 5 \
+                        --cite-density-min 10 --refs-min 20 \
                         --strict-shape
 
                  c. Exit 0 → proceed to step 8. Soft warnings printed
@@ -751,11 +757,11 @@ jobs:
                     whether the flagged section would read better
                     with a viz, but they don't block.
                     Exit 1 → the stderr lists every DSL grammar
-                    error, invalid class/tag, OR design-gate
-                    violation. Fix the body in-place and re-run.
-                    Iterate until clean. Do NOT proceed to commit
-                    until exit 0. Common design fixes when the gate
-                    fails on diversity:
+                    error, invalid class/tag, design-gate violation,
+                    OR research-quality gate violation. Fix the body
+                    in-place and re-run. Iterate until clean. Do NOT
+                    proceed to commit until exit 0. Common design
+                    fixes when the gate fails on diversity:
                       - 4+ percentage shares of one whole in prose
                         → `:::donut` with `{label, value}` items
                       - "the top N are…" list in prose
@@ -766,6 +772,14 @@ jobs:
                         → `:::timeline` with `{date, headline, body}`
                       - 4+ headline KPIs presented as separate
                         sentences → `:::stats` grid
+                    Common quality fixes:
+                      - cite density too low → every substantive
+                        factual claim needs a [^N] marker; if you
+                        wrote a number without a source, find one
+                        or remove the claim
+                      - refs too few → run more research waves; you
+                        need at least 20 distinct source URLs in
+                        the :::references block
                  d. This loop is cheap — token cost is just reading
                     short error messages. Lean on it instead of
                     self-validating against the rule list in prose.
@@ -773,8 +787,11 @@ jobs:
             8. SAVE. Write the final (already-clean) `.ara.md` to:
                   $GEN_DRAFT
 
-            9. COMMIT via the writer (Bash). Pass originating values via
-               the pre-set env vars:
+            9. COMMIT via the writer (Bash). The writer RE-RUNS the
+               same quality gates at commit time so local and CI
+               validation cannot drift. Pass originating values via
+               the pre-set env vars and the same gate thresholds the
+               compile-check used in step 7.5:
 
                   python3 scripts/write_generative_research.py \
                     --topic "$GEN_TOPIC" \
@@ -783,6 +800,7 @@ jobs:
                     --source "$GEN_SOURCE" \
                     --prompt "$GEN_PROMPT" \
                     --model claude-opus-4-7 \
+                    --cite-density-min 10 --refs-min 20 \
                     --html-body "$GEN_DRAFT"
 
                If $GEN_SLUG is empty, OMIT the --slug flag entirely (do
@@ -793,6 +811,7 @@ jobs:
                     --source "$GEN_SOURCE" \
                     --prompt "$GEN_PROMPT" \
                     --model claude-opus-4-7 \
+                    --cite-density-min 10 --refs-min 20 \
                     --html-body "$GEN_DRAFT"
 
             CONSTRAINTS:
@@ -1252,14 +1271,20 @@ jobs:
 
             7.5. COMPILE CHECK (deterministic; before commit).
                  a. Write the draft `.ara.md` to $GEN_DRAFT.
-                 b. Run with design gates active (corpus audit shows
-                    real articles emit 0–3 viz primitives and 5–10
-                    callouts; we hold this run to ≥ 3 viz + ≤ 5
-                    callouts and warn on percentages-without-viz):
+                 b. Run with design AND research-quality gates active.
+                    Corpus audit shows real articles emit 0–3 viz
+                    primitives and 5–10 callouts; we hold this run
+                    to ≥ 3 viz + ≤ 5 callouts. cite-density-min and
+                    refs-min encode the QUALITY TARGETS as build gates
+                    (previously prose-only; corpus audit found 4
+                    historical articles shipped with zero citations).
+                    --strict-shape adds soft warnings on percentages-
+                    without-viz (advisory, doesn't block):
 
                       python3 scripts/check_generative_research.py \
                         "$GEN_DRAFT" \
                         --diversity-min 3 --callout-max 5 \
+                        --cite-density-min 10 --refs-min 20 \
                         --strict-shape
 
                  c. Exit 0 → proceed to step 8. Soft warnings printed
@@ -1267,11 +1292,11 @@ jobs:
                     whether the flagged section would read better
                     with a viz, but they don't block.
                     Exit 1 → the stderr lists every DSL grammar
-                    error, invalid class/tag, OR design-gate
-                    violation. Fix the body in-place and re-run.
-                    Iterate until clean. Do NOT proceed to commit
-                    until exit 0. Common design fixes when the gate
-                    fails on diversity:
+                    error, invalid class/tag, design-gate violation,
+                    OR research-quality gate violation. Fix the body
+                    in-place and re-run. Iterate until clean. Do NOT
+                    proceed to commit until exit 0. Common design
+                    fixes when the gate fails on diversity:
                       - 4+ percentage shares of one whole in prose
                         → `:::donut` with `{label, value}` items
                       - "the top N are…" list in prose
@@ -1282,6 +1307,14 @@ jobs:
                         → `:::timeline` with `{date, headline, body}`
                       - 4+ headline KPIs presented as separate
                         sentences → `:::stats` grid
+                    Common quality fixes:
+                      - cite density too low → every substantive
+                        factual claim needs a [^N] marker; if you
+                        wrote a number without a source, find one
+                        or remove the claim
+                      - refs too few → run more research waves; you
+                        need at least 20 distinct source URLs in
+                        the :::references block
                  d. This loop is cheap — token cost is just reading
                     short error messages. Lean on it instead of
                     self-validating against the rule list in prose.
@@ -1289,8 +1322,11 @@ jobs:
             8. SAVE. Write the final (already-clean) `.ara.md` to:
                   $GEN_DRAFT
 
-            9. COMMIT via the writer (Bash). Pass originating values via
-               the pre-set env vars:
+            9. COMMIT via the writer (Bash). The writer RE-RUNS the
+               same quality gates at commit time so local and CI
+               validation cannot drift. Pass originating values via
+               the pre-set env vars and the same gate thresholds the
+               compile-check used in step 7.5:
 
                   python3 scripts/write_generative_research.py \
                     --topic "$GEN_TOPIC" \
@@ -1299,6 +1335,7 @@ jobs:
                     --source "$GEN_SOURCE" \
                     --prompt "$GEN_PROMPT" \
                     --model deepseek-v4-pro \
+                    --cite-density-min 10 --refs-min 20 \
                     --html-body "$GEN_DRAFT"
 
                If $GEN_SLUG is empty, OMIT the --slug flag entirely (do
@@ -1309,6 +1346,7 @@ jobs:
                     --source "$GEN_SOURCE" \
                     --prompt "$GEN_PROMPT" \
                     --model deepseek-v4-pro \
+                    --cite-density-min 10 --refs-min 20 \
                     --html-body "$GEN_DRAFT"
 
             CONSTRAINTS:
@@ -1435,6 +1473,33 @@ jobs:
           echo "file=$FILENAME" >> "$GITHUB_OUTPUT"
           echo "has_file=true" >> "$GITHUB_OUTPUT"
           echo "Generated: research/generative/$FILENAME"
+
+      # Deterministic post-write quality gate. The agent runs the same
+      # gate during its compile-check loop, and the writer re-runs it
+      # at commit time — this third pass is the workflow-level seatbelt
+      # that survives agent flag-drift. If the committed article fails
+      # the gate, the build fails (and the file is reverted from main
+      # via the rollback step below). Workflow uses cite-density-min 10
+      # + refs-min 20 (corpus-validated against research/generative/*;
+      # discriminates 0-cite articles from the 100+ cite recent corpus).
+      # Skip the meta/fixture seeds — they're not subject to the gate.
+      - name: Post-write quality gate
+        id: quality
+        if: steps.outfile.outputs.has_file == 'true'
+        env:
+          FILE: ${{ steps.outfile.outputs.file }}
+        run: |
+          set -euo pipefail
+          path="research/generative/$FILE"
+          if python3 scripts/check_generative_research.py "$path" \
+                --cite-density-min 10 --refs-min 20; then
+            echo "Post-write quality gate PASSED for $path"
+            echo "passed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Post-write quality gate FAILED for $path"
+            echo "passed=false" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
 
       # Per-run quality report — corpus-audit metrics on the article
       # this run produced. We can't see the agent's compile-check

--- a/.github/workflows/generative-research.yml
+++ b/.github/workflows/generative-research.yml
@@ -1562,6 +1562,7 @@ jobs:
         if: steps.outfile.outputs.has_file == 'true'
         env:
           FILE: ${{ steps.outfile.outputs.file }}
+          PRE_SHA: ${{ steps.pre.outputs.sha }}
         run: |
           set -euo pipefail
           path="research/generative/$FILE"
@@ -1572,6 +1573,14 @@ jobs:
           else
             echo "::error::Post-write quality gate FAILED for $path"
             echo "passed=false" >> "$GITHUB_OUTPUT"
+            # Reset the locally-committed bad article so the runner tree
+            # is clean for the next run. The Push step is gated on
+            # steps.quality.outputs.passed == 'true' (so the bad article
+            # never reaches main), but on self-hosted runners that retain
+            # workspace state between jobs, a left-behind orphan commit
+            # could leak into a subsequent run's `git diff` window.
+            git reset --hard "$PRE_SHA"
+            git clean -fd -- research/generative || true
             exit 1
           fi
 
@@ -1594,9 +1603,10 @@ jobs:
       # by removing the `if [ ! -f "$findings" ]` early-return.
       - name: Verifier-findings audit
         id: verifier-audit
-        if: steps.outfile.outputs.has_file == 'true'
+        if: steps.outfile.outputs.has_file == 'true' && steps.quality.outputs.passed == 'true'
         env:
           FILE: ${{ steps.outfile.outputs.file }}
+          PRE_SHA: ${{ steps.pre.outputs.sha }}
         run: |
           set -euo pipefail
           findings="$GITHUB_WORKSPACE/.gen-verifier-findings.json"
@@ -1606,10 +1616,19 @@ jobs:
             echo "skipped=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          python3 scripts/check_generative_research.py \
-            "$article" \
-            --audit-verifier-findings "$findings"
-          echo "skipped=false" >> "$GITHUB_OUTPUT"
+          if python3 scripts/check_generative_research.py \
+              "$article" --audit-verifier-findings "$findings"; then
+            echo "skipped=false" >> "$GITHUB_OUTPUT"
+          else
+            # Same reset-on-failure pattern as the quality gate above.
+            # Push step is also gated on this audit's outcome so the
+            # bad article never reaches main, but the local commit on
+            # the runner must go away to keep subsequent jobs clean.
+            echo "::error::Verifier-findings audit FAILED for $article"
+            git reset --hard "$PRE_SHA"
+            git clean -fd -- research/generative || true
+            exit 1
+          fi
 
       # Per-run quality report — corpus-audit metrics on the article
       # this run produced. We can't see the agent's compile-check
@@ -1677,9 +1696,31 @@ jobs:
       # (which can happen even with concurrency:false if a label event and
       # a workflow_dispatch race across the queue boundary) and on push
       # rejections (auth / non-fast-forward).
+      #
+      # Gating: `always() && steps.outfile.outputs.has_file == 'true'`
+      # used to be enough — it published any committed article even if
+      # the model step's outcome was "failure" (e.g. timeout cap hit
+      # after a valid commit). After Post-write quality gate +
+      # Verifier-findings audit were added, that gating became unsafe:
+      # those steps exit non-zero on failure but `always()` ignored
+      # them and pushed the bad article anyway. The push step now
+      # requires:
+      #   - an article was committed (has_file)
+      #   - the post-write quality gate passed
+      #   - the verifier-findings audit either passed or was skipped
+      #     (skipped = verifier didn't emit JSON, treated as soft-fail
+      #     per that step's documented policy)
+      # We keep `always()` so a model-step "failure" outcome on a job
+      # that produced a valid article still publishes — the model
+      # outcome is independent of article validity.
       - name: Push changes
         id: push
-        if: always() && steps.outfile.outputs.has_file == 'true'
+        if: >-
+          always()
+          && steps.outfile.outputs.has_file == 'true'
+          && steps.quality.outputs.passed == 'true'
+          && (steps.verifier-audit.outputs.skipped == 'true'
+              || steps.verifier-audit.outcome == 'success')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/research/generative/.gitignore
+++ b/research/generative/.gitignore
@@ -1,0 +1,4 @@
+# Lock file created by scripts/write_generative_research.py to serialize
+# concurrent index.json mutations under fcntl.flock. Never committed —
+# it's a per-host runtime artifact, not project state.
+index.json.lock

--- a/scripts/check_generative_research.py
+++ b/scripts/check_generative_research.py
@@ -24,6 +24,31 @@ stays additive):
                       rank-list). This catches the "179 percentages,
                       zero donuts" pattern the corpus audit surfaced.
 
+Optional research-quality gates (also off by default). Each is a
+hard fail when the flag is passed. These convert the prose targets
+in the workflow prompt into deterministic build checks:
+  --cite-density-min FLOAT  minimum cited claims per 1,000 words.
+                            Counts <a class="ara-cite"> markers /
+                            (words / 1000). Workflow default: 10.0.
+                            (Corpus audit: 4 articles shipped at 0.0
+                             density before this gate existed.)
+  --refs-min INT            minimum entries in the <ol class="ara-refs">
+                            references list (counted by id="ref-N" li
+                            elements). Workflow default: 20.
+  --primary-share-min FLOAT minimum share (0.0-1.0) of references
+                            whose host is a primary source. Primary =
+                            *.gov, *.edu, arxiv.org, first-party AI/
+                            chip-lab domains, official IR/blogs.
+                            Heuristic — see PRIMARY_HOST_SUFFIXES.
+                            Recommended >= 0.30 once calibrated.
+  --cited-claims-min FLOAT  minimum share (0.0-1.0) of "substantive"
+                            sentences that carry at least one cite
+                            marker. Substantive = sentence containing
+                            a digit, '%', '$', or 2+ adjacent
+                            capitalized words / a 3+ char all-caps
+                            token. Heuristic; high false-positive on
+                            section headings — start conservative.
+
 Exit status:
   0  — body is valid; safe to commit
   1  — body fails validation; the error is printed to stderr with
@@ -36,6 +61,7 @@ Usage:
   python3 scripts/check_generative_research.py - < body.html     # stdin
   python3 scripts/check_generative_research.py path --kind standalone
   python3 scripts/check_generative_research.py path --diversity-min 3 --callout-max 5
+  python3 scripts/check_generative_research.py path --cite-density-min 10 --refs-min 20
 
 The agent loop in the workflow / local skill: write the body, run this
 check, fix anything it reports, re-check, and only then call the real
@@ -47,6 +73,7 @@ from __future__ import annotations
 import argparse
 import re
 import sys
+from html.parser import HTMLParser
 from pathlib import Path
 
 # Reuse the writer's validator so this script and the commit-time check
@@ -73,6 +100,263 @@ DISTRIBUTION_VIZ = frozenset([
     "ara-bars", "ara-rank-list",
 ])
 FALLBACK_PRIMITIVES = frozenset(["ara-table", "ara-callout", "ara-quote"])
+
+# ---------------------------------------------------------------------------
+# Quality-gate heuristics — convert prose targets into deterministic checks.
+# ---------------------------------------------------------------------------
+#
+# A "primary source" is one whose host matches a documented suffix. This is
+# heuristic; calibrated against the corpus in research/generative/* — the
+# task accepts that the list will need pruning over time. Keep the suffix
+# list small and well-justified rather than spraying every dot-com.
+PRIMARY_HOST_SUFFIXES = (
+    # Government, military, intergovernmental
+    ".gov", ".gov.uk", ".mil", ".int",
+    # Academic + research institutions
+    ".edu", ".ac.uk", ".ac.jp",
+    # Preprint + peer-reviewed repositories
+    "arxiv.org", "openreview.net", "biorxiv.org", "medrxiv.org",
+    "ncbi.nlm.nih.gov", "pubmed.ncbi.nlm.nih.gov", "europepmc.org",
+    "semanticscholar.org", "ssrn.com", "openalex.org",
+    # AI / ML / research-lab primary
+    "anthropic.com", "openai.com", "deepmind.com", "deepmind.google",
+    "ai.meta.com", "research.facebook.com", "transformer-circuits.pub",
+    "huggingface.co", "x.ai", "mistral.ai", "cohere.com",
+    # Cloud / chip / infra primaries (corp domains + dev portals)
+    "google.com", "research.google", "blog.google", "googleblog.com",
+    "microsoft.com", "azure.microsoft.com",
+    "aws.amazon.com", "amazon.com", "amazon.science",
+    "nvidia.com", "amd.com", "intel.com", "apple.com",
+    "developer.apple.com",
+    "mlcommons.org",
+    # Chip / inference vendor primaries observed in the corpus
+    "cerebras.ai", "cerebras.net", "groq.com", "fireworks.ai",
+    "together.ai", "deepinfra.com", "replicate.com", "deepseek.com",
+    # Standards bodies
+    "ietf.org", "w3.org", "rfc-editor.org", "iso.org",
+)
+# Hosts that EXACTLY match these get marked primary regardless of suffix
+# matching. Use sparingly — for explicit IR / first-party portals.
+PRIMARY_HOST_EXACT = frozenset({
+    "investor.natera.com", "investor.bloomenergy.com",
+    "investor.cerebras.net", "ir.coreweave.com", "ir.iren.com",
+    "iris.energy",
+    # GitHub source URLs count as primary for code/docs claims
+    "github.com",
+})
+
+
+def _normalize_host(host: str) -> str:
+    h = host.lower().strip()
+    if h.startswith("www."):
+        h = h[4:]
+    return h
+
+
+def is_primary_source(host: str | None) -> bool:
+    if not host:
+        return False
+    h = _normalize_host(host)
+    if h in PRIMARY_HOST_EXACT:
+        return True
+    for suf in PRIMARY_HOST_SUFFIXES:
+        # suffix match supports both `.gov` (matches `data.gov`) and
+        # `arxiv.org` (matches `www.arxiv.org` after the strip above)
+        if h == suf.lstrip("."):
+            return True
+        if h.endswith(suf):
+            return True
+    return False
+
+
+class _ReferenceHrefCollector(HTMLParser):
+    """Walks the HTML and collects URLs found INSIDE `<li id="ref-N">`
+    items — i.e. the references list. Plain in-body links don't count
+    (they're often footnote anchors like #ref-5, not source URLs)."""
+
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self._depth_in_ref_li = 0
+        self.ref_urls: list[str] = []
+
+    def handle_starttag(self, tag, attrs):
+        a = dict(attrs)
+        if tag == "li" and a.get("id", "").startswith("ref-"):
+            self._depth_in_ref_li = 1
+            return
+        if self._depth_in_ref_li > 0:
+            if tag == "li":  # nested li, unusual but possible
+                self._depth_in_ref_li += 1
+            if tag == "a":
+                href = a.get("href", "")
+                if href.startswith(("http://", "https://")):
+                    self.ref_urls.append(href)
+
+    def handle_endtag(self, tag):
+        if tag == "li" and self._depth_in_ref_li > 0:
+            self._depth_in_ref_li -= 1
+
+
+def _word_count(body_html: str) -> int:
+    text = re.sub(r"<[^>]+>", " ", body_html)
+    return len(text.split())
+
+
+def count_cite_markers(body_html: str) -> int:
+    """How many citation superscripts appear in the article body. We
+    count the rendered ara-cite class (one per [^N] in the DSL). Multi-
+    cite footnotes (`[^1,2,3]`) compile to 3 separate <a class="ara-cite">
+    spans so each gets counted — that matches the "claims with cite"
+    intent more closely than counting outer <sup> wrappers would."""
+    return len(re.findall(r'class="ara-cite', body_html))
+
+
+def count_references(body_html: str) -> int:
+    """How many entries in the references list."""
+    return len(re.findall(r'id="ref-\d+"', body_html))
+
+
+def primary_share(body_html: str) -> tuple[float, int, int]:
+    """Return (share, primary_count, total_refs) of references whose
+    host is a primary source. Share is 0.0 when no refs exist."""
+    collector = _ReferenceHrefCollector()
+    collector.feed(body_html)
+    refs = collector.ref_urls
+    if not refs:
+        return 0.0, 0, 0
+    primary = 0
+    for url in refs:
+        m = re.match(r"^https?://([^/]+)", url)
+        host = m.group(1) if m else None
+        if is_primary_source(host):
+            primary += 1
+    return primary / len(refs), primary, len(refs)
+
+
+_SUBSTANTIVE_NE = re.compile(r"\b[A-Z][a-zA-Z]+(?:\s+[A-Z][a-zA-Z]+)+|\b[A-Z]{3,}\b")
+_SENT_SPLIT = re.compile(r"(?<=[.!?])\s+")
+_CITE_MARKER = "\x00CITE\x00"
+
+
+def cited_claim_share(body_html: str) -> tuple[float, int, int]:
+    """Heuristic: among substantive sentences, what share carries a cite?
+
+    Substantive = sentence contains a digit, '%', '$', OR a named-entity
+    proxy (two-or-more adjacent capitalized words, or a 3+ char ALL-CAPS
+    token). This catches "$2.3B in Q4 2026" and "Cerebras WSE-3" but
+    also section headings — false-positive expected.
+
+    We pre-substitute `<sup>…<a class="ara-cite">…</a>…</sup>` with a
+    sentinel so cite presence survives the strip-tags pass.
+
+    Returns (share, cited_substantive, total_substantive). Share is 0.0
+    when no substantive sentences exist (empty/HTML-only body).
+    """
+    marked = re.sub(
+        r'<sup[^>]*>\s*<a[^>]*class="ara-cite"[^>]*>[^<]*</a>\s*</sup>',
+        f" {_CITE_MARKER} ",
+        body_html,
+        flags=re.IGNORECASE,
+    )
+    text = re.sub(r"<[^>]+>", " ", marked)
+    sents = _SENT_SPLIT.split(text)
+    total = 0
+    cited = 0
+    for s in sents:
+        if not s.strip():
+            continue
+        clean = s.replace(_CITE_MARKER, "")
+        is_subs = (
+            any(c.isdigit() for c in clean)
+            or "%" in clean
+            or "$" in clean
+            or bool(_SUBSTANTIVE_NE.search(clean))
+        )
+        if is_subs:
+            total += 1
+            if _CITE_MARKER in s:
+                cited += 1
+    if total == 0:
+        return 0.0, 0, 0
+    return cited / total, cited, total
+
+
+def cite_density(body_html: str) -> tuple[float, int, int]:
+    """Citations per 1000 words. Returns (density, cites, words)."""
+    cites = count_cite_markers(body_html)
+    words = _word_count(body_html)
+    if words == 0:
+        return 0.0, cites, 0
+    return (cites / words) * 1000.0, cites, words
+
+
+def enforce_quality(body_html: str, args: argparse.Namespace) -> list[str]:
+    """Return a list of quality-gate failure messages. Empty = pass.
+    Only the flags that were explicitly set are checked."""
+    errors: list[str] = []
+
+    if args.cite_density_min is not None:
+        density, cites, words = cite_density(body_html)
+        if density < args.cite_density_min:
+            errors.append(
+                f"quality: cite density {density:.2f}/1k words "
+                f"({cites} cites in {words} words), need >= "
+                f"{args.cite_density_min:.2f}. Add citations to the "
+                f"claims that lack them — the gate counts <sup>"
+                f"<a class=\"ara-cite\">N</a></sup> markers."
+            )
+
+    if args.refs_min is not None:
+        refs = count_references(body_html)
+        if refs < args.refs_min:
+            errors.append(
+                f"quality: only {refs} reference entries, need >= "
+                f"{args.refs_min}. The references list is the "
+                f":::references block at the bottom of the article."
+            )
+
+    if args.primary_share_min is not None:
+        share, prim, total = primary_share(body_html)
+        if total == 0:
+            errors.append(
+                "quality: no reference URLs found in the article; "
+                "cannot evaluate primary-source share. The references "
+                "block (li elements with id='ref-N') is missing or "
+                "has no http(s):// links."
+            )
+        elif share < args.primary_share_min:
+            errors.append(
+                f"quality: primary-source share {share*100:.1f}% "
+                f"({prim}/{total} refs), need >= "
+                f"{args.primary_share_min*100:.1f}%. Primary = "
+                f".gov/.edu, arxiv, official AI-lab / chip-vendor / "
+                f"infra-vendor blogs and IR. See PRIMARY_HOST_SUFFIXES "
+                f"in scripts/check_generative_research.py for the list. "
+                f"Replace TechCrunch / Bloomberg / sell-side commentary "
+                f"with the underlying SEC filing, paper, IR page, or "
+                f"first-party blog."
+            )
+
+    if args.cited_claims_min is not None:
+        share, cited, total = cited_claim_share(body_html)
+        if total == 0:
+            errors.append(
+                "quality: no substantive sentences detected — article "
+                "body may be empty or HTML-only."
+            )
+        elif share < args.cited_claims_min:
+            errors.append(
+                f"quality: cited-claim share {share*100:.1f}% "
+                f"({cited}/{total} substantive sentences carry a "
+                f"<sup><a class=\"ara-cite\">…</a></sup> marker), need "
+                f">= {args.cited_claims_min*100:.1f}%. Substantive = "
+                f"sentence with a digit, '%', '$', or a multi-word "
+                f"capitalized phrase. Heuristic — section headings "
+                f"may inflate the denominator; consider raising the "
+                f"threshold once measured."
+            )
+
+    return errors
 
 
 def count_classes(body_html: str) -> dict[str, int]:
@@ -174,6 +458,54 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="enable soft-warning heuristics (percentages-without-donut, etc.)",
     )
+    # Research-quality gates. None = inactive (preserves backward-compat for
+    # the bare `check_generative_research.py path.html` invocation). The
+    # workflow passes explicit thresholds in step 7.5.
+    p.add_argument(
+        "--cite-density-min",
+        type=float,
+        default=None,
+        metavar="FLOAT",
+        help=(
+            "fail if cite density < N citations per 1,000 words. "
+            "Recommended workflow value: 10.0 (corpus-validated; "
+            "discriminates 0-cite articles from 100+ cite articles)."
+        ),
+    )
+    p.add_argument(
+        "--refs-min",
+        type=int,
+        default=None,
+        metavar="INT",
+        help=(
+            "fail if the references list has < N entries. "
+            "Recommended workflow value: 20."
+        ),
+    )
+    p.add_argument(
+        "--primary-share-min",
+        type=float,
+        default=None,
+        metavar="FLOAT",
+        help=(
+            "fail if < FLOAT (0-1) of references are from primary sources. "
+            "Heuristic via PRIMARY_HOST_SUFFIXES; calibrate before "
+            "wiring into the build gate."
+        ),
+    )
+    p.add_argument(
+        "--cited-claims-min",
+        type=float,
+        default=None,
+        metavar="FLOAT",
+        help=(
+            "fail if < FLOAT (0-1) of substantive sentences carry a "
+            "cite marker. Substantive = sentence with a digit, percent "
+            "sign, dollar sign, or named-entity proxy. Heuristic with "
+            "high false-positive on headings; calibrate before wiring "
+            "into the build gate."
+        ),
+    )
     args = p.parse_args(argv)
 
     if args.body_path != "-" and not Path(args.body_path).exists():
@@ -213,6 +545,31 @@ def main(argv: list[str] | None = None) -> int:
             print(
                 "Design gates failed. Either restructure the article to "
                 "use more primitives, or relax the threshold for this run.",
+                file=sys.stderr,
+            )
+            return 1
+
+    # Research-quality gates (deterministic checks for the QUALITY TARGETS
+    # the workflow prompt documents in prose). Each gate is opt-in; absent
+    # flags = no check. Same kind=fragment scope as the design gates.
+    if args.kind == KIND_FRAGMENT and any(
+        v is not None for v in (
+            args.cite_density_min,
+            args.refs_min,
+            args.primary_share_min,
+            args.cited_claims_min,
+        )
+    ):
+        errors = enforce_quality(body, args)
+        if errors:
+            for line in errors:
+                print(line, file=sys.stderr)
+            print(
+                "Quality gates failed. The article does not meet the "
+                "research-quality bar enforced by this build. Fix the "
+                "underlying issues (add citations, swap secondary "
+                "sources for primary, extend the references list) and "
+                "re-check.",
                 file=sys.stderr,
             )
             return 1

--- a/scripts/check_generative_research.py
+++ b/scripts/check_generative_research.py
@@ -229,21 +229,43 @@ def count_cite_markers(body_html: str) -> int:
 
 
 def count_references(body_html: str) -> int:
-    """How many references list entries carry at least one http(s) URL.
+    """How many DISTINCT http(s) source URLs appear in the references list.
 
-    Previously counted every `<li id="ref-N">` regardless of whether
-    the entry actually had a source URL. An article with 20 title-only
-    or duplicate-href references could pass `--refs-min 20` with zero
-    real sources — defeating the gate's intent. We now count distinct
-    ref-li elements that produced at least one `<a href="http(s)://…">`
-    inside them. Mixed lists (some entries with URLs, some without)
-    still count the URL-bearing entries — tolerant of legitimate
-    no-URL entries like personal-communication citations, strict
-    against pure-title attack patterns.
+    Two layers of strictness, both responses to codex review feedback:
+      1. Only counts URLs inside `<li id="ref-N">` items, not in-body
+         hyperlinks.
+      2. Counts the number of DISTINCT URLs after normalization (lower-
+         case host, trailing-slash-stripped). An article with 20 ref-li
+         entries that all point to the same URL counts as 1, not 20 —
+         the workflow's "20 distinct source URLs" target wouldn't be met
+         by a single URL repeated 20 times.
+
+    A ref-li with no URL (title-only / personal-communication) does not
+    contribute. A ref-li with multiple URLs contributes each distinct
+    URL it carries.
     """
     collector = _ReferenceHrefCollector()
     collector.feed(body_html)
-    return collector.refs_with_urls
+    return len({_normalize_url(u) for u in collector.ref_urls})
+
+
+def _normalize_url(url: str) -> str:
+    """Normalize a URL for distinct-counting. Lowercase scheme+host,
+    strip trailing slash, drop default ports. Path/query are kept as-is
+    (so /a vs /b are distinct, but http://X/ and https://X are not)."""
+    m = re.match(r"^(https?)://([^/]+)(/.*)?$", url.strip())
+    if not m:
+        return url.strip().lower()
+    scheme, host, path = m.group(1).lower(), m.group(2).lower(), m.group(3) or ""
+    if host.startswith("www."):
+        host = host[4:]
+    # Drop default ports
+    if scheme == "http" and host.endswith(":80"):
+        host = host[:-3]
+    elif scheme == "https" and host.endswith(":443"):
+        host = host[:-4]
+    path = path.rstrip("/")
+    return f"{scheme}://{host}{path}"
 
 
 def primary_share(body_html: str) -> tuple[float, int, int]:
@@ -521,12 +543,23 @@ def audit_verifier_findings(
         probe = _norm(_strip_cite_markers(text))[:80]
         if not probe:
             continue
-        if probe in body_norm and probe not in mark_norm:
+        # Count distinct occurrences instead of using `probe in mark`:
+        # if the claim appears N times in the body and only K < N are
+        # wrapped in <mark>, the prior `probe not in mark_norm` test
+        # would falsely treat the claim as demoted because the probe
+        # exists somewhere in the mark blob. Strict version: an
+        # unmarked occurrence survives if total body occurrences
+        # exceeds the mark-region occurrences.
+        body_occurrences = body_norm.count(probe)
+        mark_occurrences = mark_norm.count(probe)
+        if body_occurrences > mark_occurrences:
             surviving.append(
                 {
                     "id": claim.get("id"),
                     "probe": probe,
                     "citation": claim.get("citation"),
+                    "body_occurrences": body_occurrences,
+                    "mark_occurrences": mark_occurrences,
                 }
             )
 

--- a/scripts/check_generative_research.py
+++ b/scripts/check_generative_research.py
@@ -359,6 +359,29 @@ def enforce_quality(body_html: str, args: argparse.Namespace) -> list[str]:
     return errors
 
 
+# Citation marker patterns we strip before matching verifier-findings
+# probes against the body. The verifier reads the .ara.md DSL (which
+# uses `[^N]` / `[^1,2,3]`) but the body we compare against is the
+# compiled HTML (which renders `[^N]` as `<sup><a class="ara-cite">N</a></sup>`).
+# Without normalization, a probe containing `[^12]` will never match a
+# body containing `<sup>...12...</sup>` → surviving unsupported claim
+# is treated as "removed" → false pass.
+_DSL_CITE_MARKER_RE = re.compile(r"\[\^[0-9,\s]+\]")
+_RENDERED_CITE_RE = re.compile(
+    r'<sup[^>]*>\s*<a[^>]*class="ara-cite"[^>]*>[^<]*</a>\s*</sup>',
+    flags=re.IGNORECASE,
+)
+
+
+def _strip_cite_markers(s: str) -> str:
+    """Remove both DSL `[^N]` and rendered `<sup><a class="ara-cite">…</a></sup>`
+    citation markers so verifier-findings text (DSL-shape) and HTML
+    body text (rendered-shape) match each other after normalization."""
+    s = _RENDERED_CITE_RE.sub(" ", s)
+    s = _DSL_CITE_MARKER_RE.sub(" ", s)
+    return s
+
+
 def audit_verifier_findings(
     findings_path: Path, body_html: str
 ) -> tuple[int, list[dict]]:
@@ -376,10 +399,15 @@ def audit_verifier_findings(
             ...
         ]}
 
-    Heuristic: the first ~80 chars of `text` (lowercased, whitespace-
-    collapsed) is the probe. If the probe appears in the article body
-    text AND is not inside a `<mark>…</mark>` region, the claim
-    survived without being demoted → fail.
+    Heuristic: strip citation markers (both DSL `[^N]` and the rendered
+    `<sup><a class="ara-cite">N</a></sup>` form) from BOTH the claim
+    text and the body before normalizing. The verifier reads DSL; the
+    compiled HTML we audit uses the rendered form. Without stripping
+    on both sides, any cited claim looks "removed" because the marker
+    shapes never match. The first ~80 chars of the normalized text is
+    the probe. If the probe appears in the body text AND is not inside
+    a `<mark>…</mark>` region, the claim survived without being
+    demoted → fail.
 
     Limitations (call out in PR + reviewer-facing docs):
       * Whole-claim-demotion semantics: if the agent demotes only the
@@ -412,11 +440,19 @@ def audit_verifier_findings(
             f"got: {type(data).__name__}"
         )
 
-    text_no_tags = re.sub(r"<[^>]+>", " ", body_html)
+    # Strip cite markers on the HTML side BEFORE tag-stripping so the
+    # rendered <sup>…</sup> wrapper disappears cleanly. Then strip
+    # remaining HTML tags. Both DSL and rendered citation forms are
+    # gone, so the probe and body live on equal footing.
+    body_decited = _strip_cite_markers(body_html)
+    text_no_tags = re.sub(r"<[^>]+>", " ", body_decited)
     mark_regions: list[str] = re.findall(
         r"<mark[^>]*>(.*?)</mark>", body_html, flags=re.DOTALL | re.IGNORECASE
     )
-    mark_blob = " ".join(mark_regions)
+    # Same cite-stripping inside the mark regions — claim text inside
+    # a <mark> wrapper can also carry a `<sup>…</sup>` cite, and we
+    # want it to match a DSL-shaped probe.
+    mark_blob = " ".join(_strip_cite_markers(m) for m in mark_regions)
 
     def _norm(s: str) -> str:
         return re.sub(r"\s+", " ", s).strip().lower()
@@ -440,7 +476,11 @@ def audit_verifier_findings(
             # rather than failing (the verifier itself flagged the
             # missing data; rerun policy is upstream).
             continue
-        probe = _norm(text)[:80]
+        # Strip cites from the probe text too, so a DSL-shaped probe
+        # like "Nvidia hit 75% margin [^12]" doesn't fail to match a
+        # body whose corresponding sentence has already had the cite
+        # stripped from the HTML side.
+        probe = _norm(_strip_cite_markers(text))[:80]
         if not probe:
             continue
         if probe in body_norm and probe not in mark_norm:

--- a/scripts/check_generative_research.py
+++ b/scripts/check_generative_research.py
@@ -359,6 +359,102 @@ def enforce_quality(body_html: str, args: argparse.Namespace) -> list[str]:
     return errors
 
 
+def audit_verifier_findings(
+    findings_path: Path, body_html: str
+) -> tuple[int, list[dict]]:
+    """Check that every `unsupported` claim flagged by the verifier
+    sub-agent was either demoted (wrapped in `<mark>` / `==…==`) or
+    removed during bounded revision.
+
+    The verifier writes a structured findings JSON at the path passed
+    to this function:
+
+        {"claims": [
+            {"id": "c1", "text": "<verbatim claim text>",
+             "verdict": "supported|weak|unsupported",
+             "citation": "<url or null>"},
+            ...
+        ]}
+
+    Heuristic: the first ~80 chars of `text` (lowercased, whitespace-
+    collapsed) is the probe. If the probe appears in the article body
+    text AND is not inside a `<mark>…</mark>` region, the claim
+    survived without being demoted → fail.
+
+    Limitations (call out in PR + reviewer-facing docs):
+      * Whole-claim-demotion semantics: if the agent demotes only the
+        load-bearing number inside a longer claim sentence, the probe
+        may match in body-text but NOT inside the mark region → false
+        fail. Acceptable — pushes the agent toward marking the whole
+        sentence.
+      * Paraphrase-on-revision: if the agent rewrites the claim text
+        on revision, the probe won't match anywhere → treated as
+        "removed" → pass. Acceptable — paraphrase to a supported
+        variant is a valid bounded-revision outcome.
+
+    Returns (unsupported_total, surviving) where `surviving` is a list
+    of dicts {id, probe, citation} for every unsupported claim that
+    failed the audit. Empty `surviving` = pass.
+
+    Raises ValueError if the findings JSON is malformed.
+    """
+    import json as _json
+
+    try:
+        data = _json.loads(findings_path.read_text(encoding="utf-8"))
+    except (_json.JSONDecodeError, OSError) as e:
+        raise ValueError(f"could not parse verifier findings JSON: {e}") from e
+
+    claims = data.get("claims") if isinstance(data, dict) else None
+    if not isinstance(claims, list):
+        raise ValueError(
+            "verifier findings JSON missing top-level 'claims' array; "
+            f"got: {type(data).__name__}"
+        )
+
+    text_no_tags = re.sub(r"<[^>]+>", " ", body_html)
+    mark_regions: list[str] = re.findall(
+        r"<mark[^>]*>(.*?)</mark>", body_html, flags=re.DOTALL | re.IGNORECASE
+    )
+    mark_blob = " ".join(mark_regions)
+
+    def _norm(s: str) -> str:
+        return re.sub(r"\s+", " ", s).strip().lower()
+
+    body_norm = _norm(text_no_tags)
+    mark_norm = _norm(mark_blob)
+
+    surviving: list[dict] = []
+    unsupported_total = 0
+    for claim in claims:
+        if not isinstance(claim, dict):
+            continue
+        verdict = str(claim.get("verdict", "")).lower()
+        if verdict != "unsupported":
+            continue
+        unsupported_total += 1
+        text = str(claim.get("text", "")).strip()
+        if not text:
+            # Verifier flagged a claim but gave no body text — we
+            # can't audit. Treat as "needs manual review" by skipping
+            # rather than failing (the verifier itself flagged the
+            # missing data; rerun policy is upstream).
+            continue
+        probe = _norm(text)[:80]
+        if not probe:
+            continue
+        if probe in body_norm and probe not in mark_norm:
+            surviving.append(
+                {
+                    "id": claim.get("id"),
+                    "probe": probe,
+                    "citation": claim.get("citation"),
+                }
+            )
+
+    return unsupported_total, surviving
+
+
 def count_classes(body_html: str) -> dict[str, int]:
     """Return a {class_name: count} map of every ara-* class in the
     article's HTML output, after compile."""
@@ -506,6 +602,25 @@ def main(argv: list[str] | None = None) -> int:
             "into the build gate."
         ),
     )
+    # Verifier-findings audit mode. When this flag is set we skip
+    # validate_body / design / quality gates and instead audit the
+    # body against the verifier sub-agent's JSON artifact. The
+    # workflow's "bounded revision" step (step 7 of the agent prompt)
+    # is otherwise unobservable from the build — this gate makes it
+    # auditable.
+    p.add_argument(
+        "--audit-verifier-findings",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help=(
+            "path to .gen-verifier-findings.json written by the "
+            "verifier sub-agent. When set, the script switches to "
+            "audit mode: validates the JSON and fails if any "
+            "unsupported claim survived in the body without being "
+            "demoted (<mark>) or removed."
+        ),
+    )
     args = p.parse_args(argv)
 
     if args.body_path != "-" and not Path(args.body_path).exists():
@@ -527,6 +642,48 @@ def main(argv: list[str] | None = None) -> int:
             return 1
     else:
         body = raw
+
+    # Verifier-findings audit mode. Runs ONLY when --audit-verifier-findings
+    # is set. Bypasses validate_body / design / quality so the audit can run
+    # against a fully-committed (already-validated) article without redoing
+    # those checks.
+    if args.audit_verifier_findings:
+        findings_path = Path(args.audit_verifier_findings)
+        if not findings_path.exists():
+            print(
+                f"check: verifier findings file not found: {findings_path}",
+                file=sys.stderr,
+            )
+            return 2
+        try:
+            total, surviving = audit_verifier_findings(findings_path, body)
+        except ValueError as e:
+            print(f"check: {e}", file=sys.stderr)
+            return 1
+        print(
+            f"verifier-findings audit: {total} unsupported claim(s) "
+            f"flagged; {len(surviving)} still present in the body outside "
+            f"a <mark> region.",
+            file=sys.stderr,
+        )
+        if surviving:
+            print(
+                "Bounded revision failed: the following unsupported "
+                "claims were not demoted or removed:",
+                file=sys.stderr,
+            )
+            for c in surviving[:10]:
+                print(
+                    f"  - id={c['id']}: {c['probe']!r}",
+                    file=sys.stderr,
+                )
+            if len(surviving) > 10:
+                print(
+                    f"  ... and {len(surviving) - 10} more",
+                    file=sys.stderr,
+                )
+            return 1
+        return 0
 
     try:
         validate_body(body, args.kind)

--- a/scripts/check_generative_research.py
+++ b/scripts/check_generative_research.py
@@ -172,17 +172,27 @@ def is_primary_source(host: str | None) -> bool:
 class _ReferenceHrefCollector(HTMLParser):
     """Walks the HTML and collects URLs found INSIDE `<li id="ref-N">`
     items — i.e. the references list. Plain in-body links don't count
-    (they're often footnote anchors like #ref-5, not source URLs)."""
+    (they're often footnote anchors like #ref-5, not source URLs).
+
+    Tracks two metrics:
+      * `ref_urls`: every http(s) URL found inside a ref-li (one entry
+                    may have multiple — used by primary_share).
+      * `refs_with_urls`: count of distinct ref-li entries that
+                    contained at least one URL (used by count_references
+                    to gate against "20 title-only refs" attack)."""
 
     def __init__(self):
         super().__init__(convert_charrefs=True)
         self._depth_in_ref_li = 0
+        self._current_ref_has_url = False
         self.ref_urls: list[str] = []
+        self.refs_with_urls: int = 0
 
     def handle_starttag(self, tag, attrs):
         a = dict(attrs)
         if tag == "li" and a.get("id", "").startswith("ref-"):
             self._depth_in_ref_li = 1
+            self._current_ref_has_url = False
             return
         if self._depth_in_ref_li > 0:
             if tag == "li":  # nested li, unusual but possible
@@ -191,10 +201,17 @@ class _ReferenceHrefCollector(HTMLParser):
                 href = a.get("href", "")
                 if href.startswith(("http://", "https://")):
                     self.ref_urls.append(href)
+                    self._current_ref_has_url = True
 
     def handle_endtag(self, tag):
         if tag == "li" and self._depth_in_ref_li > 0:
             self._depth_in_ref_li -= 1
+            if self._depth_in_ref_li == 0:
+                # We just closed the outermost ref-li; commit its
+                # has-url flag to the counter.
+                if self._current_ref_has_url:
+                    self.refs_with_urls += 1
+                self._current_ref_has_url = False
 
 
 def _word_count(body_html: str) -> int:
@@ -212,8 +229,21 @@ def count_cite_markers(body_html: str) -> int:
 
 
 def count_references(body_html: str) -> int:
-    """How many entries in the references list."""
-    return len(re.findall(r'id="ref-\d+"', body_html))
+    """How many references list entries carry at least one http(s) URL.
+
+    Previously counted every `<li id="ref-N">` regardless of whether
+    the entry actually had a source URL. An article with 20 title-only
+    or duplicate-href references could pass `--refs-min 20` with zero
+    real sources — defeating the gate's intent. We now count distinct
+    ref-li elements that produced at least one `<a href="http(s)://…">`
+    inside them. Mixed lists (some entries with URLs, some without)
+    still count the URL-bearing entries — tolerant of legitimate
+    no-URL entries like personal-communication citations, strict
+    against pure-title attack patterns.
+    """
+    collector = _ReferenceHrefCollector()
+    collector.feed(body_html)
+    return collector.refs_with_urls
 
 
 def primary_share(body_html: str) -> tuple[float, int, int]:
@@ -451,8 +481,16 @@ def audit_verifier_findings(
     )
     # Same cite-stripping inside the mark regions — claim text inside
     # a <mark> wrapper can also carry a `<sup>…</sup>` cite, and we
-    # want it to match a DSL-shaped probe.
-    mark_blob = " ".join(_strip_cite_markers(m) for m in mark_regions)
+    # want it to match a DSL-shaped probe. ALSO strip remaining HTML
+    # tags from inside the mark; demoted sentences may contain inline
+    # markup (`<em>`, `<strong>`, `<a>`, `<code>`) that would
+    # otherwise leave the mark blob in a different shape from the
+    # tag-stripped body, causing valid demotions to fail the audit.
+    mark_blob = re.sub(
+        r"<[^>]+>",
+        " ",
+        " ".join(_strip_cite_markers(m) for m in mark_regions),
+    )
 
     def _norm(s: str) -> str:
         return re.sub(r"\s+", " ", s).strip().lower()

--- a/scripts/test_check_generative_research.py
+++ b/scripts/test_check_generative_research.py
@@ -267,6 +267,142 @@ class EnforceQualityCompositionTest(unittest.TestCase):
         self.assertTrue(any("primary-source share" in e for e in errs))
 
 
+class VerifierFindingsAuditTest(unittest.TestCase):
+    """The audit makes bounded-revision (step 7 of the agent prompt)
+    deterministically observable. Without it, "the verifier said X
+    was unsupported and we addressed it" was faith-based."""
+
+    def _write_findings(self, tmpdir: Path, claims: list[dict]) -> Path:
+        import json
+        path = tmpdir / "findings.json"
+        path.write_text(json.dumps({"claims": claims}), encoding="utf-8")
+        return path
+
+    def test_unsupported_claim_left_in_body_fails(self):
+        import tempfile
+        body = (
+            '<article class="ara-doc">'
+            '<p>Nvidia hit 75 percent margin in Q4 2026 due to GPU demand.</p>'
+            '</article>'
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            findings = self._write_findings(tmpdir, [{
+                "id": "c1",
+                "text": "Nvidia hit 75 percent margin in Q4 2026 due to GPU demand.",
+                "verdict": "unsupported",
+                "citation": None,
+            }])
+            total, surviving = chk.audit_verifier_findings(findings, body)
+            self.assertEqual(total, 1)
+            self.assertEqual(len(surviving), 1)
+            self.assertEqual(surviving[0]["id"], "c1")
+
+    def test_unsupported_claim_demoted_inside_mark_passes(self):
+        import tempfile
+        body = (
+            '<article class="ara-doc">'
+            '<p><mark class="ara-mark">Nvidia hit 75 percent margin in Q4 2026 due to GPU demand.</mark></p>'
+            '</article>'
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            findings = self._write_findings(Path(tmp), [{
+                "id": "c1",
+                "text": "Nvidia hit 75 percent margin in Q4 2026 due to GPU demand.",
+                "verdict": "unsupported",
+                "citation": None,
+            }])
+            total, surviving = chk.audit_verifier_findings(findings, body)
+            self.assertEqual(total, 1)
+            self.assertEqual(surviving, [])
+
+    def test_unsupported_claim_removed_passes(self):
+        import tempfile
+        body = (
+            '<article class="ara-doc">'
+            '<p>Different, supported claim about Nvidia revenue.</p>'
+            '</article>'
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            findings = self._write_findings(Path(tmp), [{
+                "id": "c1",
+                "text": "Nvidia hit 75 percent margin in Q4 2026 due to GPU demand.",
+                "verdict": "unsupported",
+                "citation": None,
+            }])
+            total, surviving = chk.audit_verifier_findings(findings, body)
+            self.assertEqual(total, 1)
+            self.assertEqual(surviving, [])
+
+    def test_supported_claims_ignored(self):
+        import tempfile
+        body = '<article><p>This claim is fine.</p></article>'
+        with tempfile.TemporaryDirectory() as tmp:
+            findings = self._write_findings(Path(tmp), [
+                {"id": "c1", "text": "This claim is fine.", "verdict": "supported", "citation": "https://x.gov/y"},
+                {"id": "c2", "text": "Something else.", "verdict": "weak", "citation": None},
+            ])
+            total, surviving = chk.audit_verifier_findings(findings, body)
+            # 0 unsupported → audit passes vacuously
+            self.assertEqual(total, 0)
+            self.assertEqual(surviving, [])
+
+    def test_whitespace_and_case_tolerant(self):
+        import tempfile
+        body = (
+            '<article><p>nvidia hit 75 PERCENT margin in q4 2026 due to gpu demand.</p></article>'
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            findings = self._write_findings(Path(tmp), [{
+                "id": "c1",
+                "text": "Nvidia hit 75 percent margin in Q4 2026 due to GPU demand.",
+                "verdict": "unsupported",
+                "citation": None,
+            }])
+            total, surviving = chk.audit_verifier_findings(findings, body)
+            # case-insensitive match → claim still present, must FAIL
+            self.assertEqual(len(surviving), 1)
+
+    def test_malformed_json_raises(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "bad.json"
+            path.write_text("{not json")
+            with self.assertRaises(ValueError):
+                chk.audit_verifier_findings(path, "<article></article>")
+
+    def test_top_level_not_object_raises(self):
+        import tempfile, json
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "bad.json"
+            path.write_text(json.dumps([1, 2, 3]))
+            with self.assertRaises(ValueError):
+                chk.audit_verifier_findings(path, "<article></article>")
+
+    def test_missing_claims_key_raises(self):
+        import tempfile, json
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "bad.json"
+            path.write_text(json.dumps({"findings": []}))
+            with self.assertRaises(ValueError):
+                chk.audit_verifier_findings(path, "<article></article>")
+
+    def test_empty_text_skipped_not_failed(self):
+        import tempfile
+        body = '<article><p>Something here.</p></article>'
+        with tempfile.TemporaryDirectory() as tmp:
+            findings = self._write_findings(Path(tmp), [{
+                "id": "c1",
+                "text": "",
+                "verdict": "unsupported",
+                "citation": None,
+            }])
+            total, surviving = chk.audit_verifier_findings(findings, body)
+            # Empty text → can't audit → not added to surviving
+            self.assertEqual(total, 1)
+            self.assertEqual(surviving, [])
+
+
 class SanityAgainstKnownGoodArticleTest(unittest.TestCase):
     """The task explicitly named this file as a high-quality article
     that the gates must accept. If we ever ratchet defaults up and

--- a/scripts/test_check_generative_research.py
+++ b/scripts/test_check_generative_research.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Unit tests for the research-quality gates added to
+scripts/check_generative_research.py.
+
+These tests cover the heuristics themselves (not the validate_body
+plumbing — that has its own tests in test_ara_dsl.py). For each gate
+we assert behavior on a hand-built synthetic article plus a sanity
+check against a known-good article in research/generative/."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import unittest
+from pathlib import Path
+
+# Reuse the same sys.path bootstrap the script itself uses.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import check_generative_research as chk  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SANITY_GOOD = (
+    REPO_ROOT
+    / "research"
+    / "generative"
+    / "2026-05-16T085517--cerebras-wse-3-vs-nvidia-gb200-cost-per-token-economics.html"
+)
+
+
+def _ns(**overrides):
+    """Build an argparse.Namespace with all gate flags = None, then
+    apply overrides. Lets each test focus on a single gate."""
+    defaults = dict(
+        cite_density_min=None,
+        refs_min=None,
+        primary_share_min=None,
+        cited_claims_min=None,
+    )
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def _article(refs_count=0, cites_count=0, body_words=100, primary_hosts=None):
+    """Build a minimal synthetic article body. By default zero refs
+    and zero cites; pass counts to populate."""
+    body_text = " ".join(["Lorem"] * body_words)
+    sup_block = "".join(
+        f'<sup><a class="ara-cite" href="#ref-{i + 1}">{i + 1}</a></sup>'
+        for i in range(cites_count)
+    )
+    if primary_hosts is None:
+        primary_hosts = ["example.com"] * refs_count
+    refs_lis = "".join(
+        f'<li id="ref-{i + 1}"><a href="https://{primary_hosts[i]}/x">src</a></li>'
+        for i in range(refs_count)
+    )
+    refs_block = (
+        f'<ol class="ara-refs">{refs_lis}</ol>' if refs_count else ""
+    )
+    return (
+        '<article class="ara-doc">'
+        f"<h2>Test</h2><p>{body_text}{sup_block}</p>"
+        f"{refs_block}"
+        "</article>"
+    )
+
+
+class PrimarySourceClassificationTest(unittest.TestCase):
+    def test_government_suffix_is_primary(self):
+        self.assertTrue(chk.is_primary_source("data.gov"))
+        self.assertTrue(chk.is_primary_source("sec.gov"))
+        self.assertTrue(chk.is_primary_source("emp.lbl.gov"))
+
+    def test_education_suffix_is_primary(self):
+        self.assertTrue(chk.is_primary_source("stanford.edu"))
+        self.assertTrue(chk.is_primary_source("ox.ac.uk"))
+
+    def test_arxiv_and_research_repos_primary(self):
+        self.assertTrue(chk.is_primary_source("arxiv.org"))
+        self.assertTrue(chk.is_primary_source("openreview.net"))
+        self.assertTrue(chk.is_primary_source("biorxiv.org"))
+
+    def test_first_party_corp_blogs_primary(self):
+        self.assertTrue(chk.is_primary_source("anthropic.com"))
+        self.assertTrue(chk.is_primary_source("blog.google"))
+        self.assertTrue(chk.is_primary_source("developer.nvidia.com"))
+        self.assertTrue(chk.is_primary_source("cerebras.ai"))
+
+    def test_subdomain_inherits_primary(self):
+        # subdomain of a registered primary suffix
+        self.assertTrue(chk.is_primary_source("investor.bloomenergy.com"))
+        # bloomenergy.com is in EXACT list via investor. — confirm the bare host
+        self.assertTrue(chk.is_primary_source("investor.natera.com"))
+
+    def test_typical_secondary_press_not_primary(self):
+        self.assertFalse(chk.is_primary_source("techcrunch.com"))
+        self.assertFalse(chk.is_primary_source("theinformation.com"))
+        self.assertFalse(chk.is_primary_source("bloomberg.com"))
+        self.assertFalse(chk.is_primary_source("cnbc.com"))
+
+    def test_www_prefix_normalized(self):
+        self.assertTrue(chk.is_primary_source("www.sec.gov"))
+        self.assertTrue(chk.is_primary_source("www.arxiv.org"))
+
+    def test_none_or_empty_not_primary(self):
+        self.assertFalse(chk.is_primary_source(None))
+        self.assertFalse(chk.is_primary_source(""))
+
+
+class CiteDensityTest(unittest.TestCase):
+    def test_zero_cites_density_zero(self):
+        body = _article(cites_count=0, body_words=500)
+        density, cites, words = chk.cite_density(body)
+        self.assertEqual(cites, 0)
+        self.assertEqual(density, 0.0)
+        self.assertGreater(words, 0)
+
+    def test_density_proportional_to_cites(self):
+        body = _article(cites_count=15, body_words=1500)
+        density, cites, _ = chk.cite_density(body)
+        self.assertEqual(cites, 15)
+        self.assertAlmostEqual(density, 10.0, delta=0.5)
+
+    def test_gate_below_threshold_fails(self):
+        # 5 cites in 1000 words = density 5.0; gate at 10 fails
+        body = _article(cites_count=5, body_words=1000)
+        errs = chk.enforce_quality(body, _ns(cite_density_min=10.0))
+        self.assertEqual(len(errs), 1)
+        self.assertIn("cite density", errs[0])
+
+    def test_gate_above_threshold_passes(self):
+        body = _article(cites_count=20, body_words=1000)
+        errs = chk.enforce_quality(body, _ns(cite_density_min=10.0))
+        self.assertEqual(errs, [])
+
+
+class RefsMinTest(unittest.TestCase):
+    def test_zero_refs_below_threshold(self):
+        body = _article(refs_count=0)
+        errs = chk.enforce_quality(body, _ns(refs_min=20))
+        self.assertEqual(len(errs), 1)
+        self.assertIn("reference entries", errs[0])
+
+    def test_meets_threshold_passes(self):
+        body = _article(refs_count=20)
+        errs = chk.enforce_quality(body, _ns(refs_min=20))
+        self.assertEqual(errs, [])
+
+
+class PrimaryShareTest(unittest.TestCase):
+    def test_all_secondary_fails(self):
+        body = _article(
+            refs_count=10,
+            primary_hosts=["techcrunch.com"] * 10,
+        )
+        share, prim, total = chk.primary_share(body)
+        self.assertEqual(prim, 0)
+        self.assertEqual(total, 10)
+        self.assertEqual(share, 0.0)
+
+    def test_all_primary_passes(self):
+        body = _article(
+            refs_count=10,
+            primary_hosts=["arxiv.org", "sec.gov", "anthropic.com"] * 4,
+        )
+        share, prim, total = chk.primary_share(body)
+        self.assertEqual(total, 10)
+        self.assertEqual(prim, 10)
+        self.assertEqual(share, 1.0)
+        errs = chk.enforce_quality(body, _ns(primary_share_min=0.5))
+        self.assertEqual(errs, [])
+
+    def test_below_threshold_fails(self):
+        body = _article(
+            refs_count=10,
+            primary_hosts=(["arxiv.org"] * 3 + ["techcrunch.com"] * 7),
+        )
+        errs = chk.enforce_quality(body, _ns(primary_share_min=0.5))
+        self.assertEqual(len(errs), 1)
+        self.assertIn("primary-source share", errs[0])
+
+    def test_no_refs_fails_with_message(self):
+        body = _article(refs_count=0)
+        errs = chk.enforce_quality(body, _ns(primary_share_min=0.5))
+        self.assertEqual(len(errs), 1)
+        self.assertIn("no reference URLs", errs[0])
+
+
+class CitedClaimShareTest(unittest.TestCase):
+    def test_all_substantive_uncited_zero_share(self):
+        body = (
+            '<article class="ara-doc">'
+            "<p>Cerebras posted $5.55 billion in 2026. "
+            "Nvidia reported 75 percent margin. "
+            "OpenAI raised funding rounds.</p>"
+            "</article>"
+        )
+        share, cited, total = chk.cited_claim_share(body)
+        self.assertGreater(total, 0)
+        self.assertEqual(cited, 0)
+        self.assertEqual(share, 0.0)
+
+    def test_cited_substantive_counted(self):
+        body = (
+            '<article class="ara-doc">'
+            '<p>Cerebras posted $5.55 billion in 2026'
+            '<sup><a class="ara-cite" href="#ref-1">1</a></sup>. '
+            'Nvidia reported 75 percent margin'
+            '<sup><a class="ara-cite" href="#ref-2">2</a></sup>.</p>'
+            "</article>"
+        )
+        share, cited, total = chk.cited_claim_share(body)
+        self.assertEqual(cited, total)
+        self.assertEqual(share, 1.0)
+
+    def test_gate_threshold_enforced(self):
+        # Two substantive sentences, only one cited → 0.5 share
+        body = (
+            '<article class="ara-doc"><p>'
+            "Cerebras posted $5.55 billion in 2026"
+            '<sup><a class="ara-cite" href="#ref-1">1</a></sup>. '
+            "Nvidia reported 75 percent margin."
+            "</p></article>"
+        )
+        errs = chk.enforce_quality(body, _ns(cited_claims_min=0.8))
+        self.assertEqual(len(errs), 1)
+        self.assertIn("cited-claim share", errs[0])
+        # Same body at threshold 0.4 → passes
+        errs = chk.enforce_quality(body, _ns(cited_claims_min=0.4))
+        self.assertEqual(errs, [])
+
+
+class ReferenceHrefCollectorTest(unittest.TestCase):
+    def test_only_ref_li_hrefs_counted(self):
+        body = (
+            '<article>'
+            # In-body link to another section — should NOT count
+            '<p>See <a href="https://techcrunch.com/article">this</a>.</p>'
+            '<ol class="ara-refs">'
+            '<li id="ref-1"><a href="https://arxiv.org/abs/123">paper</a></li>'
+            '<li id="ref-2"><a href="https://sec.gov/edgar/x">filing</a></li>'
+            '</ol>'
+            '</article>'
+        )
+        c = chk._ReferenceHrefCollector()
+        c.feed(body)
+        self.assertEqual(len(c.ref_urls), 2)
+        self.assertIn("https://arxiv.org/abs/123", c.ref_urls)
+        self.assertIn("https://sec.gov/edgar/x", c.ref_urls)
+        self.assertNotIn("https://techcrunch.com/article", c.ref_urls)
+
+
+class EnforceQualityCompositionTest(unittest.TestCase):
+    def test_multiple_failures_all_reported(self):
+        body = _article(
+            cites_count=2, refs_count=2, body_words=500,
+            primary_hosts=["techcrunch.com", "cnbc.com"],
+        )
+        errs = chk.enforce_quality(
+            body,
+            _ns(cite_density_min=10.0, refs_min=20, primary_share_min=0.5),
+        )
+        # All three should fail
+        self.assertEqual(len(errs), 3)
+        self.assertTrue(any("cite density" in e for e in errs))
+        self.assertTrue(any("reference entries" in e for e in errs))
+        self.assertTrue(any("primary-source share" in e for e in errs))
+
+
+class SanityAgainstKnownGoodArticleTest(unittest.TestCase):
+    """The task explicitly named this file as a high-quality article
+    that the gates must accept. If we ever ratchet defaults up and
+    this article fails, that's a signal to recalibrate, not to ratchet."""
+
+    @unittest.skipUnless(SANITY_GOOD.exists(), "fixture article not present")
+    def test_cerebras_wse_passes_workflow_gates(self):
+        body = SANITY_GOOD.read_text(encoding="utf-8")
+        errs = chk.enforce_quality(
+            body,
+            _ns(cite_density_min=10.0, refs_min=20),
+        )
+        self.assertEqual(
+            errs, [],
+            "cerebras-wse-3 article must pass the workflow gates "
+            "(--cite-density-min 10 --refs-min 20). Errors: " + "; ".join(errs),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_check_generative_research.py
+++ b/scripts/test_check_generative_research.py
@@ -245,9 +245,49 @@ class ReferenceHrefCollectorTest(unittest.TestCase):
         c = chk._ReferenceHrefCollector()
         c.feed(body)
         self.assertEqual(len(c.ref_urls), 2)
+        self.assertEqual(c.refs_with_urls, 2)
         self.assertIn("https://arxiv.org/abs/123", c.ref_urls)
         self.assertIn("https://sec.gov/edgar/x", c.ref_urls)
         self.assertNotIn("https://techcrunch.com/article", c.ref_urls)
+
+    def test_refs_with_urls_excludes_title_only_entries(self):
+        """Title-only refs (no <a>) must not count toward refs_with_urls.
+        Stops the '20 title-only refs' attack on refs-min gate."""
+        body = (
+            '<article>'
+            '<ol class="ara-refs">'
+            '<li id="ref-1"><a href="https://arxiv.org/abs/1">paper 1</a></li>'
+            # title-only entry
+            '<li id="ref-2">Personal communication, Smith 2024</li>'
+            # entry with non-http anchor (e.g. internal hash) — also excluded
+            '<li id="ref-3"><a href="#footnote">footnote</a></li>'
+            '<li id="ref-4"><a href="https://sec.gov/x">filing</a></li>'
+            '</ol>'
+            '</article>'
+        )
+        c = chk._ReferenceHrefCollector()
+        c.feed(body)
+        # 2 URL-bearing refs, 4 total ref-li elements
+        self.assertEqual(c.refs_with_urls, 2)
+        self.assertEqual(len(c.ref_urls), 2)
+
+    def test_count_references_uses_url_bearing_count(self):
+        """20 title-only refs must NOT pass --refs-min 20."""
+        title_only = "".join(
+            f'<li id="ref-{i + 1}">Just a title, no link.</li>'
+            for i in range(20)
+        )
+        body = (
+            '<article class="ara-doc"><p>Body.</p>'
+            f'<ol class="ara-refs">{title_only}</ol>'
+            '</article>'
+        )
+        # Old behavior: count_references returns 20 (would pass refs-min 20).
+        # New behavior: returns 0 (no URL-bearing entries).
+        self.assertEqual(chk.count_references(body), 0)
+        errs = chk.enforce_quality(body, _ns(refs_min=20))
+        self.assertEqual(len(errs), 1)
+        self.assertIn("reference entries", errs[0])
 
 
 class EnforceQualityCompositionTest(unittest.TestCase):
@@ -413,6 +453,33 @@ class VerifierFindingsAuditTest(unittest.TestCase):
                 "Cite-stripped probe should match cite-stripped body and "
                 "FAIL the audit. Without P2 fix, this returns surviving=[] "
                 "(false pass).",
+            )
+
+    def test_demoted_claim_with_inline_markup_passes(self):
+        """When the demoted sentence contains inline markup like <em>,
+        <strong>, <a>, the mark blob carries those tags but the
+        tag-stripped body does not. Without symmetric tag-stripping
+        on mark regions, a valid demotion fails the audit."""
+        import tempfile
+        body = (
+            '<article class="ara-doc">'
+            '<p><mark class="ara-mark">OpenAI raised <strong>$40 billion</strong> in <em>2026</em>.</mark></p>'
+            '</article>'
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            findings = self._write_findings(Path(tmp), [{
+                "id": "c1",
+                "text": "OpenAI raised $40 billion in 2026.",
+                "verdict": "unsupported",
+                "citation": None,
+            }])
+            total, surviving = chk.audit_verifier_findings(findings, body)
+            self.assertEqual(total, 1)
+            self.assertEqual(
+                len(surviving), 0,
+                "demoted claim with inline markup must be detected as "
+                "demoted (was falsely flagged surviving without the "
+                "mark-region tag-strip fix)",
             )
 
     def test_probe_matches_through_multi_cite_marker(self):

--- a/scripts/test_check_generative_research.py
+++ b/scripts/test_check_generative_research.py
@@ -387,6 +387,75 @@ class VerifierFindingsAuditTest(unittest.TestCase):
             with self.assertRaises(ValueError):
                 chk.audit_verifier_findings(path, "<article></article>")
 
+    def test_probe_matches_through_dsl_cite_marker(self):
+        """Verifier text uses [^N] (DSL form), body has rendered cite.
+        Without stripping, probe never matches → false pass.
+        With stripping, probe matches → correctly FAIL."""
+        import tempfile
+        body = (
+            '<article class="ara-doc">'
+            '<p>Nvidia hit 75 percent margin in Q4 2026'
+            '<sup><a class="ara-cite" href="#ref-12">12</a></sup>.</p>'
+            '</article>'
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            findings = self._write_findings(Path(tmp), [{
+                "id": "c1",
+                # DSL-shape: how the verifier reads it from .ara.md
+                "text": "Nvidia hit 75 percent margin in Q4 2026[^12].",
+                "verdict": "unsupported",
+                "citation": "https://...",
+            }])
+            total, surviving = chk.audit_verifier_findings(findings, body)
+            self.assertEqual(total, 1)
+            self.assertEqual(
+                len(surviving), 1,
+                "Cite-stripped probe should match cite-stripped body and "
+                "FAIL the audit. Without P2 fix, this returns surviving=[] "
+                "(false pass).",
+            )
+
+    def test_probe_matches_through_multi_cite_marker(self):
+        """Multi-cite `[^1,2,3]` form must also strip cleanly."""
+        import tempfile
+        body = (
+            '<article class="ara-doc">'
+            '<p>OpenAI raised $40 billion in 2026'
+            '<sup><a class="ara-cite" href="#ref-1">1</a></sup>'
+            '<sup><a class="ara-cite" href="#ref-2">2</a></sup>.</p>'
+            '</article>'
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            findings = self._write_findings(Path(tmp), [{
+                "id": "c2",
+                "text": "OpenAI raised $40 billion in 2026[^1,2].",
+                "verdict": "unsupported",
+                "citation": None,
+            }])
+            total, surviving = chk.audit_verifier_findings(findings, body)
+            self.assertEqual(len(surviving), 1, "multi-cite must strip too")
+
+    def test_strip_cite_markers_helper(self):
+        import re as _re
+        def collapse(s): return _re.sub(r"\s+", " ", s).strip()
+        # DSL form
+        self.assertEqual(
+            collapse(chk._strip_cite_markers("Claim with [^1] cite.")),
+            "Claim with cite.",
+        )
+        # Multi-cite
+        self.assertEqual(
+            collapse(chk._strip_cite_markers("Claim [^1,2,3] here.")),
+            "Claim here.",
+        )
+        # Rendered form
+        self.assertEqual(
+            collapse(chk._strip_cite_markers(
+                'Claim<sup><a class="ara-cite" href="#ref-9">9</a></sup> end.'
+            )),
+            "Claim end.",
+        )
+
     def test_empty_text_skipped_not_failed(self):
         import tempfile
         body = '<article><p>Something here.</p></article>'

--- a/scripts/test_check_generative_research.py
+++ b/scripts/test_check_generative_research.py
@@ -42,7 +42,13 @@ def _ns(**overrides):
 
 def _article(refs_count=0, cites_count=0, body_words=100, primary_hosts=None):
     """Build a minimal synthetic article body. By default zero refs
-    and zero cites; pass counts to populate."""
+    and zero cites; pass counts to populate.
+
+    Each ref gets a DISTINCT URL path so count_references()'s distinct-
+    URL counting works as the test expects. To inject duplicates,
+    pass primary_hosts with repeated entries (the path-suffix is what
+    makes them distinct, so passing the same host N times still yields
+    N distinct URLs in the synthetic article)."""
     body_text = " ".join(["Lorem"] * body_words)
     sup_block = "".join(
         f'<sup><a class="ara-cite" href="#ref-{i + 1}">{i + 1}</a></sup>'
@@ -50,8 +56,11 @@ def _article(refs_count=0, cites_count=0, body_words=100, primary_hosts=None):
     )
     if primary_hosts is None:
         primary_hosts = ["example.com"] * refs_count
+    # Add /{i} to each URL so the helper yields refs_count distinct URLs
+    # by default; tests that want to verify duplicate-handling should
+    # construct their own bodies inline.
     refs_lis = "".join(
-        f'<li id="ref-{i + 1}"><a href="https://{primary_hosts[i]}/x">src</a></li>'
+        f'<li id="ref-{i + 1}"><a href="https://{primary_hosts[i]}/x/{i + 1}">src</a></li>'
         for i in range(refs_count)
     )
     refs_block = (
@@ -282,12 +291,45 @@ class ReferenceHrefCollectorTest(unittest.TestCase):
             f'<ol class="ara-refs">{title_only}</ol>'
             '</article>'
         )
-        # Old behavior: count_references returns 20 (would pass refs-min 20).
-        # New behavior: returns 0 (no URL-bearing entries).
         self.assertEqual(chk.count_references(body), 0)
         errs = chk.enforce_quality(body, _ns(refs_min=20))
         self.assertEqual(len(errs), 1)
         self.assertIn("reference entries", errs[0])
+
+    def test_count_references_counts_distinct_urls(self):
+        """20 refs all pointing to the same URL must NOT pass --refs-min 20.
+        Workflow target is '20 DISTINCT source URLs', so duplicates can't
+        satisfy the gate."""
+        same_url = "".join(
+            f'<li id="ref-{i + 1}"><a href="https://arxiv.org/abs/2401.00001">paper</a></li>'
+            for i in range(20)
+        )
+        body = (
+            '<article class="ara-doc"><p>Body.</p>'
+            f'<ol class="ara-refs">{same_url}</ol>'
+            '</article>'
+        )
+        # All 20 li elements have URLs but only 1 distinct URL → count = 1.
+        self.assertEqual(chk.count_references(body), 1)
+        errs = chk.enforce_quality(body, _ns(refs_min=20))
+        self.assertEqual(len(errs), 1, "duplicate URL spam must fail refs-min")
+
+    def test_url_normalization_for_distinct_counting(self):
+        """www prefix, trailing slash, default port, case → normalized.
+        Scheme (http vs https) is intentionally kept distinct."""
+        self.assertEqual(
+            chk._normalize_url("https://www.example.com/x"),
+            chk._normalize_url("https://EXAMPLE.com/x/"),
+        )
+        self.assertEqual(
+            chk._normalize_url("https://example.com:443/x"),
+            chk._normalize_url("https://example.com/x"),
+        )
+        # Different paths remain distinct
+        self.assertNotEqual(
+            chk._normalize_url("https://example.com/a"),
+            chk._normalize_url("https://example.com/b"),
+        )
 
 
 class EnforceQualityCompositionTest(unittest.TestCase):
@@ -454,6 +496,60 @@ class VerifierFindingsAuditTest(unittest.TestCase):
                 "FAIL the audit. Without P2 fix, this returns surviving=[] "
                 "(false pass).",
             )
+
+    def test_duplicate_occurrences_partial_demotion_fails(self):
+        """When the same unsupported claim appears N times and only 1
+        copy is wrapped in <mark>, the OTHER copies still survive
+        outside a mark region — audit must fail. The pre-fix
+        `probe in mark_norm` test would pass because the probe exists
+        somewhere in the mark blob."""
+        import tempfile
+        body = (
+            '<article class="ara-doc">'
+            # First occurrence wrapped in mark (demoted)
+            '<p><mark class="ara-mark">Nvidia hit 75 percent margin in Q4 2026.</mark></p>'
+            # Second occurrence unwrapped (still surviving — should fail)
+            '<p>Nvidia hit 75 percent margin in Q4 2026.</p>'
+            '</article>'
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            findings = self._write_findings(Path(tmp), [{
+                "id": "c1",
+                "text": "Nvidia hit 75 percent margin in Q4 2026.",
+                "verdict": "unsupported",
+                "citation": None,
+            }])
+            total, surviving = chk.audit_verifier_findings(findings, body)
+            self.assertEqual(total, 1)
+            self.assertEqual(
+                len(surviving), 1,
+                "When 2 occurrences exist and only 1 is demoted, the "
+                "other survives — audit must fail. Without the count-"
+                "based fix, the old `probe in mark_norm` returned True "
+                "and the audit would falsely pass.",
+            )
+            self.assertEqual(surviving[0]['body_occurrences'], 2)
+            self.assertEqual(surviving[0]['mark_occurrences'], 1)
+
+    def test_duplicate_occurrences_all_demoted_passes(self):
+        """When the same claim appears N times and ALL N are demoted,
+        the audit correctly passes."""
+        import tempfile
+        body = (
+            '<article class="ara-doc">'
+            '<p><mark class="ara-mark">Nvidia hit 75 percent margin in Q4 2026.</mark></p>'
+            '<p><mark class="ara-mark">Nvidia hit 75 percent margin in Q4 2026.</mark></p>'
+            '</article>'
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            findings = self._write_findings(Path(tmp), [{
+                "id": "c1",
+                "text": "Nvidia hit 75 percent margin in Q4 2026.",
+                "verdict": "unsupported",
+                "citation": None,
+            }])
+            total, surviving = chk.audit_verifier_findings(findings, body)
+            self.assertEqual(surviving, [])
 
     def test_demoted_claim_with_inline_markup_passes(self):
         """When the demoted sentence contains inline markup like <em>,

--- a/scripts/write_generative_research.py
+++ b/scripts/write_generative_research.py
@@ -522,6 +522,40 @@ def main(argv: list[str] | None = None) -> int:
         default=str(Path(__file__).resolve().parent.parent),
         help="repo root (default: parent of scripts/)",
     )
+    # Research-quality gates — same flags as scripts/check_generative_research.py.
+    # When set, the writer re-validates the compiled body AFTER validate_body()
+    # and BEFORE allocating the slug + writing files. A failure here aborts
+    # before any disk state changes so retries start clean. The workflow passes
+    # the same flags to both check_generative_research and write_generative_research
+    # to guarantee local-vs-CI behavior matches.
+    p.add_argument(
+        "--cite-density-min",
+        type=float,
+        default=None,
+        metavar="FLOAT",
+        help="fail commit if cite density < N citations per 1,000 words",
+    )
+    p.add_argument(
+        "--refs-min",
+        type=int,
+        default=None,
+        metavar="INT",
+        help="fail commit if references list has < N entries",
+    )
+    p.add_argument(
+        "--primary-share-min",
+        type=float,
+        default=None,
+        metavar="FLOAT",
+        help="fail commit if < FLOAT (0-1) of references are primary sources",
+    )
+    p.add_argument(
+        "--cited-claims-min",
+        type=float,
+        default=None,
+        metavar="FLOAT",
+        help="fail commit if < FLOAT (0-1) of substantive sentences carry a cite",
+    )
     args = p.parse_args(argv)
 
     repo = Path(args.repo_root).resolve()
@@ -539,6 +573,34 @@ def main(argv: list[str] | None = None) -> int:
     else:
         body = raw
     validate_body(body, args.kind)
+
+    # Research-quality gates (mirror check_generative_research.py flags).
+    # Only fires when at least one threshold is explicitly set. The check
+    # script is the source of truth for the heuristics; we import it here
+    # rather than reimplement so behavior cannot drift between local-check
+    # and commit-time enforcement.
+    if args.kind == KIND_FRAGMENT and any(
+        v is not None for v in (
+            args.cite_density_min,
+            args.refs_min,
+            args.primary_share_min,
+            args.cited_claims_min,
+        )
+    ):
+        # Defer import so the writer has no hard dependency on the check
+        # module unless quality gates are requested.
+        from check_generative_research import enforce_quality  # noqa: E402
+        errs = enforce_quality(body, args)
+        if errs:
+            print(
+                "write_generative_research: quality gate(s) failed; "
+                "REFUSING to commit. Fix the article and retry.",
+                file=sys.stderr,
+            )
+            for line in errs:
+                print(f"  - {line}", file=sys.stderr)
+            raise SystemExit(1)
+
     if not body.endswith("\n"):
         body += "\n"
 

--- a/scripts/write_generative_research.py
+++ b/scripts/write_generative_research.py
@@ -619,11 +619,17 @@ def main(argv: list[str] | None = None) -> int:
     # picks the final slug (appending `-2`, `-3`, ... if taken) inside the
     # critical section, so the slug is guaranteed unique against the file's
     # state at write time. See append_index_atomically().
-    written_html = False
-    written_source: Path | None = None
+    #
+    # Track the actual paths we wrote (with the FINAL allocated slug, which
+    # may be base_slug-2 / -3 / ...). If the index rewrite fails after the
+    # HTML/DSL files were written, the except branch removes the orphans —
+    # so the cleanup must reference the real paths, not derive them from
+    # base_slug (which would miss `foo-2.html`).
+    written_html_path: Path | None = None
+    written_source_path: Path | None = None
     try:
         def _build_row(final_slug: str) -> dict:
-            nonlocal written_html, written_source
+            nonlocal written_html_path, written_source_path
             filename = f"{stamp}--{final_slug}.html"
             html_path = gen_dir / filename
             if html_path.exists():
@@ -634,14 +640,14 @@ def main(argv: list[str] | None = None) -> int:
                     f"refusing to overwrite existing file: {html_path}"
                 )
             html_path.write_text(body, encoding="utf-8")
-            written_html = True
+            written_html_path = html_path
             if is_dsl:
                 source_path = gen_dir / f"{stamp}--{final_slug}.ara.md"
                 source_path.write_text(
                     raw if raw.endswith("\n") else raw + "\n",
                     encoding="utf-8",
                 )
-                written_source = source_path
+                written_source_path = source_path
             return {
                 "slug": final_slug,
                 "file": filename,
@@ -657,17 +663,19 @@ def main(argv: list[str] | None = None) -> int:
         slug, index = append_index_atomically(index_path, base_slug, _build_row)
     except BaseException:
         # If the locked append failed AFTER we wrote the HTML / DSL source,
-        # remove the orphans so a retry starts clean. (The index either
-        # never appended, or atomic_write_json's tmp file was cleaned up by
-        # its own except branch — both safe to redo.)
-        if written_html:
+        # remove the orphans so a retry starts clean. We use the ACTUAL
+        # written paths captured by _build_row, not paths derived from
+        # base_slug — the allocated slug may be `base_slug-2`/`-3`/... so
+        # deriving from base_slug would miss the real orphan and leave it
+        # in the worktree forever.
+        if written_html_path is not None:
             try:
-                (gen_dir / f"{stamp}--{base_slug}.html").unlink(missing_ok=True)
+                written_html_path.unlink(missing_ok=True)
             except OSError:
                 pass
-        if written_source is not None:
+        if written_source_path is not None:
             try:
-                written_source.unlink(missing_ok=True)
+                written_source_path.unlink(missing_ok=True)
             except OSError:
                 pass
         raise
@@ -678,9 +686,9 @@ def main(argv: list[str] | None = None) -> int:
     print(f"updated {index_path.relative_to(repo)} ({len(index)} entries)")
 
     files_to_commit = [html_path, index_path]
-    if written_source is not None:
-        print(f"wrote {written_source.relative_to(repo)} (DSL source)")
-        files_to_commit.insert(1, written_source)
+    if written_source_path is not None:
+        print(f"wrote {written_source_path.relative_to(repo)} (DSL source)")
+        files_to_commit.insert(1, written_source_path)
 
     if not args.no_commit:
         git_commit(

--- a/scripts/write_generative_research.py
+++ b/scripts/write_generative_research.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import argparse
 import difflib
+import fcntl
 import html.parser
 import json
 import math
@@ -74,12 +75,25 @@ def _components_md_path() -> Path:
 def load_valid_classes() -> set[str]:
     """Parse COMPONENTS.md for every documented ara-* class (including
     modifier forms like ara-callout--info). Cached after first call so
-    we don't re-read the file for every validated article in a batch."""
+    we don't re-read the file for every validated article in a batch.
+
+    Raises loudly if the file is missing or no classes can be parsed.
+    Previously this returned an empty set, which caused the validator
+    to silently reject EVERY article with "undocumented class" — a
+    silent system failure when COMPONENTS.md was renamed/moved/corrupted.
+    """
     global _VALID_CLASSES_CACHE
     if _VALID_CLASSES_CACHE is not None:
         return _VALID_CLASSES_CACHE
     md_path = _components_md_path()
-    text = md_path.read_text(encoding="utf-8") if md_path.exists() else ""
+    if not md_path.exists():
+        raise RuntimeError(
+            f"COMPONENTS.md not found at {md_path}. The fragment validator "
+            f"parses the ara-* class vocabulary from this file; without it "
+            f"every article would be rejected as 'undocumented class'. "
+            f"Restore the file or set _COMPONENTS_MD_PATH for tests."
+        )
+    text = md_path.read_text(encoding="utf-8")
     # Only the component vocabulary table is authoritative. COMPONENTS.md
     # also contains explicit anti-examples like `ara-grid`; scraping every
     # backticked ara-* token would incorrectly make those valid classes.
@@ -88,6 +102,13 @@ def load_valid_classes() -> set[str]:
         m = re.match(r"\|\s*`(ara-[a-z0-9-]+)`\s*\|", line)
         if m:
             found.add(m.group(1))
+    if not found:
+        raise RuntimeError(
+            f"COMPONENTS.md at {md_path} parsed to ZERO ara-* classes. "
+            f"The vocabulary table format may have changed (expected lines "
+            f"like '| `ara-foo` | ...'). Without classes loaded, every "
+            f"article would be silently rejected."
+        )
     _VALID_CLASSES_CACHE = found
     return found
 
@@ -360,6 +381,8 @@ def atomic_write_json(path: Path, data) -> None:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2, ensure_ascii=False)
             f.write("\n")
+            f.flush()
+            os.fsync(f.fileno())
         os.replace(tmp, path)
     except Exception:
         try:
@@ -379,6 +402,84 @@ def load_index(path: Path) -> list:
     if not isinstance(data, list):
         raise ValueError(f"{path} is not a JSON array")
     return data
+
+
+def _parse_index_text(text: str, path: Path) -> list:
+    """Parse JSON-array index text. Empty/whitespace-only treated as []."""
+    text = text.strip()
+    if not text:
+        return []
+    data = json.loads(text)
+    if not isinstance(data, list):
+        raise ValueError(f"{path} is not a JSON array")
+    return data
+
+
+def append_index_atomically(index_path: Path, base_slug: str, row_builder) -> tuple[str, list]:
+    """Read-modify-write `index.json` under an exclusive file lock.
+
+    Two concurrent invocations of write_generative_research.py on the same
+    machine used to race here: each read a snapshot, derived a unique slug
+    against that snapshot, and both wrote back the full array. The second
+    writer's write-back wiped the first writer's appended row. The workflow's
+    post-push union-by-slug merge only repairs damage that survives to the
+    push step.
+
+    Locking strategy:
+      * fcntl.flock(LOCK_EX) on a SEPARATE lockfile next to index.json.
+        Locking on index.json itself would not work: os.replace() rotates
+        the file to a fresh inode, so subsequent writers would open the
+        new inode (no lock) and miss the critical section. The lockfile
+        is created once and never renamed.
+      * Inside the locked region we re-read index.json — any earlier
+        in-memory snapshot is stale by definition.
+      * Slug uniqueness is decided against the LIVE on-disk index, then
+        the row is appended and the file is rewritten via
+        atomic_write_json (os.replace).
+
+    Args:
+      index_path: research/generative/index.json
+      base_slug:  slug stem; we append `-2`, `-3`, ... if the locked snapshot
+                  already contains it.
+      row_builder: callable(final_slug: str) -> dict — builds the index row
+                   once we've allocated a unique slug under the lock. Any
+                   side effects (writing the HTML/DSL files) should happen
+                   INSIDE the builder so they are also serialized.
+
+    Returns: (final_slug, updated_index)
+    """
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    if not index_path.exists():
+        index_path.write_text("[]\n", encoding="utf-8")
+    lock_path = index_path.with_suffix(index_path.suffix + ".lock")
+    # Open the lockfile with O_CREAT — multiple processes share the same
+    # underlying inode. flock is advisory and POSIX-only (Linux runner +
+    # macOS dev). Windows would need msvcrt.locking; not supported here.
+    lock_fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
+    try:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        # Re-read inside the lock — sibling writers may have appended
+        # since the caller looked at the file.
+        current = _parse_index_text(
+            index_path.read_text(encoding="utf-8"), index_path
+        )
+        existing_slugs = {
+            row.get("slug") for row in current if isinstance(row, dict)
+        }
+        slug = base_slug
+        n = 2
+        while slug in existing_slugs:
+            slug = f"{base_slug}-{n}"
+            n += 1
+        row = row_builder(slug)
+        current.append(row)
+        atomic_write_json(index_path, current)
+    finally:
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        finally:
+            os.close(lock_fd)
+    return slug, current
 
 
 def git_commit(repo: Path, files: list[Path], message: str) -> None:
@@ -449,49 +550,75 @@ def main(argv: list[str] | None = None) -> int:
     iso = now.isoformat().replace("+00:00", "Z")
 
     index_path = gen_dir / "index.json"
-    index = load_index(index_path)
 
-    # Slug is the dashboard's hash route key, so it must be unique across the index.
-    existing_slugs = {row.get("slug") for row in index if isinstance(row, dict)}
-    slug = base_slug
-    n = 2
-    while slug in existing_slugs:
-        slug = f"{base_slug}-{n}"
-        n += 1
+    # Slug uniqueness + index-array mutation happen under fcntl.LOCK_EX so
+    # two concurrent writers cannot both observe slug `foo`, write `foo.html`,
+    # and clobber each other's index entry. The lock-and-mutate helper also
+    # picks the final slug (appending `-2`, `-3`, ... if taken) inside the
+    # critical section, so the slug is guaranteed unique against the file's
+    # state at write time. See append_index_atomically().
+    written_html = False
+    written_source: Path | None = None
+    try:
+        def _build_row(final_slug: str) -> dict:
+            nonlocal written_html, written_source
+            filename = f"{stamp}--{final_slug}.html"
+            html_path = gen_dir / filename
+            if html_path.exists():
+                # Extremely unlikely now that slug uniqueness is locked,
+                # but stamp+slug collision is still theoretically possible
+                # if two runs in the same second pick the same slug. Bail.
+                raise SystemExit(
+                    f"refusing to overwrite existing file: {html_path}"
+                )
+            html_path.write_text(body, encoding="utf-8")
+            written_html = True
+            if is_dsl:
+                source_path = gen_dir / f"{stamp}--{final_slug}.ara.md"
+                source_path.write_text(
+                    raw if raw.endswith("\n") else raw + "\n",
+                    encoding="utf-8",
+                )
+                written_source = source_path
+            return {
+                "slug": final_slug,
+                "file": filename,
+                "kind": args.kind,
+                "title": title,
+                "model": args.model,
+                "created_at": iso,
+                "source": args.source,
+                "prompt": args.prompt or args.topic,
+                "tags": tags,
+            }
+
+        slug, index = append_index_atomically(index_path, base_slug, _build_row)
+    except BaseException:
+        # If the locked append failed AFTER we wrote the HTML / DSL source,
+        # remove the orphans so a retry starts clean. (The index either
+        # never appended, or atomic_write_json's tmp file was cleaned up by
+        # its own except branch — both safe to redo.)
+        if written_html:
+            try:
+                (gen_dir / f"{stamp}--{base_slug}.html").unlink(missing_ok=True)
+            except OSError:
+                pass
+        if written_source is not None:
+            try:
+                written_source.unlink(missing_ok=True)
+            except OSError:
+                pass
+        raise
 
     filename = f"{stamp}--{slug}.html"
     html_path = gen_dir / filename
-    if html_path.exists():
-        raise SystemExit(f"refusing to overwrite existing file: {html_path}")
-
-    row = {
-        "slug": slug,
-        "file": filename,
-        "kind": args.kind,
-        "title": title,
-        "model": args.model,
-        "created_at": iso,
-        "source": args.source,
-        "prompt": args.prompt or args.topic,
-        "tags": tags,
-    }
-    index.append(row)
-
-    html_path.write_text(body, encoding="utf-8")
-    atomic_write_json(index_path, index)
-
     print(f"wrote {html_path.relative_to(repo)}")
     print(f"updated {index_path.relative_to(repo)} ({len(index)} entries)")
 
     files_to_commit = [html_path, index_path]
-    if is_dsl:
-        # Store the source next to the artifact so future edits and
-        # backfills don't have to re-derive the DSL from the compiled
-        # HTML. Filename: <stamp>--<slug>.ara.md.
-        source_path = gen_dir / f"{stamp}--{slug}.ara.md"
-        source_path.write_text(raw if raw.endswith("\n") else raw + "\n", encoding="utf-8")
-        print(f"wrote {source_path.relative_to(repo)} (DSL source)")
-        files_to_commit.insert(1, source_path)
+    if written_source is not None:
+        print(f"wrote {written_source.relative_to(repo)} (DSL source)")
+        files_to_commit.insert(1, written_source)
 
     if not args.no_commit:
         git_commit(


### PR DESCRIPTION
## Summary

Converts three aspirational behaviors in the generative-research pipeline into deterministic gates:

1. **Race-safe index.json mutation** — `scripts/write_generative_research.py` now serializes `research/generative/index.json` read-modify-write under `fcntl.LOCK_EX` on a sibling lockfile. Two concurrent writers used to race: each read a snapshot, allocated a slug against stale data, and the second writer's write-back overwrote the first writer's appended row. A 5-process subprocess race test now produces 5 unique slugs and zero lost rows (previously: 1 row). `load_valid_classes()` raises loudly when COMPONENTS.md is missing or parses to zero classes — previously returned empty set and the validator silently rejected every article as "undocumented class".

2. **Quality targets are now build gates** — the workflow prompt's `QUALITY TARGETS` block ("≥12 cites per 1000 words, ≥20 refs, ≥50% primary, ≥90% cited claims") was prose only. Corpus audit (`research/generative/*.html`) found **4 articles shipped with literally zero citations**, and 3 more with mid-single-digit reference counts. Added 4 opt-in CLI flags to `scripts/check_generative_research.py` with matching flags in `scripts/write_generative_research.py` so local-check and commit-time-check can't drift:
   - `--cite-density-min FLOAT` (cites per 1,000 words)
   - `--refs-min INT` (DISTINCT URL count in references list — codex-tightened: title-only spam and URL-duplicate spam both fail)
   - `--primary-share-min FLOAT` (share of refs from primary hosts — defined in `PRIMARY_HOST_SUFFIXES`)
   - `--cited-claims-min FLOAT` (share of substantive sentences with a cite marker — heuristic, documented limits)

   Workflow now wires `--cite-density-min 10 --refs-min 20` into:
   - the agent's compile-check loop (step 7.5 of both Claude and DeepSeek prompts)
   - the writer's commit-time gate (step 9 of both prompts)
   - a **new post-write workflow step** that runs the same check against the committed file (third pass — survives agent flag-drift)

   `primary-share-min` and `cited-claims-min` are available but NOT yet wired into the operational gate. Corpus shows primary-share would over-eject good articles (most run 25-40% even with real effort), and cited-claims tops out at ~58% in the best corpus article — the spec's 0.9 default is aspirational. Both flags exist; calibrate before raising the bar.

3. **Verifier output captured as auditable JSON** — the verifier sub-agent's findings used to live in the action's chat context only. The "bounded revision" pass was faith-based: no way to verify whether the agent actually addressed the unsupported claims it flagged. The verifier prompt (both Claude and DeepSeek prompt blocks) now MUST also write `$GITHUB_WORKSPACE/.gen-verifier-findings.json` with shape `{"claims": [{"id", "text", "verdict", "citation"}, ...]}`. A new deterministic workflow step (`Verifier-findings audit`) and matching `audit_verifier_findings()` function + `--audit-verifier-findings PATH` CLI flag in `check_generative_research.py` audit the final committed body. If any `unsupported` claim survives without being demoted (`<mark>`) or removed, the build fails. Soft-fail when JSON is absent (tighten to hard-fail once verifier reliability is confirmed).

## Sanity test

The task explicitly named `research/generative/2026-05-16T085517--cerebras-wse-3-vs-nvidia-gb200-cost-per-token-economics.html` as a high-quality article that must pass the gates. It does.

Full corpus validation (24 articles) at the workflow defaults `--cite-density-min 10 --refs-min 20`:
- **14 PASS** — every recent 100+ cite, 30+ ref article
- **10 FAIL** — the 4 zero-citation articles, the components fixture (1 cite, intentionally a visual reference), 4 early low-cite articles, and natera (13 refs)

**Task's "7 historical articles with 0 citations" was loose recall.** Actual breakdown:
- 4 articles with literal 0 cites / 0 refs (xmaquina-intelligence, xmaquina-project, akamai-brief, why-generative meta)
- 1 components fixture (1 cite / 1 ref by design)
- 3 early articles at 16 cites / 9-12 refs each (research-situational, spacex-ipo, cerebras-early)
- 1 mid-quality at 37 cites / 34 refs but density 8.7 (aschenbrenner — borderline)
- 1 short article at 44 cites / 13 refs (natera — fails refs-min only)

The 4 literal-zero-cite articles are the clearest historical failures; the remaining 6 surface the gradient.

## Codex review

3 review passes, each smaller in severity:

- **Pass 1**: 1 P1 + 2 P2 → fixed in `be98b2f`
  - [P1] Push step `if: always()` ignored quality-gate failures and published bad articles
  - [P2] verifier-audit didn't normalize DSL `[^N]` vs rendered `<sup>` cite markers
  - [P3] suffixed-slug orphan cleanup used base_slug instead of allocated slug
- **Pass 2**: 3 P2 → fixed in `0b9f943`
  - mark-region tag-stripping asymmetry; refs-min didn't require URLs; stale verifier JSON across retries
- **Pass 3**: 2 P2 → fixed in `23ff601`
  - refs-min URL-duplicate spam; verifier-audit `probe in mark_norm` false-passed partial demotion of duplicates

After Pass 3 the issues were getting smaller, stopped per the advisor.

## Heuristic limits (documented in code)

- `cited_claim_share()` counts every sentence with a digit/$/%/named-entity as "substantive" — high false-positive on section headings. Workflow does NOT wire this gate yet.
- `audit_verifier_findings()` whole-claim-demotion semantics: if the agent demotes only a load-bearing substring inside a longer sentence, the audit reports the claim as surviving. Pushes the agent toward marking the whole sentence.
- `audit_verifier_findings()` paraphrase-on-revision: if the agent rewrites the claim text, the probe won't match → treated as "removed" → pass. Acceptable.
- Verifier audit is soft-fail when JSON is missing. Once verifier consistently emits, tighten to hard-fail.

## Test plan

- [x] All 18 existing `test_ara_dsl.py` tests pass
- [x] 43 new tests in `test_check_generative_research.py` (heuristics, audit semantics, sanity)
- [x] 5-way concurrent subprocess race test (no lost rows, slugs unique)
- [x] CLI smoke test: writer rejects bad article, no orphan files; cerebras article passes
- [x] CLI smoke test: `--audit-verifier-findings` PASS for demoted/removed, FAIL for survived
- [x] Workflow YAML validates with PyYAML
- [x] Corpus sanity: cerebras-wse-3 passes, 4 zero-cite articles fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)