### PR TITLE
ci: provision Node 22 for the dashboard job (Vite 8 needs >= 20.19)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,15 @@ jobs:
           # dashboard would serve pointer text instead of images/audio.
           lfs: true
 
+      # Vite 8 requires Node.js >= 20.19. The self-hosted runner ships Node 18,
+      # and `bun run build` shells out to `vite build` which uses the system
+      # node shebang. Provision Node 22 explicitly so Vite has the runtime it
+      # needs. Keep ahead of Vite's minimum to leave headroom.
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 


### PR DESCRIPTION
## Problem

After PR #50 (vite 7→8) merged, CI on main started failing:

\`\`\`
You are using Node.js 18.20.4. Vite requires Node.js version 20.19+ or 22.12+.
ReferenceError: CustomEvent is not defined
\`\`\`

The self-hosted runner has Node 18 as the system default. \`bun run build\` runs the \`build\` script (\`vite build\`), and \`vite\`'s shebang points to the system node — bypassing bun's runtime.

The Dependabot triage agent's local build (PR #50) passed because the dev machine had a newer Node — a classic CI-vs-local drift.

## Fix

Add \`actions/setup-node@v6\` with \`node-version: '22'\` before Setup Bun in the dashboard job. Twitter/RSS/etc. workflows already use this exact pattern.

## Verification

- YAML parses cleanly.
- Matches existing Node 22 convention across the repo (twitter matrix workflow, etc.).
- No behavioral change to non-dashboard jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)