### PR TITLE
fix(dashboard): correct slope label collision + multi-word unit format

### DIFF
--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -1163,12 +1163,18 @@ function formatUnitValue(value: number, unit: string, digits?: number): string {
   const n = formatNumber(value, digits);
   const u = unit.trim();
   if (!u) return n;
+  // Currency prefix with trailing context, e.g. "$/kW" → "$5/kW".
   const currency = u.match(/^([$€£¥₩])(.+)$/);
   if (currency) return `${currency[1]}${n}${currency[2]}`;
+  // Bare currency symbol prefixes the number with no space, e.g. "$" → "$5".
   if (/^[$€£¥₩]$/.test(u)) return `${u}${n}`;
+  // Percent and percent-prefixed phrases bind tight to the number ("17%", "17% bit share").
   if (u === '%') return `${n}%`;
-  if (/^[A-Za-z][A-Za-z0-9/%.-]*$/.test(u)) return `${n} ${u}`;
-  return `${u}${n}`;
+  if (u.startsWith('%')) return `${n}${u}`;
+  // Everything else (alphabetic units like "GB/s", non-ASCII like "μm",
+  // multi-word phrases like "k wpm" / "RMB B", or units with punctuation
+  // like "index (2019=100)") renders as "<value> <unit>" with a single space.
+  return `${n} ${u}`;
 }
 
 function fitSvgText(text: string, maxPx: number, fontPx: number, mono = false): string {
@@ -1453,6 +1459,27 @@ function renderDonuts(root: HTMLElement): void {
   }
 }
 
