### PR TITLE
fix(dashboard): TS6 typecheck errors in renderSlopes (latent since PR #49 + PR #54)

### DIFF
--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -1415,10 +1415,17 @@ function bindAraTooltip(target: Element): void {
   ensureAraTooltipDelegates();
   if (target.getAttribute(ARA_TOOLTIP_BOUND_ATTR) === '1') return;
   target.setAttribute(ARA_TOOLTIP_BOUND_ATTR, '1');
-  const showFromMouse = (event: MouseEvent): void => {
+  // Typed as EventListener (not MouseEvent) because addEventListener on the
+  // base Element interface uses ElementEventMap, which does not include
+  // pointer/mouse events — TS6 routes through the string-based overload that
+  // requires Event. PointerEvent extends MouseEvent at runtime, so the
+  // instanceof narrowing covers both pointer* and mouse* listeners below.
+  const showFromMouse: EventListener = (event) => {
+    if (!(event instanceof MouseEvent)) return;
     showAraTooltip(target, event.clientX, event.clientY);
   };
-  const moveFromMouse = (event: MouseEvent): void => {
+  const moveFromMouse: EventListener = (event) => {
+    if (!(event instanceof MouseEvent)) return;
     const tooltip = document.getElementById('araTooltip') as HTMLDivElement | null;
     if (!tooltip || tooltip.hidden) return;
     placeAraTooltip(tooltip, event.clientX, event.clientY);
@@ -1460,7 +1467,7 @@ function stackSegmentCategory(seg: HTMLElement): string {
     ? stack.nextElementSibling
     : stack?.parentElement?.querySelector('.ara-stack-legend');
   const legendItem = legend?.querySelector(`.ara-stack-dot--${idx}`)?.closest('li');
-  return compactText(legendItem) || `Segment ${idx}`;
+  return compactText(legendItem ?? null) || `Segment ${idx}`;
 }
 
 function decorateDataTooltips(root: HTMLElement): void {


### PR DESCRIPTION
## Summary

`bunx tsc --noEmit` failed on `main` with 5 errors after PR #49 (TS 5.9→6.0) and PR #54 (slope renderer) both merged. The errors are not in `renderSlopes` itself — they're in `bindAraTooltip` (lines 1426-1430) and `stackSegmentCategory` (line 1463). PR #54 introduced ara-tooltip wiring that TS 5.9 accepted; TS 6.0 rejected once main combined both PRs.

## Per-error diagnosis + fix

### TS2769 ×4 — `target.addEventListener('pointerenter'|'pointermove'|'mouseenter'|'mousemove', showFromMouse|moveFromMouse)`

The handlers `target: Element` calls `addEventListener` with a `MouseEvent`-typed listener. `Element`'s `ElementEventMap` does NOT include `pointer*`/`mouse*` events (only `HTMLElementEventMap` and `SVGElementEventMap` do), so overload 1 fails on the event-name literal. Overload 2 (`string` + `EventListener`) fails by parameter contravariance: `(e: MouseEvent) => void` is NOT assignable to `(e: Event) => void`. TS 5.9 was looser; TS 6.0 tightened it.

Why lines 1428/1431 (`pointerleave`/`mouseleave`) still compile: they reference `hideAraTooltip: () => void`, which IS assignable to `(e: Event) => void` (zero-arg).

**Fix:** Annotated `showFromMouse` and `moveFromMouse` as `EventListener`, then narrowed inside with `if (!(event instanceof MouseEvent)) return;`. Runtime behavior is identical — `PointerEvent extends MouseEvent` at runtime so the narrowing covers all four pointer/mouse listeners. Two annotations replace four call-site casts; preferred per the task contract.

### TS2345 ×1 — `compactText(legendItem)` at line 1463

`compactText` accepts `Element | null`. The chain `legend?.querySelector(...)?.closest('li')` yields `HTMLLIElement | null | undefined` because optional chaining on `legend` short-circuits to `undefined`, then the second `?.` carries it through. `undefined` is not assignable to `Element | null`.

**Fix:** Coerce at the call site — `compactText(legendItem ?? null)`. Minimal change, doesn't widen `compactText`'s contract for other callers.

## Why latent

- PR #49 bumped TypeScript to 6.0 but the existing main.ts compiled clean at that point.
- PR #54 added `bindAraTooltip` + `stackSegmentCategory` under TS 5.9 in a worktree.
- When PR #54 merged into main after PR #49, the strict-overload + tightened optional-chain inference combined to surface 5 errors.

## Verification

- `bunx tsc --noEmit -p tsconfig.json` exits 0
- `vite build` succeeds (107.79 kB bundle, identical output)
- `bun run build` blocked by an unrelated LFS pointer hydration check in `scripts/prebuild.mjs` — not caused by this diff
- No `as any`, no `!` non-null assertions, no behavior change

## Codex verdict

**PASS — no introduced correctness issues.**

> "The diff only adjusts event listener typing/narrowing and null normalization for an existing helper call. I found no introduced correctness issues; TypeScript compilation succeeds, while the full build is blocked by unrelated Git LFS pointer files in the checkout."

## Test plan

- [ ] CI typecheck passes
- [ ] Dashboard renders correctly (tooltips still bind on pointer hover/focus)
- [ ] Stack-segment tooltips still show the right legend category