### PR TITLE
Harden pipeline watchdog: dual-tier freshness check + hooker alerts

### DIFF
--- a/.github/actions/lane-freshness-alert/action.yml
+++ b/.github/actions/lane-freshness-alert/action.yml
@@ -1,0 +1,91 @@
+name: Lane freshness alert
+description: >-
+  Check research-lane freshness (git-commit recency vs per-lane cadence) and,
+  on staleness, alert via hooker (relays to Telegram) and fail the job. Stdlib
+  Python only, so it runs identically on ubuntu-latest and the self-hosted
+  runner. Intended to be invoked from both tiers so the watchdog survives
+  whichever tier an outage takes down.
+
+inputs:
+  hooker_url:
+    description: Hooker base URL (e.g. https://hooker.guzus.xyz). Alert is skipped if empty.
+    required: false
+    default: ""
+  hooker_token:
+    description: Hooker bearer token. Alert is skipped if empty.
+    required: false
+    default: ""
+  topic:
+    description: Hooker topic that relays to Telegram.
+    required: false
+    default: ara-research
+
+runs:
+  using: composite
+  steps:
+    # The script writes stale / stale_lanes / idempotency_key / report to
+    # $GITHUB_OUTPUT (registered as this step's outputs) and a table to the
+    # job step summary. `|| true` keeps this step green so the alert step can
+    # still fire on staleness; the explicit "Fail if stale" step sets the
+    # job's final red status. (Avoids relying on composite continue-on-error.)
+    - name: Check lane freshness
+      id: check
+      shell: bash
+      run: python3 scripts/check_lane_freshness.py || true
+
+    # Loud alert that reaches a human. Idempotency-Key is a per-day hash over
+    # the stale set, so the ubuntu-latest and self-hosted jobs (and repeat runs
+    # the same day) collapse to a single delivered message; a change in the
+    # stale set produces a new key and re-alerts.
+    - name: Alert via hooker (relays to Telegram)
+      if: steps.check.outputs.stale == 'true'
+      shell: bash
+      continue-on-error: true
+      env:
+        HOOKER_URL: ${{ inputs.hooker_url }}
+        HOOKER_TOKEN: ${{ inputs.hooker_token }}
+        TOPIC: ${{ inputs.topic }}
+        STALE_LANES: ${{ steps.check.outputs.stale_lanes }}
+        IDEMPOTENCY_KEY: ${{ steps.check.outputs.idempotency_key }}
+        REPO: ${{ github.repository }}
+        SERVER: ${{ github.server_url }}
+      run: |
+        set -euo pipefail
+        if [ -z "${HOOKER_URL:-}" ] || [ -z "${HOOKER_TOKEN:-}" ]; then
+          echo "Hooker credentials missing — skipping alert (staleness still fails the job)"
+          exit 0
+        fi
+        count=$(printf '%s' "$STALE_LANES" | tr ',' '\n' | grep -c . || true)
+        # Lane names come from a controlled allowlist, but escape defensively
+        # since the body uses parse_mode:HTML.
+        SAFE_LANES=$(printf '%s' "$STALE_LANES" \
+          | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g')
+        TEXT=$(printf 'Stale lanes: %s\n\nThese research lanes have not committed within their expected cadence — likely a workflow outage. Check the GitHub Actions billing/spending limit and the self-hosted runner.' "$SAFE_LANES")
+        ACTIONS_URL="${SERVER%/}/${REPO}/actions/workflows/liveness-check.yml"
+        jq -n \
+          --arg title "🚨 ARA pipeline: ${count} lane(s) stale" \
+          --arg text "$TEXT" \
+          --arg btn "Investigate (Actions)" \
+          --arg url "$ACTIONS_URL" \
+          '{
+            title: $title,
+            text: $text,
+            priority: 5,
+            tags: ["ara", "alert", "liveness"],
+            parse_mode: "HTML",
+            reply_markup: { inline_keyboard: [[{ text: $btn, url: $url }]] }
+          }' > "${RUNNER_TEMP:-/tmp}/hooker-lane-freshness.json"
+        curl -sS --fail-with-body -X POST "${HOOKER_URL%/}/publish/${TOPIC}" \
+          -H "Authorization: Bearer ${HOOKER_TOKEN}" \
+          -H "Content-Type: application/json" \
+          -H "Idempotency-Key: ${IDEMPOTENCY_KEY}" \
+          --data-binary "@${RUNNER_TEMP:-/tmp}/hooker-lane-freshness.json"
+
+    - name: Fail if stale
+      if: steps.check.outputs.stale == 'true'
+      shell: bash
+      env:
+        STALE_LANES: ${{ steps.check.outputs.stale_lanes }}
+      run: |
+        echo "::error::stale lanes: ${STALE_LANES}"
+        exit 1

--- a/.github/workflows/liveness-check.yml
+++ b/.github/workflows/liveness-check.yml
@@ -1,23 +1,29 @@
 name: Pipeline Liveness Check
 
-# Daily heartbeat that verifies each research subdirectory has produced a
-# file within the last 48h. Designed to make silent pipeline outages loud:
-# audit found research/rss/ went 20 days stale with zero alarm.
+# Freshness watchdog that makes silent pipeline outages loud. For each
+# scheduled research lane it measures git-commit recency against a per-lane
+# cadence threshold (see scripts/check_lane_freshness.py) and, on staleness,
+# alerts via hooker (relays to Telegram) AND fails the job.
 #
-# Uses GitHub-hosted ubuntu-latest (not the self-hosted runner) so this
-# check still fires even when the self-hosted runner is down — which is
-# precisely the failure mode we need to catch.
+# Two-tier by design. No single runner survives both failure modes:
+#   - A GitHub Actions billing/spending-limit block kills *ubuntu-latest*
+#     (the job never even starts) — this is what silently froze rss/twitter/
+#     arxiv/bluesky for 2+ days with zero alarm, because the previous
+#     ubuntu-only watchdog was killed by the same block.
+#   - A self-hosted runner outage kills the *self-hosted* tier.
+# So we run the identical check on BOTH tiers: whichever tier is alive does
+# the alerting. The alert goes out over hooker (an external endpoint), NOT via
+# GitHub's native workflow-failure email — that email requires the job to run,
+# which is exactly what a billing block prevents.
 #
-# Failure surface: on staleness this workflow exits non-zero. GitHub's
-# native workflow-failure email/notification is the alert. Deliberately
-# NOT using `gh issue create` to avoid spamming the repo with duplicate
-# issues every day until the underlying pipeline is fixed.
+# Alerts dedupe via a per-day Idempotency-Key over the stale set, so the two
+# jobs (and repeat runs) collapse to one Telegram message per stale set per day.
 
 on:
   schedule:
-    # Daily at 12:00 UTC (12 hours after midnight pipelines run, giving
-    # them plenty of room to publish before we check).
-    - cron: '0 12 * * *'
+    # Every 6h: catches an hourly lane (rss) within ~6h instead of the old
+    # 48h-and-no-alert. Self-hosted cost is a few seconds per run.
+    - cron: '0 */6 * * *'
   workflow_dispatch:
 
 concurrency:
@@ -25,88 +31,38 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check:
+  # ubuntu-latest: survives a self-hosted runner outage.
+  ubuntu:
+    name: Freshness (ubuntu-latest)
     runs-on: ubuntu-latest
     permissions:
       contents: read
-
     steps:
-      - name: Checkout repository
+      - name: Checkout (full history, no LFS blobs)
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0   # git log needs full history; depth:1 breaks it
+          lfs: false       # we only read commit metadata, not file contents
+      - name: Check freshness + alert on staleness
+        uses: ./.github/actions/lane-freshness-alert
+        with:
+          hooker_url: ${{ secrets.HOOKER_URL }}
+          hooker_token: ${{ secrets.HOOKER_TOKEN }}
 
-      - name: Check freshness of each research subdir
-        run: |
-          set -uo pipefail
-
-          # Filenames carry the canonical date as a YYYY-MM-DD prefix
-          # (e.g. 2026-05-17.md, 2026-05-17-reddit.md, 2026-05-17-papers.md).
-          # We parse the filename, not the file mtime, because git checkout
-          # rewrites mtimes to the checkout time — making mtime useless for
-          # measuring pipeline output freshness.
-
-          today_epoch=$(date -u +%s)
-          # Threshold in seconds, not days, to avoid the truncation bug where
-          # `(now - newest) / 86400` reports `2` for anything in the 48h..72h
-          # window — which would silently let a 60h-stale subdir pass an
-          # "alert above 48h" check until it crossed 72h.
-          max_age_seconds=$(( 48 * 3600 ))
-          fail=0
-          report=""
-
-          subdirs="rss twitter bluesky community arxiv digest"
-
-          for sub in $subdirs; do
-            dir="research/$sub"
-            if [ ! -d "$dir" ]; then
-              report="${report}MISSING DIR: $dir\n"
-              fail=1
-              continue
-            fi
-
-            # Extract YYYY-MM-DD prefix from each filename, take the max.
-            # `grep -oE '^[0-9]{4}-[0-9]{2}-[0-9]{2}'` skips files that
-            # don't start with a date (subdirs, READMEs, etc.).
-            newest_date=$(
-              ls -1 "$dir" 2>/dev/null \
-                | grep -oE '^[0-9]{4}-[0-9]{2}-[0-9]{2}' \
-                | sort -u \
-                | tail -1
-            )
-
-            if [ -z "$newest_date" ]; then
-              report="${report}EMPTY: $dir (no date-prefixed files found)\n"
-              fail=1
-              continue
-            fi
-
-            # GNU date on ubuntu-latest. Convert YYYY-MM-DD to epoch.
-            newest_epoch=$(date -u -d "${newest_date}T00:00:00Z" +%s 2>/dev/null || echo 0)
-            if [ "$newest_epoch" -eq 0 ]; then
-              report="${report}PARSE ERROR: $dir (newest=$newest_date)\n"
-              fail=1
-              continue
-            fi
-
-            age_seconds=$(( today_epoch - newest_epoch ))
-            age_hours=$(( age_seconds / 3600 ))
-
-            if [ "$age_seconds" -gt "$max_age_seconds" ]; then
-              report="${report}STALE: $dir -- newest file dated $newest_date (${age_hours}h old, max 48h)\n"
-              fail=1
-            else
-              echo "OK: $dir -- newest $newest_date (${age_hours}h old)"
-            fi
-          done
-
-          if [ "$fail" -ne 0 ]; then
-            echo ""
-            echo "::error::Pipeline liveness check FAILED -- one or more research subdirs are stale."
-            echo ""
-            printf "%b" "$report"
-            echo ""
-            echo "Investigate the corresponding workflow(s) on the self-hosted runner."
-            exit 1
-          fi
-
-          echo ""
-          echo "All research subdirs are fresh."
+  # self-hosted: survives an ubuntu-latest billing/spending-limit block.
+  self-hosted:
+    name: Freshness (self-hosted)
+    runs-on: [self-hosted, Linux]
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout (full history, no LFS blobs)
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          lfs: false
+      - name: Check freshness + alert on staleness
+        uses: ./.github/actions/lane-freshness-alert
+        with:
+          hooker_url: ${{ secrets.HOOKER_URL }}
+          hooker_token: ${{ secrets.HOOKER_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ and opens a PR with methodology fixes.
 | `check_model_tickets.py` | Validator for `research/models/tickets/*.md` against the schema in `docs/model-tickets.md`. The CRUD agent in `24h-model-timeline.yml` runs it after every pass; CI runs it on every PR. |
 | `check_wiki.py` | Validator for `research/wiki/` pages against the schema in `docs/wiki-schema.md`. `uv run python scripts/check_wiki.py` (exit 0 = safe); `--lint` adds advisory checks. The ingest agent in `wiki-ingest.yml` runs it until exit 0; CI runs it on every PR. |
 | `wiki_search.py` | Search wrapper over `research/wiki/` (`uv run python scripts/wiki_search.py "<query>"`). The ingest agent runs it before writing any page so it UPDATEs an existing page instead of duplicating. |
+| `check_lane_freshness.py` | Freshness watchdog. Measures git-commit recency per research lane against per-lane cadence thresholds; exits 2 (and emits a hooker/Telegram alert from `liveness-check.yml`) when a lane is stale. Stdlib-only so it runs on both runner tiers. |
 | `test_ara_dsl.py`, `test_dedupe_headline_alerts.py` | Pytest-style tests run in CI. |
 
 ## GitHub Actions Workflows
@@ -68,7 +69,7 @@ Workflows split between two runners:
   GitHub-hosted runners so they don't queue behind the single self-hosted
   job slot. Currently: `hourly-rss.yml`, `daily-arxiv.yml`,
   `2h-bluesky.yml`, `daily-improve.yml`, `claude-code-review.yml`,
-  `claude.yml`, `liveness-check.yml`.
+  `claude.yml`.
 - **`runs-on: [self-hosted, Linux]`** — workflows that genuinely need
   the self-hosted runner's persistent state (bird CLI + birdy daemon,
   LFS-hydrated `research/` checkout, Puppeteer/Chrome, large agent
@@ -77,6 +78,12 @@ Workflows split between two runners:
   `daily-front-page.yml`, `generative-research.yml`,
   `24h-model-timeline.yml`, `ai-news-research.yml`, `ci.yml`,
   `research-issue.yml`, `4h-community.yml`, `wiki-ingest.yml`.
+- **Both tiers** — `liveness-check.yml` (the freshness watchdog) runs one
+  job on each runner. No single runner survives both failure modes — an
+  `ubuntu-latest` billing/spending-limit block (kills the GitHub-hosted
+  tier) vs. a self-hosted outage — so the watchdog must run on both;
+  whichever tier is alive emits the hooker/Telegram alert. See the
+  workflow header for the rationale.
 
 Claude workflows use `anthropics/claude-code-action@v1` with the model
 passed via `claude_args: "--model opus"` (never as a separate `model:`

--- a/scripts/check_lane_freshness.py
+++ b/scripts/check_lane_freshness.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Pipeline freshness watchdog.
+
+Measures how long it has been since each scheduled research lane last
+produced output, and flags any lane that has gone stale relative to its
+expected cadence. Designed to make silent pipeline outages loud.
+
+Why git-commit recency (not file mtime, not filename dates):
+  - mtime is rewritten to checkout-time by `actions/checkout`, so it is
+    useless for measuring output freshness on a fresh CI checkout.
+  - Filename-date prefixes (the previous liveness check's approach) only
+    work for lanes whose files are named `YYYY-MM-DD-*`. Slug-named lanes
+    (wiki entities, model tickets, generative articles) have no date in
+    the filename, so that method silently can't see them.
+  - The commit timestamp of the last commit touching `research/<lane>/`
+    is universal across every lane and directly reflects "did this lane
+    write anything." That is the signal we use.
+
+Requires full git history for the paths under inspection. In CI, check
+out with `fetch-depth: 0` (a shallow clone makes `git log` unreliable;
+we warn when we detect one).
+
+Exit codes:
+  0  every lane is fresh
+  2  one or more lanes are stale or their directory is missing (alert)
+  1  internal error (e.g. not a git repository)
+
+Per-lane thresholds are tuned to each lane's schedule (see CLAUDE.md
+"GitHub Actions Workflows") with a buffer of roughly two missed cycles
+plus runner-queue slack, so a single transient failure does not page.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Callable, Optional
+
+# lane -> max tolerated age in hours before we consider it stale.
+# Cadence comments reference the schedules documented in CLAUDE.md.
+# On-demand lanes (generative, issues) and experimental A/B lanes
+# (twitter-deepseek*, twitter-viral) are intentionally excluded: they
+# have no fixed cadence, so staleness is not a meaningful signal there.
+LANE_THRESHOLDS_HOURS: dict[str, float] = {
+    "rss": 4,           # hourly at :30
+    "twitter": 9,       # every 3h at :07
+    "community": 11,    # every 4h at :19
+    "bluesky": 30,      # daily at 00:11
+    "arxiv": 30,        # daily at 06:13
+    "digest": 30,       # daily at 00:00
+    "models": 30,       # daily at 06:29
+    "front-page": 30,   # daily at 00:30
+    "wiki": 30,         # daily, after the digest (workflow_run)
+}
+
+FRESH = "fresh"
+STALE = "stale"
+MISSING = "missing"
+UNKNOWN = "unknown"
+
+# States that should trigger an alert.
+ALERTING_STATES = frozenset({STALE, MISSING})
+
+
+@dataclass
+class LaneStatus:
+    lane: str
+    threshold_hours: float
+    age_hours: Optional[float]
+    state: str
+
+    @property
+    def alerting(self) -> bool:
+        return self.state in ALERTING_STATES
+
+
+def _git(args: list[str], repo_root: str) -> Optional[str]:
+    """Run a git command in repo_root; return stripped stdout or None."""
+    try:
+        out = subprocess.run(
+            ["git", *args],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    return out.stdout.strip()
+
+
+def lane_dir_exists(lane: str, repo_root: str) -> bool:
+    return os.path.isdir(os.path.join(repo_root, "research", lane))
+
+
+def lane_age_hours(lane: str, now_epoch: int, repo_root: str) -> Optional[float]:
+    """Hours since the last commit touching research/<lane>/.
+
+    Returns None when the lane has no commits reachable in the current
+    history (e.g. a shallow clone, or a genuinely never-written lane).
+    """
+    path = f"research/{lane}"
+    last = _git(["log", "-1", "--format=%ct", "--", path], repo_root)
+    if not last:
+        return None
+    try:
+        commit_epoch = int(last)
+    except ValueError:
+        return None
+    return (now_epoch - commit_epoch) / 3600.0
+
+
+def classify(age_hours: Optional[float], threshold_hours: float, dir_exists: bool) -> str:
+    if not dir_exists:
+        return MISSING
+    if age_hours is None:
+        return UNKNOWN
+    return STALE if age_hours > threshold_hours else FRESH
+
+
+def evaluate(
+    thresholds: dict[str, float],
+    now_epoch: int,
+    repo_root: str,
+    *,
+    age_fn: Callable[[str, int, str], Optional[float]] = lane_age_hours,
+    dir_exists_fn: Callable[[str, str], bool] = lane_dir_exists,
+) -> list[LaneStatus]:
+    """Evaluate every configured lane. age_fn/dir_exists_fn are injectable
+    so the logic can be unit-tested without a real repository."""
+    results: list[LaneStatus] = []
+    for lane, threshold in thresholds.items():
+        exists = dir_exists_fn(lane, repo_root)
+        age = age_fn(lane, now_epoch, repo_root) if exists else None
+        results.append(LaneStatus(lane, threshold, age, classify(age, threshold, exists)))
+    return results
+
+
+def _fmt_age(age_hours: Optional[float]) -> str:
+    if age_hours is None:
+        return "?"
+    if age_hours < 48:
+        return f"{age_hours:.1f}h"
+    return f"{age_hours / 24:.1f}d"
+
+
+def format_report(statuses: list[LaneStatus]) -> str:
+    """Human/markdown-friendly table. Stale and missing lanes first."""
+    icon = {FRESH: "✅", STALE: "🔴", MISSING: "❓", UNKNOWN: "⚠️"}
+    order = {STALE: 0, MISSING: 1, UNKNOWN: 2, FRESH: 3}
+    rows = sorted(statuses, key=lambda s: (order[s.state], s.lane))
+    lines = ["| lane | state | age | threshold |", "|---|---|---|---|"]
+    for s in rows:
+        lines.append(
+            f"| `{s.lane}` | {icon[s.state]} {s.state} "
+            f"| {_fmt_age(s.age_hours)} | {s.threshold_hours:g}h |"
+        )
+    return "\n".join(lines)
+
+
+def idempotency_key(stale_lanes: list[str], now: datetime) -> str:
+    """Stable per-day key over the stale set, so the same outage reported
+    by both the ubuntu-latest and self-hosted watchdog jobs (and by repeat
+    runs the same day) collapses to a single delivered alert. A change in
+    the stale set (escalation) produces a new key."""
+    date = now.strftime("%Y-%m-%d")
+    part = "-".join(sorted(stale_lanes)) if stale_lanes else "none"
+    return f"lane-freshness-{date}-{part}"
+
+
+def _emit_github_output(stale_lanes: list[str], report: str, key: str) -> None:
+    out_path = os.environ.get("GITHUB_OUTPUT")
+    if not out_path:
+        return
+    stale = "true" if stale_lanes else "false"
+    delim = "__ARA_REPORT_EOF__"
+    with open(out_path, "a", encoding="utf-8") as fh:
+        fh.write(f"stale={stale}\n")
+        fh.write(f"stale_lanes={','.join(sorted(stale_lanes))}\n")
+        fh.write(f"idempotency_key={key}\n")
+        fh.write(f"report<<{delim}\n{report}\n{delim}\n")
+
+
+def _emit_step_summary(report: str, stale_lanes: list[str]) -> None:
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    header = (
+        f"### 🔴 Pipeline freshness: {len(stale_lanes)} lane(s) stale\n\n"
+        if stale_lanes
+        else "### ✅ Pipeline freshness: all lanes fresh\n\n"
+    )
+    with open(summary_path, "a", encoding="utf-8") as fh:
+        fh.write(header + report + "\n")
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Research lane freshness watchdog.")
+    parser.add_argument(
+        "--now",
+        help="ISO-8601 UTC timestamp to evaluate against (default: now). For testing.",
+    )
+    parser.add_argument(
+        "--repo",
+        default=None,
+        help="Repository root (default: git toplevel of CWD, else CWD).",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of a table.")
+    args = parser.parse_args(argv)
+
+    if args.now:
+        # Python <3.11's fromisoformat rejects a trailing 'Z'; normalize it.
+        raw = args.now[:-1] + "+00:00" if args.now.endswith("Z") else args.now
+        try:
+            now_dt = datetime.fromisoformat(raw)
+        except ValueError:
+            print(f"error: --now is not a valid ISO-8601 timestamp: {args.now}", file=sys.stderr)
+            return 1
+        if now_dt.tzinfo is None:
+            now_dt = now_dt.replace(tzinfo=timezone.utc)
+    else:
+        now_dt = datetime.now(timezone.utc)
+    now_epoch = int(now_dt.timestamp())
+
+    repo_root = args.repo or _git(["rev-parse", "--show-toplevel"], ".") or os.getcwd()
+
+    if _git(["rev-parse", "--is-inside-work-tree"], repo_root) != "true":
+        print(f"error: {repo_root} is not a git repository", file=sys.stderr)
+        return 1
+    if _git(["rev-parse", "--is-shallow-repository"], repo_root) == "true":
+        print(
+            "::warning::shallow clone detected — git history is incomplete, "
+            "freshness may be unreliable. Check out with fetch-depth: 0.",
+            file=sys.stderr,
+        )
+
+    statuses = evaluate(LANE_THRESHOLDS_HOURS, now_epoch, repo_root)
+    stale_lanes = [s.lane for s in statuses if s.alerting]
+    report = format_report(statuses)
+    key = idempotency_key(stale_lanes, now_dt)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "now": now_dt.isoformat(),
+                    "stale_lanes": sorted(stale_lanes),
+                    "idempotency_key": key,
+                    "lanes": [
+                        {
+                            "lane": s.lane,
+                            "state": s.state,
+                            "age_hours": s.age_hours,
+                            "threshold_hours": s.threshold_hours,
+                        }
+                        for s in statuses
+                    ],
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(report)
+
+    _emit_github_output(stale_lanes, report, key)
+    _emit_step_summary(report, stale_lanes)
+
+    if stale_lanes:
+        print(f"\n::error::stale lanes detected: {', '.join(sorted(stale_lanes))}", file=sys.stderr)
+        return 2
+    print("\nall lanes fresh", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_check_lane_freshness.py
+++ b/scripts/test_check_lane_freshness.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from datetime import datetime, timezone
+
+import check_lane_freshness as clf
+
+
+class ClassifyTest(unittest.TestCase):
+    def test_missing_dir_is_missing_regardless_of_age(self):
+        self.assertEqual(clf.classify(None, 30, dir_exists=False), clf.MISSING)
+        self.assertEqual(clf.classify(1.0, 30, dir_exists=False), clf.MISSING)
+
+    def test_no_commits_is_unknown(self):
+        # dir exists but git returned no commit (e.g. shallow clone)
+        self.assertEqual(clf.classify(None, 30, dir_exists=True), clf.UNKNOWN)
+
+    def test_within_threshold_is_fresh(self):
+        self.assertEqual(clf.classify(3.9, 4, dir_exists=True), clf.FRESH)
+
+    def test_over_threshold_is_stale(self):
+        self.assertEqual(clf.classify(4.1, 4, dir_exists=True), clf.STALE)
+
+    def test_exactly_at_threshold_is_fresh(self):
+        # boundary: equal age is not yet stale
+        self.assertEqual(clf.classify(30.0, 30, dir_exists=True), clf.FRESH)
+
+
+class EvaluateTest(unittest.TestCase):
+    def _evaluate_with(self, ages, present):
+        thresholds = {"rss": 4, "twitter": 9, "wiki": 30, "gone": 30}
+
+        def age_fn(lane, now_epoch, repo_root):
+            return ages.get(lane)
+
+        def dir_exists_fn(lane, repo_root):
+            return lane in present
+
+        return clf.evaluate(
+            thresholds,
+            now_epoch=0,
+            repo_root="/nonexistent",
+            age_fn=age_fn,
+            dir_exists_fn=dir_exists_fn,
+        )
+
+    def test_mixed_states(self):
+        statuses = self._evaluate_with(
+            ages={"rss": 12.0, "twitter": 1.0, "wiki": 200.0},
+            present={"rss", "twitter", "wiki"},  # "gone" absent
+        )
+        by_lane = {s.lane: s for s in statuses}
+        self.assertEqual(by_lane["rss"].state, clf.STALE)      # 12h > 4h
+        self.assertEqual(by_lane["twitter"].state, clf.FRESH)  # 1h <= 9h
+        self.assertEqual(by_lane["wiki"].state, clf.STALE)     # 200h > 30h
+        self.assertEqual(by_lane["gone"].state, clf.MISSING)   # dir absent
+
+        alerting = sorted(s.lane for s in statuses if s.alerting)
+        self.assertEqual(alerting, ["gone", "rss", "wiki"])
+
+    def test_all_fresh(self):
+        statuses = self._evaluate_with(
+            ages={"rss": 0.5, "twitter": 0.5, "wiki": 0.5, "gone": 0.5},
+            present={"rss", "twitter", "wiki", "gone"},
+        )
+        self.assertEqual([s for s in statuses if s.alerting], [])
+
+
+class IdempotencyKeyTest(unittest.TestCase):
+    def setUp(self):
+        self.now = datetime(2026, 5, 28, 6, 0, tzinfo=timezone.utc)
+
+    def test_order_independent(self):
+        a = clf.idempotency_key(["twitter", "rss"], self.now)
+        b = clf.idempotency_key(["rss", "twitter"], self.now)
+        self.assertEqual(a, b)
+
+    def test_includes_date_and_set(self):
+        self.assertEqual(
+            clf.idempotency_key(["rss", "twitter"], self.now),
+            "lane-freshness-2026-05-28-rss-twitter",
+        )
+
+    def test_empty_set(self):
+        self.assertEqual(
+            clf.idempotency_key([], self.now),
+            "lane-freshness-2026-05-28-none",
+        )
+
+    def test_different_set_different_key(self):
+        a = clf.idempotency_key(["rss"], self.now)
+        b = clf.idempotency_key(["rss", "twitter"], self.now)
+        self.assertNotEqual(a, b)
+
+
+@unittest.skipIf(shutil.which("git") is None, "git not available")
+class GitIntegrationTest(unittest.TestCase):
+    """Exercises the real `git log` path with deterministic backdated commits."""
+
+    def setUp(self):
+        self.repo = tempfile.mkdtemp(prefix="lane-fresh-")
+        self._git("init", "-q")
+        self._git("config", "user.email", "test@example.com")
+        self._git("config", "user.name", "Test")
+
+    def tearDown(self):
+        shutil.rmtree(self.repo, ignore_errors=True)
+
+    def _git(self, *args, env_extra=None):
+        env = os.environ.copy()
+        if env_extra:
+            env.update(env_extra)
+        subprocess.run(["git", *args], cwd=self.repo, check=True,
+                       capture_output=True, text=True, env=env)
+
+    def _commit_lane(self, lane, iso_date):
+        d = os.path.join(self.repo, "research", lane)
+        os.makedirs(d, exist_ok=True)
+        with open(os.path.join(d, "2026-01-01.md"), "a", encoding="utf-8") as fh:
+            fh.write("x\n")
+        self._git("add", "-A")
+        # Pin both author and committer date so %ct is deterministic.
+        self._git(
+            "commit", "-q", "-m", f"{lane} {iso_date}",
+            env_extra={"GIT_AUTHOR_DATE": iso_date, "GIT_COMMITTER_DATE": iso_date},
+        )
+
+    def test_age_reflects_last_commit_time(self):
+        # rss last written 10 days ago; twitter 1 hour ago.
+        self._commit_lane("rss", "2026-05-18T00:00:00Z")
+        self._commit_lane("twitter", "2026-05-28T05:00:00Z")
+
+        now_epoch = int(datetime(2026, 5, 28, 6, 0, tzinfo=timezone.utc).timestamp())
+        rss_age = clf.lane_age_hours("rss", now_epoch, self.repo)
+        tw_age = clf.lane_age_hours("twitter", now_epoch, self.repo)
+
+        self.assertIsNotNone(rss_age)
+        self.assertIsNotNone(tw_age)
+        self.assertAlmostEqual(rss_age, 10 * 24 + 6, delta=0.5)  # 246h
+        self.assertAlmostEqual(tw_age, 1.0, delta=0.5)
+
+        # And end-to-end classification with the real thresholds.
+        statuses = clf.evaluate(
+            {"rss": clf.LANE_THRESHOLDS_HOURS["rss"],
+             "twitter": clf.LANE_THRESHOLDS_HOURS["twitter"]},
+            now_epoch, self.repo,
+        )
+        by_lane = {s.lane: s.state for s in statuses}
+        self.assertEqual(by_lane["rss"], clf.STALE)
+        self.assertEqual(by_lane["twitter"], clf.FRESH)
+
+    def test_absent_lane_dir_is_missing(self):
+        self._commit_lane("rss", "2026-05-28T05:00:00Z")
+        now_epoch = int(datetime(2026, 5, 28, 6, 0, tzinfo=timezone.utc).timestamp())
+        statuses = clf.evaluate({"bluesky": 30}, now_epoch, self.repo)
+        self.assertEqual(statuses[0].state, clf.MISSING)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

A GitHub Actions **billing/spending-limit block** has silently frozen the `rss`, `twitter`, `arxiv`, and `bluesky` lanes since **2026-05-26** (and `wiki` since 05-24) — with **zero alarm**. The digest is now openly synthesizing stale data ("arXiv: carry from the May 21–26 window").

The watchdog meant to catch this was blind to it:

1. **It ran only on `ubuntu-latest`** — which a billing block kills (the job never starts). It died in the same instant as the lanes it watches.
2. **Its only alert was the native workflow-failure email** — which requires the job to *run*. Under a billing block, no job → no email → silent decay.

## Fix

First-principles: **no single runner survives both failure modes** (an `ubuntu-latest` billing block vs. a self-hosted outage). So:

- **Run the identical check on both tiers.** Whichever tier is alive emits the alert. `ubuntu-latest` covers a self-hosted outage; self-hosted covers an `ubuntu-latest` billing block.
- **Alert over hooker** (external endpoint → Telegram), not email. A per-day `Idempotency-Key` over the stale set collapses the two jobs + repeat runs to **one message per stale set per day**; an escalating set re-alerts.
- **Signal = git-commit recency per lane** — universal across slug-named lanes (wiki, models), robust to checkout mtime rewrites. Replaces the old filename-date method that couldn't see non-date-named lanes.
- **Per-lane cadence thresholds** (rss 4h, twitter 9h, community 11h, daily lanes 30h) instead of a flat 48h.
- **Every 6h** (was daily): an hourly lane is now caught within ~6h instead of 48h-and-no-alert.

## What's here

| File | |
|---|---|
| `scripts/check_lane_freshness.py` | stdlib-only checker (runs on both tiers); per-lane thresholds; emits step outputs + GH step-summary table; exit 2 on staleness |
| `scripts/test_check_lane_freshness.py` | 13 unit + real-git integration tests |
| `.github/actions/lane-freshness-alert/` | composite: check → hooker alert → fail-if-stale (shared by both jobs) |
| `.github/workflows/liveness-check.yml` | rewritten: two jobs (`ubuntu-latest` + `[self-hosted, Linux]`) |
| `CLAUDE.md` | runner split (liveness-check now dual-tier) + scripts table |

## Validation

- `uv run python -m unittest discover -s scripts -p 'test_*.py'` → **222 passed** (209 prior + 13 new).
- `actionlint` → clean (exit 0).
- **Live run against this repo correctly flags the real outage** and confirms the healthy lanes:

```
| lane         | state    | age   | threshold |
| arxiv        | 🔴 stale | 2.4d  | 30h |
| bluesky      | 🔴 stale | 2.7d  | 30h |
| rss          | 🔴 stale | 2.1d  | 4h  |
| twitter      | 🔴 stale | 2.1d  | 9h  |
| wiki         | 🔴 stale | 4.2d  | 30h |
| community    | ✅ fresh | 4.3h  | 11h |
| digest       | ✅ fresh | 17.5h | 30h |
| front-page   | ✅ fresh | 12.3h | 30h |
| models       | ✅ fresh | 10.2h | 30h |
```

## Out of scope

Clearing the **billing/spending-limit block** (the root cause of the current outage) is account-level — Settings → Billing & plans. This PR only ensures the *next* silent stall is caught in hours, not days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)