### PR TITLE
Apply self-improve workflow fixes (RSS feeds, Bluesky handle hygiene, HN pre-fetch)

### DIFF
--- a/.github/workflows/2h-bluesky.yml
+++ b/.github/workflows/2h-bluesky.yml
@@ -2,8 +2,11 @@ name: Bluesky AI Researcher Feed (Daily)
 
 on:
   schedule:
-    # Run once daily at 00:11 UTC
-    - cron: '11 0 * * *'
+    # Run twice daily (00:11 and 12:11 UTC). A single daily snapshot of a
+    # small set of sporadically-posting researchers repeatedly yielded <3
+    # posts (the digest flagged "Bluesky: 1 feed snapshot" as the lane's weak
+    # point); a second pass roughly doubles candidate posts per day.
+    - cron: '11 0,12 * * *'
   workflow_dispatch:
 
 concurrency:
@@ -38,21 +41,39 @@ jobs:
 
           # Public keyword search now returns HTTP 403 without an authenticated
           # session. Author feeds remain public, so use a curated AI-source list.
+          #
+          # Handle hygiene — every handle below was re-verified live via
+          # getAuthorFeed on 2026-05-29 (displayName + most-recent post date).
+          # Each entry is a real, currently-active AI voice. Handles that
+          # resolved to the WRONG person, to an EMPTY feed, or to a long-dormant
+          # account were removed (Bluesky reassigns/aliases handles, so an old
+          # entry can silently start surfacing a stranger's posts — exactly the
+          # "ingesting the wrong Simon Willison" bug this list previously had):
+          #   - simonw.bsky.social      -> "Simon Wigzell" (Swedish comics blog),
+          #                                NOT Simon Willison. Corrected to the
+          #                                custom-domain handle simonwillison.net.
+          #   - emilymbender.bsky.social -> now "Sam Cole" (samleecole), wrong person
+          #   - mmitchell.bsky.social    -> now "Larry Hunter" (proflhunter), wrong person
+          #   - rasbt.bsky.social        -> now "fry69", not Sebastian Raschka
+          #   - karpathy.bsky.social     -> last post 2023-05-27 (dormant)
+          #   - arankomatsuzaki...       -> last post 2024-12-17 (dormant)
+          #   - huggingface / deeplearning / jeremyhoward / swyx / moyix /
+          #     schmidhuber .bsky.social -> empty feeds (no posts returned)
+          # Re-add any of these only after API-verifying a correct active handle.
+          # Added 2026-05-29 (each verified posting within ~3 days): natolambert
+          # (post-training/open models), emollick (applied AI), alexhanna
+          # (AI policy/ethics), minimaxir (ML engineering).
+          # Custom-domain handles (no .bsky.social suffix, e.g. simonwillison.net)
+          # are fine: getAuthorFeed resolves the handle to a DID either way, and
+          # the slug logic below keeps the full handle string as the filename.
           handles=(
-            "karpathy.bsky.social"
-            "emilymbender.bsky.social"
-            "mmitchell.bsky.social"
-            "huggingface.bsky.social"
-            "deeplearning.bsky.social"
-            "rasbt.bsky.social"
-            "jeremyhoward.bsky.social"
             "yoavgo.bsky.social"
-            "swyx.bsky.social"
-            "simonw.bsky.social"
             "hardmaru.bsky.social"
-            "moyix.bsky.social"
-            "arankomatsuzaki.bsky.social"
-            "schmidhuber.bsky.social"
+            "simonwillison.net"
+            "natolambert.bsky.social"
+            "emollick.bsky.social"
+            "alexhanna.bsky.social"
+            "minimaxir.bsky.social"
           )
 
           for handle in "${handles[@]}"; do
@@ -80,7 +101,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
-            --model sonnet --allowedTools "Read,Write,Edit,Bash(git:*)"
+            --model sonnet --allowedTools "Read,Write,Edit,Bash(ls:*),Bash(git:*)"
           prompt: |
             You are a Bluesky AI feed curator. Process REAL-TIME posts from Bluesky.
 
@@ -89,21 +110,11 @@ jobs:
 
             ## SOURCE FILES
 
