### PR TITLE
refactor: migrate stateless workflows to ubuntu-latest to free self-hosted queue

### DIFF
--- a/.github/workflows/2h-bluesky.yml
+++ b/.github/workflows/2h-bluesky.yml
@@ -152,9 +152,24 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Retry loop: parallel ubuntu-latest writers can race on `main`.
+          # The self-hosted runner serialized everything so this never
+          # collided; ubuntu-latest does not. Without the retry, a
+          # non-fast-forward push would be silently swallowed by `|| echo`,
+          # losing the just-written research artifact. If Claude didn't
+          # commit anything (no new content), HEAD == origin/main after
+          # the rebase and `git push` is a no-op.
           git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git
-          git pull --rebase || true
-          git push || echo "Nothing to push"
+          for i in 1 2 3 4 5; do
+            git fetch origin main \
+              && git pull --rebase origin main \
+              && git push origin HEAD:main \
+              && exit 0
+            echo "Push attempt $i failed (likely race with another writer), retrying..."
+            sleep $(( i * 5 + RANDOM % 5 ))
+          done
+          echo "Push failed after 5 retries" >&2
+          exit 1
 
       - name: Publish Hooker workflow telemetry
         if: always()

--- a/.github/workflows/2h-bluesky.yml
+++ b/.github/workflows/2h-bluesky.yml
@@ -12,7 +12,8 @@ concurrency:
 
 jobs:
   bluesky-feed:
-    runs-on: [self-hosted, Linux]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,8 @@ jobs:
     # trigger with a `pr_number` input in a follow-up).
     if: contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
 
