### PR TITLE
feat(gen-research): corroboration + qsanity quality gates

### DIFF
--- a/.github/workflows/generative-research.yml
+++ b/.github/workflows/generative-research.yml
@@ -1308,18 +1308,28 @@ jobs:
                     (previously prose-only; corpus audit found 4
                     historical articles shipped with zero citations).
                     --strict-shape adds soft warnings on percentages-
-                    without-viz (advisory, doesn't block):
+                    without-viz (advisory, doesn't block).
+                    --qsanity scans for numeric implausibility shapes
+                    (donut sums > 105%, market share > 100%, YoY > 1000%,
+                    far-future date typos) — warn-only in v1, never
+                    blocks. Useful for catching NBIS-class numeric
+                    hallucinations the citation gates don't see:
 
                       python3 scripts/check_generative_research.py \
                         "$GEN_DRAFT" \
                         --diversity-min 3 --callout-max 5 \
                         --cite-density-min 10 --refs-min 20 \
+                        --qsanity \
                         --strict-shape
 
                  c. Exit 0 → proceed to step 8. Soft warnings printed
                     on stderr are advisory — read them and consider
                     whether the flagged section would read better
-                    with a viz, but they don't block.
+                    with a viz, but they don't block. qsanity warnings
+                    are similarly advisory — verify each one is
+                    correct before ignoring (a single typo'd year /
+                    digit-shifted percentage is the kind of failure
+                    the verifier can miss).
                     Exit 1 → the stderr lists every DSL grammar
                     error, invalid class/tag, design-gate violation,
                     OR research-quality gate violation. Fix the body
@@ -1367,6 +1377,7 @@ jobs:
                     --prompt "$(cat .gen-input/prompt.txt)" \
                     --model claude-opus-4-7 \
                     --cite-density-min 10 --refs-min 20 \
+                    --qsanity \
                     --html-body "$GEN_DRAFT"
 
                If $GEN_SLUG is empty, OMIT the --slug flag entirely (do
@@ -1378,6 +1389,7 @@ jobs:
                     --prompt "$(cat .gen-input/prompt.txt)" \
                     --model claude-opus-4-7 \
                     --cite-density-min 10 --refs-min 20 \
+                    --qsanity \
                     --html-body "$GEN_DRAFT"
 
             CONSTRAINTS:
@@ -2329,18 +2341,28 @@ jobs:
                     (previously prose-only; corpus audit found 4
                     historical articles shipped with zero citations).
                     --strict-shape adds soft warnings on percentages-
-                    without-viz (advisory, doesn't block):
+                    without-viz (advisory, doesn't block).
+                    --qsanity scans for numeric implausibility shapes
+                    (donut sums > 105%, market share > 100%, YoY > 1000%,
+                    far-future date typos) — warn-only in v1, never
+                    blocks. Useful for catching NBIS-class numeric
+                    hallucinations the citation gates don't see:
 
                       python3 scripts/check_generative_research.py \
                         "$GEN_DRAFT" \
                         --diversity-min 3 --callout-max 5 \
                         --cite-density-min 10 --refs-min 20 \
+                        --qsanity \
                         --strict-shape
 
                  c. Exit 0 → proceed to step 8. Soft warnings printed
                     on stderr are advisory — read them and consider
                     whether the flagged section would read better
-                    with a viz, but they don't block.
+                    with a viz, but they don't block. qsanity warnings
+                    are similarly advisory — verify each one is
+                    correct before ignoring (a single typo'd year /
+                    digit-shifted percentage is the kind of failure
+                    the verifier can miss).
                     Exit 1 → the stderr lists every DSL grammar
                     error, invalid class/tag, design-gate violation,
                     OR research-quality gate violation. Fix the body
@@ -2388,6 +2410,7 @@ jobs:
                     --prompt "$(cat .gen-input/prompt.txt)" \
                     --model deepseek-v4-pro \
                     --cite-density-min 10 --refs-min 20 \
+                    --qsanity \
                     --html-body "$GEN_DRAFT"
 
                If $GEN_SLUG is empty, OMIT the --slug flag entirely (do
@@ -2399,6 +2422,7 @@ jobs:
                     --prompt "$(cat .gen-input/prompt.txt)" \
                     --model deepseek-v4-pro \
                     --cite-density-min 10 --refs-min 20 \
+                    --qsanity \
                     --html-body "$GEN_DRAFT"
 
             CONSTRAINTS:

--- a/scripts/check_generative_research.py
+++ b/scripts/check_generative_research.py
@@ -214,6 +214,79 @@ class _ReferenceHrefCollector(HTMLParser):
                 self._current_ref_has_url = False
 
 
+class _RefHostMapCollector(HTMLParser):
+    """Walks the HTML and builds {ref_num: host} for every
+    `<li id="ref-N">`'s first http(s) URL.
+
+    Used by the corroboration gate: each cite `[^N]` in the body
+    rendered to `<sup><a class="ara-cite" href="#ref-N">N</a></sup>`
+    must be resolvable to a SOURCE HOST so the gate can count
+    distinct hosts per claim.
+
+    Storage choice: only the FIRST http(s) URL inside each ref-li
+    is captured. A ref-li with multiple URLs usually has the
+    primary source first (publisher / DOI / arxiv) and supplementary
+    secondary URLs after. Counting all of them per ref-li would
+    artificially inflate host diversity — a single ref entry should
+    represent a single source. Single-source-per-entry matches the
+    bibliographic convention used in the corpus.
+
+    Hosts are normalized via _normalize_host (lowercase, strip www.).
+    """
+
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self._depth_in_ref_li = 0
+        self._current_ref_num: int | None = None
+        self._current_ref_host: str | None = None  # locked once first URL seen
+        self.ref_hosts: dict[int, str] = {}
+
+    def handle_starttag(self, tag, attrs):
+        a = dict(attrs)
+        if tag == "li":
+            ref_id = a.get("id", "")
+            if ref_id.startswith("ref-"):
+                try:
+                    n = int(ref_id[4:])
+                except ValueError:
+                    n = None
+                if n is not None:
+                    self._depth_in_ref_li = 1
+                    self._current_ref_num = n
+                    self._current_ref_host = None
+                    return
+            if self._depth_in_ref_li > 0:
+                self._depth_in_ref_li += 1
+        if self._depth_in_ref_li > 0 and tag == "a":
+            href = a.get("href", "")
+            if (
+                href.startswith(("http://", "https://"))
+                and self._current_ref_host is None
+            ):
+                m = re.match(r"^https?://([^/]+)", href)
+                if m:
+                    self._current_ref_host = _normalize_host(m.group(1))
+
+    def handle_endtag(self, tag):
+        if tag == "li" and self._depth_in_ref_li > 0:
+            self._depth_in_ref_li -= 1
+            if self._depth_in_ref_li == 0:
+                if self._current_ref_num is not None and self._current_ref_host:
+                    self.ref_hosts[self._current_ref_num] = self._current_ref_host
+                self._current_ref_num = None
+                self._current_ref_host = None
+
+
+def build_ref_host_map(body_html: str) -> dict[int, str]:
+    """Return {ref_num: normalized_host} for every URL-bearing ref-li in
+    the article. Ref entries without an http(s) URL (title-only refs)
+    are omitted. This map is the lookup table for the corroboration
+    gate: each cite marker `[^N]` resolves to a host via this map."""
+    c = _RefHostMapCollector()
+    c.feed(body_html)
+    return c.ref_hosts
+
+
 def _word_count(body_html: str) -> int:
     text = re.sub(r"<[^>]+>", " ", body_html)
     return len(text.split())
@@ -342,6 +415,389 @@ def cite_density(body_html: str) -> tuple[float, int, int]:
     return (cites / words) * 1000.0, cites, words
 
 
+# ---------------------------------------------------------------------------
+# Corroboration gate (--min-corroborating-sources).
+# ---------------------------------------------------------------------------
+#
+# A claim "cited at all" passes the existing cited-claims gate even when
+# its only source is wrong (the NBIS failure pattern: adjacent-but-wrong
+# numeric cite). The corroboration gate adds a SECOND-INDEPENDENT-SOURCE
+# requirement for substantive factual claims. Single-source claims must
+# be explicitly acknowledged via `==single-source: ...==` wrapping.
+#
+# Heuristics here are intentionally conservative:
+#   * "Substantive claim" = sentence with cite marker AND (digit OR
+#     percent OR dollar OR named-entity proxy). Same shape as
+#     cited_claim_share() — reuses the same sensitivity.
+#   * "Distinct sources" = distinct normalized hosts of the cited refs.
+#     A claim cited 3 times to the same host counts as 1 host.
+#   * "Single-source exemption" = the claim sentence is fully contained
+#     inside a `<mark class="ara-mark">…</mark>` region whose inner text
+#     begins with "single-source:" (case/whitespace tolerant). The agent
+#     opts in by wrapping the claim in `==single-source: claim text==`
+#     in the DSL.
+#
+# Sentence boundaries are approximate (regex split on .!?). Cite markers
+# at the END of a sentence belong to that sentence. A multi-cite cluster
+# `[^1][^2][^3]` at sentence end contributes refs 1, 2, 3 to that
+# sentence's host count.
+
+# Regex matches the rendered cite sup wrapper, capturing the ref number
+# so we can map back to its host. Multi-cite `[^1,2]` compiles to
+# adjacent <sup> elements so this finditer naturally yields each.
+_RENDERED_CITE_WITH_NUM_RE = re.compile(
+    r'<sup[^>]*>\s*<a[^>]*class="ara-cite"[^>]*href="#ref-([0-9]+)"[^>]*>'
+    r'[^<]*</a>\s*</sup>',
+    flags=re.IGNORECASE,
+)
+# Match <mark class="ara-mark">…</mark> regions; we don't depend on the
+# class because validate_body already restricts <mark> use to ara-mark.
+_MARK_REGION_RE = re.compile(
+    r"<mark[^>]*>(.*?)</mark>", flags=re.DOTALL | re.IGNORECASE
+)
+# Headings often look "substantive" after tag-strip ("Cerebras WSE-3
+# Pricing") because they're multi-word capitalized — but they rarely
+# carry citations, and when they do, the cite is for the section
+# topic, not a factual claim. Skip headings before sentence segmentation
+# so they can't contribute false-positive substantive sentences.
+_HEADING_STRIP_RE = re.compile(
+    r"<h[1-6][^>]*>.*?</h[1-6]>", flags=re.DOTALL | re.IGNORECASE
+)
+
+
+def _extract_mark_inner_texts(body_html: str) -> list[str]:
+    """Return the inner text of every `<mark>` region in the body,
+    with cite markers and HTML tags stripped and whitespace normalized.
+
+    Used to detect `==single-source: ...==` opt-out wrapping. The mark
+    region INCLUDES the prefix `single-source:` followed by the claim
+    text — both come from the same DSL `==…==` invocation that compiled
+    to one <mark> region.
+
+    Cite markers are stripped (rendered `<sup>…</sup>` -> nothing)
+    so the inner text matches the claim sentence extracted from the
+    body, which is also cite-stripped in _norm_for_match."""
+    out: list[str] = []
+    for m in _MARK_REGION_RE.finditer(body_html):
+        inner_raw = m.group(1)
+        # Strip cite-marker WRAPPERS first (while we still have full
+        # HTML) so the digit text inside `<sup><a>N</a></sup>` doesn't
+        # survive the tag strip.
+        inner_decited = _strip_cite_markers(inner_raw)
+        inner = re.sub(r"<[^>]+>", " ", inner_decited)
+        inner = re.sub(r"\s+", " ", inner).strip()
+        if inner:
+            out.append(inner)
+    return out
+
+
+_SINGLE_SOURCE_PREFIX = "single-source:"
+
+
+def _strip_single_source_prefix(s: str) -> str:
+    """Remove a leading `single-source:` (case-insensitive) from a
+    normalized text. Returns the original if no prefix present."""
+    if s.lower().startswith(_SINGLE_SOURCE_PREFIX):
+        return s[len(_SINGLE_SOURCE_PREFIX):].lstrip(" :;,-")
+    return s
+
+
+def _is_single_source_exempt(sentence_text: str, mark_inners: list[str]) -> bool:
+    """A sentence is exempt from corroboration when the agent explicitly
+    flagged it as single-sourced via `==single-source: ...==`.
+
+    The compiled HTML for that DSL form is
+        <mark class="ara-mark">single-source: <sentence body></mark>
+    The `single-source:` literal text appears in BOTH the mark inner
+    AND the sentence text extracted from the body (because tag-stripping
+    leaves the literal prose intact). So we strip the prefix from BOTH
+    sides before matching probe -> mark.
+
+    Match policy: case-insensitive prefix on "single-source:", and the
+    sentence's first ~60 substantive chars (after prefix strip) must
+    appear inside the mark region's content (after prefix strip).
+    Lenient enough to survive whitespace / cite-marker drift between
+    probe and rendered mark."""
+    if not mark_inners:
+        return False
+    probe = _norm_for_match(sentence_text)
+    probe = _strip_single_source_prefix(probe)
+    if not probe:
+        return False
+    probe_head = probe[:60]
+    for inner in mark_inners:
+        inner_l = inner.lower().strip()
+        if not inner_l.startswith(_SINGLE_SOURCE_PREFIX):
+            continue
+        # Strip the prefix and any leading punctuation from the mark
+        # body, then normalize for matching.
+        body_after_prefix = inner_l[len(_SINGLE_SOURCE_PREFIX):].lstrip(" :;,-")
+        body_after_prefix = _norm_for_match(body_after_prefix)
+        if probe_head and probe_head in body_after_prefix:
+            return True
+    return False
+
+
+def _norm_for_match(s: str) -> str:
+    """Normalize text for case/whitespace-tolerant probe matching.
+    Also strips citation markers (DSL `[^N]` and rendered `<sup>…</sup>`
+    forms) so a probe extracted from one form matches text from the
+    other. Returns lowercase, whitespace-collapsed, no cite-markers."""
+    s = _strip_cite_markers(s)
+    s = re.sub(r"<[^>]+>", " ", s)
+    s = re.sub(r"\s+", " ", s).strip().lower()
+    return s
+
+
+def _claim_sentences_with_refs(
+    body_html: str,
+) -> list[tuple[str, list[int]]]:
+    """Walk the article body, return [(sentence_text, [ref_nums...]), ...]
+    for every substantive sentence that carries at least one cite marker.
+
+    Algorithm:
+      1. Strip <h1..h6> regions — headings rarely carry meaningful
+         claims and their multi-word capitalized form would inflate
+         the substantive-sentence rate.
+      2. Replace each rendered cite sup with a sentinel that carries
+         the ref number so sentence segmentation preserves the
+         ref-to-sentence association.
+      3. Strip remaining HTML tags. Split on .!? boundaries.
+      4. For each sentence with a sentinel, check if it's substantive
+         (digit/percent/dollar/multi-word capitalized). Yield (text,
+         [ref nums extracted from sentinels]).
+    """
+    body = _HEADING_STRIP_RE.sub(" ", body_html)
+    # Sentinel: \x00C<num>\x00 — distinct from existing _CITE_MARKER
+    # and survives tag-strip + sentence-split intact.
+    def _cite_sub(m: re.Match) -> str:
+        return f" \x00C{m.group(1)}\x00 "
+    marked = _RENDERED_CITE_WITH_NUM_RE.sub(_cite_sub, body)
+    text = re.sub(r"<[^>]+>", " ", marked)
+    sentinel_re = re.compile(r"\x00C([0-9]+)\x00")
+    sents = _SENT_SPLIT.split(text)
+    out: list[tuple[str, list[int]]] = []
+    for s in sents:
+        if not s.strip():
+            continue
+        nums = [int(n) for n in sentinel_re.findall(s)]
+        if not nums:
+            continue
+        # Strip sentinels before substantive-check so the cite digits
+        # don't make every cited sentence look "substantive."
+        clean = sentinel_re.sub(" ", s)
+        is_subs = (
+            any(c.isdigit() for c in clean)
+            or "%" in clean
+            or "$" in clean
+            or bool(_SUBSTANTIVE_NE.search(clean))
+        )
+        if is_subs:
+            out.append((clean.strip(), nums))
+    return out
+
+
+def corroboration_audit(
+    body_html: str, min_hosts: int
+) -> tuple[list[dict], int]:
+    """Return (failing_claims, total_claims).
+
+    Each failing_claims entry: {"text": str, "ref_nums": [int],
+                                "hosts": [str], "distinct_hosts": int}
+    Total_claims = number of substantive cited sentences considered
+    (NOT count of failures). Useful for the "X of Y claims pass" report."""
+    if min_hosts < 1:
+        raise ValueError(f"min_hosts must be >= 1, got {min_hosts}")
+    ref_hosts = build_ref_host_map(body_html)
+    mark_inners = _extract_mark_inner_texts(body_html)
+    claims = _claim_sentences_with_refs(body_html)
+    failing: list[dict] = []
+    for text, nums in claims:
+        hosts: list[str] = []
+        for n in nums:
+            h = ref_hosts.get(n)
+            if h:
+                hosts.append(h)
+        distinct = sorted(set(hosts))
+        if len(distinct) >= min_hosts:
+            continue
+        # Below threshold — check single-source exemption.
+        if _is_single_source_exempt(text, mark_inners):
+            continue
+        failing.append({
+            "text": text,
+            "ref_nums": nums,
+            "hosts": distinct,
+            "distinct_hosts": len(distinct),
+        })
+    return failing, len(claims)
+
+
+# ---------------------------------------------------------------------------
+# Quantitative sanity (--qsanity) — heuristic numeric implausibility scan.
+# ---------------------------------------------------------------------------
+#
+# v1 is intentionally NARROW and WARN-ONLY. Each pattern targets a
+# common implausibility shape that's caused real article rework:
+#   1. :::donut percentages summing > 105% (compiled to ara-donut-*)
+#   2. Single-entity market share > 100%
+#   3. YoY growth claims > 1000%
+#   4. Future dates more than 10 years out (warn — forecasts are legitimate
+#      but typo'd years are common; warning encourages a sanity look)
+#
+# Patterns NOT shipped in v1 (high false-positive risk per spec):
+#   - Revenue-per-employee ratio (requires proximity pairing; FP risk on
+#     early-stage SaaS with intentionally lean teams)
+#   - P/S valuation/revenue ratio (same problem)
+#   - Compute-claim plausibility tables (needs per-accelerator domain
+#     encoding the spec admits is hard)
+#
+# All hits are stderr warnings — exit status unchanged. Once we have
+# precision data from a few hundred runs, individual patterns may be
+# promoted to hard-fail. Documented as such in CLI help.
+
+_QSANITY_FUTURE_YEAR_HORIZON = 10  # years past current — beyond this is flagged
+_QSANITY_DONUT_SUM_LIMIT = 105.0   # percent; rounding tolerance
+_QSANITY_MARKET_SHARE_LIMIT = 100.0
+_QSANITY_YOY_LIMIT = 1000.0
+
+
+def _qsanity_donut_sums(body_html: str) -> list[str]:
+    """For each `<ul class="ara-donut">` block, sum the `data-pct`
+    values of its immediate `<li>` items. Flag if the sum exceeds
+    the soft limit (allows 5% rounding tolerance).
+
+    Why ul-scope: the compiler renders donut items as
+        <ul class="ara-donut" data-...><li data-pct="N">label</li>...</ul>
+    so the sum of data-pct over each ul should equal 100. A sum of
+    175 is the textbook implausibility — either the agent listed
+    overlapping categories or hallucinated values that don't share
+    a denominator."""
+    warns: list[str] = []
+    # Match each <ul class="ara-donut"...>...</ul> block. Greedy across
+    # other elements is fine because donut bodies are tiny.
+    donut_blocks = re.findall(
+        r'<ul[^>]*class="ara-donut[^"]*"[^>]*>(.*?)</ul>',
+        body_html, flags=re.DOTALL | re.IGNORECASE,
+    )
+    for i, block in enumerate(donut_blocks):
+        pcts = re.findall(r'data-pct="([0-9]+(?:\.[0-9]+)?)"', block)
+        if not pcts:
+            continue
+        total = sum(float(p) for p in pcts)
+        if total > _QSANITY_DONUT_SUM_LIMIT:
+            warns.append(
+                f"qsanity: :::donut #{i + 1} percentages sum to {total:.1f}% "
+                f"({len(pcts)} slices) — exceeds {_QSANITY_DONUT_SUM_LIMIT:.0f}% "
+                f"tolerance. Donuts represent slices of one whole; "
+                f"if the categories overlap, use :::bars or :::rank-list "
+                f"instead. Recheck the values for hallucinated digits."
+            )
+    return warns
+
+
+def _qsanity_text_only(body_html: str) -> str:
+    """Return body text with HTML stripped. Helper for prose-pattern
+    scans that don't depend on HTML structure."""
+    # Strip cite markers first so "[citing 12.5%]" type artifacts don't
+    # confuse the number extractors.
+    s = re.sub(r"<[^>]+>", " ", body_html)
+    return re.sub(r"\s+", " ", s)
+
+
+def _qsanity_market_share_over_100(body_html: str) -> list[str]:
+    """Flag any prose mention of "N% market share" / "N% of the market"
+    where N > 100. Single-entity market share > 100% is impossible; a
+    hit is almost certainly a digit-transposition (75% → 175%) or a
+    units error (basis points / total addressable confusion)."""
+    warns: list[str] = []
+    text = _qsanity_text_only(body_html)
+    # Capture the immediate context (up to 80 chars) for the warning.
+    pattern = re.compile(
+        r'\b(\d{2,3}(?:\.\d+)?)\s*%\s*(?:market\s+share|of\s+the\s+market)',
+        flags=re.IGNORECASE,
+    )
+    for m in pattern.finditer(text):
+        val = float(m.group(1))
+        if val > _QSANITY_MARKET_SHARE_LIMIT:
+            # Snip a small window around the match for context
+            start = max(0, m.start() - 30)
+            end = min(len(text), m.end() + 30)
+            context = text[start:end].strip()
+            warns.append(
+                f"qsanity: market share {val:.1f}% > "
+                f"{_QSANITY_MARKET_SHARE_LIMIT:.0f}% (impossible) "
+                f"near: …{context}…"
+            )
+    return warns
+
+
+def _qsanity_yoy_growth(body_html: str) -> list[str]:
+    """Flag YoY growth claims > _QSANITY_YOY_LIMIT (default 1000%).
+    Hit shape: `\\d+%\\s+(YoY|year-over-year|year over year)`.
+
+    Genuine 1000%+ YoY growth exists (low base effects in startups)
+    but is rare enough to deserve a sanity check. Pattern is permissive
+    on YoY phrasing variants but conservative on the number itself
+    (only 4+ digit percentages flagged)."""
+    warns: list[str] = []
+    text = _qsanity_text_only(body_html)
+    pattern = re.compile(
+        r'\b(\d{4,}(?:\.\d+)?)\s*%\s*(?:YoY|year[-\s]over[-\s]year)',
+        flags=re.IGNORECASE,
+    )
+    for m in pattern.finditer(text):
+        val = float(m.group(1))
+        if val > _QSANITY_YOY_LIMIT:
+            start = max(0, m.start() - 30)
+            end = min(len(text), m.end() + 30)
+            context = text[start:end].strip()
+            warns.append(
+                f"qsanity: YoY growth {val:.0f}% > "
+                f"{_QSANITY_YOY_LIMIT:.0f}% (extreme — verify it's not a "
+                f"digit-shift error) near: …{context}…"
+            )
+    return warns
+
+
+def _qsanity_future_dates(body_html: str, current_year: int) -> list[str]:
+    """Flag any 4-digit year > current_year + horizon. Forecasts and
+    long-horizon timelines are legitimate; the warning's job is to
+    surface them for sanity check, not to block. Excludes years
+    inside well-known patent / patent-app number contexts (rare)."""
+    warns: list[str] = []
+    text = _qsanity_text_only(body_html)
+    # Find 4-digit numbers in 19XX-21XX range — covers all plausible
+    # year mentions without flagging stray 4-digit identifiers.
+    pattern = re.compile(r'\b(19\d{2}|20\d{2}|21\d{2})\b')
+    horizon = current_year + _QSANITY_FUTURE_YEAR_HORIZON
+    flagged_years: set[int] = set()
+    for m in pattern.finditer(text):
+        y = int(m.group(1))
+        if y > horizon and y not in flagged_years:
+            flagged_years.add(y)
+            warns.append(
+                f"qsanity: year {y} appears in body — more than "
+                f"{_QSANITY_FUTURE_YEAR_HORIZON} years past current "
+                f"({current_year}). Forecast / timeline context is "
+                f"fine; verify it's not a typo."
+            )
+    return warns
+
+
+def qsanity_scan(body_html: str, current_year: int) -> list[str]:
+    """Run all qsanity patterns. Returns the combined warning list.
+
+    Each pattern is independent — adding a new one means writing
+    another `_qsanity_*` function and appending its return value."""
+    warns: list[str] = []
+    warns.extend(_qsanity_donut_sums(body_html))
+    warns.extend(_qsanity_market_share_over_100(body_html))
+    warns.extend(_qsanity_yoy_growth(body_html))
+    warns.extend(_qsanity_future_dates(body_html, current_year))
+    return warns
+
+
 def enforce_quality(body_html: str, args: argparse.Namespace) -> list[str]:
     """Return a list of quality-gate failure messages. Empty = pass.
     Only the flags that were explicitly set are checked."""
@@ -407,6 +863,32 @@ def enforce_quality(body_html: str, args: argparse.Namespace) -> list[str]:
                 f"may inflate the denominator; consider raising the "
                 f"threshold once measured."
             )
+
+    if getattr(args, "min_corroborating_sources", None) is not None:
+        n = args.min_corroborating_sources
+        failing, total = corroboration_audit(body_html, n)
+        if failing:
+            lines = [
+                f"quality: {len(failing)} of {total} substantive cited "
+                f"claim(s) lack {n} distinct source host(s). Each claim "
+                f"below needs an additional source from a different "
+                f"publisher, or wrap the sentence in "
+                f"`==single-source: claim text==` to acknowledge the "
+                f"single-source citation (which compiles to <mark>):",
+            ]
+            for f in failing[:8]:
+                preview = f["text"][:120]
+                if len(f["text"]) > 120:
+                    preview += "…"
+                hosts_str = ", ".join(f["hosts"]) if f["hosts"] else "(no resolvable host)"
+                lines.append(
+                    f"  - cites=[{','.join(str(r) for r in f['ref_nums'])}] "
+                    f"hosts={hosts_str} "
+                    f"distinct_hosts={f['distinct_hosts']}: {preview!r}"
+                )
+            if len(failing) > 8:
+                lines.append(f"  ... and {len(failing) - 8} more failing claim(s)")
+            errors.append("\n".join(lines))
 
     return errors
 
@@ -713,6 +1195,39 @@ def main(argv: list[str] | None = None) -> int:
             "into the build gate."
         ),
     )
+    p.add_argument(
+        "--min-corroborating-sources",
+        type=int,
+        default=None,
+        metavar="INT",
+        help=(
+            "fail if any substantive cited claim is supported by fewer "
+            "than INT DISTINCT source HOSTS. A claim sentence is "
+            "'substantive' if it carries a cite marker AND contains "
+            "a digit / percent / dollar / multi-word capitalized phrase. "
+            "Hosts are extracted from the first URL in each `<li id=\"ref-N\">` "
+            "entry. To explicitly acknowledge a single-source claim, "
+            "wrap the sentence as `==single-source: claim text==` in the "
+            "DSL (compiles to <mark class=\"ara-mark\">), and the gate "
+            "exempts it. Default off (opt-in); recommended workflow "
+            "value once calibrated: 2. Heuristic — see "
+            "corroboration_audit() docstring for caveats."
+        ),
+    )
+    p.add_argument(
+        "--qsanity",
+        action="store_true",
+        help=(
+            "scan the article for implausible numeric patterns and "
+            "print warnings to stderr. WARN-ONLY (does not fail the "
+            "build) in v1 — heuristics are conservative but can have "
+            "false positives. Patterns checked: :::donut percentage "
+            "sums above 105, single-entity market share above 100, "
+            "YoY growth above 1000, dates more than 10 years past "
+            "current. Documented patterns may be promoted to hard-fail "
+            "in future revisions once precision is established."
+        ),
+    )
     # Verifier-findings audit mode. When this flag is set we skip
     # validate_body / design / quality gates and instead audit the
     # body against the verifier sub-agent's JSON artifact. The
@@ -826,6 +1341,7 @@ def main(argv: list[str] | None = None) -> int:
             args.refs_min,
             args.primary_share_min,
             args.cited_claims_min,
+            args.min_corroborating_sources,
         )
     ):
         errors = enforce_quality(body, args)
@@ -847,6 +1363,25 @@ def main(argv: list[str] | None = None) -> int:
     if args.kind == KIND_FRAGMENT and args.strict_shape:
         for line in soft_warnings(body):
             print(line, file=sys.stderr)
+
+    # Quantitative-sanity scan (--qsanity). Warn-only in v1: each
+    # heuristic prints to stderr but exit status is unchanged. See
+    # qsanity_scan() and the _qsanity_* helpers for the pattern set
+    # and the rationale for each. Promotion to hard-fail is deferred
+    # until per-pattern precision is established by running the scan
+    # against the historical corpus and inspecting false positives.
+    if args.kind == KIND_FRAGMENT and args.qsanity:
+        from datetime import datetime, timezone
+        cy = datetime.now(timezone.utc).year
+        qwarns = qsanity_scan(body, cy)
+        for line in qwarns:
+            print(line, file=sys.stderr)
+        if qwarns:
+            print(
+                f"qsanity: {len(qwarns)} warning(s) — review each; not "
+                "blocking the build.",
+                file=sys.stderr,
+            )
 
     size = len(body.encode("utf-8"))
     src = "compiled from DSL" if is_dsl else "raw HTML"

--- a/scripts/check_generative_research.py
+++ b/scripts/check_generative_research.py
@@ -663,31 +663,88 @@ _QSANITY_YOY_LIMIT = 1000.0
 
 
 def _qsanity_donut_sums(body_html: str) -> list[str]:
-    """For each `<ul class="ara-donut">` block, sum the `data-pct`
-    values of its immediate `<li>` items. Flag if the sum exceeds
-    the soft limit (allows 5% rounding tolerance).
+    """For each `<div class="ara-donut">` block (or legacy `<ul>` form),
+    sum the slice values and flag if the sum exceeds 105% (rounding
+    tolerance).
 
-    Why ul-scope: the compiler renders donut items as
-        <ul class="ara-donut" data-...><li data-pct="N">label</li>...</ul>
-    so the sum of data-pct over each ul should equal 100. A sum of
-    175 is the textbook implausibility — either the agent listed
-    overlapping categories or hallucinated values that don't share
-    a denominator."""
+    Compiler emits donuts as `<div class="ara-donut" data-labels="A,B,C"
+    data-values="80,50,45"></div>` — see emit_donut() in compile_ara.py.
+    Earlier draft of this helper matched `<ul>` with `<li data-pct>`,
+    which never fires in production (caught by codex review). Both
+    shapes are supported here so hand-authored `:::raw` donut markup
+    (if anyone ever writes it) is also scanned.
+
+    A sum of 175 is the textbook implausibility — either the agent
+    listed overlapping categories or hallucinated values that don't
+    share a denominator.
+
+    Known false-positive class: donuts used for COMPARATIVE MAGNITUDE
+    rather than percentage share. Example surfaced by corpus scan:
+    home-inference-rack article uses a donut to compare $/M-tokens
+    pricing across models ($180, $30, $25, $18) — the sum (253) has
+    no meaning. v1 ships warn-only specifically so authors can ignore
+    these legitimate non-share donuts. If a future iteration wants to
+    hard-fail on donut sum, also require `data-pct` semantics in the
+    DSL (e.g., introduce a `:::pct-donut` directive) so the gate has
+    explicit consent to treat slices as shares."""
     warns: list[str] = []
-    # Match each <ul class="ara-donut"...>...</ul> block. Greedy across
-    # other elements is fine because donut bodies are tiny.
-    donut_blocks = re.findall(
+    donut_index = 0
+
+    # Primary shape: <div class="ara-donut" data-values="80,50,45"></div>
+    # Self-closing divs would be unusual but the compiler emits them with
+    # an explicit closing tag, so this regex matches either form.
+    for m in re.finditer(
+        r'<div[^>]*class="ara-donut[^"]*"([^>]*)>(?:.*?</div>)?',
+        body_html, flags=re.DOTALL | re.IGNORECASE,
+    ):
+        donut_index += 1
+        attrs = m.group(1)
+        values_match = re.search(
+            r'data-values="([0-9.,\s-]+)"', attrs
+        )
+        if not values_match:
+            continue
+        raw_values = values_match.group(1)
+        nums: list[float] = []
+        for part in raw_values.split(","):
+            part = part.strip()
+            if not part:
+                continue
+            try:
+                nums.append(float(part))
+            except ValueError:
+                # Non-numeric token — skip the donut rather than warn
+                # on parse error. validate_body would have already
+                # rejected an article with truly malformed data-values.
+                nums = []
+                break
+        if not nums:
+            continue
+        total = sum(nums)
+        if total > _QSANITY_DONUT_SUM_LIMIT:
+            warns.append(
+                f"qsanity: :::donut #{donut_index} values sum to {total:.1f}% "
+                f"({len(nums)} slices) — exceeds {_QSANITY_DONUT_SUM_LIMIT:.0f}% "
+                f"tolerance. Donuts represent slices of one whole; "
+                f"if the categories overlap, use :::bars or :::rank-list "
+                f"instead. Recheck the values for hallucinated digits."
+            )
+
+    # Legacy / hand-authored shape: <ul class="ara-donut">
+    # <li data-pct="N">label</li>... </ul>. Kept for compatibility
+    # with any article authored via :::raw that hand-rolls a donut.
+    for block in re.findall(
         r'<ul[^>]*class="ara-donut[^"]*"[^>]*>(.*?)</ul>',
         body_html, flags=re.DOTALL | re.IGNORECASE,
-    )
-    for i, block in enumerate(donut_blocks):
+    ):
         pcts = re.findall(r'data-pct="([0-9]+(?:\.[0-9]+)?)"', block)
         if not pcts:
             continue
+        donut_index += 1
         total = sum(float(p) for p in pcts)
         if total > _QSANITY_DONUT_SUM_LIMIT:
             warns.append(
-                f"qsanity: :::donut #{i + 1} percentages sum to {total:.1f}% "
+                f"qsanity: :::donut #{donut_index} percentages sum to {total:.1f}% "
                 f"({len(pcts)} slices) — exceeds {_QSANITY_DONUT_SUM_LIMIT:.0f}% "
                 f"tolerance. Donuts represent slices of one whole; "
                 f"if the categories overlap, use :::bars or :::rank-list "

--- a/scripts/test_check_generative_research.py
+++ b/scripts/test_check_generative_research.py
@@ -35,6 +35,7 @@ def _ns(**overrides):
         refs_min=None,
         primary_share_min=None,
         cited_claims_min=None,
+        min_corroborating_sources=None,
     )
     defaults.update(overrides)
     return argparse.Namespace(**defaults)
@@ -633,6 +634,384 @@ class VerifierFindingsAuditTest(unittest.TestCase):
             # Empty text → can't audit → not added to surviving
             self.assertEqual(total, 1)
             self.assertEqual(surviving, [])
+
+
+class CorroborationGateTest(unittest.TestCase):
+    """Gate 1: --min-corroborating-sources. Each substantive cited claim
+    needs N distinct source hosts unless explicitly wrapped in
+    `==single-source: ...==`.
+
+    The corpus calibration (PR body) shows N=2 default would fail 84%
+    of historical claims, so the gate ships opt-in only. Tests assert
+    correctness, not the default-on policy."""
+
+    def _article_with_refs(self, body_inner: str, refs: list[tuple[int, str]]) -> str:
+        """Build an article with explicit (ref_num, host) ref entries.
+        Each ref gets a distinct URL path so URL-normalization can't
+        collapse them."""
+        ref_lis = "".join(
+            f'<li id="ref-{n}"><a href="https://{host}/path/{n}">src</a></li>'
+            for n, host in refs
+        )
+        return (
+            '<article class="ara-doc">'
+            f"<p>{body_inner}</p>"
+            f'<ol class="ara-refs">{ref_lis}</ol>'
+            "</article>"
+        )
+
+    def test_claim_with_two_distinct_hosts_passes(self):
+        body = self._article_with_refs(
+            'OpenAI raised $40 billion in 2026'
+            '<sup><a class="ara-cite" href="#ref-1">1</a></sup>'
+            '<sup><a class="ara-cite" href="#ref-2">2</a></sup>.',
+            [(1, "anthropic.com"), (2, "openai.com")],
+        )
+        failing, total = chk.corroboration_audit(body, 2)
+        self.assertEqual(total, 1)
+        self.assertEqual(failing, [])
+
+    def test_claim_with_two_cites_same_host_fails(self):
+        """Two cites both to the same host (different URLs on same
+        host) count as 1 distinct host — claim fails @ N=2."""
+        body = self._article_with_refs(
+            'Cerebras shipped 142x speedup'
+            '<sup><a class="ara-cite" href="#ref-1">1</a></sup>'
+            '<sup><a class="ara-cite" href="#ref-2">2</a></sup>.',
+            [(1, "cerebras.ai"), (2, "cerebras.ai")],
+        )
+        failing, total = chk.corroboration_audit(body, 2)
+        self.assertEqual(total, 1)
+        self.assertEqual(len(failing), 1)
+        self.assertEqual(failing[0]["distinct_hosts"], 1)
+        self.assertEqual(failing[0]["hosts"], ["cerebras.ai"])
+
+    def test_single_source_wrapping_exempts_claim(self):
+        """A failing-by-host-count claim wrapped in <mark> whose inner
+        text begins with `single-source:` is exempt — that's the
+        agent's explicit acknowledgment."""
+        body = self._article_with_refs(
+            '<mark class="ara-mark">single-source: Cerebras posted '
+            '21 PB/s aggregate bandwidth'
+            '<sup><a class="ara-cite" href="#ref-1">1</a></sup>.</mark>',
+            [(1, "cerebras.ai")],
+        )
+        failing, total = chk.corroboration_audit(body, 2)
+        self.assertEqual(total, 1)
+        self.assertEqual(failing, [],
+                         "single-source: wrapping must exempt the claim")
+
+    def test_single_source_exemption_via_dsl_compile(self):
+        """Wraps the claim via DSL `==single-source: ...==` (the
+        intended author-facing syntax) and confirms the compiled
+        HTML survives the corroboration audit. Guards against the
+        compile output shape changing under us."""
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        from compile_ara import parse_inline
+        sentence = (
+            '==single-source: Cerebras posted 21 PB/s bandwidth[^1].=='
+        )
+        compiled = parse_inline(sentence)
+        body = (
+            '<article class="ara-doc">'
+            f'<p>{compiled}</p>'
+            '<ol class="ara-refs">'
+            '<li id="ref-1"><a href="https://cerebras.ai/x">src</a></li>'
+            '</ol></article>'
+        )
+        failing, total = chk.corroboration_audit(body, 2)
+        self.assertEqual(failing, [],
+                         "DSL-compiled single-source wrap must exempt")
+
+    def test_no_cited_claims_passes_trivially(self):
+        """An article with no cited substantive sentences (e.g. a
+        methodology piece) passes the gate vacuously."""
+        body = (
+            '<article class="ara-doc">'
+            '<p>This is a methodology piece with no factual claims.</p>'
+            '<p>It explains an approach without numbers or attributions.</p>'
+            '</article>'
+        )
+        failing, total = chk.corroboration_audit(body, 2)
+        self.assertEqual(total, 0)
+        self.assertEqual(failing, [])
+
+    def test_non_substantive_cited_sentence_ignored(self):
+        """A cited sentence with no number/percent/dollar/name-entity
+        proxy isn't a 'substantive claim' — gate ignores it."""
+        body = self._article_with_refs(
+            'see this related work'
+            '<sup><a class="ara-cite" href="#ref-1">1</a></sup>.',
+            [(1, "arxiv.org")],
+        )
+        # No digits, no $, no %, no multi-word capitalized phrase →
+        # not substantive, not counted.
+        failing, total = chk.corroboration_audit(body, 2)
+        self.assertEqual(total, 0)
+
+    def test_headings_excluded_from_substantive_count(self):
+        """Headings often look substantive (multi-word capitalized)
+        but rarely carry meaningful claims. The pre-strip step removes
+        them so they can't contribute false positives."""
+        body = (
+            '<article class="ara-doc">'
+            '<h2>Cerebras WSE-3 Architecture'
+            '<sup><a class="ara-cite" href="#ref-1">1</a></sup></h2>'
+            '<p>A non-substantive cited sentence is here too.</p>'
+            '<ol class="ara-refs">'
+            '<li id="ref-1"><a href="https://cerebras.ai/x">src</a></li>'
+            '</ol></article>'
+        )
+        failing, total = chk.corroboration_audit(body, 2)
+        # Heading-cited claim is stripped; body claim has no cite → 0 total
+        self.assertEqual(total, 0)
+
+    def test_multi_cite_one_resolvable_one_orphan(self):
+        """A cite to a ref-num that doesn't exist in the references
+        list (orphan citation) doesn't contribute a host. If the only
+        OTHER cite is a duplicate host, claim fails."""
+        body = self._article_with_refs(
+            'Nvidia hit $62B revenue'
+            '<sup><a class="ara-cite" href="#ref-1">1</a></sup>'
+            '<sup><a class="ara-cite" href="#ref-99">99</a></sup>.',
+            [(1, "nvidia.com")],  # ref-99 is orphan
+        )
+        failing, total = chk.corroboration_audit(body, 2)
+        self.assertEqual(total, 1)
+        self.assertEqual(len(failing), 1)
+        self.assertEqual(failing[0]["distinct_hosts"], 1)
+        self.assertEqual(failing[0]["hosts"], ["nvidia.com"])
+
+    def test_enforce_quality_threading(self):
+        """Gate 1 plumbs through enforce_quality()."""
+        body = self._article_with_refs(
+            'Nvidia hit $62B in Q4 2026'
+            '<sup><a class="ara-cite" href="#ref-1">1</a></sup>.',
+            [(1, "nvidia.com")],
+        )
+        errs = chk.enforce_quality(body, _ns(min_corroborating_sources=2))
+        self.assertEqual(len(errs), 1)
+        self.assertIn("distinct source host", errs[0])
+        self.assertIn("single-source", errs[0])
+
+    def test_enforce_quality_threshold_one_passes(self):
+        """At N=1 the gate degenerates to 'every cited claim has a
+        resolvable host' which is the existing cited-claims-min gate.
+        Still useful as a smoke test."""
+        body = self._article_with_refs(
+            'Nvidia hit $62B revenue'
+            '<sup><a class="ara-cite" href="#ref-1">1</a></sup>.',
+            [(1, "nvidia.com")],
+        )
+        errs = chk.enforce_quality(body, _ns(min_corroborating_sources=1))
+        self.assertEqual(errs, [])
+
+    def test_ref_host_map_skips_title_only_refs(self):
+        """Refs without an http(s) URL don't get added to the host map
+        — a cite pointing at them resolves to no host (treated as not
+        contributing to the distinct-host count)."""
+        body = (
+            '<article class="ara-doc"><p>Claim with cite.</p>'
+            '<ol class="ara-refs">'
+            '<li id="ref-1">Personal communication.</li>'
+            '<li id="ref-2"><a href="https://arxiv.org/x">paper</a></li>'
+            '</ol></article>'
+        )
+        m = chk.build_ref_host_map(body)
+        self.assertNotIn(1, m)
+        self.assertEqual(m.get(2), "arxiv.org")
+
+    def test_www_prefix_normalized_in_host_map(self):
+        """Hosts in the map are normalized (lowercase, www stripped)
+        so duplicate-host detection treats www.example.com and
+        example.com as the same source."""
+        body = (
+            '<article class="ara-doc"><p>x</p>'
+            '<ol class="ara-refs">'
+            '<li id="ref-1"><a href="https://www.Cerebras.ai/x">a</a></li>'
+            '<li id="ref-2"><a href="https://CEREBRAS.AI/y">b</a></li>'
+            '</ol></article>'
+        )
+        m = chk.build_ref_host_map(body)
+        self.assertEqual(m.get(1), "cerebras.ai")
+        self.assertEqual(m.get(2), "cerebras.ai")
+
+    def test_first_url_per_ref_li_is_canonical(self):
+        """A ref entry with multiple URLs uses ONLY the first http URL
+        for host classification — bibliographic convention is primary
+        source first."""
+        body = (
+            '<article class="ara-doc"><p>x</p>'
+            '<ol class="ara-refs">'
+            '<li id="ref-1">'
+            '<a href="https://arxiv.org/abs/2024.001">paper</a>'
+            ' (also at <a href="https://medium.com/repost">medium</a>)'
+            '</li></ol></article>'
+        )
+        m = chk.build_ref_host_map(body)
+        # First URL is arxiv; medium does NOT register as the ref host
+        self.assertEqual(m.get(1), "arxiv.org")
+
+    def test_corroboration_invalid_min(self):
+        """N must be >= 1."""
+        body = '<article><p>x</p></article>'
+        with self.assertRaises(ValueError):
+            chk.corroboration_audit(body, 0)
+
+
+class QSanityGateTest(unittest.TestCase):
+    """Gate 2: --qsanity. Warn-only in v1 — qsanity_scan returns the
+    list of warning lines; the CLI prints to stderr but doesn't fail
+    the build. Tests assert pattern correctness."""
+
+    def test_donut_summing_over_100_warns(self):
+        """A :::donut block with data-pct values summing > 105% is flagged.
+        Per the qsanity rationale: donut slices are slices of one
+        whole — if they overlap, the chart is wrong."""
+        body = (
+            '<article class="ara-doc">'
+            '<ul class="ara-donut" data-title="x">'
+            '<li data-pct="80">A</li>'
+            '<li data-pct="50">B</li>'
+            '<li data-pct="45">C</li>'
+            '</ul></article>'
+        )
+        warns = chk.qsanity_scan(body, 2026)
+        self.assertEqual(len(warns), 1)
+        self.assertIn("175", warns[0])  # the sum
+        self.assertIn("donut", warns[0].lower())
+
+    def test_donut_summing_under_limit_silent(self):
+        """Donut summing to 100% (or 105% with rounding tolerance) is silent."""
+        body = (
+            '<article class="ara-doc">'
+            '<ul class="ara-donut" data-title="x">'
+            '<li data-pct="40">A</li>'
+            '<li data-pct="35">B</li>'
+            '<li data-pct="25">C</li>'
+            '</ul></article>'
+        )
+        warns = chk.qsanity_scan(body, 2026)
+        self.assertEqual([w for w in warns if "donut" in w.lower()], [])
+
+    def test_donut_rounding_tolerance(self):
+        """Sum of 103% is within the 105% tolerance — should NOT warn."""
+        body = (
+            '<article class="ara-doc">'
+            '<ul class="ara-donut" data-title="x">'
+            '<li data-pct="34">A</li>'
+            '<li data-pct="35">B</li>'
+            '<li data-pct="34">C</li>'
+            '</ul></article>'
+        )
+        warns = chk.qsanity_scan(body, 2026)
+        self.assertEqual([w for w in warns if "donut" in w.lower()], [])
+
+    def test_market_share_over_100_warns(self):
+        body = (
+            '<article class="ara-doc">'
+            '<p>Cerebras commands a 175% market share in wafer-scale chips.</p>'
+            '</article>'
+        )
+        warns = chk.qsanity_scan(body, 2026)
+        self.assertTrue(any("175" in w and "market share" in w for w in warns))
+
+    def test_market_share_at_99_silent(self):
+        body = (
+            '<article class="ara-doc">'
+            '<p>Cerebras commands a 99% market share in wafer-scale chips.</p>'
+            '</article>'
+        )
+        warns = chk.qsanity_scan(body, 2026)
+        self.assertEqual([w for w in warns if "market share" in w], [])
+
+    def test_yoy_growth_over_1000_warns(self):
+        body = (
+            '<article class="ara-doc">'
+            '<p>Revenue grew 2500% YoY in Q4 2026.</p>'
+            '</article>'
+        )
+        warns = chk.qsanity_scan(body, 2026)
+        self.assertTrue(any("2500" in w and "YoY" in w for w in warns))
+
+    def test_yoy_growth_at_500_silent(self):
+        body = (
+            '<article class="ara-doc">'
+            '<p>Revenue grew 500% YoY in Q4 2026.</p>'
+            '</article>'
+        )
+        warns = chk.qsanity_scan(body, 2026)
+        self.assertEqual([w for w in warns if "YoY" in w], [])
+
+    def test_future_date_over_horizon_warns(self):
+        body = (
+            '<article class="ara-doc">'
+            '<p>The forecast projects a peak in 2055 based on current rates.</p>'
+            '</article>'
+        )
+        warns = chk.qsanity_scan(body, 2026)
+        # 2055 > 2026+10 → warn
+        self.assertTrue(any("2055" in w for w in warns))
+
+    def test_future_date_in_horizon_silent(self):
+        """2032 is within 10y horizon of 2026 — silent."""
+        body = (
+            '<article class="ara-doc">'
+            '<p>By 2032 the market is expected to mature.</p>'
+            '</article>'
+        )
+        warns = chk.qsanity_scan(body, 2026)
+        self.assertEqual([w for w in warns if "2032" in w], [])
+
+    def test_past_year_silent(self):
+        """Historical references aren't flagged."""
+        body = (
+            '<article class="ara-doc">'
+            '<p>The IPO was filed in 2024 and priced in 2026.</p>'
+            '</article>'
+        )
+        warns = chk.qsanity_scan(body, 2026)
+        self.assertEqual(warns, [])
+
+    def test_future_date_deduped(self):
+        """The same year mentioned twice should only warn once."""
+        body = (
+            '<article class="ara-doc">'
+            '<p>The 2055 forecast vs the 2055 actual is informative.</p>'
+            '</article>'
+        )
+        warns = chk.qsanity_scan(body, 2026)
+        self.assertEqual(len([w for w in warns if "2055" in w]), 1)
+
+    def test_clean_article_no_warnings(self):
+        body = (
+            '<article class="ara-doc">'
+            '<p>Revenue was $5.55 billion in Q4 2026, with 75% gross margin.</p>'
+            '</article>'
+        )
+        warns = chk.qsanity_scan(body, 2026)
+        self.assertEqual(warns, [])
+
+    def test_nbis_class_pattern_revenue_per_employee(self):
+        """Documents that the original NBIS-class failure (e.g.
+        '1000 employees, $5T revenue' = $5B per employee, implausible)
+        is NOT caught by v1's pattern set. This is intentional — the
+        revenue/employee pairing pattern requires reliable proximity
+        matching which has high false-positive rates on early-stage
+        SaaS. Documented in PR body and the --qsanity CLI help.
+
+        If a future iteration wants to add this pattern, build it
+        with a tight (<80 char) proximity window and start warn-only.
+        """
+        body = (
+            '<article class="ara-doc">'
+            '<p>NBIS had $5T revenue with 1000 employees.</p>'
+            '</article>'
+        )
+        warns = chk.qsanity_scan(body, 2026)
+        # This pattern is documented as out-of-scope for v1.
+        # When/if added, update this test.
+        self.assertEqual(warns, [])
 
 
 class SanityAgainstKnownGoodArticleTest(unittest.TestCase):

--- a/scripts/test_check_generative_research.py
+++ b/scripts/test_check_generative_research.py
@@ -864,10 +864,76 @@ class QSanityGateTest(unittest.TestCase):
     list of warning lines; the CLI prints to stderr but doesn't fail
     the build. Tests assert pattern correctness."""
 
-    def test_donut_summing_over_100_warns(self):
-        """A :::donut block with data-pct values summing > 105% is flagged.
-        Per the qsanity rationale: donut slices are slices of one
-        whole — if they overlap, the chart is wrong."""
+    def test_donut_summing_over_100_warns_compiled_shape(self):
+        """The actual compiler output for :::donut is
+            <div class="ara-donut" data-labels="A,B,C" data-values="80,50,45">
+        not a <ul>/<li> shape. Codex review caught the original
+        implementation matching only the wrong shape — now we test
+        against what the compiler actually emits, by compiling DSL
+        through the real compiler instead of hand-rolling HTML."""
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        from compile_ara import compile_source
+        src = (
+            "---\n"
+            "title: T\n"
+            "---\n"
+            "\n"
+            "## 1. Test\n"
+            "\n"
+            ":::donut\n"
+            "- label: A\n"
+            "  value: 80\n"
+            "- label: B\n"
+            "  value: 50\n"
+            "- label: C\n"
+            "  value: 45\n"
+            ":::\n"
+        )
+        body = compile_source(src)
+        # Confirm compiler shape — div with data-values, not ul/li
+        self.assertIn('<div class="ara-donut"', body)
+        self.assertIn('data-values="80,50,45"', body)
+        # And the qsanity scan flags the over-100 sum
+        warns = chk.qsanity_scan(body, 2026)
+        donut_warns = [w for w in warns if "donut" in w.lower()]
+        self.assertEqual(len(donut_warns), 1, f"got: {donut_warns}")
+        self.assertIn("175", donut_warns[0])
+
+    def test_donut_summing_under_limit_silent_compiled_shape(self):
+        """Compiled donut summing to 100% is silent."""
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        from compile_ara import compile_source
+        src = (
+            "---\ntitle: T\n---\n\n## 1. Test\n\n"
+            ":::donut\n"
+            "- label: A\n  value: 40\n"
+            "- label: B\n  value: 35\n"
+            "- label: C\n  value: 25\n"
+            ":::\n"
+        )
+        body = compile_source(src)
+        warns = chk.qsanity_scan(body, 2026)
+        self.assertEqual([w for w in warns if "donut" in w.lower()], [])
+
+    def test_donut_rounding_tolerance_compiled_shape(self):
+        """Sum of 103% is within the 105% tolerance."""
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        from compile_ara import compile_source
+        src = (
+            "---\ntitle: T\n---\n\n## 1. Test\n\n"
+            ":::donut\n"
+            "- label: A\n  value: 34\n"
+            "- label: B\n  value: 35\n"
+            "- label: C\n  value: 34\n"
+            ":::\n"
+        )
+        body = compile_source(src)
+        warns = chk.qsanity_scan(body, 2026)
+        self.assertEqual([w for w in warns if "donut" in w.lower()], [])
+
+    def test_donut_legacy_ul_shape_still_supported(self):
+        """The pre-fix <ul>/<li data-pct> shape is also matched, in
+        case anyone hand-rolled a donut via :::raw."""
         body = (
             '<article class="ara-doc">'
             '<ul class="ara-donut" data-title="x">'
@@ -877,31 +943,17 @@ class QSanityGateTest(unittest.TestCase):
             '</ul></article>'
         )
         warns = chk.qsanity_scan(body, 2026)
-        self.assertEqual(len(warns), 1)
-        self.assertIn("175", warns[0])  # the sum
-        self.assertIn("donut", warns[0].lower())
+        donut_warns = [w for w in warns if "donut" in w.lower()]
+        self.assertEqual(len(donut_warns), 1)
+        self.assertIn("175", donut_warns[0])
 
-    def test_donut_summing_under_limit_silent(self):
-        """Donut summing to 100% (or 105% with rounding tolerance) is silent."""
+    def test_donut_legacy_ul_under_limit_silent(self):
         body = (
             '<article class="ara-doc">'
             '<ul class="ara-donut" data-title="x">'
             '<li data-pct="40">A</li>'
             '<li data-pct="35">B</li>'
             '<li data-pct="25">C</li>'
-            '</ul></article>'
-        )
-        warns = chk.qsanity_scan(body, 2026)
-        self.assertEqual([w for w in warns if "donut" in w.lower()], [])
-
-    def test_donut_rounding_tolerance(self):
-        """Sum of 103% is within the 105% tolerance — should NOT warn."""
-        body = (
-            '<article class="ara-doc">'
-            '<ul class="ara-donut" data-title="x">'
-            '<li data-pct="34">A</li>'
-            '<li data-pct="35">B</li>'
-            '<li data-pct="34">C</li>'
             '</ul></article>'
         )
         warns = chk.qsanity_scan(body, 2026)

--- a/scripts/write_generative_research.py
+++ b/scripts/write_generative_research.py
@@ -629,6 +629,35 @@ def main(argv: list[str] | None = None) -> int:
         metavar="FLOAT",
         help="fail commit if < FLOAT (0-1) of substantive sentences carry a cite",
     )
+    # Corroboration gate (--min-corroborating-sources). Mirrors the same flag
+    # in scripts/check_generative_research.py. Opt-in only — corpus calibration
+    # showed default N=2 would block legitimate articles, so workflow default
+    # does NOT pass this flag. Provided here so local invocations / future
+    # workflow tightening can use it.
+    p.add_argument(
+        "--min-corroborating-sources",
+        type=int,
+        default=None,
+        metavar="INT",
+        help=(
+            "fail commit if any substantive cited claim is supported by "
+            "fewer than INT distinct source hosts. Single-source claims "
+            "may opt out via `==single-source: claim text==` wrapping "
+            "in the DSL. Opt-in only — not yet on by default."
+        ),
+    )
+    # qsanity scan (--qsanity). Mirrors the same flag in
+    # scripts/check_generative_research.py. Warn-only in v1; passes through
+    # to the check at validation time so the commit reflects the same
+    # warnings the agent would have seen.
+    p.add_argument(
+        "--qsanity",
+        action="store_true",
+        help=(
+            "warn-only quantitative-sanity scan; prints to stderr "
+            "without failing the commit. See scripts/check_generative_research.py."
+        ),
+    )
     args = p.parse_args(argv)
 
     repo = Path(args.repo_root).resolve()
@@ -658,6 +687,7 @@ def main(argv: list[str] | None = None) -> int:
             args.refs_min,
             args.primary_share_min,
             args.cited_claims_min,
+            args.min_corroborating_sources,
         )
     ):
         # Defer import so the writer has no hard dependency on the check
@@ -673,6 +703,16 @@ def main(argv: list[str] | None = None) -> int:
             for line in errs:
                 print(f"  - {line}", file=sys.stderr)
             raise SystemExit(1)
+
+    # qsanity warn-only scan. Same opt-in flag as check_generative_research.
+    # Printed at commit time so authors see exactly the warnings the
+    # check would have emitted, even if the agent skipped the local
+    # compile-check step. Never fails the commit in v1.
+    if args.kind == KIND_FRAGMENT and args.qsanity:
+        from check_generative_research import qsanity_scan  # noqa: E402
+        cy = datetime.now(timezone.utc).year
+        for line in qsanity_scan(body, cy):
+            print(f"  - {line}", file=sys.stderr)
 
     if not body.endswith("\n"):
         body += "\n"


### PR DESCRIPTION
## Summary

Two new opt-in quality gates in `scripts/check_generative_research.py` that target failure modes the existing cite-density / refs-count / primary-share gates cannot see:

- **`--min-corroborating-sources N`** — every substantive cited claim must carry N **distinct source hosts**. Single-source claims may opt-out via `==single-source: claim text==` (compiles to `<mark class="ara-mark">`). Catches the **NBIS-class failure**: a single source supports a claim even when the cited source is adjacent-but-wrong.
- **`--qsanity`** — scans for numeric implausibility shapes: `:::donut` percentages summing > 105%, single-entity market share > 100%, YoY growth > 1000%, dates more than 10 years past current. **WARN-ONLY in v1** (does not fail the build) — heuristics have known false-positive shapes.

## Why each gate exists

The existing PR #45 gates count cites; they don't audit whether the cite is sufficient. A claim with a single (possibly wrong) source passes today's quality gates. The corroboration gate forces multi-host attribution unless the agent explicitly acknowledges single-sourcing — the NBIS failure pattern in production was a hallucinated number cited to an adjacent-but-wrong source, which today's gates accept.

`--qsanity` catches the orthogonal class: claims that are correctly cited but numerically impossible (175% market share, $5T revenue, donuts summing past 100%, far-future date typos).

## Corpus calibration — 26 articles, 1590 substantive cited claims

| Gate | Fail rate (claims) | Articles passing fully |
|------|--------------------|------------------------|
| `--min-corroborating-sources 1` | 19 / 1590 (1%) | 25 / 26 |
| `--min-corroborating-sources 2` | 1339 / 1590 (84%) | 5 / 26 (all 5 are seed/meta with 0 claims) |
| `--min-corroborating-sources 3` | 1514 / 1590 (95%) | 5 / 26 (same 5 seeds) |
| `--qsanity` (warn-only) | 13 warns across 7 / 26 articles | n/a |

**Critical finding**: the cerebras-wse-3 known-good article cited as the test-suite fixture has 67 of 87 claims (77%) failing at N=2. Default `--min-corroborating-sources 2` would block essentially every legitimate article.

### Deviation from spec — workflow wiring decision

The task spec recommended wiring both `--min-corroborating-sources 2` AND `--qsanity` into `.github/workflows/generative-research.yml` step 7.5 + step 9. The corpus calibration falsifies the N=2 hypothesis: 0 substantive articles in the existing corpus pass it. Per the task quality bar ("Don't ship false-positive-heavy heuristics that would block legitimate articles"), this PR wires only `--qsanity` into the workflow. The corroboration gate ships as a CLI/writer flag, opt-in only.

Path forward to wire N=2: either (a) update the agent prompt to require multi-host sourcing for every claim, then retro-validate; or (b) ratchet to N=2 only for new domains where 2+ sources are reliably available; or (c) ship a `--min-corroborating-sources 1` default in the workflow (catches 19 orphan-ref claims in 1 historical article — a useful but milder signal).

## Workflow changes

- Step 7.5 (Claude + DeepSeek backends): adds `--qsanity` to the compile-check invocation. Mirrors the `--strict-shape` opt-in pattern (warn-only, advisory).
- Step 9 (writer invocation): adds `--qsanity` flag for parity, so commit-time logs match the agent's compile-check warnings.
- Post-write quality gate (line 1727): unchanged. Warn-only doesn't change exit status, so it's not added there.

## Codex review verdict — caught a real bug

Initial implementation matched `<ul>/<li data-pct>` for the donut-sum heuristic. Codex's review caught that `compile_ara.emit_donut` actually emits `<div class="ara-donut" data-values="80,50,45">` — so the heuristic was dead in production.

After the fix:
- Tests now compile real DSL through the compiler (lock against shape drift).
- Re-scan of the corpus surfaced a legitimate-but-flagged donut in the home-inference-rack article (253% sum from $/M-token pricing — comparative magnitude, not percentage share).
- Documented as the known false-positive class. Confirms warn-only is the right default for v1.

Codex verdict: P2 finding (advisory, not critical). Addressed before merge.

## Known limitations

- **Corroboration gate**: "substantive claim" detection is heuristic (sentence with cite AND digit/percent/dollar/named-entity proxy). Headings are excluded explicitly, but some borderline sentences may still be misclassified. Calibrated against the corpus.
- **qsanity revenue/employee, P/S ratio, compute claims**: NOT shipped in v1. Listed in the spec but require proximity-pairing which has high false-positive rates on early-stage SaaS. Test `test_nbis_class_pattern_revenue_per_employee` explicitly documents this as v1-out-of-scope.
- **qsanity donut sums**: false-positive on donuts used for comparative magnitudes rather than percentage share (surfaced in the corpus scan). Documented in the helper docstring. Future tightening could introduce a `:::pct-donut` directive that opts in to the gate.
- **Single-source exemption is opt-in via DSL wrapping**: the gate cannot retro-apply to existing articles. Agent prompt would need a sentence-level opt-out convention to use the gate in CI without false positives.

## Test plan

- [x] All 90 tests pass: `python3 -m unittest scripts.test_check_generative_research scripts.test_ara_dsl`
- [x] Corroboration gate hand-tested against full corpus (26 articles); fail rates documented above
- [x] qsanity gate hand-tested; 13 warnings surfaced (12 legitimate forecast-context future dates + 1 known-FP comparative donut)
- [x] CLI help renders correctly (regression on `%` chars caught + fixed)
- [x] Writer accepts the new flags and passes them through to the validator
- [x] Workflow YAML still parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Codex review run; one P2 finding (donut HTML shape mismatch) caught and fixed