### PR TITLE
refactor(ci): extract safe-push composite action, roll out to writer workflows

### DIFF
--- a/.github/actions/safe-push/action.yml
+++ b/.github/actions/safe-push/action.yml
@@ -36,6 +36,16 @@ inputs:
       enable this.
     required: false
     default: 'false'
+  allow-divergent-ref:
+    description: >
+      If 'true', skip the safety check that the workflow's trigger ref
+      (github.ref_name) matches the target branch. Default 'false' refuses
+      to push when the workflow was launched (typically via workflow_dispatch)
+      from a non-default branch, because pushing HEAD:<branch> would land
+      that feature branch's commits onto <branch>. Opt in only for
+      workflows that genuinely need to publish from a non-default ref.
+    required: false
+    default: 'false'
   github-token:
     description: GITHUB_TOKEN used to set the authenticated origin URL.
     required: true
@@ -57,13 +67,30 @@ runs:
         SAFE_PUSH_MAX_ATTEMPTS: ${{ inputs.max-attempts }}
         SAFE_PUSH_INDEX_MERGE: ${{ inputs.index-merge }}
         SAFE_PUSH_REPOSITORY: ${{ github.repository }}
+        SAFE_PUSH_REF_NAME: ${{ github.ref_name }}
+        SAFE_PUSH_ALLOW_DIVERGENT_REF: ${{ inputs.allow-divergent-ref }}
       run: |
         set -euo pipefail
-        git remote set-url origin "https://x-access-token:${SAFE_PUSH_GITHUB_TOKEN}@github.com/${SAFE_PUSH_REPOSITORY}.git"
 
         BRANCH="${SAFE_PUSH_BRANCH}"
         MAX_ATTEMPTS="${SAFE_PUSH_MAX_ATTEMPTS}"
         INDEX_MERGE="${SAFE_PUSH_INDEX_MERGE}"
+
+        # Safety: refuse to push if the workflow's trigger ref doesn't match
+        # the target branch. Without this check, a workflow_dispatch run
+        # launched from a feature branch — actions/checkout defaults to
+        # github.ref, so the checked-out HEAD is the feature branch — would
+        # rebase that feature branch onto $BRANCH and push it as HEAD:$BRANCH,
+        # silently landing unreviewed commits on the default branch.
+        # Cron triggers always run against the repo's default branch, so this
+        # check is a no-op for the common (scheduled-publisher) case.
+        if [ "${SAFE_PUSH_REF_NAME}" != "${BRANCH}" ] \
+            && [ "${SAFE_PUSH_ALLOW_DIVERGENT_REF}" != "true" ]; then
+          echo "::error::Refusing to push from ref '${SAFE_PUSH_REF_NAME}' to '${BRANCH}'. Likely a workflow_dispatch run launched from a non-default ref — pushing now would land that ref's commits onto ${BRANCH}. If this is intentional (e.g. a release workflow that publishes from a non-default ref), set 'allow-divergent-ref: true' on the safe-push action call."
+          exit 1
+        fi
+
+        git remote set-url origin "https://x-access-token:${SAFE_PUSH_GITHUB_TOKEN}@github.com/${SAFE_PUSH_REPOSITORY}.git"
 
         # Concurrent writers can land on $BRANCH while this job runs. Retry
         # the fetch+rebase+push loop a few times; each iteration stashes

