### PR TITLE
fix(dashboard): wrap and auto-shrink long donut center-labels to fit hole

### DIFF
--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -1235,20 +1235,35 @@ function wrapDonutCenterLabel(
   const clean = label.trim();
   if (!clean) return { lines: [], fontSize: maxFontSize };
 
-  const words = clean.split(/\s+/);
-  const lineCap = Math.min(maxLines, words.length);
-
-  // 1-line path first: if the whole string fits at max font, use it.
-  // This preserves the exact pre-change rendering for short labels.
-  // Uses approxSvgTextWidth with mono=true (0.62 ratio) to stay consistent
+  // 1-line fast path: if the whole string fits at max font, use it.
+  // Preserves the exact pre-change rendering for short labels.
+  // Uses approxSvgTextWidth with mono=true (0.62 ratio) for consistency
   // with the rest of the SVG-text helpers in this file.
   if (approxSvgTextWidth(clean, maxFontSize, true) <= usableWidth) {
     return { lines: [clean], fontSize: maxFontSize };
   }
 
-  // Try N = 1..lineCap. For each N, find the split that minimizes the
+  const words = clean.split(/\s+/);
+
+  // Guard against pathological input. splitWordsIntoLines is recursive and
+  // enumerates O(W^(maxLines-1)) split positions; with maxLines=3 that's
+  // O(W^2). Realistic donut center-labels are 1-4 words (the longest in
+  // the corpus is "The three-leg bottleneck" at 3 words). If a malformed
+  // ara source ever stuffs a paragraph into center-label, bypass the wrap
+  // enumeration entirely and render the whole label on a single shrunk
+  // line — better than hanging the page or silently dropping words.
+  const WORD_ENUM_CAP = 12;
+  if (words.length > WORD_ENUM_CAP) {
+    const ideal = usableWidth / Math.max(1, clean.length * 0.62);
+    const fontSize = Math.max(minFontSize, Math.min(maxFontSize, ideal));
+    return { lines: [clean], fontSize };
+  }
+
+  // Try N = 1..maxLines. For each N, find the split that minimizes the
   // widest line, then compute the largest font that fits that line.
-  // Prefer fewer lines if they can still hit the max font.
+  // Prefer the largest font (which tends to be the highest N that still
+  // fits comfortably). Short-circuit once we hit the max font.
+  const lineCap = Math.min(maxLines, words.length);
   let best: { lines: string[]; fontSize: number } | null = null;
   for (let n = 1; n <= lineCap; n++) {
     const lines = splitWordsIntoLines(words, n);
@@ -1507,13 +1522,20 @@ function renderDonuts(root: HTMLElement): void {
       const usableWidth = ri * 2 * 0.85;
       const wrapped = wrapDonutCenterLabel(centerLabel, 18, 9, usableWidth, 3);
       if (wrapped.lines.length === 1) {
-        // Preserve the original 1-line rendering bit-for-bit (font-size 18,
-        // y = cy + 1) so short labels like "2024" do not visually shift.
+        // 1-line. Two sub-cases:
+        //   - At max font (18): use the original y = cy + 1 nudge to keep
+        //     short labels like "2024" bit-identical to the pre-fix output.
+        //   - Below max font (single oversize token, e.g. "Verylongunhyphenatedword"):
+        //     respect the shrunk font and center at cy. Without this branch
+        //     the shrink fallback would be silently discarded and the label
+        //     would still overflow the donut hole.
+        const fs = wrapped.fontSize;
+        const atMax = fs >= 18;
         const text = svgEl<SVGTextElement>('text', {
           class: 'ara-donut-center-label',
           x: cx,
-          y: cy + 1,
-          'font-size': '18',
+          y: atMax ? cy + 1 : cy,
+          'font-size': atMax ? '18' : fs.toFixed(2),
         });
         text.textContent = wrapped.lines[0];
         svg.appendChild(text);

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -1188,6 +1188,85 @@ function appendSvgTitle(el: SVGElement, text: string): void {
   el.appendChild(title);
 }
 
+/** Distribute words across `lineCount` lines, minimizing the longest line
+ * (in characters, including the inter-word space). Greedy enumeration of
+ * split points; O(W^(lineCount-1)) so we cap lineCount at 3 and words at ≤8
+ * for the donut center-label case. Returns null if lineCount > words.length. */
+function splitWordsIntoLines(words: string[], lineCount: number): string[] | null {
+  if (lineCount < 1 || lineCount > words.length) return null;
+  if (lineCount === 1) return [words.join(' ')];
+
+  const widthOf = (line: string) => line.length; // monospace: width ≈ chars
+  let best: { lines: string[]; widest: number } | null = null;
+
+  // Enumerate all ways to choose (lineCount-1) split positions from
+  // (words.length-1) gaps. Recursive walk for arbitrary lineCount.
+  const walk = (startWord: number, linesLeft: number, acc: string[]) => {
+    if (linesLeft === 1) {
+      const tail = words.slice(startWord).join(' ');
+      const candidate = [...acc, tail];
+      const widest = Math.max(...candidate.map(widthOf));
+      if (!best || widest < best.widest) best = { lines: candidate, widest };
+      return;
+    }
+    // Leave at least (linesLeft - 1) words for the remaining lines.
+    const maxEnd = words.length - (linesLeft - 1);
+    for (let end = startWord + 1; end <= maxEnd; end++) {
+      const line = words.slice(startWord, end).join(' ');
+      walk(end, linesLeft - 1, [...acc, line]);
+    }
+  };
+  walk(0, lineCount, []);
+  return best ? (best as { lines: string[]; widest: number }).lines : null;
+}
+
+/** Wrap a donut center-label into up to `maxLines` lines and pick a font
+ * size that fits the widest line within `usableWidth` SVG units. Prefers
+ * fewer lines at larger fonts. Falls back to clamped `minFontSize` for a
+ * single ultra-long unhyphenated word (it will visually overflow, which
+ * is better than dropping the label). */
+function wrapDonutCenterLabel(
+  label: string,
+  maxFontSize: number,
+  minFontSize: number,
+  usableWidth: number,
+  maxLines = 3,
+): { lines: string[]; fontSize: number } {
+  const clean = label.trim();
+  if (!clean) return { lines: [], fontSize: maxFontSize };
+
+  const words = clean.split(/\s+/);
+  const lineCap = Math.min(maxLines, words.length);
+
+  // 1-line path first: if the whole string fits at max font, use it.
+  // This preserves the exact pre-change rendering for short labels.
+  // Uses approxSvgTextWidth with mono=true (0.62 ratio) to stay consistent
+  // with the rest of the SVG-text helpers in this file.
+  if (approxSvgTextWidth(clean, maxFontSize, true) <= usableWidth) {
+    return { lines: [clean], fontSize: maxFontSize };
+  }
+
+  // Try N = 1..lineCap. For each N, find the split that minimizes the
+  // widest line, then compute the largest font that fits that line.
+  // Prefer fewer lines if they can still hit the max font.
+  let best: { lines: string[]; fontSize: number } | null = null;
+  for (let n = 1; n <= lineCap; n++) {
+    const lines = splitWordsIntoLines(words, n);
+    if (!lines) continue;
+    const widestChars = Math.max(...lines.map((l) => l.length));
+    // font ≤ usableWidth / (widestChars * 0.62)
+    const ideal = usableWidth / Math.max(1, widestChars * 0.62);
+    const fontSize = Math.max(minFontSize, Math.min(maxFontSize, ideal));
+    if (!best || fontSize > best.fontSize) {
+      best = { lines, fontSize };
+    }
+    // If this N hits the cap, no point trying more lines (more lines
+    // can't beat a max-font fit at fewer lines).
+    if (fontSize >= maxFontSize) break;
+  }
+  return best ?? { lines: [clean], fontSize: minFontSize };
+}
+
 /** Build a polyline d-attribute from (x,y) pairs. */
 function pathFromPoints(points: Array<[number, number]>): string {
   if (!points.length) return '';
@@ -1422,10 +1501,45 @@ function renderDonuts(root: HTMLElement): void {
       svg.appendChild(slice);
     });
 
-    if (centerLabel) {
-      const text = svgEl<SVGTextElement>('text', { class: 'ara-donut-center-label', x: cx, y: cy + 1, 'font-size': '18' });
-      text.textContent = centerLabel;
-      svg.appendChild(text);
+    if (centerLabel.trim()) {
+      // Conservative usable width: 85% of the donut hole diameter to leave
+      // breathing room from the slices. ri = 56 → hole = 112 → usable = ~95.
+      const usableWidth = ri * 2 * 0.85;
+      const wrapped = wrapDonutCenterLabel(centerLabel, 18, 9, usableWidth, 3);
+      if (wrapped.lines.length === 1) {
+        // Preserve the original 1-line rendering bit-for-bit (font-size 18,
+        // y = cy + 1) so short labels like "2024" do not visually shift.
+        const text = svgEl<SVGTextElement>('text', {
+          class: 'ara-donut-center-label',
+          x: cx,
+          y: cy + 1,
+          'font-size': '18',
+        });
+        text.textContent = wrapped.lines[0];
+        svg.appendChild(text);
+      } else if (wrapped.lines.length > 1) {
+        // Multi-line: center the block vertically around cy. With
+        // dominant-baseline: middle (from CSS), each tspan's y is its
+        // vertical center. Stack lines with lineHeight = fontSize * 1.1.
+        const fs = wrapped.fontSize;
+        const lineHeight = fs * 1.1;
+        const firstY = cy - ((wrapped.lines.length - 1) * lineHeight) / 2;
+        const text = svgEl<SVGTextElement>('text', {
+          class: 'ara-donut-center-label',
+          x: cx,
+          y: firstY,
+          'font-size': String(fs.toFixed(2)),
+        });
+        wrapped.lines.forEach((line, i) => {
+          const tspan = svgEl<SVGTSpanElement>('tspan', {
+            x: cx,
+            y: (firstY + i * lineHeight).toFixed(2),
+          });
+          tspan.textContent = line;
+          text.appendChild(tspan);
+        });
+        svg.appendChild(text);
+      }
     }
     svgWrap.appendChild(svg);
     el.appendChild(svgWrap);


### PR DESCRIPTION
## Problem

Long donut center-labels like `\"The three-leg bottleneck\"` (23 chars, 3 words) overflowed the donut hole on https://ara.guzus.xyz/research/how-the-hbm-is-made — the SVG `<text>` element at fixed font-size 18 rendered ~257 SVG units wide vs. only ~112 units of available hole width (inner radius 56), and got visually swallowed by the surrounding slices. Short labels in the same article (`\"2024\"`, etc.) rendered correctly. The DSL allows arbitrary label length but the renderer assumed short labels.

## Solution

Two helpers in `dashboard/src/main.ts`:

- **`splitWordsIntoLines(words, n)`** — enumerates all n-line splits, picks the one that minimizes the widest line. O(W^(n-1)); bounded by a word cap (12) inside the caller.
- **`wrapDonutCenterLabel(label, max, min, usableWidth, maxLines=3)`** — fast path: if the whole label fits at max font (18), return as-is. Otherwise iterate `n = 1..maxLines`, pick the largest font that fits the widest line, clamped to `[9, 18]`. Pathological input (>12 words, e.g. a paragraph) bypasses enumeration and renders the whole label on one shrunk line.

In `renderDonuts`:

- Treat whitespace-only labels as empty (skip).
- **1-line at max font (18):** render exactly as before — `y = cy + 1`, `font-size = \"18\"`. Bit-identical to pre-fix output for short labels.
- **1-line at shrunk font** (single oversize token): use the computed font, center at `cy`.
- **Multi-line:** render `<tspan>` elements with explicit `y` per line, stacked with `lineHeight = fontSize * 1.1`, centered vertically around `cy`. Relies on the existing `dominant-baseline: middle` CSS so each tspan's y is its midline.

Conservative usable width = `2 * ri * 0.85 ≈ 95` SVG units leaves breathing room from the slice ring.

## Test labels — before / after

| Label | Before | After |
|---|---|---|
| `\"2024\"` (4 chars) | 1 line @ 18 (fits) | 1 line @ 18, bit-identical (`y=cy+1`) |
| `\"458 GW\"`, `\"$/M out\"`, `\"$16.4B\"`, `\"AI power\"` | 1 line @ 18 (fits) | 1 line @ 18, bit-identical |
| `\"80% imported\"` (12c, 2w) | 1 line @ 18, overflows (~134 units vs 95 budget) | 2 lines @ 18 (`\"80%\"` / `\"imported\"`) |
| `\"H1 2025 mix\"` (11c, 3w) | 1 line @ 18, overflows (~123 units) | 2 lines @ 18 (`\"H1 2025\"` / `\"mix\"`) |
| `\"2025 global units\"` (17c, 3w) | 1 line @ 18, overflows (~190 units) | 3 lines @ 18 (`\"2025\"` / `\"global\"` / `\"units\"`) |
| `\"World's largest\"` (15c, 2w) | 1 line @ 18, overflows (~167 units) | 2 lines @ 18 (`\"World's\"` / `\"largest\"`) |
| `\"The three-leg bottleneck\"` (23c, 3w) | 1 line @ 18, overflows (~258 units), visually clipped | **3 lines @ ~15** (`\"The\"` / `\"three-leg\"` / `\"bottleneck\"`) |
| `\"Verylongunhyphenatedword\"` (24c, 1w) | 1 line @ 18, overflows | 1 line @ 9 (shrunk, may slightly overflow — acceptable vs. dropped label) |
| `\"\"` / `\"   \"` | rendered empty `<text>` (truthy `\"\"` would have skipped, `\"   \"` would render) | not rendered |
| 50-word paragraph (pathological) | 1 line @ 18, massive overflow | 1 line @ 9 in <1ms (cap bypass — no O(W^2) hang) |

## Codex review

`/codex review` ran adversarial review against `main`. **GATE: PASS** (no `[P1]` critical findings).

Two `[P2]` advisory findings were addressed in the second commit:

1. **\"Use computed font size for single-line labels\"** — the prior 1-line branch hardcoded font 18, discarding the shrunk font computed for oversize single tokens. Fixed: 1-line branch now splits on `fs >= 18`, using `y=cy+1` only for the bit-identical max-font case and `y=cy` with the shrunk font otherwise.
2. **\"Cap the word list before enumerating split points\"** — `splitWordsIntoLines` enumerates O(W^2) splits for n=3; an unbounded `words.length` could hang the page on a paragraph-sized label. Fixed: `WORD_ENUM_CAP = 12` bypasses enumeration for pathological input and falls back to a single shrunk line (verified <1ms on a 50-word input).

## Files touched

- `dashboard/src/main.ts` — only the `renderDonuts` center-label block + two new helper functions next to `appendSvgTitle`. CSS, geometry, slice rendering, and legend rendering are untouched.

## Test plan

- [x] `bun run build` passes cleanly
- [x] `bunx tsc --noEmit` clean
- [x] Standalone unit verification of `wrapDonutCenterLabel` over all listed labels matches predicted outcomes
- [x] Pathological 50-word paragraph completes in <1ms
- [ ] Manual visual check at https://ara.guzus.xyz/research/how-the-hbm-is-made after deploy: \"The three-leg bottleneck\" donut shows label fully inside hole; \"2024\" donut unchanged
- [ ] Spot-check other articles with center-labels (\"$16.4B\", \"458 GW\", \"AI power\", \"H1 2025 mix\", \"80% imported\", \"2025 global units\") render correctly

Bundle delta: +0.04 KB gzipped (32.02 → 32.06).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>