### PR TITLE
Fix wiki-ingest convergence: raise --max-turns 50->80 + bound/commit-early the agent (lane frozen since 2026-05-24 seed)

### DIFF
--- a/.github/workflows/wiki-ingest.yml
+++ b/.github/workflows/wiki-ingest.yml
@@ -84,6 +84,23 @@ jobs:
       # of expected runs without leaving a quietly-hung job to chew runner
       # time forever.
       #
+      # --max-turns 80 (was 50): the lane is a strict superset of the
+      # 24h-model-timeline CRUD loop (which runs at 60). Per significant
+      # subject this agent spends ~3+ turns — wiki_search (Bash) -> read the
+      # matched page (Read) -> Edit — BEFORE the per-run index.md + log.md
+      # writes, the build_wiki_index.py regen, and the
+      # "iterate check_wiki until exit 0" validate loop. On a real digest
+      # (10-25 KB, a dozen-plus subjects) 50 turns was exhausted mid-pass and
+      # the agent died with the SDK error "Reached maximum number of turns
+      # (50)" BEFORE STEP 6's commit — so nothing was ever committed and the
+      # lane sat frozen at its 2026-05-24 seed (see PR diagnosis). 80 gives
+      # the validate-fix loop real headroom while staying well inside the
+      # 90-min wall clock; we stop short of generative-research's 120 because
+      # this agent only edits short markdown pages (no long-form article) and
+      # over-provisioning turns on the ephemeral runner invites runaway/OOM.
+      # The prompt now also bounds work per run and commits a valid PARTIAL
+      # pass rather than racing the cap to zero with an empty tree.
+      #
       # continue-on-error keeps the runner alive past a Claude failure so
       # the "Inspect Claude outcome" step below can decide what to surface
       # to job.status (and so hooker-telemetry's `if: always()` step still
@@ -101,7 +118,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
-            --model opus --max-turns 50 --allowedTools "Read,Write,Edit,Bash(uv:*),Bash(git:*),Bash(ls:*),Bash(cat:*),Bash(grep:*),Bash(jq:*),WebSearch,Task,TodoWrite"
+            --model opus --max-turns 80 --allowedTools "Read,Write,Edit,Bash(uv:*),Bash(git:*),Bash(ls:*),Bash(cat:*),Bash(grep:*),Bash(jq:*),WebSearch,Task,TodoWrite"
           prompt: |
             You maintain the LLM Wiki: a compounding, interlinked knowledge
             base of markdown pages at research/wiki/. One page per
@@ -158,13 +175,36 @@ jobs:
               or corroborate a single specific claim — never as a general
               research pass.
 
-            STEP 2 — EXTRACT SIGNIFICANT SUBJECTS.
+            STEP 2 — EXTRACT SIGNIFICANT SUBJECTS (AND BOUND THE SET).
               From the curated input, pull the entities (companies, models,
               people, products), concepts (techniques, architectures,
               benchmarks, ideas), and themes (ongoing storylines, trends)
               that are genuinely significant today. A passing mention is not
               a page. Favor depth on the day's real developments over
               breadth.
+
+              You have a finite turn budget and EACH subject costs several
+              turns (search + read + edit). Rank the subjects by significance
+              and cap this pass: handle AT MOST the top ~8 subjects (prefer
+              updating existing pages — that is cheaper and is the default —
+              over minting new ones). The wiki compounds daily; anything you
+              skip today gets picked up the next run. Do NOT attempt to cover
+              every subject in one pass — that is exactly what exhausted the
+              turn budget before the commit and left the lane frozen. A small,
+              valid, COMMITTED pass beats an ambitious one that dies with
+              nothing on disk.
+
+            TURN-BUDGET DISCIPLINE (read before STEP 3).
+              Treat STEP 5b + STEP 6 (regenerate index.json, then commit) as a
+              checkpoint you MUST reach with turns to spare — not an
+              afterthought. As you work, keep a rough count of turns used. If
+              you sense you are running low (e.g. past ~60 turns) before
+              you've finished every intended subject, STOP starting new
+              subjects, finish whatever page you are mid-edit on, then jump
+              straight to STEP 4 → 5 → 5b → 6 and COMMIT what you have.
+              Committing a validator-clean partial pass is success; running
+              out of turns mid-edit with an uncommitted tree is the failure
+              this lane has been hitting. When in doubt, commit early.
 
             STEP 3 — FOR EACH SUBJECT, SEARCH FIRST, THEN CRUD.
               This is the core dedup discipline. For every subject, BEFORE
@@ -219,6 +259,13 @@ jobs:
 
               (`git add research/wiki/` includes the regenerated index.json.)
               Do NOT run `git push`. A later workflow step publishes.
+
+              This commit is the WHOLE POINT of the run. Always reach it,
+              even after a deliberately bounded/partial pass (see STEP 2 and
+              the turn-budget discipline). The only acceptable "No changes"
+              outcome is when the digest genuinely contained nothing new for
+              the wiki — never because you ran out of turns before getting
+              here.
 
             CONSTRAINTS
               - The validator is the contract enforcer; treat docs/wiki-schema.md