--- a/.github/actions/safe-push/action.yml
+++ b/.github/actions/safe-push/action.yml
@@ -1,0 +1,229 @@
+name: Safe push
+description: >
+  Safely push the current branch's commits to a remote target branch, with
+  per-attempt stash + rebase + push retry loop. Stashes any leftover
+  working-tree state (tracked OR untracked) BEFORE rebasing so the rebase
+  cannot fail to start with "cannot rebase: You have unstaged changes".
+  Distinguishes "rebase paused on conflicts" from "rebase failed to start"
+  so operators get an honest diagnostic instead of a false-positive
+  "Unhandleable conflict" message.
+
+  Faithful port of the post-PR-#58 push step from
+  .github/workflows/generative-research.yml. The algorithm, helpers, and
+  diagnostics are the same; only the JSON-merge auto-resolution path is
+  gated behind an opt-in input because non-generative writers do not write
+  to research/generative/index.json.
+
+  Outputs `pushed=true` on a successful push attempt (no-op pushes — where
+  HEAD already matches the remote — also count as success and emit
+  `pushed=true`, matching the prior behavior of consumers that gated
+  downstream notifications on this output).
+
+inputs:
+  branch:
+    description: Target branch to push to. Defaults to main.
+    required: false
+    default: 'main'
+  max-attempts:
+    description: Maximum number of fetch+rebase+push attempts before giving up.
+    required: false
+    default: '5'
+  index-merge:
+    description: >
+      If 'true', attempt union-by-slug JSON merge on conflicts limited to
+      research/generative/index.json. Any other conflicted path still hard-
+      fails. Defaults to 'false' — only generative-research.yml should
+      enable this.
+    required: false
+    default: 'false'
+  github-token:
+    description: GITHUB_TOKEN used to set the authenticated origin URL.
+    required: true
+
+outputs:
+  pushed:
+    description: 'true if the push succeeded (including no-op pushes); empty otherwise.'
+    value: ${{ steps.do-push.outputs.pushed }}
+
+runs:
+  using: composite
+  steps:
+    - name: Safe push (stash + rebase + retry)
+      id: do-push
+      shell: bash
+      env:
+        SAFE_PUSH_GITHUB_TOKEN: ${{ inputs.github-token }}
+        SAFE_PUSH_BRANCH: ${{ inputs.branch }}
+        SAFE_PUSH_MAX_ATTEMPTS: ${{ inputs.max-attempts }}
+        SAFE_PUSH_INDEX_MERGE: ${{ inputs.index-merge }}
+        SAFE_PUSH_REPOSITORY: ${{ github.repository }}
+      run: |
+        set -euo pipefail
+        git remote set-url origin "https://x-access-token:${SAFE_PUSH_GITHUB_TOKEN}@github.com/${SAFE_PUSH_REPOSITORY}.git"
+
+        BRANCH="${SAFE_PUSH_BRANCH}"
+        MAX_ATTEMPTS="${SAFE_PUSH_MAX_ATTEMPTS}"
+        INDEX_MERGE="${SAFE_PUSH_INDEX_MERGE}"
+
+        # Concurrent writers can land on $BRANCH while this job runs. Retry
+        # the fetch+rebase+push loop a few times; each iteration stashes
+        # leftover working-tree state so the rebase can always start.
+        #
+        # JSON-array index auto-merge (research/generative/index.json) is
+        # gated by INDEX_MERGE. When disabled, any conflicted path — even
+        # research/generative/index.json — hard-fails. Only the generative-
+        # research workflow opts in.
+
+        merge_index_json() {
+          local path="$1"
+          echo "Auto-merging $path (union by slug)"
+          local ours theirs
+          ours=$(mktemp); theirs=$(mktemp)
+          git show ":2:$path" > "$ours"
+          git show ":3:$path" > "$theirs"
+          jq -s '
+            (.[0] + .[1])
+            | unique_by(.slug)
+            | sort_by(.created_at)
+          ' "$ours" "$theirs" > "$path"
+          rm -f "$ours" "$theirs"
+          git add "$path"
+        }
+
+        ATTEMPTS=0
+        while [ "$ATTEMPTS" -lt "$MAX_ATTEMPTS" ]; do
+          ATTEMPTS=$((ATTEMPTS + 1))
+          echo "::group::push attempt $ATTEMPTS / $MAX_ATTEMPTS"
+
+          git fetch origin "$BRANCH"
+
+          # Stash any leftover working-tree state (tracked modifications
+          # OR untracked artifacts) that would otherwise make `git rebase`
+          # refuse to start with "cannot rebase: You have unstaged
+          # changes". We don't try to trace the source — anything dirty
+          # here is incidental to the writer's commit and unrelated to
+          # publishing it.
+          #
+          # Per-attempt stash: if push fails and we loop, the next
+          # iteration's pre-check will re-stash whatever the pop
+          # reintroduced. The stash message includes the attempt number
+          # so a dangling stash (max-attempts exhaustion) is debuggable.
+          STASHED=false
+          if ! git diff --quiet \
+              || ! git diff --cached --quiet \
+              || [ -n "$(git ls-files --others --exclude-standard)" ]; then
+            if git stash push --include-untracked --quiet \
+                -m "push-retry-stash-attempt-$ATTEMPTS"; then
+              STASHED=true
+            else
+              # Defensive: pre-check said dirty but stash push failed
+              # (unusual repo state). Don't crash the loop under
+              # `set -e`; rebase will fail loudly below with the
+              # actual problem.
+              echo "::warning::pre-rebase stash push failed; proceeding without stash"
+            fi
+          fi
+
+          # Stash cleanup helpers, used on both happy and unhappy paths.
+          # Pop must succeed before we push: a popped-but-conflicted
+          # stash leaves unmerged markers in the working tree and a
+          # silent push of the writer's commit would drop whatever
+          # tracked state was in the stash. Drop is for hard-fail
+          # exits where we'd otherwise leak a named stash onto the
+          # self-hosted runner (stash content is incidental artifacts;
+          # we log it before dropping for operator visibility).
+          pop_stash_or_fail() {
+            if [ "$STASHED" != "true" ]; then return 0; fi
+            if git stash pop --quiet; then
+              STASHED=false
+              return 0
+            fi
+            echo "::error::stash pop conflicted after rebase; refusing to push (working tree has unmerged content)"
+            git status --short || true
+            echo "Stash entries left on runner:"
+            git stash list | head -3 || true
+            exit 1
+          }
+          drop_stash_if_any() {
+            if [ "$STASHED" != "true" ]; then return 0; fi
+            echo "Dropping stashed pre-rebase state (hard-fail path):"
+            git stash list | head -3 || true
+            git stash drop --quiet || true
+            STASHED=false
+          }
+
+          if git -c core.editor=true rebase "origin/$BRANCH"; then
+            # Rebase clean. Restore the pre-rebase state before push so
+            # the working tree matches what the writer intended. If
+            # pop conflicts we hard-fail rather than push a commit
+            # that excludes potentially-meaningful stashed state.
+            pop_stash_or_fail
+          elif [ -d .git/rebase-merge ] || [ -d .git/rebase-apply ]; then
+            # Rebase actually started and paused on conflicts. The only
+            # path we know how to safely auto-resolve is the JSON-array
+            # index file research/generative/index.json, and only when
+            # INDEX_MERGE is opted in.
+            CONFLICTED=$(git diff --name-only --diff-filter=U | sort -u)
+            echo "Conflicted paths:"
+            echo "$CONFLICTED"
+            if [ -z "$CONFLICTED" ]; then
+              # Shouldn't happen: rebase dir exists but no conflicts.
+              # Bail safely and let the retry loop try again rather
+              # than hard-fail on a transient state. Pop best-effort
+              # here — we're going to re-stash on the next iteration's
+              # pre-check anyway.
+              echo "::warning::rebase in progress but no conflicts detected; aborting and retrying"
+              git rebase --abort 2>/dev/null || true
+              if [ "$STASHED" = "true" ]; then
+                git stash pop --quiet || \
+                  echo "::warning::stash pop conflicted in retry path; stash left in place"
+                STASHED=false
+              fi
+              echo "::endgroup::"
+              sleep $((2 * ATTEMPTS))
+              continue
+            fi
+            if [ "$INDEX_MERGE" = "true" ] \
+                && [ "$CONFLICTED" = "research/generative/index.json" ]; then
+              merge_index_json "research/generative/index.json"
+              if ! git -c core.editor=true rebase --continue; then
+                echo "::error::rebase --continue failed even after JSON merge"
+                git rebase --abort 2>/dev/null || true
+                drop_stash_if_any
+                exit 1
+              fi
+              pop_stash_or_fail
+            else
+              echo "::error::Unhandleable conflict on path(s) above"
+              git rebase --abort 2>/dev/null || true
+              drop_stash_if_any
+              exit 1
+            fi
+          else
+            # Rebase failed before it ever started — no rebase-merge /
+            # rebase-apply directory exists. The classic cause is a
+            # dirty working tree the stash above didn't capture
+            # (e.g. permissions issue, submodule state, weird repo
+            # layout). This is NOT a merge conflict; emit a real
+            # diagnostic so operators stop chasing the
+            # "Unhandleable conflict on path(s) above" red herring.
+            echo "::error::git rebase failed to start (no rebase-merge/rebase-apply directory). Likely cause: dirty working tree that wasn't stashed. Check upstream steps for files written after the writer's commit, and inspect the runner's git status output below."
+            git status --short || true
+            drop_stash_if_any
+            exit 1
+          fi
+
+          if git push origin "HEAD:$BRANCH"; then
+            echo "::endgroup::"
+            echo "Pushed successfully on attempt $ATTEMPTS"
+            echo "pushed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "::endgroup::"
+          echo "Push rejected ($BRANCH moved during attempt $ATTEMPTS); retrying"
+          sleep $((2 * ATTEMPTS))
+        done
+
+        echo "::error::Failed to push after $MAX_ATTEMPTS attempts"
+        exit 1