-    runs-on: [self-hosted, Linux]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -27,7 +27,8 @@ jobs:
       (github.event_name == 'issues' &&
         (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
         contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
-    runs-on: [self-hosted, Linux]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/daily-arxiv.yml
+++ b/.github/workflows/daily-arxiv.yml
@@ -12,7 +12,8 @@ concurrency:
 
 jobs:
   arxiv-research:
-    runs-on: [self-hosted, Linux]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/daily-arxiv.yml
+++ b/.github/workflows/daily-arxiv.yml
@@ -148,9 +148,24 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Retry loop: parallel ubuntu-latest writers can race on `main`.
+          # The self-hosted runner serialized everything so this never
+          # collided; ubuntu-latest does not. Without the retry, a
+          # non-fast-forward push would be silently swallowed by `|| echo`,
+          # losing the just-written research artifact. If Claude didn't
+          # commit anything (no new content), HEAD == origin/main after
+          # the rebase and `git push` is a no-op.
           git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git
-          git pull --rebase || true
-          git push || echo "Nothing to push"
+          for i in 1 2 3 4 5; do
+            git fetch origin main \
+              && git pull --rebase origin main \
+              && git push origin HEAD:main \
+              && exit 0
+            echo "Push attempt $i failed (likely race with another writer), retrying..."
+            sleep $(( i * 5 + RANDOM % 5 ))
+          done
+          echo "Push failed after 5 retries" >&2
+          exit 1
 
       - name: Read summary for Telegram
         id: summary

--- a/.github/workflows/daily-improve.yml
+++ b/.github/workflows/daily-improve.yml
@@ -12,7 +12,8 @@ concurrency:
 
 jobs:
   self-improve:
-    runs-on: [self-hosted, Linux]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/hourly-rss.yml
+++ b/.github/workflows/hourly-rss.yml
@@ -199,9 +199,24 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Retry loop: parallel ubuntu-latest writers can race on `main`.
+          # The self-hosted runner serialized everything so this never
+          # collided; ubuntu-latest does not. Without the retry, a
+          # non-fast-forward push would be silently swallowed by `|| echo`,
+          # losing the just-written research artifact. If Claude didn't
+          # commit anything (no new content), HEAD == origin/main after
+          # the rebase and `git push` is a no-op.
           git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git
-          git pull --rebase || true
-          git push || echo "Nothing to push"
+          for i in 1 2 3 4 5; do
+            git fetch origin main \
+              && git pull --rebase origin main \
+              && git push origin HEAD:main \
+              && exit 0
+            echo "Push attempt $i failed (likely race with another writer), retrying..."
+            sleep $(( i * 5 + RANDOM % 5 ))
+          done
+          echo "Push failed after 5 retries" >&2
+          exit 1
 
       - name: Publish Hooker workflow telemetry
         if: always()

--- a/.github/workflows/hourly-rss.yml
+++ b/.github/workflows/hourly-rss.yml
@@ -12,7 +12,8 @@ concurrency:
 
 jobs:
   rss-feed:
-    runs-on: [self-hosted, Linux]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
       id-token: write

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,10 +56,26 @@ and opens a PR with methodology fixes.
 
 ## GitHub Actions Workflows
 
-All workflows use `runs-on: [self-hosted, Linux]`. There is no
-GitHub-hosted fallback. Claude workflows use
-`anthropics/claude-code-action@v1` with the model passed via
-`claude_args: "--model opus"` (never as a separate `model:` input).
+Workflows split between two runners:
+
+- **`runs-on: ubuntu-latest`** — stateless workflows (no bird-CLI state,
+  no LFS hydration, no Puppeteer/Chrome, no warm caches). These run on
+  GitHub-hosted runners so they don't queue behind the single self-hosted
+  job slot. Currently: `hourly-rss.yml`, `daily-arxiv.yml`,
+  `2h-bluesky.yml`, `daily-improve.yml`, `claude-code-review.yml`,
+  `claude.yml`, `liveness-check.yml`.
+- **`runs-on: [self-hosted, Linux]`** — workflows that genuinely need
+  the self-hosted runner's persistent state (bird CLI + birdy daemon,
+  LFS-hydrated `research/` checkout, Puppeteer/Chrome, large agent
+  pipelines). Currently: `hourly-twitter.yml`,
+  `hourly-twitter-deepseek-*.yml`, `daily-digest.yml`,
+  `daily-front-page.yml`, `generative-research.yml`,
+  `24h-model-timeline.yml`, `ai-news-research.yml`, `ci.yml`,
+  `research-issue.yml`, `4h-community.yml`.
+
+Claude workflows use `anthropics/claude-code-action@v1` with the model
+passed via `claude_args: "--model opus"` (never as a separate `model:`
+input).
 
 ### Aggregation (raw signal → `research/<source>/`)
 
@@ -183,10 +199,21 @@ output or break the pipeline. Read them before editing.
    `continue-on-error: true` style. Don't add hard dependencies on
    telemetry success.
 
-5. **Self-hosted runner is the only target.** All workflows pin
-   `runs-on: [self-hosted, Linux]`. Don't switch to
-   `ubuntu-latest`; the runner has bird CLI, yfinance, pnpm/Oracle,
-   and the right cookies/secrets baked in.
+5. **Runner choice is load-bearing — pick by state dependency.** Two
+   runners, two rules:
+   - **Self-hosted** for workflows that depend on baked-in state: bird
+     CLI + warm birdy daemon (`hourly-twitter*`, `24h-model-timeline`),
+     LFS-hydrated `research/` for prior-output context
+     (`daily-digest`, `daily-front-page`, `ci.yml` dashboard job),
+     Puppeteer/Chrome (`daily-front-page`), or pre-installed
+     pnpm/Oracle/yfinance.
+   - **`ubuntu-latest`** for stateless workflows. The self-hosted runner
+     processes one job at a time; stateless work on `ubuntu-latest`
+     frees that queue. See the "GitHub Actions Workflows" section for
+     the current split. Before flipping a workflow from self-hosted to
+     `ubuntu-latest`, verify it doesn't read pre-populated dirs, depend
+     on warm caches, or need bird/birdy state — the cost of getting
+     this wrong is a silently-broken pipeline.
 
 6. **bird CLI calls must be graceful.** Always pass `--json --plain`
    and pipe to a fallback (`|| echo "[]"`). The Twitter cookies expire;


### PR DESCRIPTION
## Why

The self-hosted Linux runner processes one job at a time. The Twitter, digest, front-page, generative-research, and model-timeline lanes all genuinely need it (warm birdy daemon, LFS-hydrated `research/` checkout, Puppeteer/Chrome, pre-installed pnpm/Oracle). The aggregation and meta-workflows that just `curl` + invoke Claude do **not** need it. They were inheriting queue latency without using any of the self-hosted capabilities.

Migrating 6 stateless workflows to `ubuntu-latest` frees the self-hosted queue for the work that genuinely needs it.

## Per-workflow verdict

| Workflow | Verdict | Reasoning |
|---|---|---|
| `hourly-rss.yml` | **GO -> ubuntu-latest** | curl-only RSS pull + Haiku/Claude processing. No warm state, no specialized binaries. |
| `daily-arxiv.yml` | **GO -> ubuntu-latest** | `npx arxiv-mcp-server` installs in seconds. No persistent state needed. |
| `2h-bluesky.yml` | **GO -> ubuntu-latest** | curl Bluesky public REST API. Pure stateless. |
| `daily-improve.yml` | **GO -> ubuntu-latest** | `gh` CLI pre-installed on ubuntu-latest. Pushes to `improve/YYYY-MM-DD` branches, not `main`. |
| `claude-code-review.yml` | **GO -> ubuntu-latest** | Single Claude action run on PR diff. No persistent state. |
| `claude.yml` | **GO -> ubuntu-latest** | Single Claude action run on `@claude` mentions. No persistent state. |
| `hourly-twitter*.yml` | **NO-GO** (out of scope) | Warm birdy daemon + bird-CLI cookies baked into runner. |
| `daily-digest.yml` | **NO-GO** (out of scope) | Depends on prior twitter/rss/bluesky local files in `research/`. |
| `daily-front-page.yml` | **NO-GO** (out of scope) | Puppeteer + Chromium are pre-installed; cold-install would add 1-3 min per run. |
| `generative-research.yml` | **NO-GO** (out of scope) | Long-running multi-agent pipeline, specialized backend config. |
| `24h-model-timeline.yml` | **NO-GO** (out of scope) | Heavy bird-CLI usage; needs warm birdy. |
| `ai-news-research.yml` | **NO-GO** (out of scope) | Uses Perplexity/Exa MCP with specialized config. |
| `ci.yml` | **NO-GO** | The dashboard job uses `actions/checkout@v4` with `lfs: true`. On `ubuntu-latest` this would cold-fetch all historical PNGs/MP3s in `research/front-page/` and `research/audio/` on every run (the genuine state advantage). Also depends on pre-installed git-lfs and bun. |
| `liveness-check.yml` | **(already on ubuntu-latest)** | Intentionally — must fire when self-hosted is down. Unchanged. |

## Changes per migrated file

For each of the 6 GO workflows: `runs-on: [self-hosted, Linux]` -> `runs-on: ubuntu-latest`, plus a fresh `timeout-minutes:` (15 min for RSS/Bluesky, 30 min for the rest).

## Race fix surfaced by /codex review

Codex flagged that the 3 main-writers (hourly-rss, daily-arxiv, 2h-bluesky) now commit + push to `main` in parallel from ubuntu-latest. The self-hosted runner had implicitly serialized all jobs, so push collisions never occurred. The prior pattern `git push || echo "Nothing to push"` silently swallowed non-fast-forward failures, which under parallel execution would lose the just-written research artifact.

**Fix:** 5-attempt retry loop with jittered backoff (fetch + pull --rebase + push as one chain per attempt). Loud failure (`exit 1`) instead of silent data loss after retries exhausted, so hooker telemetry surfaces it.

The 3 non-writer migrated workflows (daily-improve pushes to feature branches; claude.yml and claude-code-review.yml have no push step) are unaffected.

## CLAUDE.md update

- "GitHub Actions Workflows" section now describes the split runner topology with which workflows live on which runner.
- Load-bearing rule #5 was previously "Self-hosted runner is the only target. Don't switch to ubuntu-latest." Replaced with state-dependency-based guidance: self-hosted for warm-cache/LFS/Puppeteer/bird needs, ubuntu-latest for stateless. Future migrations have a documented checklist to follow.

## Cost analysis (private repo, 2,000 GHA min/month free tier)

Rough monthly minute consumption on `ubuntu-latest` after this PR:

| Workflow | Runs/mo | Avg duration | Minutes/mo |
|---|---|---|---|
| hourly-rss | 720 (24/day) | ~2 min | ~1,440 |
| claude-code-review | ~30 (PR-driven) | ~5 min | ~150 |
| daily-improve | 30 | ~10 min | ~300 |
| daily-arxiv | 30 | ~5 min | ~150 |
| 2h-bluesky | 30 | ~3 min | ~90 |
| claude.yml | ~10 (mention-driven) | ~3 min | ~30 |
| liveness-check (already) | 30 | ~1 min | ~30 |
| **Total** | | | **~2,190 min/mo** |

This modestly exceeds the 2,000-min free tier. Overage on private repos is $0.008/min, so the ~190 min overage costs ~$1.50/mo. The queue-throughput gain on the self-hosted side is worth far more than that in practice.

Cold-start cost per ubuntu-latest job: ~30-60s vs ~5-10s warm self-hosted. Offset entirely by removing queue wait (the self-hosted queue could stack 5-10 hourly jobs deep during burst).

## Test plan

- [ ] Wait for next scheduled `hourly-rss` cron (`:30`) to verify ubuntu-latest run succeeds end-to-end (curl + Claude action + commit + push retry path)
- [ ] Trigger `2h-bluesky` via workflow_dispatch and confirm success on ubuntu-latest
- [ ] On the next PR opened, verify `claude-code-review.yml` runs on ubuntu-latest without losing Claude action behavior
- [ ] Watch hooker telemetry dashboard for any new `failure` alerts after merge
- [ ] Watch GitHub Actions billing / minutes-used in repo settings for the first week

## Codex /codex review verdict

- **GATE: PASS** (1 P2 advisory, addressed in commit `bf8f61e6` as the push retry loop above)
- Model: gpt-5.5 with `model_reasoning_effort=high`
- Cross-model agreement: not run (no prior `/review` in this session)