+/** In-place anti-overlap: sort by current Y, walk top-down, push each label
+ * down by `lineHeight` when it would collide with the one above. Mutates the
+ * input array. Stable: items that don't actually overlap keep their original
+ * positions, so slope charts whose data is comfortably spaced render
+ * pixel-identically to before.
+ *
+ * Note: this only de-collides downward (positions can grow but never shrink),
+ * which is sufficient for SVG text where the visual cost of being a few
+ * pixels low is much smaller than overshooting upward off the baseline grid. */
+function antiOverlap(positions: number[], lineHeight: number): void {
+  if (positions.length < 2) return;
+  const order = positions.map((_, i) => i).sort((a, b) => positions[a] - positions[b]);
+  for (let j = 1; j < order.length; j++) {
+    const prev = positions[order[j - 1]];
+    const cur = positions[order[j]];
+    if (cur - prev < lineHeight) {
+      positions[order[j]] = prev + lineHeight;
+    }
+  }
+}
+
 /** Two-period slopegraph. data-items, data-left-values, data-right-values,
  * data-left-label, data-right-label. Lines colored green/red by direction. */
 function renderSlopes(root: HTMLElement): void {
@@ -1501,11 +1528,24 @@ function renderSlopes(root: HTMLElement): void {
     rh.textContent = rightLabel;
     svg.appendChild(rh);
 
+    // Pass 1: compute dot Y for each item and the desired label Y (baseline + 4
+    // so the text visually centers on the dot for 12px font).
+    const lys = items.map((_, i) => yFor(leftValues[i]));
+    const rys = items.map((_, i) => yFor(rightValues[i]));
+    const labelLY = lys.map((y) => y + 4);
+    const labelRY = rys.map((y) => y + 4);
+
+    // Pass 2: anti-overlap each side independently. Dots stay at lys/rys; only
+    // label Y positions get nudged when two values would collide.
+    const lineHeight = 14; // 12px font + ~2px breathing room.
+    antiOverlap(labelLY, lineHeight);
+    antiOverlap(labelRY, lineHeight);
+
     items.forEach((_, i) => {
       const lv = leftValues[i];
       const rv = rightValues[i];
-      const ly = yFor(lv);
-      const ry = yFor(rv);
+      const ly = lys[i];
+      const ry = rys[i];
       const direction = rv > lv ? 'up' : rv < lv ? 'down' : 'flat';
       const line = svgEl<SVGLineElement>('line', {
         class: `ara-slope-line ${direction !== 'flat' ? `ara-slope-line--${direction}` : ''}`.trim(),
@@ -1518,12 +1558,12 @@ function renderSlopes(root: HTMLElement): void {
       svg.appendChild(svgEl('circle', { class: 'ara-slope-dot', cx: colL + 6, cy: ly, r: 3 }));
       svg.appendChild(svgEl('circle', { class: 'ara-slope-dot', cx: colR - 6, cy: ry, r: 3 }));
       const lRaw = leftTexts[i];
-      const lLabel = svgEl<SVGTextElement>('text', { class: 'ara-slope-label', x: colL - 8, y: ly + 4, 'text-anchor': 'end' });
+      const lLabel = svgEl<SVGTextElement>('text', { class: 'ara-slope-label', x: colL - 8, y: labelLY[i], 'text-anchor': 'end' });
       lLabel.textContent = fitSvgText(lRaw, colL - 8, 12);
       if (lLabel.textContent !== lRaw) setSvgFullLabel(lLabel, lRaw);
       svg.appendChild(lLabel);
       const rRaw = rightTexts[i];
-      const rLabel = svgEl<SVGTextElement>('text', { class: 'ara-slope-label', x: colR + 8, y: ry + 4, 'text-anchor': 'start' });
+      const rLabel = svgEl<SVGTextElement>('text', { class: 'ara-slope-label', x: colR + 8, y: labelRY[i], 'text-anchor': 'start' });
       rLabel.textContent = fitSvgText(rRaw, W - colR - 8, 12);
       if (rLabel.textContent !== rRaw) setSvgFullLabel(rLabel, rRaw);
       svg.appendChild(rLabel);

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -1459,23 +1459,45 @@ function renderDonuts(root: HTMLElement): void {
   }
 }
 
-/** In-place anti-overlap: sort by current Y, walk top-down, push each label
- * down by `lineHeight` when it would collide with the one above. Mutates the
- * input array. Stable: items that don't actually overlap keep their original
- * positions, so slope charts whose data is comfortably spaced render
- * pixel-identically to before.
+/** In-place bounded anti-overlap. Sort items by current Y, walk top-down to
+ * push colliders down by `lineHeight`, then if the bottommost item exceeds
+ * `maxY` clamp it and walk back up pushing earlier items higher to make room.
+ * Mutates the input array.
  *
- * Note: this only de-collides downward (positions can grow but never shrink),
- * which is sufficient for SVG text where the visual cost of being a few
- * pixels low is much smaller than overshooting upward off the baseline grid. */
-function antiOverlap(positions: number[], lineHeight: number): void {
+ * Properties:
+ * - Stable: items that don't overlap keep their original positions, so
+ *   comfortable slope charts render pixel-identically to before this pass.
+ * - Bounded: no item ends up below `maxY`, so labels can't get clipped by
+ *   the SVG viewBox even when many values cluster at the bottom of the chart.
+ *   (Bottom-bound only; the symmetric top-clip case would need yTop and
+ *   doesn't trigger for any real data we render today.) */
+function antiOverlap(positions: number[], lineHeight: number, maxY: number): void {
   if (positions.length < 2) return;
   const order = positions.map((_, i) => i).sort((a, b) => positions[a] - positions[b]);
+  // Forward sweep: push each colliding label down by lineHeight.
   for (let j = 1; j < order.length; j++) {
     const prev = positions[order[j - 1]];
     const cur = positions[order[j]];
     if (cur - prev < lineHeight) {
       positions[order[j]] = prev + lineHeight;
+    }
+  }
+  // Backward sweep: if the bottommost label overflows the viewport, clamp it
+  // and push preceding labels up only as far as needed to keep `lineHeight`
+  // between them. The clamp shrinks the gap from `lineHeight` toward zero
+  // (labels can still overlap if too many cluster at the very bottom) but
+  // keeps every label inside the SVG so nothing disappears.
+  const last = order.length - 1;
+  if (positions[order[last]] > maxY) {
+    positions[order[last]] = maxY;
+    for (let j = last - 1; j >= 0; j--) {
+      const below = positions[order[j + 1]];
+      if (positions[order[j]] > below - lineHeight) {
+        positions[order[j]] = below - lineHeight;
+      } else {
+        // No more pressure to push; everything above is already clear.
+        break;
+      }
     }
   }
 }
@@ -1536,10 +1558,13 @@ function renderSlopes(root: HTMLElement): void {
     const labelRY = rys.map((y) => y + 4);
 
     // Pass 2: anti-overlap each side independently. Dots stay at lys/rys; only
-    // label Y positions get nudged when two values would collide.
+    // label Y positions get nudged when two values would collide. `maxLabelY`
+    // keeps the descender of a 12px label inside the SVG viewBox so the pass
+    // never clips a label off the bottom.
     const lineHeight = 14; // 12px font + ~2px breathing room.
-    antiOverlap(labelLY, lineHeight);
-    antiOverlap(labelRY, lineHeight);
+    const maxLabelY = H - 4; // ~3px below the baseline is where the descender ends.
+    antiOverlap(labelLY, lineHeight, maxLabelY);
+    antiOverlap(labelRY, lineHeight, maxLabelY);
 
     items.forEach((_, i) => {
       const lv = leftValues[i];


### PR DESCRIPTION
## Summary

Two distinct rendering bugs in the slope chart, visible on the HBM article's HBM-vendor `:::slope` directive ([ara.guzus.xyz/research/how-the-hbm-is-made](https://ara.guzus.xyz/research/how-the-hbm-is-made), section 07, second slope).

### Bug 1: `formatUnitValue` fallback concatenated unit + value with no space

`dashboard/src/main.ts:1162-1175` — The previous fallback `return \`${u}${n}\`` prefixed the unit string directly to the number. Anything that didn't match the regex `^[A-Za-z][A-Za-z0-9/%.-]*$` fell into this branch. That covered every multi-word unit (`"k wpm"`, `"RMB B"`), every non-ASCII unit (`"μm"`), every percent-prefixed phrase (`"% bit share"`), and every unit with punctuation (`"index (2019=100)"`).

In the HBM chart, `unit="% bit share"` produced labels like `"SK Hynix % bit share62"` — the value buried inside the unit phrase, no separator.

**Fix:** simplify the formatter so every non-special unit renders as `{value} {unit}` with a single space. Percent-prefixed phrases bind tight to the number (`"17% bit share"`, not `"17 % bit share"`) because that matches the conventional typographic form and how the HBM article reads in prose.

Before vs after, sampled from the universe of unit strings actually used in `research/generative/*.ara.md`:

| value | unit              | before                 | after                  |
|------:|-------------------|------------------------|------------------------|
| 17    | `"% bit share"`   | `"% bit share17"`      | `"17% bit share"`      |
| 62    | `"k wpm"`         | `"k wpm62"`            | `"62 k wpm"`           |
| 5     | `"μm"`            | `"μm5"`                | `"5 μm"`               |
| 21    | `"RMB B"`         | `"RMB B21"`            | `"21 RMB B"`           |
| 100   | `"index (2019=100)"` | `"index (2019=100)100"` | `"100 index (2019=100)"` |
| 62    | `"%"`             | `"62%"`                | `"62%"` (unchanged)    |
| 62    | `"$"`             | `"$62"`                | `"$62"` (unchanged)    |
| 62    | `"GB/s"`          | `"62 GB/s"`            | `"62 GB/s"` (unchanged)|
| 62    | `"$/kW"`          | `"$62/kW"`             | `"$62/kW"` (unchanged) |

Audited every `(y-)?unit=...` occurrence in `research/generative/` (32 distinct units). All previously-correct units are pixel-identical. Six previously-broken units (`% bit share`, `k wpm`, `RMB B`, `μm`, `index (...)`, plus the leading-space variants) are now correct.

### Bug 2: Slope labels overlapped when values were close

`dashboard/src/main.ts:1462-1531` — Each label was positioned at `y: ly + 4` inline. When two items projected to near-identical Y positions, labels collided. In the HBM chart, Micron (21) and Samsung (17) on the left side were ~5px apart and overlapped on top of each other.

**Fix:** Two-pass structure with bounded anti-overlap.

1. Compute dot Y for each item (`lys[i]`, `rys[i]`) and the desired label Y (dot + 4).
2. Run `antiOverlap(positions, lineHeight, maxY)` on each side independently. Sort by current Y, forward sweep top-down pushing colliders down by `lineHeight` (14px). If the bottommost label exceeds `maxY = H - 4`, clamp it and walk back up pushing earlier labels higher to preserve spacing. Dots stay at true positions; only labels move.

Stable on non-overlapping data — comfortable slope charts render pixel-identically. Bounded — labels can't clip off the SVG bottom even when 3+ items tie at the chart's minimum.

HBM chart label Y positions (3 items each side, H=128, maxLabelY=124):

| side  | item     | dot Y  | label Y before | label Y after |
|-------|----------|-------:|---------------:|--------------:|
| left  | SK Hynix |  40.00 |          44.00 |         44.00 |
| left  | Micron   | 107.42 |         111.42 |        110.00 |
| left  | Samsung  | 114.00 |         118.00 |        124.00 |
| right | SK Hynix |  48.22 |          52.22 |         52.22 |
| right | Micron   | 107.42 |         111.42 |        123.78 |
| right | Samsung  | 105.78 |         109.78 |        109.78 |

## Codex round-trip

First codex review flagged one [P2]: down-only anti-overlap could push the bottommost label past the SVG viewBox, clipping it. The HBM data itself already had Samsung at y=125.42 with H=128, 0.42px past the descender margin — a real regression, not hypothetical.

Second commit (`2166b4f0`) added the `maxY` bound and backward-sweep pass. Verified against five cases including 3-tied-at-bottom (input `[118,118,118]` → output `[96,110,124]`, all distinct, all within bounds) and 6-items-piled-near-bottom (full 14px spacing maintained).

Re-ran codex review against the final diff: clean, no findings.

## Notes

- Touches only `dashboard/src/main.ts`. CSS, prebuild, articles, and workflows unchanged.
- The `formatUnitValue` simplification is shared by line-chart, slope, area-chart, and others. Backward-compat audit shows every currently-correct unit is unchanged; six broken units are fixed.
- `"% bit share"` rendering: chose `"17% bit share"` (tight binding) over `"17 % bit share"` (loose). Deliberate, matches conventional typographic form.

## Test plan

- [ ] Visit https://ara.guzus.xyz/research/how-the-hbm-is-made and scroll to section 07. Confirm the second `:::slope` chart renders three distinct, non-overlapping labels on each side, with values like `"SK Hynix 62% bit share"`.
- [ ] Spot-check other articles using line-chart and slope (e.g. `home-inference-rack`, `compare-claude-power-bottlenecks`) to confirm no visual regression on units like `$`, `GB/s`, `tok/s`, `GW`.
- [ ] `cd dashboard && bun run build` compiles cleanly (verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)