### PR TITLE
fix(ci): generative-research push step survives dirty working tree

### DIFF
--- a/.github/workflows/generative-research.yml
+++ b/.github/workflows/generative-research.yml
@@ -1923,14 +1923,65 @@ jobs:
 
             git fetch origin main
 
-            if git rebase origin/main; then
-              :
-            else
-              # rebase paused on conflicts. The only path we know how to
-              # safely auto-resolve is research/generative/index.json.
+            # Stash any leftover working-tree state (tracked modifications
+            # OR untracked artifacts like .gen-verifier-findings.json) that
+            # would otherwise make `git rebase` refuse to start with
+            # "cannot rebase: You have unstaged changes". We don't try to
+            # trace the source — anything dirty here is incidental to the
+            # writer's commit and unrelated to publishing it.
+            #
+            # Per-attempt stash: if push fails and we loop, the next
+            # iteration's pre-check will re-stash whatever the pop
+            # reintroduced. The stash message includes the attempt number
+            # so a dangling stash (max-attempts exhaustion) is debuggable.
+            STASHED=false
+            if ! git diff --quiet \
+                || ! git diff --cached --quiet \
+                || [ -n "$(git ls-files --others --exclude-standard)" ]; then
+              if git stash push --include-untracked --quiet \
+                  -m "push-retry-stash-attempt-$ATTEMPTS"; then
+                STASHED=true
+              else
+                # Defensive: pre-check said dirty but stash push failed
+                # (unusual repo state). Don't crash the loop under
+                # `set -e`; rebase will fail loudly below with the
+                # actual problem.
+                echo "::warning::pre-rebase stash push failed; proceeding without stash"
+              fi
+            fi
+
+            if git -c core.editor=true rebase origin/main; then
+              # Rebase clean. Restore the pre-rebase state before push so
+              # the working tree matches what the writer intended. Pop is
+              # best-effort: if it conflicts (e.g. rebase moved the same
+              # lines the stash touched) we leave the stash in place
+              # rather than fail — push has not happened yet and the
+              # operator can recover from `git stash list` on the runner.
+              if [ "$STASHED" = "true" ]; then
+                git stash pop --quiet || \
+                  echo "::warning::stash pop conflicted; stash left in place"
+              fi
+            elif [ -d .git/rebase-merge ] || [ -d .git/rebase-apply ]; then
+              # Rebase actually started and paused on conflicts. The only
+              # path we know how to safely auto-resolve is the JSON-array
+              # index file research/generative/index.json.
               CONFLICTED=$(git diff --name-only --diff-filter=U | sort -u)
               echo "Conflicted paths:"
               echo "$CONFLICTED"
+              if [ -z "$CONFLICTED" ]; then
+                # Shouldn't happen: rebase dir exists but no conflicts.
+                # Bail safely and let the retry loop try again rather
+                # than hard-fail on a transient state.
+                echo "::warning::rebase in progress but no conflicts detected; aborting and retrying"
+                git rebase --abort 2>/dev/null || true
+                if [ "$STASHED" = "true" ]; then
+                  git stash pop --quiet || \
+                    echo "::warning::stash pop conflicted; stash left in place"
+                fi
+                echo "::endgroup::"
+                sleep $((2 * ATTEMPTS))
+                continue
+              fi
               if [ "$CONFLICTED" = "research/generative/index.json" ]; then
                 merge_index_json "research/generative/index.json"
                 if ! git -c core.editor=true rebase --continue; then
@@ -1938,11 +1989,26 @@ jobs:
                   git rebase --abort 2>/dev/null || true
                   exit 1
                 fi
+                if [ "$STASHED" = "true" ]; then
+                  git stash pop --quiet || \
+                    echo "::warning::stash pop conflicted; stash left in place"
+                fi
               else
                 echo "::error::Unhandleable conflict on path(s) above"
                 git rebase --abort 2>/dev/null || true
                 exit 1
               fi
+            else
+              # Rebase failed before it ever started — no rebase-merge /
+              # rebase-apply directory exists. The classic cause is a
+              # dirty working tree the stash above didn't capture
+              # (e.g. permissions issue, submodule state, weird repo
+              # layout). This is NOT a merge conflict; emit a real
+              # diagnostic so operators stop chasing the
+              # "Unhandleable conflict on path(s) above" red herring.
+              echo "::error::git rebase failed to start (no rebase-merge/rebase-apply directory). Likely cause: dirty working tree that wasn't stashed. Check upstream steps for files written after the writer's commit, and inspect the runner's git status output below."
+              git status --short || true
+              exit 1
             fi
 
             if git push origin HEAD:main; then