-            Read these pre-fetched Bluesky JSON files from data/bluesky/:
-            - data/bluesky/arankomatsuzaki.json
-            - data/bluesky/deeplearning.json
-            - data/bluesky/emilymbender.json
-            - data/bluesky/hardmaru.json
-            - data/bluesky/huggingface.json
-            - data/bluesky/jeremyhoward.json
-            - data/bluesky/karpathy.json
-            - data/bluesky/mmitchell.json
-            - data/bluesky/moyix.json
-            - data/bluesky/rasbt.json
-            - data/bluesky/schmidhuber.json
-            - data/bluesky/simonw.json
-            - data/bluesky/swyx.json
-            - data/bluesky/yoavgo.json
+            Read EVERY `*.json` file in `data/bluesky/` (one per tracked
+            account; run `ls data/bluesky/` first to enumerate them). Do NOT
+            rely on a hardcoded filename list — the curated handle set changes
+            over time (handles get fixed, added, or dropped), so always process
+            whatever files are actually present.
 
             The Bluesky JSON structure is:
             - feed[].post.author.handle (username like "user.bsky.social")
@@ -144,7 +155,7 @@ jobs:
             ## FILTERS
 
             INCLUDE:
-            - Posts from last 24 hours
+            - Posts from last 48 hours
             - Announcements about AI models, releases
             - Technical discussions
             - Links to papers or blog posts
@@ -153,7 +164,7 @@ jobs:
             SKIP:
             - Generic "AI is amazing" posts
             - Spam or promotional content
-            - Posts older than 24 hours
+            - Posts older than 48 hours
             - Low engagement posts
             - Pure reposts where feed[].reason is a repost reason
 

--- a/.github/workflows/2h-bluesky.yml
+++ b/.github/workflows/2h-bluesky.yml
@@ -1,4 +1,4 @@
-name: Bluesky AI Researcher Feed (Daily)
+name: Bluesky AI Researcher Feed (Twice Daily)
 
 on:
   schedule:

--- a/.github/workflows/4h-community.yml
+++ b/.github/workflows/4h-community.yml
@@ -75,6 +75,39 @@ jobs:
           cp /tmp/reddit/*.rss data/reddit/ || echo "No files to copy"
           ls -la data/reddit/
 
+      # Deterministic HN pre-fetch (mirrors the Reddit RSS approach above).
+      # The mcp-hackernews MCP server has failed intermittently inside the
+      # agent ("HN live data unavailable — network access restricted"),
+      # leaving the HN section empty while Reddit (pre-fetched) stayed fine.
+      # The Algolia HN Search API is the public, no-auth JSON backend that
+      # powers HN's own search, so fetching it here in a shell step gives the
+      # agent a guaranteed HN source. Graceful fallback to an empty result set
+      # on failure, honoring CLAUDE.md rule #6 (fetch gracefully, never crash).
+      - name: Fetch Hacker News front page (Algolia)
+        id: hackernews
+        run: |
+          mkdir -p /tmp/hn
+
+          echo "Fetching HN front page (Algolia)..."
+          curl -sL -m 30 \
+            "https://hn.algolia.com/api/v1/search?tags=front_page&hitsPerPage=50" \
+            -H "User-Agent: AIResearchBot/1.0" \
+            > /tmp/hn/frontpage.json || printf '{"hits":[]}\n' > /tmp/hn/frontpage.json
+
+          # Guard against HTML error pages / truncated bodies: if the file
+          # doesn't look like the expected JSON, replace with an empty set.
+          if ! grep -q '"hits"' /tmp/hn/frontpage.json; then
+            echo "Algolia response missing hits[] — writing empty set"
+            printf '{"hits":[]}\n' > /tmp/hn/frontpage.json
+          fi
+          echo "HN frontpage.json size: $(wc -c < /tmp/hn/frontpage.json) bytes"
+
+      - name: Copy HN data to working directory
+        run: |
+          mkdir -p data/hn
+          cp /tmp/hn/*.json data/hn/ || echo "No files to copy"
+          ls -la data/hn/
+
       - name: Create MCP Config
         run: |
           cat > /tmp/mcp-config.json << 'EOF'
@@ -103,8 +136,26 @@ jobs:
 
             ## TASK 1: Hacker News
 
-            Use the Hacker News MCP tools to get current top/new stories.
-            Filter for AI/ML/LLM related content.
+            PRIMARY SOURCE (always available): read the pre-fetched front page
+            from data/hn/frontpage.json. This is the Algolia HN Search API
+            response; each item in hits[] has:
+            - title          (story title)
+            - url            (external link; may be null for Ask/Show HN)
+            - points         (score)
+            - num_comments   (comment count)
+            - objectID       (HN story id)
+
+            Build the HN discussion link as:
+              https://news.ycombinator.com/item?id={objectID}
+
+            Filter hits[] for AI/ML/LLM-related content and rank by points.
+
+            SUPPLEMENT (best-effort): if the Hacker News MCP tools respond, use
+            them to refine scores/comment counts or pull "new" stories not yet
+            on the front page. If the MCP tools error or return nothing, DO NOT
+            leave the HN section empty — data/hn/frontpage.json is sufficient on
+            its own. Never emit an "HN data unavailable" placeholder while
+            frontpage.json has hits.
 
             Write to: research/community/${{ steps.datetime.outputs.date }}-hn.md
 

--- a/.github/workflows/hourly-rss.yml
+++ b/.github/workflows/hourly-rss.yml
@@ -90,6 +90,58 @@ jobs:
             -H "User-Agent: Mozilla/5.0 (compatible; AIResearchBot/1.0)" \
             > /tmp/rss/venturebeat_ai.xml 2>/dev/null || echo "<rss></rss>" > /tmp/rss/venturebeat_ai.xml
 
+          # Ars Technica AI RSS (section feed; probed HTTP 200, fresh items)
+          curl -sL "https://arstechnica.com/ai/feed/" \
+            -H "User-Agent: Mozilla/5.0 (compatible; AIResearchBot/1.0)" \
+            > /tmp/rss/arstechnica_ai.xml 2>/dev/null || echo "<rss></rss>" > /tmp/rss/arstechnica_ai.xml
+
+          # MIT Technology Review — AI section. Long-form AI journalism the
+          # daily-digest synthesizer cites; probed HTTP 200 with fresh items.
+          curl -sL "https://www.technologyreview.com/topic/artificial-intelligence/feed/" \
+            -H "User-Agent: Mozilla/5.0 (compatible; AIResearchBot/1.0)" \
+            > /tmp/rss/mit_tech_review_ai.xml 2>/dev/null || echo "<rss></rss>" > /tmp/rss/mit_tech_review_ai.xml
+
+          # The Decoder — AI-only news outlet (probed HTTP 200, fresh items)
+          curl -sL "https://the-decoder.com/feed/" \
+            -H "User-Agent: Mozilla/5.0 (compatible; AIResearchBot/1.0)" \
+            > /tmp/rss/the_decoder.xml 2>/dev/null || echo "<rss></rss>" > /tmp/rss/the_decoder.xml
+
+          # MarkTechPost — high-volume AI research/news aggregator surfacing new
+          # papers, model releases, and open-source drops (probed HTTP 200).
+          curl -sL "https://www.marktechpost.com/feed/" \
+            -H "User-Agent: Mozilla/5.0 (compatible; AIResearchBot/1.0)" \
+            > /tmp/rss/marktechpost.xml 2>/dev/null || echo "<rss></rss>" > /tmp/rss/marktechpost.xml
+
+          # --- Expert / independent commentary (promoted from second-hand
+          # Twitter/HN pickup to first-class RSS input). All probed HTTP 200
+          # with entries dated within the last few days. NOTE: SemiAnalysis's
+          # public feed (semianalysis.com/feed/) was deliberately NOT added —
+          # it returns HTTP 200 but its newest item is from 2025-09-16 (the
+          # public RSS is frozen behind their paywall), so the 24h freshness
+          # filter would drop everything and only add a dead section.
+
+          # Simon Willison's Weblog (Atom) — high-signal hands-on LLM coverage.
+          # Atom uses entry/title/link[@href]/published, not item/.../pubDate.
+          curl -sL "https://simonwillison.net/atom/everything/" \
+            -H "User-Agent: Mozilla/5.0 (compatible; AIResearchBot/1.0)" \
+            > /tmp/rss/simonwillison.xml 2>/dev/null || echo "<feed></feed>" > /tmp/rss/simonwillison.xml
+
+          # Interconnects (Nathan Lambert) — open-model / post-training analysis.
+          curl -sL "https://www.interconnects.ai/feed" \
+            -H "User-Agent: Mozilla/5.0 (compatible; AIResearchBot/1.0)" \
+            > /tmp/rss/interconnects.xml 2>/dev/null || echo "<rss></rss>" > /tmp/rss/interconnects.xml
+
+          # Import AI (Jack Clark, Anthropic co-founder) — frontier-lab essays;
+          # pairs with anthropic.xml for "what Anthropic is thinking" coverage.
+          curl -sL "https://jack-clark.net/feed/" \
+            -H "User-Agent: Mozilla/5.0 (compatible; AIResearchBot/1.0)" \
+            > /tmp/rss/import_ai.xml 2>/dev/null || echo "<rss></rss>" > /tmp/rss/import_ai.xml
+
+          # One Useful Thing (Ethan Mollick, Wharton) — applied-AI essays.
+          curl -sL "https://www.oneusefulthing.org/feed" \
+            -H "User-Agent: Mozilla/5.0 (compatible; AIResearchBot/1.0)" \
+            > /tmp/rss/one_useful_thing.xml 2>/dev/null || echo "<rss></rss>" > /tmp/rss/one_useful_thing.xml
+
           echo "RSS feeds fetched successfully"
           ls -la /tmp/rss/
 
@@ -124,12 +176,26 @@ jobs:
             - techcrunch_ai.xml (TechCrunch AI)
             - verge_ai.xml (The Verge AI)
             - venturebeat_ai.xml (VentureBeat AI)
+            - arstechnica_ai.xml (Ars Technica AI)
+            - mit_tech_review_ai.xml (MIT Technology Review — AI)
+            - the_decoder.xml (The Decoder — AI-only outlet)
+            - marktechpost.xml (MarkTechPost — AI research/news aggregator)
+
+            **Expert / Independent Commentary:**
+            - simonwillison.xml (Simon Willison's Weblog — Atom feed;
+              hands-on LLM coverage. Atom uses entry/title/link[@href]/published
+              instead of item/title/link/pubDate. Include only AI/LLM entries.)
+            - interconnects.xml (Nathan Lambert — open-model / post-training)
+            - import_ai.xml (Jack Clark / Anthropic — frontier-lab essays)
+            - one_useful_thing.xml (Ethan Mollick — applied-AI essays)
 
             RSS XML structure:
             - channel/item/title (article title)
             - channel/item/link (article URL)
             - channel/item/pubDate (publication date)
             - channel/item/description (summary)
+            Atom (simonwillison.xml) structure:
+            - feed/entry/title, feed/entry/link[@href], feed/entry/published
 
             ## OUTPUT
 
@@ -165,6 +231,33 @@ jobs:
             - [Title](url) - date
 
             #### VentureBeat
+            - [Title](url) - date
+
+            #### Ars Technica
+            - [Title](url) - date
+
+            #### MIT Technology Review
+            - [Title](url) - date
+
+            #### The Decoder
+            - [Title](url) - date
+
+            #### MarkTechPost
+            - [Title](url) - date
+
+            ### 🧠 Expert Commentary
+
+            #### Simon Willison
+            - [Title](url) - date
+              > Brief summary
+
+            #### Interconnects (Nathan Lambert)
+            - [Title](url) - date
+
+            #### Import AI (Jack Clark)
+            - [Title](url) - date
+
+            #### One Useful Thing (Ethan Mollick)
             - [Title](url) - date
 
             ### 📄 New arXiv Papers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ input).
 | `hourly-twitter.yml` | every 3h `:07` | `research/twitter/` + `research/summaries/` + Telegram headline alerts |
 | `hourly-twitter-deepseek-agentic.yml` | every 6h `:37` | `research/twitter-deepseek/` (DeepSeek V4 Pro via Anthropic shim, capped at 5 follow-up bird calls) |
 | `hourly-twitter-deepseek-pi.yml` | manual only | `research/twitter-deepseek-pi/` (A/B test using `pi-mono` harness) |
-| `2h-bluesky.yml` | daily `00:11` | `research/bluesky/` |
+| `2h-bluesky.yml` | twice daily `00:11`,`12:11` | `research/bluesky/` |
 | `4h-community.yml` | every 4h `:19` | `research/community/*-hn.md`, `*-reddit.md` |
 | `daily-arxiv.yml` | daily `06:13` | `research/arxiv/` |
 


### PR DESCRIPTION
## What this PR does

The `daily-improve.yml` self-improvement loop is a good **diagnosis** engine,
but only 1 of 7 improve PRs ever merged: `claude[bot]` lacks the App-level
`workflows: write` permission and cannot push edits to `.github/workflows/*`.
Six improve PRs sit OPEN with correct-but-unapplied fixes. This PR applies the
**still-valid, independently-stress-tested** subset, pushed as `guzus`.

Every proposed feed and handle was **re-probed live on 2026-05-29** before
applying — the premise "this fix is still valid and needed" was tested, not
assumed. That surfaced both rejections and brand-new bugs (below).

The six old improve PRs (#66, #67, #68, #71, #75, #78) are intentionally left
**OPEN, not closed**.

## `hourly-rss.yml` — add 8 feeds (union of #66 / #67 / #68, deduplicated)

Each returned HTTP 200 **and** had an item dated within the last few days when
probed on 2026-05-29:

| Feed | URL | Newest item (probe) |
|---|---|---|
| Ars Technica AI | `arstechnica.com/ai/feed/` | 2026-05-28 |
| MIT Technology Review AI | `technologyreview.com/topic/artificial-intelligence/feed/` | 2026-05-28 |
| The Decoder | `the-decoder.com/feed/` | 2026-05-28 |
| MarkTechPost | `marktechpost.com/feed/` | 2026-05-28 |
| Simon Willison (Atom) | `simonwillison.net/atom/everything/` | 2026-05-27 |
| Interconnects (Nathan Lambert) | `interconnects.ai/feed` | 2026-05-26 |
| Import AI (Jack Clark) | `jack-clark.net/feed/` | 2026-05-26 |
| One Useful Thing (Ethan Mollick) | `oneusefulthing.org/feed` | 2026-05-26 |

The three PRs overlapped heavily (Simon Willison appeared in all three; Ars
Technica + MIT Tech Review in two each) — deduplicated to one entry per feed,
wired into the fetch step, the prompt SOURCE FILES list (with an Atom-structure
note for Simon Willison), and the OUTPUT format (a new `🧠 Expert Commentary`
section).

### Stress-test REJECTION: SemiAnalysis (proposed in #66)
`semianalysis.com/feed/` returns HTTP 200 with 10 items — but the **newest item
is dated 2025-09-16** (~8 months stale; their public RSS is frozen behind a
paywall). The RSS lane filters to "last 24 hours," so this feed would contribute
**nothing** while adding a permanently-dead section. #66's probe counted items
but never checked recency. Not added; rationale documented inline.

## `2h-bluesky.yml` — merge #67 + #71 + #75 + newly-found broken handles

All handles re-verified live via `getAuthorFeed` (displayName + most-recent post
date) on 2026-05-29.

**Fixes the PRs correctly diagnosed (all confirmed live):**
- `simonw.bsky.social` → resolves to **"Simon Wigzell," a Swedish comics
  blogger**, not Simon Willison. Corrected to `simonwillison.net` (verified
  "Simon Willison", active 2026-05-27). [#75]
- Dropped dormant `karpathy.bsky.social` (last post 2023-05-27) and
  `arankomatsuzaki.bsky.social` (2024-12-17). [#75]
- Dropped empty `huggingface.bsky.social` / `deeplearning.bsky.social`. [#67]
- Added verified-active `natolambert`, `emollick`, `alexhanna`, `minimaxir`
  (each posting within ~3 days). [#67]
- Twice-daily cadence (`11 0,12 * * *`) + 24h→48h window. [#71]
- Replaced the prompt's hardcoded `data/bluesky/*.json` list with "read every
  `*.json`" + added `Bash(ls:*)`, killing the array↔prompt drift that let the
  wrong-handle bug persist. [#75]

**NEW bugs no PR caught — the *same* wrong-person bug class as `simonw`:**
The live probe revealed that Bluesky has reassigned/aliased several old handles
to *different people*, so they were silently injecting a stranger's posts under
a named AI researcher:
- `emilymbender.bsky.social` → now **"Sam Cole"** (`samleecole`)
- `mmitchell.bsky.social` → now **"Larry Hunter"** (`proflhunter`)
- `rasbt.bsky.social` → now **"fry69"** (not Sebastian Raschka)

Plus empty feeds (burning API calls for nothing, same logic #75 applied to
karpathy): `jeremyhoward`, `swyx`, `moyix`, `schmidhuber`.

These were **dropped**, not remapped: no correct, currently-active replacement
handle could be verified (e.g. `emilybender.bsky.social` exists but last posted
2024-09-20; `sebastianraschka.com` / `margaretmitchell.bsky.social` return
empty). Per #75's own discipline, no handles were guessed — re-add only after
API-verifying a correct active handle.

Net curated list: 7 verified-active handles (yoavgo, hardmaru, simonwillison.net,
natolambert, emollick, alexhanna, minimaxir).

## `4h-community.yml` — deterministic HN pre-fetch (#78)

HN intermittently went empty ("HN live data unavailable") across ~15 days
because Reddit is pre-fetched deterministically (`curl` RSS → `data/reddit/`)
while HN relied solely on an in-agent `mcp-hackernews` MCP with no fallback.

Added the same deterministic pre-fetch via the public **Algolia HN Search API**
(`hn.algolia.com/api/v1/search?tags=front_page`) — **verified live today: 50
fresh hits, all documented fields present** (`title`, `url`, `points`,
`num_comments`, `objectID`). New shell steps fetch → `data/hn/frontpage.json`
(graceful `{"hits":[]}` fallback + HTML-error guard, honoring CLAUDE.md rule #6
and paralleling the Reddit/Bluesky untracked-working-tree pattern). Prompt
TASK 1 rewritten: `frontpage.json` is the PRIMARY source; `mcp-hackernews`
demoted to a best-effort supplement; "HN data unavailable" placeholder
forbidden while hits exist.

## Validation

- `actionlint` (v1.7.12, go 1.25) **exit 0** on all three changed workflows —
  this includes its embedded shellcheck on every `run:` block, so the new bash
  steps are clean.
- `uv run python -c "yaml.safe_load(...)"` round-trips all three cleanly.
- No Python files were touched (the unittest suite was not required).

## ⚠️ META fix NOT applied here — needs a user-created secret (blocked)

The root cause of the whole "diagnose but can't apply" problem is that
`daily-improve.yml` authenticates its `git push` with `secrets.GITHUB_TOKEN`
(and the `anthropics/claude-code-action@v1` step acts as the `claude[bot]`
GitHub App). **Neither can write `.github/workflows/*`** — GitHub refuses
workflow-file writes without App-installation-level `Workflows: write`, which
**cannot be granted from a workflow's `permissions:` block** (correctly noted in
`daily-improve.yml:21-24`).

I deliberately did **not** commit an inert workflow edit referencing a
non-existent secret. The exact actuator fix, for a maintainer:

1. **Create a secret** (one of):
   - A **fine-grained PAT** (or classic PAT with the `workflow` scope) on an
     account with push access, stored as e.g. `WORKFLOW_PAT`; **or**
   - A **deploy key** with write access, stored as e.g. `WORKFLOW_DEPLOY_KEY`.
2. **Edit `daily-improve.yml`** to use it instead of `GITHUB_TOKEN` for the
   push path:
   - Line ~43 (`Configure authenticated git remote` step `env:`): replace
     `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` with
     `GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}`.
   - Line ~161 (`Push changes if on branch` step `env:`): same replacement.
   - (The `actions/checkout` step would also need `token: ${{ secrets.WORKFLOW_PAT }}`
     if a deploy key isn't used, so the persisted credential carries the
     `workflow` scope.)

Once that lands, future `daily-improve` runs can push workflow edits directly
and this manual-application step disappears.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