--- a/.github/workflows/24h-model-timeline.yml
+++ b/.github/workflows/24h-model-timeline.yml
@@ -152,19 +152,19 @@ jobs:
             git add research/models/
             git commit -m "Model timeline update ${{ steps.datetime.outputs.timestamp }}" || echo "No changes"
 
+      # Use the shared safe-push composite action (post-PR-#58 algorithm):
+      # stash any leftover working-tree state before rebasing, so the
+      # rebase cannot fail to start with "cannot rebase: You have unstaged
+      # changes". The action exposes `outputs.pushed`, consumed by the
+      # Vercel deploy step below. Push failures now propagate as a real
+      # job failure (previously the no-retry inline step quietly set
+      # pushed=false on real errors).
+      # See .github/actions/safe-push/action.yml.
       - name: Push changes
         id: push
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git
-          git pull --rebase || true
-          if git push; then
-            echo "pushed=true" >> $GITHUB_OUTPUT
-          else
-            echo "pushed=false" >> $GITHUB_OUTPUT
-            echo "Nothing to push"
-          fi
+        uses: ./.github/actions/safe-push
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Vercel's GitHub App webhook should fire on bot pushes too (no
       # cascade-trigger restriction at the webhook layer), but if the

--- a/.github/workflows/2h-bluesky.yml
+++ b/.github/workflows/2h-bluesky.yml
@@ -163,35 +163,19 @@ jobs:
             git add research/bluesky/
             git commit -m "Bluesky feed ${{ steps.datetime.outputs.timestamp }}"
 