--- a/.github/workflows/generative-research.yml
+++ b/.github/workflows/generative-research.yml
@@ -1950,17 +1950,40 @@ jobs:
               fi
             fi
 
+            # Stash cleanup helpers, used on both happy and unhappy paths.
+            # Pop must succeed before we push: a popped-but-conflicted
+            # stash leaves unmerged markers in the working tree and a
+            # silent push of the writer's commit would drop whatever
+            # tracked state was in the stash. Drop is for hard-fail
+            # exits where we'd otherwise leak a named stash onto the
+            # self-hosted runner (stash content is incidental artifacts;
+            # we log it before dropping for operator visibility).
+            pop_stash_or_fail() {
+              if [ "$STASHED" != "true" ]; then return 0; fi
+              if git stash pop --quiet; then
+                STASHED=false
+                return 0
+              fi
+              echo "::error::stash pop conflicted after rebase; refusing to push (working tree has unmerged content)"
+              git status --short || true
+              echo "Stash entries left on runner:"
+              git stash list | head -3 || true
+              exit 1
+            }
+            drop_stash_if_any() {
+              if [ "$STASHED" != "true" ]; then return 0; fi
+              echo "Dropping stashed pre-rebase state (hard-fail path):"
+              git stash list | head -3 || true
+              git stash drop --quiet || true
+              STASHED=false
+            }
+
             if git -c core.editor=true rebase origin/main; then
               # Rebase clean. Restore the pre-rebase state before push so
-              # the working tree matches what the writer intended. Pop is
-              # best-effort: if it conflicts (e.g. rebase moved the same
-              # lines the stash touched) we leave the stash in place
-              # rather than fail — push has not happened yet and the
-              # operator can recover from `git stash list` on the runner.
-              if [ "$STASHED" = "true" ]; then
-                git stash pop --quiet || \
-                  echo "::warning::stash pop conflicted; stash left in place"
-              fi
+              # the working tree matches what the writer intended. If
+              # pop conflicts we hard-fail rather than push a commit
+              # that excludes potentially-meaningful stashed state.
+              pop_stash_or_fail
             elif [ -d .git/rebase-merge ] || [ -d .git/rebase-apply ]; then
               # Rebase actually started and paused on conflicts. The only
               # path we know how to safely auto-resolve is the JSON-array
@@ -1971,12 +1994,15 @@ jobs:
               if [ -z "$CONFLICTED" ]; then
                 # Shouldn't happen: rebase dir exists but no conflicts.
                 # Bail safely and let the retry loop try again rather
-                # than hard-fail on a transient state.
+                # than hard-fail on a transient state. Pop best-effort
+                # here — we're going to re-stash on the next iteration's
+                # pre-check anyway.
                 echo "::warning::rebase in progress but no conflicts detected; aborting and retrying"
                 git rebase --abort 2>/dev/null || true
                 if [ "$STASHED" = "true" ]; then
                   git stash pop --quiet || \
-                    echo "::warning::stash pop conflicted; stash left in place"
+                    echo "::warning::stash pop conflicted in retry path; stash left in place"
+                  STASHED=false
                 fi
                 echo "::endgroup::"
                 sleep $((2 * ATTEMPTS))
@@ -1987,15 +2013,14 @@ jobs:
                 if ! git -c core.editor=true rebase --continue; then
                   echo "::error::rebase --continue failed even after JSON merge"
                   git rebase --abort 2>/dev/null || true
+                  drop_stash_if_any
                   exit 1
                 fi
-                if [ "$STASHED" = "true" ]; then
-                  git stash pop --quiet || \
-                    echo "::warning::stash pop conflicted; stash left in place"
-                fi
+                pop_stash_or_fail
               else
                 echo "::error::Unhandleable conflict on path(s) above"
                 git rebase --abort 2>/dev/null || true
+                drop_stash_if_any
                 exit 1
               fi
             else
@@ -2008,6 +2033,7 @@ jobs:
               # "Unhandleable conflict on path(s) above" red herring.
               echo "::error::git rebase failed to start (no rebase-merge/rebase-apply directory). Likely cause: dirty working tree that wasn't stashed. Check upstream steps for files written after the writer's commit, and inspect the runner's git status output below."
               git status --short || true
