### PR TITLE
Dashboard distribution: social share image, RSS feed, broader static SEO

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -4,7 +4,23 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔭</text></svg>">
-    <title>AI Research — ara</title>
+    <!-- SEO:DEFAULT:START — default head metadata for the SPA shell. The whole
+         block (markers included) is regenerated per-page by scripts/postbuild-seo.mjs:
+         article/today/wiki routes get page-specific meta; the homepage gets a
+         homepage-specific block. Edit defaults here; postbuild keeps the markers. -->
+    <title>ara — AI research arm</title>
+    <meta name="description" content="An automated AI-news intelligence pipeline: daily digests, a model-release timeline, an LLM wiki, and long-form generative research synthesized from Twitter/X, RSS, Bluesky, Hacker News, Reddit, and arXiv." />
+    <link rel="canonical" href="https://ara.guzus.xyz/" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="ara — AI research arm" />
+    <meta property="og:title" content="ara — AI research arm" />
+    <meta property="og:description" content="Automated AI-news intelligence: daily digests, a model-release timeline, an LLM wiki, and long-form generative research." />
+    <meta property="og:url" content="https://ara.guzus.xyz/" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="ara — AI research arm" />
+    <meta name="twitter:description" content="Automated AI-news intelligence: daily digests, a model-release timeline, an LLM wiki, and long-form generative research." />
+    <link rel="alternate" type="application/rss+xml" title="ara — AI research arm" href="https://ara.guzus.xyz/feed.xml" />
+    <!-- SEO:DEFAULT:END -->
     <!-- Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-BQJ66RGXES"></script>
     <script>

--- a/dashboard/scripts/postbuild-seo.mjs
+++ b/dashboard/scripts/postbuild-seo.mjs
@@ -1,36 +1,54 @@
 #!/usr/bin/env node
-// Postbuild: emit static SEO-friendly HTML for every research article.
-// Runs after `vite build`. For each fragment-kind entry in
-// research/generative/index.json, generates dist/research/<slug>/index.html
-// containing:
-//   - per-article <title>, <meta description>, OG / Twitter Card meta
-//   - <link rel="canonical">
-//   - JSON-LD Article schema
-//   - the article body inlined into #content so non-JS crawlers and link
-//     unfurlers see the actual content (the SPA hydrates on top and
-//     replaces #content with the SPA-wrapped version, identical content)
-//   - the same Vite bundle script/style tags from the built shell
+// Postbuild: emit static SEO-friendly HTML so non-JS crawlers and link
+// unfurlers see real metadata + content. Runs after `vite build`.
 //
-// Also emits dist/sitemap.xml (article + tab URLs with lastmod) and
+// Coverage:
+//   - Homepage (dist/index.html): rewrites the SEO:DEFAULT block with a
+//     homepage-specific title/description/OG + the default social share image.
+//   - "today" route (dist/today/index.html): latest daily digest -- per-page
+//     title/description/OG + the digest body inlined into #content.
+//   - Generative articles (dist/research/<slug>/index.html): per-article
+//     title/description/OG + JSON-LD Article + article body inlined.
+//   - Wiki pages (dist/wiki/<slug>/index.html): per-page title/description/OG
+//     from research/wiki/index.json + page body inlined.
+//
+// Also emits dist/sitemap.xml (article + tab + wiki URLs with lastmod) and
 // dist/robots.txt (allow all + sitemap pointer).
 //
-// Standalone-kind entries (iframe articles) are skipped — they're already
-// self-contained HTML and need a different SEO path.
+// Social share image: the most recent research/front-page/<date>-front-page.png
+// (the purpose-built daily newspaper graphic) is reused as the default og:image
+// / twitter:image. The image is referenced by its public URL, so it resolves on
+// the deployed site even when the build environment skipped LFS hydration
+// (Vercel hydrates LFS for the production deploy).
+//
+// Standalone-kind generative entries (iframe articles) are skipped -- they are
+// already self-contained HTML and need a different SEO path.
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { marked } from 'marked';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const dashboardDir = dirname(here);
 const repoRoot = dirname(dashboardDir);
 const dist = join(dashboardDir, 'dist');
 const indexHtmlPath = join(dist, 'index.html');
-const articlesDir = join(repoRoot, 'research', 'generative');
+const researchRoot = join(repoRoot, 'research');
+const articlesDir = join(researchRoot, 'generative');
 const indexJsonPath = join(articlesDir, 'index.json');