+      # Use the shared safe-push composite action (post-PR-#58 algorithm).
+      #
+      # NOTE: a previous `rm -rf data/bluesky` pre-step is no longer
+      # needed here — the composite action stashes untracked files
+      # (including data/bluesky) before rebasing via
+      # `git stash push --include-untracked`, so they no longer block
+      # the rebase from starting. The stash is popped after a clean
+      # rebase, restoring data/bluesky into the working tree if anything
+      # downstream needs it.
       - name: Push changes
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          # Retry loop: parallel ubuntu-latest writers can race on `main`.
-          # The self-hosted runner serialized everything so this never
-          # collided; ubuntu-latest does not. Without the retry, a
-          # non-fast-forward push would be silently swallowed by `|| echo`,
-          # losing the just-written research artifact. If Claude didn't
-          # commit anything (no new content), HEAD == origin/main after
-          # the rebase and `git push` is a no-op.
-          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git
-          for i in 1 2 3 4 5; do
-            git fetch origin main
-
-            # The fetched Bluesky JSON is workspace-local input for Claude, not
-            # a publish artifact. Remove it before rebasing so untracked
-            # data/bluesky files cannot make `git pull --rebase` refuse to start.
-            rm -rf data/bluesky
-
-            if git pull --rebase origin main && git push origin HEAD:main; then
-              exit 0
-            fi
-            echo "Push attempt $i failed (likely race with another writer), retrying..."
-            sleep $(( i * 5 + RANDOM % 5 ))
-          done
-          echo "Push failed after 5 retries" >&2
-          exit 1
+        uses: ./.github/actions/safe-push
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish Hooker workflow telemetry
         if: always()

--- a/.github/workflows/4h-community.yml
+++ b/.github/workflows/4h-community.yml
@@ -171,13 +171,16 @@ jobs:
             git add research/community/
             git commit -m "Community digest ${{ steps.datetime.outputs.timestamp }}"
 
+      # Use the shared safe-push composite action (post-PR-#58 algorithm):
+      # stash any leftover working-tree state before rebasing, so the
+      # rebase cannot fail to start with "cannot rebase: You have unstaged
+      # changes". Push failures now propagate (previously silently swallowed
+      # by `git push || echo "Nothing to push"`).
+      # See .github/actions/safe-push/action.yml.
       - name: Push changes
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git
-          git pull --rebase || true
-          git push || echo "Nothing to push"
+        uses: ./.github/actions/safe-push
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish Hooker workflow telemetry
         if: always()