+              drop_stash_if_any
               exit 1
             fi
 


### PR DESCRIPTION
## Summary

The publish step in `.github/workflows/generative-research.yml` had a flaky retry-rebase loop that failed non-deterministically when `main` moved during a run. Two bugs in one failure trace (runs `25994233054` and `25997895854` both hit this):

```
push attempt 1 / 5
error: cannot rebase: You have unstaged changes.
error: Please commit or stash them.
Conflicted paths:

Unhandleable conflict on path(s) above
Process completed with exit code 1.
```

### Bug A — unstaged changes blocked the rebase
After the writer commits the article, transient working-tree state remained (e.g. untracked `.gen-verifier-findings.json`, or any modification an upstream step left behind). `git rebase` refused to start. The loop never tried to stash.

### Bug B — empty conflict list mis-classified as "unhandleable"
After `git rebase` errored out, the script greps `git diff --name-only --diff-filter=U`. With zero conflicts, the script treated this as "no JSON-only conflict, must be unhandleable" and exited 1. The actual problem was "rebase never even started" — there ARE no conflicts to handle.

## Per-bug fix

### Fix A — per-attempt stash/pop

```
# BEFORE
if git rebase origin/main; then
  :  # proceed to push
else
  CONFLICTED=$(...)
  ...
fi

# AFTER
STASHED=false
if dirty?; then
  git stash push --include-untracked  # defensive: don't crash under set -e if stash push fails
  STASHED=true
fi
if git -c core.editor=true rebase origin/main; then
  pop_stash_or_fail   # load-bearing: stash pop conflict aborts before push
elif rebase actually started; then
  ...existing JSON-merge logic, unchanged...
else
  emit a real diagnostic
fi
```

### Fix B — distinguish "rebase failed to start" from "rebase produced conflicts"

Branch on `[ -d .git/rebase-merge ] || [ -d .git/rebase-apply ]`. If true, run the existing JSON-conflict detection. If false, emit a clear `::error::` with `git status --short` so operators stop chasing the "Unhandleable conflict" red herring.

Also adds a guard inside the conflict branch: if rebase dir exists but `CONFLICTED` is empty (transient/unexpected), warn and continue the retry loop instead of hard-failing.

## Mental trace of 3+1 modes (now covered)

| Mode | Pre-check | Rebase | Pop | Push | Exit |
|------|-----------|--------|-----|------|------|
| Clean retry (dirty tree, no rebase conflict) | stash | clean | succeeds | succeeds | 0 |
| Real JSON conflict on index.json | stash | conflicts on index.json | succeeds after `--continue` | succeeds | 0 |
| Rebase truly fails to start | stash | no `.git/rebase-merge` dir | (drop) | n/a | 1 with real diagnostic |
| Stash pop conflicts (codex P1) | stash | clean | fails | **refused** | 1, no silent push |

## Codex verdict

`/codex review` against the first commit flagged **2 P1s and 3 P2s**. Both P1s were addressed in a follow-up commit (`d6744a2f`):

* **P1 #1**: original best-effort `stash pop` would silently push the writer's commit even if pop conflicted, dropping potentially-meaningful tracked state from the stash. Fixed via `pop_stash_or_fail` helper: hard-fail before push if pop fails.
* **P1 #2**: hard-fail paths (unhandleable conflict, `rebase --continue` blew up after JSON merge, rebase failed to start) leaked the per-attempt named stash onto the self-hosted runner. Fixed via `drop_stash_if_any` helper: log + drop the stash on hard-fail exits.

P2s acknowledged:
* `.git/rebase-merge` directory check is fine for this workflow's `actions/checkout` layout (no linked worktrees in CI).
* Deeper diagnostics for the empty-conflict branch are out of scope for this fix.
* "Stash push failed" warning-and-continue is intentional: rebase will surface the underlying issue more concretely than a generic stash-failure error.

## Test plan

- [ ] Workflow runs successfully on a clean retry (no conflict, transient untracked state)
- [ ] Existing JSON-array merge on `research/generative/index.json` still works (no regression in the conflict path)
- [ ] If `git rebase` fails to start, the log shows the new `::error::git rebase failed to start...` diagnostic with `git status --short` output, NOT the misleading "Unhandleable conflict on path(s) above"
- [ ] If stash pop conflicts after rebase, the workflow refuses to push and surfaces the named stash for debugging instead of silently publishing an incomplete tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)