+const frontPageDir = join(researchRoot, 'front-page');
+const digestDir = join(researchRoot, 'digest');
+const wikiDir = join(researchRoot, 'wiki');
+const wikiIndexPath = join(wikiDir, 'index.json');
 
 // Override via env (POSTBUILD_SITE_ORIGIN) for preview deploys.
 const SITE_ORIGIN = process.env.POSTBUILD_SITE_ORIGIN || 'https://ara.guzus.xyz';
+
+// Markers that delimit the default SEO block in index.html. postbuild replaces
+// the whole block (markers included) per page; if the markers are absent we
+// fall back to replacing just <title>...</title> so older shells still work.
+const SEO_BLOCK_RE = /<!-- SEO:DEFAULT:START[\s\S]*?SEO:DEFAULT:END -->/;
 
 function stripTags(html) {
   return html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
@@ -61,13 +79,67 @@ function htmlEscapeAttr(s) {
     .replace(/'/g, '&#039;');
 }
 
-// SERPs typically truncate descriptions around 155–160 chars. Aim for ~190
+// SERPs typically truncate descriptions around 155-160 chars. Aim for ~190
 // and gracefully clip on a word boundary so OG / Twitter cards stay clean.
 function truncateDescription(s, max = 190) {
   if (s.length <= max) return s;
   const clipped = s.slice(0, max);
   const lastSpace = clipped.lastIndexOf(' ');
   return (lastSpace > 100 ? clipped.slice(0, lastSpace) : clipped) + '…';
+}
+
+// Build-time defense in depth: our own generated markdown is trusted, but
+// strip anything executable before inlining a rendered snapshot into the
+// crawler-facing HTML. The SPA itself runs DOMPurify at runtime.
+function sanitizeFragment(html) {
+  return html
+    .replace(/<script\b[\s\S]*?<\/script>/gi, '')
+    .replace(/<style\b[\s\S]*?<\/style>/gi, '')
+    .replace(/<iframe\b[\s\S]*?<\/iframe>/gi, '')
+    .replace(/\son\w+\s*=\s*"[^"]*"/gi, '')
+    .replace(/\son\w+\s*=\s*'[^']*'/gi, '')
+    .replace(/javascript:/gi, '');
+}
+
+// Most recent research/front-page/<date>-front-page.png, referenced by its
+// public URL so it resolves on the deployed site regardless of whether this
+// build hydrated LFS. Returns an absolute URL string or null.
+function findShareImageUrl() {
+  if (!existsSync(frontPageDir)) return null;
+  const re = /^(\d{4}-\d{2}-\d{2})-front-page\.png$/;
+  let best = null;
+  for (const name of readdirSync(frontPageDir)) {
+    const m = re.exec(name);
+    if (m && (!best || m[1] > best)) best = m[1];
+  }
+  return best ? `${SITE_ORIGIN}/research/front-page/${best}-front-page.png` : null;
+}
+
+// Shared OG/Twitter image tags (or [] when no share image is available).
+function imageMetaTags(imageUrl, alt) {
+  if (!imageUrl) return [];
+  return [
+    `<meta property="og:image" content="${htmlEscapeAttr(imageUrl)}" />`,
+    `<meta property="og:image:alt" content="${htmlEscapeAttr(alt)}" />`,
+    `<meta name="twitter:image" content="${htmlEscapeAttr(imageUrl)}" />`,
+  ];
+}
+
+// Replace the marked SEO block with metaBlock. Fallback: if the markers are
+// absent (older shell), replace just the <title> so we never silently no-op.
+function applySeoBlock(template, metaBlockLines) {
+  const metaBlock = metaBlockLines.join('\n    ');
+  if (SEO_BLOCK_RE.test(template)) {
+    return template.replace(SEO_BLOCK_RE, metaBlock);
+  }
+  return template.replace(/<title>[\s\S]*?<\/title>/, metaBlock);
+}
+
+function inlineContent(template, innerHtml) {
+  return template.replace(
+    '<div id="content"></div>',
+    `<div id="content">${innerHtml}</div>`,
+  );
 }
 
 function extractMeta(articleHtml) {
@@ -84,7 +156,7 @@ function extractMeta(articleHtml) {
   return { title, desc };
 }
 
-function buildArticlePage(template, row, articleHtml) {
+function buildArticlePage(template, row, articleHtml, shareImageUrl) {
   const url = `${SITE_ORIGIN}/research/${row.slug}`;
   const { title: extracted, desc } = extractMeta(articleHtml);
   const title = extracted || row.title || row.slug;
@@ -97,14 +169,15 @@ function buildArticlePage(template, row, articleHtml) {
     description: desc,
     datePublished: dateIso,
     dateModified: dateIso,
-    author: { '@type': 'Organization', name: 'ara — AI research arm', url: SITE_ORIGIN },
+    author: { '@type': 'Organization', name: 'ara -- AI research arm', url: SITE_ORIGIN },
     publisher: { '@type': 'Organization', name: 'ara', url: SITE_ORIGIN },
     mainEntityOfPage: { '@type': 'WebPage', '@id': url },
     url,
   };
+  if (shareImageUrl) jsonLd.image = shareImageUrl;
 
   const metaBlock = [
-    `<title>${htmlEscapeAttr(title)} — ara</title>`,
+    `<title>${htmlEscapeAttr(title)} -- ara</title>`,
     `<meta name="description" content="${htmlEscapeAttr(desc)}" />`,
     `<link rel="canonical" href="${url}" />`,
     `<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1" />`,
@@ -112,23 +185,185 @@ function buildArticlePage(template, row, articleHtml) {
     `<meta property="og:title" content="${htmlEscapeAttr(title)}" />`,
     `<meta property="og:description" content="${htmlEscapeAttr(desc)}" />`,
     `<meta property="og:url" content="${url}" />`,
-    `<meta property="og:site_name" content="ara — AI research arm" />`,
+    `<meta property="og:site_name" content="ara -- AI research arm" />`,
     `<meta property="article:published_time" content="${dateIso}" />`,
-    `<meta name="twitter:card" content="summary" />`,
+    ...imageMetaTags(shareImageUrl, title),
+    `<meta name="twitter:card" content="${shareImageUrl ? 'summary_large_image' : 'summary'}" />`,
     `<meta name="twitter:title" content="${htmlEscapeAttr(title)}" />`,
     `<meta name="twitter:description" content="${htmlEscapeAttr(desc)}" />`,
+    `<link rel="alternate" type="application/rss+xml" title="ara -- AI research arm" href="${SITE_ORIGIN}/feed.xml" />`,
     `<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>`,
-  ].join('\n    ');
+  ];
 
-  let html = template.replace(/<title>[\s\S]*?<\/title>/, metaBlock);
-  html = html.replace(
-    '<div id="content"></div>',
-    `<div id="content"><div class="content-card gen-research-doc"><div class="content-card-body">${articleHtml}</div></div></div>`,
+  let html = applySeoBlock(template, metaBlock);
+  html = inlineContent(
+    html,
+    `<div class="content-card gen-research-doc"><div class="content-card-body">${articleHtml}</div></div>`,
   );
   return html;
 }
 
-function buildSitemap(entries) {
+function buildHomePage(template, shareImageUrl) {
+  const title = 'ara -- AI research arm';
+  const desc = truncateDescription(
+    'An automated AI-news intelligence pipeline: daily digests, a model-release ' +
+    'timeline, an LLM wiki, and long-form generative research synthesized from ' +
+    'Twitter/X, RSS, Bluesky, Hacker News, Reddit, and arXiv.',
+  );
+  const url = `${SITE_ORIGIN}/`;
+  const metaBlock = [
+    `<title>${htmlEscapeAttr(title)}</title>`,
+    `<meta name="description" content="${htmlEscapeAttr(desc)}" />`,
+    `<link rel="canonical" href="${url}" />`,
+    `<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1" />`,
+    `<meta property="og:type" content="website" />`,
+    `<meta property="og:site_name" content="ara -- AI research arm" />`,
+    `<meta property="og:title" content="${htmlEscapeAttr(title)}" />`,
+    `<meta property="og:description" content="${htmlEscapeAttr(desc)}" />`,
+    `<meta property="og:url" content="${url}" />`,
+    ...imageMetaTags(shareImageUrl, 'ara daily AI newspaper front page'),
+    `<meta name="twitter:card" content="${shareImageUrl ? 'summary_large_image' : 'summary'}" />`,
+    `<meta name="twitter:title" content="${htmlEscapeAttr(title)}" />`,
+    `<meta name="twitter:description" content="${htmlEscapeAttr(desc)}" />`,
+    `<link rel="alternate" type="application/rss+xml" title="ara -- AI research arm" href="${SITE_ORIGIN}/feed.xml" />`,
+  ];
+  return applySeoBlock(template, metaBlock);
+}
+
+function latestDigest() {
+  if (!existsSync(digestDir)) return null;
+  const re = /^(\d{4}-\d{2}-\d{2})-digest\.md$/;
+  let best = null;
+  for (const name of readdirSync(digestDir)) {
+    const m = re.exec(name);
+    if (m && (!best || m[1] > best)) best = m[1];
+  }
+  if (!best) return null;
+  return { date: best, path: join(digestDir, `${best}-digest.md`) };
+}
+
+// Pull a sentence-ish description out of the digest markdown: skip the H1 and
+// section headings, take the first substantive bullet / paragraph.
+function digestDescription(md) {
+  const lines = md.split('\n');
+  for (const raw of lines) {
+    let line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    line = line.replace(/^[-*]\s+/, '');
+    const text = decodeEntities(stripTags(marked.parseInline(line)));
+    if (text.length >= 40) return truncateDescription(text);
+  }
+  return 'The day in AI: releases, funding, research, and community signal, synthesized into a single daily digest.';
+}
+
+function buildDigestPage(template, digest, shareImageUrl) {
+  const md = readFileSync(digest.path, 'utf8');
+  const title = `AI Daily Digest -- ${digest.date}`;
+  const desc = digestDescription(md);
+  const url = `${SITE_ORIGIN}/today`;
+  const bodyHtml = sanitizeFragment(marked.parse(md));
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: title,
+    description: desc,
+    datePublished: digest.date,
+    dateModified: digest.date,
+    author: { '@type': 'Organization', name: 'ara -- AI research arm', url: SITE_ORIGIN },
+    publisher: { '@type': 'Organization', name: 'ara', url: SITE_ORIGIN },
+    mainEntityOfPage: { '@type': 'WebPage', '@id': url },
+    url,
+  };
+  if (shareImageUrl) jsonLd.image = shareImageUrl;
+
+  const metaBlock = [
+    `<title>${htmlEscapeAttr(title)} -- ara</title>`,
+    `<meta name="description" content="${htmlEscapeAttr(desc)}" />`,
+    `<link rel="canonical" href="${url}" />`,
+    `<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1" />`,
+    `<meta property="og:type" content="article" />`,
+    `<meta property="og:title" content="${htmlEscapeAttr(title)}" />`,
+    `<meta property="og:description" content="${htmlEscapeAttr(desc)}" />`,
+    `<meta property="og:url" content="${url}" />`,
+    `<meta property="og:site_name" content="ara -- AI research arm" />`,
+    `<meta property="article:published_time" content="${digest.date}" />`,
+    ...imageMetaTags(shareImageUrl, title),
+    `<meta name="twitter:card" content="${shareImageUrl ? 'summary_large_image' : 'summary'}" />`,
+    `<meta name="twitter:title" content="${htmlEscapeAttr(title)}" />`,
+    `<meta name="twitter:description" content="${htmlEscapeAttr(desc)}" />`,
+    `<link rel="alternate" type="application/rss+xml" title="ara -- AI research arm" href="${SITE_ORIGIN}/feed.xml" />`,
+    `<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>`,
+  ];
+
+  let html = applySeoBlock(template, metaBlock);
+  html = inlineContent(
+    html,
+    `<div class="content-card"><div class="content-card-body">${bodyHtml}</div></div>`,
+  );
+  return html;
+}
+
+function buildWikiPage(template, page, shareImageUrl) {
+  const url = `${SITE_ORIGIN}/wiki/${page.slug}`;
+  const title = page.title || page.slug;
+  const desc = truncateDescription(decodeEntities(stripTags(page.summary || title)));
+
+  // Inline the page body (markdown after the YAML frontmatter) for crawlers.
+  let bodyHtml = '';
+  const pagePath = page.file ? join(wikiDir, page.file) : null;
+  if (pagePath && existsSync(pagePath)) {
+    let text = readFileSync(pagePath, 'utf8');
+    if (text.startsWith('---\n')) {
+      const end = text.indexOf('\n---\n', 4);
+      if (end >= 0) text = text.slice(end + 5);
+    }
+    // [[wiki-links]] are not markdown; render as plain text for the snapshot.
+    text = text.replace(/\[\[([a-z0-9-]+)(?:\|([^\]]+))?\]\]/gi, (_, slug, label) => label || slug);
+    bodyHtml = sanitizeFragment(marked.parse(text));
+  }
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: title,
+    description: desc,
+    datePublished: page.created_at,
+    dateModified: page.updated_at || page.created_at,
+    author: { '@type': 'Organization', name: 'ara -- AI research arm', url: SITE_ORIGIN },
+    publisher: { '@type': 'Organization', name: 'ara', url: SITE_ORIGIN },
+    mainEntityOfPage: { '@type': 'WebPage', '@id': url },
+    url,
+  };
+  if (shareImageUrl) jsonLd.image = shareImageUrl;
+
+  const metaBlock = [
+    `<title>${htmlEscapeAttr(title)} -- ara wiki</title>`,
+    `<meta name="description" content="${htmlEscapeAttr(desc)}" />`,
+    `<link rel="canonical" href="${url}" />`,
+    `<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1" />`,
+    `<meta property="og:type" content="article" />`,
+    `<meta property="og:title" content="${htmlEscapeAttr(title)}" />`,
+    `<meta property="og:description" content="${htmlEscapeAttr(desc)}" />`,
+    `<meta property="og:url" content="${url}" />`,
+    `<meta property="og:site_name" content="ara -- AI research arm" />`,
+    ...imageMetaTags(shareImageUrl, title),
+    `<meta name="twitter:card" content="${shareImageUrl ? 'summary_large_image' : 'summary'}" />`,
+    `<meta name="twitter:title" content="${htmlEscapeAttr(title)}" />`,
+    `<meta name="twitter:description" content="${htmlEscapeAttr(desc)}" />`,
+    `<link rel="alternate" type="application/rss+xml" title="ara -- AI research arm" href="${SITE_ORIGIN}/feed.xml" />`,
+    `<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>`,
+  ];
+
+  let html = applySeoBlock(template, metaBlock);
+  html = inlineContent(
+    html,
+    `<div class="content-card"><div class="content-card-body"><h2>${htmlEscapeAttr(title)}</h2>${bodyHtml}</div></div>`,
+  );
+  return html;
+}
+
+function buildSitemap(entries, wikiPages) {
   const today = new Date().toISOString().slice(0, 10);
   const rootEntries = [
     { loc: SITE_ORIGIN + '/', priority: '1.0' },
@@ -137,6 +372,7 @@ function buildSitemap(entries) {
     { loc: SITE_ORIGIN + '/models', priority: '0.7' },
     { loc: SITE_ORIGIN + '/frontpage', priority: '0.6' },
     { loc: SITE_ORIGIN + '/research', priority: '0.9' },
+    { loc: SITE_ORIGIN + '/wiki', priority: '0.7' },
   ].map(e => ({ ...e, lastmod: today }));
 
   const articleEntries = entries.map(e => ({
@@ -145,7 +381,13 @@ function buildSitemap(entries) {
     priority: '0.8',
   }));
 
-  const all = [...rootEntries, ...articleEntries];
+  const wikiEntries = (wikiPages || []).map(p => ({
+    loc: `${SITE_ORIGIN}/wiki/${p.slug}`,
+    lastmod: (p.updated_at || p.created_at || today).slice(0, 10),
+    priority: '0.6',
+  }));
+
+  const all = [...rootEntries, ...articleEntries, ...wikiEntries];
   const lines = [
     '<?xml version="1.0" encoding="UTF-8"?>',
     '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
@@ -169,19 +411,118 @@ function buildRobots() {
   ].join('\n');
 }
 
+// ---- RSS 2.0 feed of recent digests + recent generative articles ----
+function rssEscape(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+function toRfc822(input) {
+  // input is a YYYY-MM-DD or ISO timestamp; fall back to now on parse failure.
+  const d = new Date(input);
+  return (isNaN(d.getTime()) ? new Date() : d).toUTCString();
+}
+
+function buildFeed(entries, shareImageUrl) {
+  const items = [];
+
+  // Recent digests (newest first, capped).
+  if (existsSync(digestDir)) {
+    const re = /^(\d{4}-\d{2}-\d{2})-digest\.md$/;
+    const dates = readdirSync(digestDir)
+      .map(n => (re.exec(n) || [])[1])
+      .filter(Boolean)
+      .sort()
+      .reverse()
+      .slice(0, 10);
+    for (const date of dates) {
+      const md = readFileSync(join(digestDir, `${date}-digest.md`), 'utf8');
+      items.push({
+        title: `AI Daily Digest -- ${date}`,
+        link: `${SITE_ORIGIN}/today`,
+        guid: `${SITE_ORIGIN}/today#${date}`,
+        date,
+        description: digestDescription(md),
+      });
+    }
+  }
+
+  // Recent generative articles (skip standalone iframes), newest first, capped.
+  const articleItems = entries
+    .filter(e => e.kind !== 'standalone')
+    .slice()
+    .sort((a, b) => String(b.created_at || '').localeCompare(String(a.created_at || '')))
+    .slice(0, 15)
+    .map(e => ({
+      title: e.title || e.slug,
+      link: `${SITE_ORIGIN}/research/${e.slug}`,
+      guid: `${SITE_ORIGIN}/research/${e.slug}`,
+      date: e.created_at,
+      description: truncateDescription(decodeEntities(stripTags(e.prompt || e.title || e.slug))),
+    }));
+  items.push(...articleItems);
+
+  // Newest first across both sources, capped to a small feed.
+  items.sort((a, b) => String(b.date || '').localeCompare(String(a.date || '')));
+  const top = items.slice(0, 25);
+  const lastBuild = top.length ? toRfc822(top[0].date) : new Date().toUTCString();
+
+  const lines = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">',
+    '  <channel>',
+    `    <title>ara -- AI research arm</title>`,
+    `    <link>${SITE_ORIGIN}/</link>`,
+    `    <atom:link href="${SITE_ORIGIN}/feed.xml" rel="self" type="application/rss+xml" />`,
+    `    <description>Automated AI-news intelligence: daily digests and long-form generative research.</description>`,
+    `    <language>en</language>`,
+    `    <lastBuildDate>${lastBuild}</lastBuildDate>`,
+  ];
+  if (shareImageUrl) {
+    lines.push(
+      '    <image>',
+      `      <url>${rssEscape(shareImageUrl)}</url>`,
+      `      <title>ara -- AI research arm</title>`,
+      `      <link>${SITE_ORIGIN}/</link>`,
+      '    </image>',
+    );
+  }
+  for (const it of top) {
+    lines.push(
+      '    <item>',
+      `      <title>${rssEscape(it.title)}</title>`,
+      `      <link>${rssEscape(it.link)}</link>`,
+      `      <guid isPermaLink="false">${rssEscape(it.guid)}</guid>`,
+      `      <pubDate>${toRfc822(it.date)}</pubDate>`,
+      `      <description>${rssEscape(it.description)}</description>`,
+      '    </item>',
+    );
+  }
+  lines.push('  </channel>', '</rss>', '');
+  return lines.join('\n');
+}
+
 // ---- run ----
 if (!existsSync(indexHtmlPath)) {
-  console.error(`postbuild-seo: ${indexHtmlPath} not found — did vite build run?`);
+  console.error(`postbuild-seo: ${indexHtmlPath} not found -- did vite build run?`);
   process.exit(1);
-}
-if (!existsSync(indexJsonPath)) {
-  console.warn(`postbuild-seo: ${indexJsonPath} not found — skipping article SEO`);
-  process.exit(0);
 }
 
 const template = readFileSync(indexHtmlPath, 'utf8');
-const entries = JSON.parse(readFileSync(indexJsonPath, 'utf8'));
+const shareImageUrl = findShareImageUrl();
 
+const entries = existsSync(indexJsonPath)
+  ? JSON.parse(readFileSync(indexJsonPath, 'utf8'))
+  : [];
+if (!existsSync(indexJsonPath)) {
+  console.warn(`postbuild-seo: ${indexJsonPath} not found -- no article pages`);
+}
+
+// 1) Generative article pages.
 let written = 0;
 let skipped = 0;
 for (const row of entries) {
@@ -195,15 +536,52 @@ for (const row of entries) {
     continue;
   }
   const articleHtml = readFileSync(articlePath, 'utf8');
-  const page = buildArticlePage(template, row, articleHtml);
+  const page = buildArticlePage(template, row, articleHtml, shareImageUrl);
   const outDir = join(dist, 'research', row.slug);
   mkdirSync(outDir, { recursive: true });
   writeFileSync(join(outDir, 'index.html'), page);
   written++;
 }
 
-writeFileSync(join(dist, 'sitemap.xml'), buildSitemap(entries));
-writeFileSync(join(dist, 'robots.txt'), buildRobots());
+// 2) "today" digest page.
+const digest = latestDigest();
+if (digest) {
+  const outDir = join(dist, 'today');
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(join(outDir, 'index.html'), buildDigestPage(template, digest, shareImageUrl));
+}
 
-console.log(`postbuild-seo: wrote ${written} article pages (${skipped} skipped)`);
-console.log('postbuild-seo: sitemap.xml + robots.txt written to dist/');
+// 3) Wiki pages.
+let wikiPages = [];
+let wikiWritten = 0;
+if (existsSync(wikiIndexPath)) {
+  try {
+    const wikiIndex = JSON.parse(readFileSync(wikiIndexPath, 'utf8'));
+    wikiPages = Array.isArray(wikiIndex.pages) ? wikiIndex.pages : [];
+    for (const page of wikiPages) {
+      if (!page.slug) continue;
+      const outDir = join(dist, 'wiki', page.slug);
+      mkdirSync(outDir, { recursive: true });
+      writeFileSync(join(outDir, 'index.html'), buildWikiPage(template, page, shareImageUrl));
+      wikiWritten++;
+    }
+  } catch (e) {
+    console.warn(`postbuild-seo: wiki index parse failed (${e.message}); skipping wiki pages`);
+  }
+}
+
+// 4) Homepage -- rewrite dist/index.html LAST (it was the template above, so
+//    article/today/wiki pages inherit the default block, not the homepage one).
+writeFileSync(indexHtmlPath, buildHomePage(template, shareImageUrl));
+
+// 5) sitemap.xml, robots.txt, feed.xml.
+writeFileSync(join(dist, 'sitemap.xml'), buildSitemap(entries, wikiPages));
+writeFileSync(join(dist, 'robots.txt'), buildRobots());
+writeFileSync(join(dist, 'feed.xml'), buildFeed(entries, shareImageUrl));
+
+console.log(
+  `postbuild-seo: ${written} article pages (${skipped} skipped), ` +
+  `${digest ? 1 : 0} digest page, ${wikiWritten} wiki pages`,
+);
+console.log(`postbuild-seo: share image: ${shareImageUrl || '(none found)'}`);
+console.log('postbuild-seo: sitemap.xml + robots.txt + feed.xml written to dist/');

--- a/dashboard/vercel.json
+++ b/dashboard/vercel.json
@@ -4,7 +4,7 @@
   "installCommand": "bun install --frozen-lockfile",
   "buildCommand": "bun run build",
   "outputDirectory": "dist",
-  "ignoreCommand": "if [ -z \"$VERCEL_GIT_PREVIOUS_SHA\" ]; then exit 1; fi; git diff --quiet \"$VERCEL_GIT_PREVIOUS_SHA\" HEAD -- ./ ../research/twitter/ ../research/models/ ../research/front-page/ ../research/digest/ ../research/audio/ ../research/generative/ || exit 1; exit 0",
+  "ignoreCommand": "if [ -z \"$VERCEL_GIT_PREVIOUS_SHA\" ]; then exit 1; fi; git diff --quiet \"$VERCEL_GIT_PREVIOUS_SHA\" HEAD -- ./ ../research/twitter/ ../research/models/ ../research/front-page/ ../research/digest/ ../research/audio/ ../research/generative/ ../research/wiki/ || exit 1; exit 0",
   "rewrites": [
     {
       "source": "/((?!research/.+|.*\\.[a-zA-Z0-9]+$).*)",


### PR DESCRIPTION
## What & why

Additive distribution multipliers for the SPA. The pipeline already produces rich
intelligence + a purpose-built daily-newspaper PNG, but had zero share image,
empty `<meta>` in the shell for crawlers, no feed, and a deploy-skip blind spot
for wiki-only pushes. All changes are **additive** — no SPA redesign, no new tabs,
no change to runtime rendering. Build was validated to stay green (Vercel
auto-deploys `main`).

## Changes

1. **Social share image** — `twitter:card` upgraded from `summary` (no image) to
   `summary_large_image`; `og:image` + `twitter:image` added. The image reuses the
   most recent `research/front-page/<date>-front-page.png` (the daily newspaper
   graphic), picked by filename date. It's referenced by **public URL**, not a
   copied file, so it resolves on the deployed site even when the build skipped LFS
   hydration (`SKIP_LFS_POINTERS=1` in CI; Vercel hydrates LFS for the prod deploy).
   Wired into every page `postbuild-seo.mjs` emits **and** the `index.html` shell.

2. **`index.html` shell `<head>`** — real default `<meta name="description">` +
   Open Graph (`og:title`/`description`/`type`/`url`/`site_name`) +
   `twitter:card=summary_large_image`, so non-JS crawlers/unfurlers see real
   metadata. The defaults live between `SEO:DEFAULT:START/END` markers; postbuild
   rewrites that whole block per page (homepage gets homepage meta + image;
   article/digest/wiki get page-specific meta). Falls back to a `<title>`-only
   replace if the markers are ever absent, so it never silently no-ops.

3. **Broader static SEO** — `postbuild-seo.mjs` now generates static, crawler-
   facing HTML (per-page title/description/OG/Twitter + JSON-LD + inlined body) for:
   - the **homepage** (`dist/index.html`),
   - the **`today`** digest route (`dist/today/index.html`, latest digest),
   - **wiki pages** (`dist/wiki/<slug>/index.html`, from `research/wiki/index.json`),
   in addition to the existing generative article fragments. Inlined bodies are run
   through a build-time sanitizer (strip script/style/iframe/`on*=`/`javascript:`)
   as defense in depth. `sitemap.xml` now also lists `/today`, `/wiki`, and each
   wiki page.

4. **RSS 2.0 feed** — `dist/feed.xml`, built during postbuild from recent digests
   (last 10) + recent generative articles (last 15), merged newest-first and capped
   at 25 items, with a channel `<image>` of the share graphic.
   `<link rel="alternate" type="application/rss+xml" href=".../feed.xml">` added to
   the shell. `feed.xml` has a file extension, so the SPA rewrite never shadows it.

5. **`vercel.json` `ignoreCommand`** — added `../research/wiki/` so wiki-only pushes
   trigger a deploy (previously omitted; wiki updates could skip the build).

## Validation (stress-tested "additive, won't break build/render")

Ran the exact CI dashboard steps from `dashboard/`:
- `bun install --frozen-lockfile` — ok
- `bunx tsc --noEmit -p tsconfig.json` — **pass**
- `SKIP_LFS_POINTERS=1 bun run build` — **green** (`39 article pages, 1 digest page, 6 wiki pages`; share image resolved to `2026-05-28-front-page.png`; `feed.xml` written)

Verified in `dist/`:
- `feed.xml` and `sitemap.xml` parse as **well-formed XML** (Python `xml` parser); feed has 25 items, RFC-822 dates, newest-first.
- `dist/index.html`, `/today`, `/research/<slug>`, `/wiki/<slug>` each carry **exactly one** `twitter:card`/`og:type`/`canonical`, with `summary_large_image` + `og:image`, and **zero** leftover `SEO:DEFAULT` markers (block correctly consumed). Article pages keep `og:type=article` and inherit the default block, not the homepage block (homepage is rewritten last).
- `/today` and `/wiki/<slug>` static pages serve their per-page `<title>` over HTTP under a static server.

### Routing note (no rewrite change needed)
Generative article SEO pages already rely on the `research/.+` exclusion in the
rewrite, so they're guaranteed static. `/today` and `/wiki/<slug>` are extensionless
and match the SPA rewrite, but Vercel checks the **filesystem before rewrites**, so
the static directory-index files are served first (same mechanism that makes the
existing `/research/<slug>` pages work in prod). Worst case for those two routes is
a graceful degradation to the homepage-meta SPA shell — never a render break — so I
deliberately did **not** touch the rewrite regex (excluding `/today` there would risk
breaking `/today/<date>` SPA date-routing).

## Follow-up (not in this PR)
Surfacing the ~6 orphaned research lanes (bluesky, rss, community/HN+Reddit, arxiv,
twitter-deepseek, audio) in the UI is larger UI work and was intentionally left out
per scope. Tracking as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)