### PR DESCRIPTION
## Diagnosis (from run logs + git history)

`research/wiki/` has **exactly one commit** — the 2026-05-24 seed. The lane has never successfully ingested. Stress-testing the three premises from the brief:

**(a) Does the trigger fire?** YES. `wiki-ingest.yml`'s `workflow_run.workflows: ["Daily AI Digest (All Sources)"]` matches the digest workflow's `name:` exactly (verified). Runs exist for every day the digest succeeded — the trigger is not the problem.

**(b) Code/config vs infra?** BOTH, but the most recent successful-digest day is a fixable code/config bug. Failure taxonomy:

| Date | Digest | wiki-ingest | Real cause |
|---|---|---|---|
| 2026-05-25 | failed | **skipped** | `if:` guard correctly skips (no fresh input). **Not a bug.** |
| 2026-05-26 | failed | **skipped** | same. **Not a bug.** |
| **2026-05-28** | success | **failure** | **CODE/CONFIG** — `Action failed: SDK execution error: Reached maximum number of turns (50)`. Claude died after ~5 min, **before STEP 6's commit**, so nothing landed. |
| 2026-05-27 | success | failure | INFRA — `The self-hosted runner lost communication with the server`. |
| 2026-05-24 (dispatch) | n/a | failure | INFRA — exit 137 (OOM SIGKILL) on one; `job was not acquired by Runner of type self-hosted` on the other. |

The self-hosted runner is an **ephemeral cloud-run worker** (`cloud-run-worker-4nn6u`), which explains the not-acquired / OOM / lost-communication deaths.

**(c) Does the agent loop terminate?** This was the false premise. The prompt is a per-subject CRUD loop (`wiki_search` → read hit → edit, for *every* significant subject) plus a "ITERATE UNTIL EXIT 0" validate loop plus index/log/index.json steps. At `--max-turns 50` on a real digest (10–25 KB, a dozen-plus subjects) the agent **runs out of turns mid-pass and never reaches the commit** — exactly the 2026-05-28 signature.

### Note on the "Inspect Claude outcome" step
On 2026-05-28 the GitHub API shows step #7 (Claude) `conclusion=success` yet step #8 (Inspect) `failure`. That is **not** a contradiction: with `continue-on-error: true`, `steps.ingest.conclusion` is forced to `success` while `steps.ingest.outcome` retains the true `failure`. The Inspect step reads `outcome`, so it correctly failed the job and reported honestly. **That guard is working as designed — left untouched.**

## Fix (the convergence bug — code/config)

Single file, `.github/workflows/wiki-ingest.yml` (+49/-2):

1. **`--max-turns 50 → 80`.** The lane is a strict superset of `24h-model-timeline.yml`'s CRUD loop, which runs at **60**. Per subject this agent spends ~3+ turns (`wiki_search` + read + edit) *before* the index.md/log.md writes, the `build_wiki_index.py` regen, and the validate-until-exit-0 loop — 50 had zero headroom. 80 gives the validate-fix loop room while staying well inside the existing 90-min wall clock. Deliberately **not** 120 (generative-research's budget): this agent only edits short markdown pages, and over-provisioning turns on the ephemeral worker invites runaway/OOM.
2. **Bound the pass + commit-early.** Raising the cap alone doesn't guarantee termination on a pathologically heavy day, so the prompt now: caps the pass to the **top ~8 subjects** (update-first, since the wiki compounds daily); adds a **TURN-BUDGET DISCIPLINE** block telling the agent to treat STEP 5b+6 (regen index.json, commit) as a checkpoint it must reach, and to **commit a validator-clean partial pass** rather than racing the cap to zero with an empty tree; and reinforces in STEP 6 that the commit is the whole point and `"No changes"` is only legitimate when the digest had nothing new.

**Not changed:** `docs/wiki-schema.md`, `scripts/check_wiki.py`, `scripts/build_wiki_index.py`, and every wiki page — all correct and in lockstep. The lane is **not** deleted or weakened, and no page is touched. (Rule #8 atomic-write does not apply: the agent's `build_wiki_index.py` write is local and the dashboard reads the *committed* `index.json`, so write→commit is the atomic boundary already.)

## Infra blocker (cannot be fixed from code)
The 2026-05-24 and 2026-05-27 deaths are genuine ephemeral-runner failures (not-acquired, exit 137 OOM, lost-communication). No code change can prevent a cloud-run worker being reclaimed mid-job. This fix reduces the *blast radius* (a bounded pass uses less context/memory, mitigating OOM) and makes the failure honest, but runner availability/sizing is an infra concern. Per the brief, the dual-tier freshness watchdog already alarms on wiki staleness, so no new alarm is added.

## Validation
- `actionlint .github/workflows/wiki-ingest.yml` → exit 0
- `uv run python scripts/check_wiki.py` → exit 0 (6 pages valid)
- `uv run python scripts/build_wiki_index.py --check` → exit 0 (index.json current)
- `uv run python -m unittest discover -s scripts -p "test_*.py"` → **Ran 222 tests, OK (skipped=6)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)