--- a/.github/workflows/ai-news-research.yml
+++ b/.github/workflows/ai-news-research.yml
@@ -285,13 +285,16 @@ jobs:
 
             CRITICAL: You MUST write a real file with actual news. Do not write placeholder content. NO DUPLICATES from previous reports.
 
+      # Use the shared safe-push composite action (post-PR-#58 algorithm):
+      # stash any leftover working-tree state before rebasing, so the
+      # rebase cannot fail to start with "cannot rebase: You have unstaged
+      # changes". Push failures now propagate (previously silently swallowed
+      # by `git push || echo "Nothing to push"`).
+      # See .github/actions/safe-push/action.yml.
       - name: Push changes
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git
-          git pull --rebase || true
-          git push || echo "Nothing to push"
+        uses: ./.github/actions/safe-push
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Read summary for Telegram
         id: summary

--- a/.github/workflows/daily-arxiv.yml
+++ b/.github/workflows/daily-arxiv.yml
@@ -144,28 +144,14 @@ jobs:
             git add research/arxiv/${{ steps.date.outputs.date }}-papers.md research/summaries/${{ steps.date.outputs.date }}-arxiv-summary.txt
             git commit -m "arXiv papers ${{ steps.date.outputs.date }}"
 
+      # Use the shared safe-push composite action (post-PR-#58 algorithm):
+      # stash any leftover working-tree state before rebasing, so the
+      # rebase cannot fail to start with "cannot rebase: You have unstaged
+      # changes". See .github/actions/safe-push/action.yml.
       - name: Push changes
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Retry loop: parallel ubuntu-latest writers can race on `main`.
-          # The self-hosted runner serialized everything so this never
-          # collided; ubuntu-latest does not. Without the retry, a
-          # non-fast-forward push would be silently swallowed by `|| echo`,
-          # losing the just-written research artifact. If Claude didn't
-          # commit anything (no new content), HEAD == origin/main after
-          # the rebase and `git push` is a no-op.
-          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git
-          for i in 1 2 3 4 5; do
-            git fetch origin main \
-              && git pull --rebase origin main \
-              && git push origin HEAD:main \
-              && exit 0
-            echo "Push attempt $i failed (likely race with another writer), retrying..."
-            sleep $(( i * 5 + RANDOM % 5 ))
-          done
-          echo "Push failed after 5 retries" >&2
-          exit 1
+        uses: ./.github/actions/safe-push
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Read summary for Telegram
         id: summary

--- a/.github/workflows/daily-digest.yml
+++ b/.github/workflows/daily-digest.yml
@@ -521,13 +521,16 @@ jobs:
           git add "$AUDIO_FILE"
           git commit -m "Audio digest ${DATE} (Gemini 3.1 TTS two-host: Charon+Puck, mp3 ${SIZE}b)" || echo "No audio changes to commit"
 
+      # Use the shared safe-push composite action (post-PR-#58 algorithm):
+      # stash any leftover working-tree state before rebasing, so the
+      # rebase cannot fail to start with "cannot rebase: You have unstaged
+      # changes". Push failures now propagate (previously silently swallowed
+      # by `git push || echo "Nothing to push"`).
+      # See .github/actions/safe-push/action.yml.
       - name: Push changes
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git
-          git pull --rebase || true
-          git push || echo "Nothing to push"
+        uses: ./.github/actions/safe-push
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Send Telegram notification (audio + caption)
         if: success()

--- a/.github/workflows/daily-front-page.yml
+++ b/.github/workflows/daily-front-page.yml
@@ -257,11 +257,11 @@ jobs:
           path.write_text(before + replacement + after)
           PY
 
-      # Commit and push
+      # Commit and push (split into two steps so we can reuse the shared
+      # safe-push composite action for the publish half).
       - name: Commit front page
         if: steps.check.outputs.exists == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TODAY: ${{ steps.date.outputs.date }}
         run: |
           # Stage ONLY today's PNG, not the entire research/front-page/ dir.
@@ -273,9 +273,18 @@ jobs:
           # `git lfs migrate import` runbook.
           git add "research/front-page/${TODAY}-front-page.png" README.md
           git commit -m "Front page ${TODAY}" || echo "Nothing to commit"
