### PR TITLE
fix: route Generative Research notification through hooker (Docker action breaks on Cloud Run)

### DIFF
--- a/.github/workflows/generative-research.yml
+++ b/.github/workflows/generative-research.yml
@@ -3398,21 +3398,49 @@ jobs:
             echo "__END_TOPIC__"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Send Telegram notification
+      - name: Send notification via hooker
         if: success() && steps.outfile.outputs.has_file == 'true' && steps.push.outputs.pushed == 'true'
         continue-on-error: true
-        uses: appleboy/telegram-action@221e6b684967abe813051ee4a37dd61770a83ad3
-        with:
-          to: ${{ secrets.TELEGRAM_CHAT_ID }}
-          token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          format: html
-          message: |
-            🧪 <b>Generative Research Published</b>
-
-            📝 Topic: ${{ steps.tg-prep.outputs.safe_topic }}
-            🤖 Backend: ${{ steps.params.outputs.backend }}
-
-            📄 <a href="https://github.com/${{ github.repository }}/blob/main/research/generative/${{ steps.outfile.outputs.file }}">View on GitHub</a>
+        # Publish the notification to hooker (hooker.guzus.xyz relays it to Telegram),
+        # so this workflow needs no Telegram bot token and no Docker — same
+        # POST /publish/<topic> contract as the hooker-telemetry step below. Values
+        # go via env (never inlined as ${{ }} in run:) to avoid shell injection; the
+        # topic is already HTML-escaped by tg-prep; jq builds the JSON so every value
+        # is safely escaped.
+        env:
+          HOOKER_URL: ${{ secrets.HOOKER_URL }}
+          HOOKER_TOKEN: ${{ secrets.HOOKER_TOKEN }}
+          TG_TOPIC: ${{ steps.tg-prep.outputs.safe_topic }}
+          TG_BACKEND: ${{ steps.params.outputs.backend }}
+          TG_FILE: ${{ steps.outfile.outputs.file }}
+          TG_REPO: ${{ github.repository }}
+          GH_RUN_ID: ${{ github.run_id }}
+          GH_RUN_ATTEMPT: ${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+          if [ -z "${HOOKER_URL:-}" ] || [ -z "${HOOKER_TOKEN:-}" ]; then
+            echo "Hooker credentials missing — skipping notification"
+            exit 0
+          fi
+          ARTICLE_URL="https://github.com/${TG_REPO}/blob/main/research/generative/${TG_FILE}"
+          BODY=$(printf '📝 Topic: %s\n🤖 Backend: %s' "${TG_TOPIC}" "${TG_BACKEND}")
+          PAYLOAD=$(jq -n \
+            --arg title "🧪 Generative Research Published" \
+            --arg text "$BODY" \
+            --arg url "$ARTICLE_URL" \
+            '{
+              title: $title,
+              text: $text,
+              priority: 3,
+              tags: ["ara", "generative-research"],
+              parse_mode: "HTML",
+              reply_markup: { inline_keyboard: [[{ text: "View on GitHub", url: $url }]] }
+            }')
+          curl -fsS --max-time 30 -X POST "${HOOKER_URL%/}/publish/ara-research" \
+            -H "Authorization: Bearer ${HOOKER_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -H "Idempotency-Key: generative-research-${GH_RUN_ID}-${GH_RUN_ATTEMPT}" \
+            --data-binary "$PAYLOAD" >/dev/null
 
       # Cleanup the staged untrusted inputs at the end of the job. Runs on
       # success and failure (if: always()) so a failed run doesn't leave the


### PR DESCRIPTION
## Problem
The **Generative Research** workflow fails on the self-hosted Cloud Run runners. It used `appleboy/telegram-action`, a **Docker-based** action — Cloud Run runners have no Docker daemon, so its `docker build` fails before `Checkout repository`, breaking the whole job (cascading into `fatal: not a git repository`). Deterministic — re-running doesn't help.

## Fix
Route the "published" notification through **hooker** (`hooker.guzus.xyz`) — the same `POST ${HOOKER_URL}/publish/<topic>` contract the existing `hooker-telemetry` step in this workflow already uses:
- Publishes to topic **`ara-research`** with `HOOKER_URL` + `HOOKER_TOKEN`. hooker relays to Telegram, so **this workflow no longer needs a Telegram bot token** — and no Docker.
- Telegram-style HTML body (topic + backend) with a **"View on GitHub"** button (`reply_markup`), `Idempotency-Key` per run/attempt, `continue-on-error`.
- `jq` builds the JSON; all interpolated values pass via `env:` (never inlined as `${{ }}` in `run:`); the topic is already HTML-escaped by `tg-prep`. No injection.

Scope: **one file**, `generative-research.yml`. `actionlint` clean; the `jq` payload builds valid JSON.

## Other workflows
`appleboy/telegram-action` is still used in `ai-news-research`, `daily-digest`, `research-issue`, `daily-arxiv`, `hourly-twitter` (×2). Happy to route those through hooker too in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
