### PR TITLE
fix: route remaining Telegram notifications through hooker

### DIFF
--- a/.github/workflows/ai-news-research.yml
+++ b/.github/workflows/ai-news-research.yml
@@ -312,20 +312,50 @@ jobs:
             echo "content=No summary available" >> $GITHUB_OUTPUT
           fi
 
-      - name: Send Telegram notification
+      # Notify via hooker (relays to Telegram). Replaces the Docker-based
+      # appleboy/telegram-action, which fails on the Cloud Run runner.
+      # hooker handles the bot token, so this job no longer needs
+      # TELEGRAM_BOT_TOKEN / TELEGRAM_CHAT_ID.
+      - name: Send notification via hooker
         if: success() && github.event_name == 'workflow_dispatch'
         continue-on-error: true
-        uses: appleboy/telegram-action@221e6b684967abe813051ee4a37dd61770a83ad3
-        with:
-          to: ${{ secrets.TELEGRAM_CHAT_ID }}
-          token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          format: markdown
-          message: |
-            🔬 *AI News Research Complete*
-
-            ${{ steps.summary.outputs.content }}
-
-            📄 [Full Report on GitHub](https://github.com/${{ github.repository }}/blob/main/research/${{ steps.date.outputs.date }}-ai-news.md)
+        env:
+          HOOKER_URL: ${{ secrets.HOOKER_URL }}
+          HOOKER_TOKEN: ${{ secrets.HOOKER_TOKEN }}
+          SUMMARY: ${{ steps.summary.outputs.content }}
+          REPO: ${{ github.repository }}
+          DATE: ${{ steps.date.outputs.date }}
+          GH_RUN_ID: ${{ github.run_id }}
+          GH_RUN_ATTEMPT: ${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+          if [ -z "${HOOKER_URL:-}" ] || [ -z "${HOOKER_TOKEN:-}" ]; then
+            echo "Hooker credentials missing — skipping notification"
+            exit 0
+          fi
+          # HTML-escape the untrusted summary before it goes into a
+          # parse_mode:"HTML" body. Order matters: escape & first.
+          SAFE=$(printf '%s' "$SUMMARY" \
+            | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g')
+          REPORT_URL="https://github.com/${REPO}/blob/main/research/${DATE}-ai-news.md"
+          jq -n \
+            --arg title "🔬 AI News Research Complete" \
+            --arg text "$SAFE" \
+            --arg btn "Full Report on GitHub" \
+            --arg url "$REPORT_URL" \
+            '{
+              title: $title,
+              text: $text,
+              priority: 3,
+              tags: ["ara", "ai-news"],
+              parse_mode: "HTML",
+              reply_markup: { inline_keyboard: [[{ text: $btn, url: $url }]] }
+            }' > /tmp/hooker-ai-news.json
+          curl -sS --fail-with-body -X POST "${HOOKER_URL%/}/publish/ara-research" \
+            -H "Authorization: Bearer ${HOOKER_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -H "Idempotency-Key: ai-news-${GH_RUN_ID}-${GH_RUN_ATTEMPT}" \
+            --data-binary "@/tmp/hooker-ai-news.json"
 
       - name: Publish Hooker workflow telemetry
         if: always()

--- a/.github/workflows/daily-arxiv.yml
+++ b/.github/workflows/daily-arxiv.yml
@@ -166,20 +166,50 @@ jobs:
             echo "content=No summary available" >> $GITHUB_OUTPUT
           fi
 
-      - name: Send Telegram notification
+      # Notify via hooker (relays to Telegram). Replaces the Docker-based
+      # appleboy/telegram-action, which fails on the Cloud Run runner.
+      # hooker handles the bot token, so this job no longer needs
+      # TELEGRAM_BOT_TOKEN / TELEGRAM_CHAT_ID.
+      - name: Send notification via hooker
         if: success() && github.event_name == 'workflow_dispatch'
         continue-on-error: true
-        uses: appleboy/telegram-action@221e6b684967abe813051ee4a37dd61770a83ad3
-        with:
-          to: ${{ secrets.TELEGRAM_CHAT_ID }}
-          token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          format: markdown
-          message: |
-            📄 *arXiv AI Papers*
-
-            ${{ steps.summary.outputs.content }}
-
-            📄 [Full Report on GitHub](https://github.com/${{ github.repository }}/blob/main/research/arxiv/${{ steps.date.outputs.date }}-papers.md)
+        env:
+          HOOKER_URL: ${{ secrets.HOOKER_URL }}
+          HOOKER_TOKEN: ${{ secrets.HOOKER_TOKEN }}
+          SUMMARY: ${{ steps.summary.outputs.content }}
+          REPO: ${{ github.repository }}
+          DATE: ${{ steps.date.outputs.date }}
+          GH_RUN_ID: ${{ github.run_id }}
+          GH_RUN_ATTEMPT: ${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+          if [ -z "${HOOKER_URL:-}" ] || [ -z "${HOOKER_TOKEN:-}" ]; then
+            echo "Hooker credentials missing — skipping notification"
+            exit 0
+          fi
+          # HTML-escape the untrusted summary before it goes into a
+          # parse_mode:"HTML" body. Order matters: escape & first.
+          SAFE=$(printf '%s' "$SUMMARY" \
+            | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g')
+          REPORT_URL="https://github.com/${REPO}/blob/main/research/arxiv/${DATE}-papers.md"
+          jq -n \
+            --arg title "📄 arXiv AI Papers" \
+            --arg text "$SAFE" \
+            --arg btn "Full Report on GitHub" \
+            --arg url "$REPORT_URL" \
+            '{
+              title: $title,
+              text: $text,
+              priority: 3,
+              tags: ["ara", "arxiv"],
+              parse_mode: "HTML",
+              reply_markup: { inline_keyboard: [[{ text: $btn, url: $url }]] }
+            }' > /tmp/hooker-arxiv.json
+          curl -sS --fail-with-body -X POST "${HOOKER_URL%/}/publish/ara-research" \
+            -H "Authorization: Bearer ${HOOKER_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -H "Idempotency-Key: arxiv-${GH_RUN_ID}-${GH_RUN_ATTEMPT}" \
+            --data-binary "@/tmp/hooker-arxiv.json"
 
       - name: Publish Hooker workflow telemetry
         if: always()

--- a/.github/workflows/hourly-twitter.yml
+++ b/.github/workflows/hourly-twitter.yml
@@ -27,8 +27,7 @@ name: Twitter AI News (matrix — claude / deepseek-agentic / deepseek-pi)
 #   CLAUDE_CODE_OAUTH_TOKEN              — claude tier (also passed to deepseek-agentic but unused there)
 #   DEEPSEEK_API_KEY                     — both deepseek tiers
 #   BIRD_AUTH_TOKEN, BIRD_CT0            — all tiers
-#   HOOKER_URL, HOOKER_TOKEN             — claude tier (headline-alert blast + telemetry)
-#   TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID — deepseek tiers (per-cycle Telegram message)
+#   HOOKER_URL, HOOKER_TOKEN             — claude tier (headline-alert blast + telemetry) and deepseek tiers (per-cycle notification, relayed to Telegram)
 #   VERCEL_DEPLOY_HOOK                   — optional, claude tier only
 
 on:
@@ -749,35 +748,95 @@ jobs:
             echo "content=No Twitter summary available" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Send Telegram notification (deepseek-agentic)
+      # Notify via hooker (relays to Telegram). Replaces the Docker-based
+      # appleboy/telegram-action, which fails on the Cloud Run runner.
+      # hooker handles the bot token, so this job no longer needs
+      # TELEGRAM_BOT_TOKEN / TELEGRAM_CHAT_ID.
+      - name: Send notification via hooker (deepseek-agentic)
         if: success() && steps.backend.outputs.name == 'deepseek-agentic'
         continue-on-error: true
-        uses: appleboy/telegram-action@221e6b684967abe813051ee4a37dd61770a83ad3
-        with:
-          to: ${{ secrets.TELEGRAM_CHAT_ID }}
-          token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          format: markdown
-          message: |
-            🐦🦌 *Twitter/X AI Pulse — DeepSeek v4 Pro Agentic*
+        env:
+          HOOKER_URL: ${{ secrets.HOOKER_URL }}
+          HOOKER_TOKEN: ${{ secrets.HOOKER_TOKEN }}
+          SUMMARY: ${{ steps.summary.outputs.content }}
+          REPO: ${{ github.repository }}
+          DATE: ${{ steps.datetime.outputs.date }}
+          GH_RUN_ID: ${{ github.run_id }}
+          GH_RUN_ATTEMPT: ${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+          if [ -z "${HOOKER_URL:-}" ] || [ -z "${HOOKER_TOKEN:-}" ]; then
+            echo "Hooker credentials missing — skipping notification"
+            exit 0
+          fi
+          # HTML-escape the untrusted summary before it goes into a
+          # parse_mode:"HTML" body. Order matters: escape & first.
+          SAFE=$(printf '%s' "$SUMMARY" \
+            | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g')
+          REPORT_URL="https://github.com/${REPO}/blob/main/research/twitter-deepseek/${DATE}.md"
+          jq -n \
+            --arg title "🐦🦌 Twitter/X AI Pulse — DeepSeek v4 Pro Agentic" \
+            --arg text "$SAFE" \
+            --arg btn "Full Update on GitHub" \
+            --arg url "$REPORT_URL" \
+            '{
+              title: $title,
+              text: $text,
+              priority: 3,
+              tags: ["ara", "twitter"],
+              parse_mode: "HTML",
+              reply_markup: { inline_keyboard: [[{ text: $btn, url: $url }]] }
+            }' > /tmp/hooker-twitter-deepseek-agentic.json
+          curl -sS --fail-with-body -X POST "${HOOKER_URL%/}/publish/ara-research" \
+            -H "Authorization: Bearer ${HOOKER_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -H "Idempotency-Key: twitter-deepseek-agentic-${GH_RUN_ID}-${GH_RUN_ATTEMPT}" \
+            --data-binary "@/tmp/hooker-twitter-deepseek-agentic.json"
 
-            ${{ steps.summary.outputs.content }}
-
-            📄 [Full Update on GitHub](https://github.com/${{ github.repository }}/blob/main/research/twitter-deepseek/${{ steps.datetime.outputs.date }}.md)
-
-      - name: Send Telegram notification (deepseek-pi)
+      # Notify via hooker (relays to Telegram). Replaces the Docker-based
+      # appleboy/telegram-action, which fails on the Cloud Run runner.
+      # hooker handles the bot token, so this job no longer needs
+      # TELEGRAM_BOT_TOKEN / TELEGRAM_CHAT_ID.
+      - name: Send notification via hooker (deepseek-pi)
         if: success() && steps.backend.outputs.name == 'deepseek-pi'
         continue-on-error: true
-        uses: appleboy/telegram-action@221e6b684967abe813051ee4a37dd61770a83ad3
-        with:
-          to: ${{ secrets.TELEGRAM_CHAT_ID }}
-          token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          format: markdown
-          message: |
-            🐦🥧 *Twitter/X AI Pulse — pi + DeepSeek (Experimental)*
-
-            ${{ steps.summary.outputs.content }}
-
-            📄 [Full Update on GitHub](https://github.com/${{ github.repository }}/blob/main/research/twitter-deepseek-pi/${{ steps.datetime.outputs.date }}.md)
+        env:
+          HOOKER_URL: ${{ secrets.HOOKER_URL }}
+          HOOKER_TOKEN: ${{ secrets.HOOKER_TOKEN }}
+          SUMMARY: ${{ steps.summary.outputs.content }}
+          REPO: ${{ github.repository }}
+          DATE: ${{ steps.datetime.outputs.date }}
+          GH_RUN_ID: ${{ github.run_id }}
+          GH_RUN_ATTEMPT: ${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+          if [ -z "${HOOKER_URL:-}" ] || [ -z "${HOOKER_TOKEN:-}" ]; then
+            echo "Hooker credentials missing — skipping notification"
+            exit 0
+          fi
+          # HTML-escape the untrusted summary before it goes into a
+          # parse_mode:"HTML" body. Order matters: escape & first.
+          SAFE=$(printf '%s' "$SUMMARY" \
+            | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g')
+          REPORT_URL="https://github.com/${REPO}/blob/main/research/twitter-deepseek-pi/${DATE}.md"
+          jq -n \
+            --arg title "🐦🥧 Twitter/X AI Pulse — pi + DeepSeek (Experimental)" \
+            --arg text "$SAFE" \
+            --arg btn "Full Update on GitHub" \
+            --arg url "$REPORT_URL" \
+            '{
+              title: $title,
+              text: $text,
+              priority: 3,
+              tags: ["ara", "twitter"],
+              parse_mode: "HTML",
+              reply_markup: { inline_keyboard: [[{ text: $btn, url: $url }]] }
+            }' > /tmp/hooker-twitter-deepseek-pi.json
+          curl -sS --fail-with-body -X POST "${HOOKER_URL%/}/publish/ara-research" \
+            -H "Authorization: Bearer ${HOOKER_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -H "Idempotency-Key: twitter-deepseek-pi-${GH_RUN_ID}-${GH_RUN_ATTEMPT}" \
+            --data-binary "@/tmp/hooker-twitter-deepseek-pi.json"
 
       # ── claude-tier auto-research throttle + topic select + dispatch ─
       # Picks ONE high-signal topic from today's twitter pulse and

--- a/.github/workflows/research-issue.yml
+++ b/.github/workflows/research-issue.yml
@@ -454,21 +454,49 @@ jobs:
             echo "__END_TITLE__"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Send Telegram notification
+      # Notify via hooker (relays to Telegram). Replaces the Docker-based
+      # appleboy/telegram-action, which fails on the Cloud Run runner.
+      # SAFE_TITLE is already HTML-escaped by the tg-prep step above, so it
+      # is used as-is (NOT re-escaped). hooker handles the bot token, so this
+      # job no longer needs TELEGRAM_BOT_TOKEN / TELEGRAM_CHAT_ID.
+      - name: Send notification via hooker
         if: success()
         continue-on-error: true
-        uses: appleboy/telegram-action@221e6b684967abe813051ee4a37dd61770a83ad3
-        with:
-          to: ${{ secrets.TELEGRAM_CHAT_ID }}
-          token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          format: html
-          message: |
-            🔬 <b>Research Complete</b>
-
-            📋 Issue: #${{ github.event.issue.number }}
-            📝 Topic: ${{ steps.tg-prep.outputs.safe_title }}
-
-            📄 <a href="https://github.com/${{ github.repository }}/blob/main/research/issues/${{ github.event.issue.number }}-research.md">View Research Report</a>
+        env:
+          HOOKER_URL: ${{ secrets.HOOKER_URL }}
+          HOOKER_TOKEN: ${{ secrets.HOOKER_TOKEN }}
+          ISSUE_NUM: ${{ github.event.issue.number }}
+          SAFE_TITLE: ${{ steps.tg-prep.outputs.safe_title }}
+          REPO: ${{ github.repository }}
+          GH_RUN_ID: ${{ github.run_id }}
+          GH_RUN_ATTEMPT: ${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+          if [ -z "${HOOKER_URL:-}" ] || [ -z "${HOOKER_TOKEN:-}" ]; then
+            echo "Hooker credentials missing — skipping notification"
+            exit 0
+          fi
+          # SAFE_TITLE is already HTML-escaped upstream — do NOT re-escape.
+          TEXT=$(printf '📋 Issue: #%s\n📝 Topic: %s' "$ISSUE_NUM" "$SAFE_TITLE")
+          REPORT_URL="https://github.com/${REPO}/blob/main/research/issues/${ISSUE_NUM}-research.md"
+          jq -n \
+            --arg title "🔬 Research Complete" \
+            --arg text "$TEXT" \
+            --arg btn "View Research Report" \
+            --arg url "$REPORT_URL" \
+            '{
+              title: $title,
+              text: $text,
+              priority: 3,
+              tags: ["ara", "research-issue"],
+              parse_mode: "HTML",
+              reply_markup: { inline_keyboard: [[{ text: $btn, url: $url }]] }
+            }' > /tmp/hooker-research-issue.json
+          curl -sS --fail-with-body -X POST "${HOOKER_URL%/}/publish/ara-research" \
+            -H "Authorization: Bearer ${HOOKER_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -H "Idempotency-Key: research-issue-${GH_RUN_ID}-${GH_RUN_ATTEMPT}" \
+            --data-binary "@/tmp/hooker-research-issue.json"
 
       - name: Publish Hooker workflow telemetry
         if: always()


### PR DESCRIPTION
## Problem
The Docker-based `appleboy/telegram-action` cannot run on the **Cloud Run** runner (no Docker daemon available), so the remaining Telegram-notification steps fail.

## Fix
Replace each `appleboy/telegram-action` step with a `curl` POST to **hooker**:

```
POST ${HOOKER_URL%/}/publish/ara-research
Authorization: Bearer ${HOOKER_TOKEN}
Content-Type: application/json
Idempotency-Key: <short-name>-<run_id>-<run_attempt>
```

hooker relays the message to Telegram, so **TELEGRAM_BOT_TOKEN / TELEGRAM_CHAT_ID are no longer needed** in these jobs (the bot token lives in hooker). All 5 steps post to the single `ara-research` topic (they previously all targeted the same chat).

The JSON body is built with `jq -n --arg ...` (safe escaping): `{title, text, priority:3, tags:[...], parse_mode:"HTML", reply_markup:{inline_keyboard:[[{text,url}]]}}`.

## Security
- No inline `${{ }}` expressions inside any `run:` script — every interpolated value is passed via the step `env:` block and referenced as `$VAR` (shell-injection defense).
- Free-text research summaries are HTML-escaped (`& < >`) in-script before `jq`, since they go into a `parse_mode:"HTML"` body. `research-issue`'s `safe_title` is already escaped by its `tg-prep` step and is used as-is (not double-escaped).
- Each step keeps its existing `if:` condition and `continue-on-error: true`, and starts with a hooker-credentials guard that skips cleanly when creds are absent.

## Scope — 4 files, 5 steps
1. `ai-news-research.yml` — "Send notification via hooker" (`workflow_dispatch`)
2. `research-issue.yml` — "Send notification via hooker" (keeps `tg-prep`)
3. `daily-arxiv.yml` — "Send notification via hooker" (`workflow_dispatch`)
4. `hourly-twitter.yml` — "Send notification via hooker (deepseek-agentic)"
5. `hourly-twitter.yml` — "Send notification via hooker (deepseek-pi)"

Also corrected the now-stale "Required secrets" comment in `hourly-twitter.yml` (deepseek tiers now use `HOOKER_*`, not `TELEGRAM_*`).

**Untouched (out of scope):** `daily-digest.yml` (already uses `curl`), the hourly-twitter claude-tier `/send-batch` step, all `hooker-telemetry` steps, and `generative-research.yml`.

## Verification
- `git status` shows only the 4 files; **zero file deletions** (clone done with `GIT_LFS_SKIP_SMUDGE=1`; 2156 tracked files intact).
- No real `uses: appleboy/telegram-action` remains in the 4 files (only explanatory comments).
- `actionlint` introduces **0 new findings** vs. the `main` baseline (32 pre-existing shellcheck `SC2086`/`SC2129` infos in unrelated date/summary steps remain; none touch the new steps).
- Each step's real `jq -n` block was extracted from the committed YAML and executed with sample values (incl. adversarial `& < > " $`) — all emit valid JSON.
- `python3 yaml.safe_load` passes for all 4 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)