-          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
-          git pull --rebase || true
-          git push || echo "Nothing to push"
+
+      # Use the shared safe-push composite action (post-PR-#58 algorithm):
+      # stash any leftover working-tree state before rebasing, so the
+      # rebase cannot fail to start with "cannot rebase: You have unstaged
+      # changes". Push failures now propagate (previously silently swallowed
+      # by `git push || echo "Nothing to push"`).
+      # See .github/actions/safe-push/action.yml.
+      - name: Push front page
+        if: steps.check.outputs.exists == 'true'
+        uses: ./.github/actions/safe-push
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Publish front page image via hooker (routes to Telegram thread)
       - name: Publish front page via hooker

--- a/.github/workflows/hourly-rss.yml
+++ b/.github/workflows/hourly-rss.yml
@@ -193,29 +193,14 @@ jobs:
             git add research/rss/
             git commit -m "RSS update ${{ steps.datetime.outputs.timestamp }}" || echo "No changes"
 
+      # Use the shared safe-push composite action (post-PR-#58 algorithm):
+      # stash any leftover working-tree state before rebasing, so the
+      # rebase cannot fail to start with "cannot rebase: You have unstaged
+      # changes". See .github/actions/safe-push/action.yml.
       - name: Push changes
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          # Retry loop: parallel ubuntu-latest writers can race on `main`.
-          # The self-hosted runner serialized everything so this never
-          # collided; ubuntu-latest does not. Without the retry, a
-          # non-fast-forward push would be silently swallowed by `|| echo`,
-          # losing the just-written research artifact. If Claude didn't
-          # commit anything (no new content), HEAD == origin/main after
-          # the rebase and `git push` is a no-op.
-          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git
-          for i in 1 2 3 4 5; do
-            git fetch origin main
-            if git pull --rebase origin main && git push origin HEAD:main; then
-              exit 0
-            fi
-            echo "Push attempt $i failed (likely race with another writer), retrying..."
-            sleep $(( i * 5 + RANDOM % 5 ))
-          done
-          echo "Push failed after 5 retries" >&2
-          exit 1
+        uses: ./.github/actions/safe-push
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish Hooker workflow telemetry
         if: always()

--- a/.github/workflows/research-issue.yml
+++ b/.github/workflows/research-issue.yml
@@ -363,13 +363,16 @@ jobs:
 
             Be thorough and practical. Focus on actionable insights that help solve the user's question.
 
+      # Use the shared safe-push composite action (post-PR-#58 algorithm):
+      # stash any leftover working-tree state before rebasing, so the
+      # rebase cannot fail to start with "cannot rebase: You have unstaged
+      # changes". Push failures now propagate (previously silently swallowed
+      # by `git push || echo "Nothing to push"`).
+      # See .github/actions/safe-push/action.yml.
       - name: Push changes
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git
-          git pull --rebase || true
-          git push || echo "Nothing to push"
+        uses: ./.github/actions/safe-push
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Read research report
         id: report


### PR DESCRIPTION
## Summary

PR #58 fixed the "cannot rebase: You have unstaged changes" push failure in `generative-research.yml` with a sophisticated stash-before-rebase + distinguish-rebase-failed-to-start algorithm. The same buggy push pattern was duplicated across nine other writer workflows. `hourly-rss.yml` just exhausted its 5 retries on this exact class of error.

This PR extracts the canonical post-#58 push step into a single reusable composite action at `.github/actions/safe-push/action.yml`, then rolls it out to every writer workflow that had the bug. Fix once, propagate to all consumers.

The composite action is a faithful port of the inline bash from `generative-research.yml`: same algorithm, same helpers (`pop_stash_or_fail`, `drop_stash_if_any`), same diagnostics, same retry loop. Only the JSON-array index-merge auto-resolution is gated behind an `index-merge` input that defaults to false.

## Audit table

| Workflow | Pre-PR pattern | Migrated | Notes |
|---|---|---|---|
| `hourly-rss.yml` | `for i; pull --rebase && push` retry loop | yes | Primary target — recently failed |
| `daily-arxiv.yml` | Same retry shape as rss | yes | |
| `2h-bluesky.yml` | Same + `rm -rf data/bluesky` pre-step | yes | Stash now handles untracked; rm removed |
| `daily-digest.yml` | `pull --rebase \|\| true; push \|\| echo` (no retries) | yes | Behavior change below |
| `4h-community.yml` | Same as daily-digest (no retries) | yes | Behavior change below |
| `24h-model-timeline.yml` | Same; has `id: push` + `outputs.pushed` | yes | Action's `outputs.pushed` preserves the contract for the Vercel deploy step |
| `ai-news-research.yml` | Same as daily-digest (no retries) | yes | Behavior change below |
| `daily-front-page.yml` | Fused `commit + push` in one step | yes | Split into commit + safe-push call |
| `research-issue.yml` | Same as daily-digest (no retries) | yes | Behavior change below |
| `generative-research.yml` | Safe (post-#58) | no | Source of canonical bash; complex `id: push` coupling — separate follow-up |
| `hourly-twitter.yml` | Custom PRE_HEAD-vs-UPSTREAM_HEAD contract | no | Independent design, already careful |
| `daily-improve.yml` | Pushes to feature branch, not main | no | Out of scope |
| `claude*.yml`, `ci.yml`, `liveness-check.yml` | No commits | no | |

## Composite action contract

```yaml
- name: Push changes
  uses: ./.github/actions/safe-push
  with:
    github-token: ${{ secrets.GITHUB_TOKEN }}
    # Optional inputs:
    # branch: main                  # target branch (default: main)
    # max-attempts: 5               # retry count (default: 5)
    # index-merge: false            # auto-merge research/generative/index.json
    # allow-divergent-ref: false    # opt-in to push from non-default ref
```

Outputs: `pushed=true` on a successful push attempt (no-op pushes — where HEAD already matches the remote — count as success and emit `pushed=true`, matching prior behavior of consumers that gated on this output).

## Behavior changes worth flagging

1. **Push errors now propagate.** Five workflows previously used `git push || echo "Nothing to push"`, which silently swallowed real push failures (auth errors, exhausted-retry non-fast-forward rejections). After this PR they fail loudly — matching hourly-rss / daily-arxiv / 2h-bluesky behavior and fixing the silent-success bug that caused phantom Hooker / Telegram notifications about content that never actually landed on main.

2. **`2h-bluesky.yml` dropped its `rm -rf data/bluesky` pre-step.** The composite action's `git stash --include-untracked` handles untracked directories, making the rm dead code.

3. **Refuse to push from a non-default ref.** Added in response to codex review (commit 2): when `workflow_dispatch` is launched from a feature branch, the action now refuses to push instead of landing that branch's commits on main. Cron triggers are unaffected (they run on the repo's default branch). Opt-out exists via `allow-divergent-ref: true` for future workflows that legitimately publish from non-default refs.

## Why generative-research.yml stays inline (for now)

The source of the canonical algorithm. Its push step has tight coupling with downstream steps that read `steps.push.outputs.pushed` under a complex `if:` gate involving quality + verifier audit outcomes. Migration is a follow-up so this PR stays minimal and focused on the rollout. Once the rollout is verified in production, the generative-research migration can lift-and-shift to the composite action.

## Codex review verdict

Two cycles:
1. First review flagged `[P2]` on the ref-divergence risk — workflow_dispatch from a feature branch could land that branch's commits on main via the composite action's `HEAD:$BRANCH` push. Addressed in commit 2 by adding the `allow-divergent-ref` guard.
2. Re-review on the updated diff: **GATE: PASS** — "preserves the retry/rebase behavior of the prior inline implementations while adding the intended stashing and ref-safety checks."

## References

- PR #58 — original fix in `generative-research.yml` that this rolls out to other writer workflows
- Recent `hourly-rss.yml` CI failure — re-discovery of the same bug class in a different consumer

## Test plan

- [ ] All touched YAML files parse (`python3 -c "import yaml; yaml.safe_load(...)"` verified locally for all 10 files)
- [ ] Composite action's `outputs.pushed` reaches the Vercel deploy step in `24h-model-timeline.yml`
- [ ] Cron-triggered runs of `hourly-rss.yml`, `daily-arxiv.yml`, `2h-bluesky.yml`, `daily-digest.yml`, `4h-community.yml`, `24h-model-timeline.yml`, `ai-news-research.yml`, `daily-front-page.yml`, `research-issue.yml` all reach the push step and either push successfully or report a real, actionable error (not "Unhandleable conflict" false positive)
- [ ] Manual `workflow_dispatch` from a feature branch fails fast with the divergent-ref guard message
- [ ] Manual `workflow_dispatch` from main works the same as cron