### PR TITLE
ci: move scheduled + Claude workflows from ubuntu-latest to the self-hosted fleet

### DIFF
--- a/.github/workflows/2h-bluesky.yml
+++ b/.github/workflows/2h-bluesky.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   bluesky-feed:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux]
     timeout-minutes: 15
     permissions:
       contents: write

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     # trigger with a `pr_number` input in a follow-up).
     if: contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
 
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux]
     timeout-minutes: 30
     permissions:
       contents: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -27,7 +27,7 @@ jobs:
       (github.event_name == 'issues' &&
         (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
         contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux]
     timeout-minutes: 30
     permissions:
       contents: read

--- a/.github/workflows/daily-arxiv.yml
+++ b/.github/workflows/daily-arxiv.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   arxiv-research:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux]
     timeout-minutes: 30
     permissions:
       contents: write

--- a/.github/workflows/daily-improve.yml
+++ b/.github/workflows/daily-improve.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   self-improve:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux]
     timeout-minutes: 30
     permissions:
       contents: write

--- a/.github/workflows/hourly-rss.yml
+++ b/.github/workflows/hourly-rss.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   rss-feed:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux]
     timeout-minutes: 15
     permissions:
       contents: write

--- a/.github/workflows/hourly-twitter.yml
+++ b/.github/workflows/hourly-twitter.yml
@@ -77,8 +77,7 @@ concurrency:
 
 jobs:
   twitter:
-    # Temporary: use GitHub-hosted runner while the self-hosted runner queue is blocked.
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux]
     permissions:
       contents: write
       actions: write


### PR DESCRIPTION
## What
Switches 7 GitHub Actions workflows from `runs-on: ubuntu-latest` to `runs-on: [self-hosted, Linux]` so they run on the **GCP Cloud Run self-hosted fleet** instead of GitHub-hosted runners.

## Why
GitHub-hosted jobs are currently blocked at startup:

> The job was not started because recent account payments have failed or your spending limit needs to be increased.

So every `ubuntu-latest` lane (RSS, Twitter, Bluesky, arXiv, Daily Self-Improvement, and the Claude issue/PR workflows) fails in 3–5s — the job never starts. The self-hosted Cloud Run pool is healthy, scales 0→N→0, and bills **no** GitHub Actions minutes, so moving these lanes onto it both unblocks them and takes them off GitHub's meter.

## Converted
| Workflow | Trigger |
|---|---|
| `hourly-rss`, `2h-bluesky`, `daily-arxiv`, `daily-improve` | schedule |
| `hourly-twitter` (matrix) | schedule/dispatch — also drops a stale *"Temporary: use GitHub-hosted runner"* comment; this lane was self-hosted originally |
| `claude`, `claude-code-review` | issue/PR events — still gated by `author_association ∈ {OWNER,MEMBER,COLLABORATOR}`; repo is private |

## Deliberately NOT changed
`liveness-check.yml` keeps its `ubuntu-latest` tier. It runs the same freshness check on **both** an `ubuntu-latest` and a `self-hosted` tier by design (see its header comment), so the pipeline watchdog survives **either** a billing block **or** a self-hosted outage. Converting it would blind the watchdog to a fleet outage. The real fix for that tier is restoring GitHub billing.

## Safety / verification
- None of the 7 need Docker (no `docker` / `services:` / `container:`). The Cloud Run lane has no Docker daemon, but the runner image bakes in node 22 / python3 / bun / uv / gh / jq / ffmpeg / poppler / git-lfs — matching the workflows already on the fleet.
- `[self-hosted, Linux]` is the exact label set the already-working self-hosted workflows use (`daily-digest`, `4h-community`, `ai-news-research`, `generative-research`, `wiki-ingest`).
- YAML parses clean; diff is `runs-on`-only (+7 / −8). Independently reviewed (incl. reading `claude-code-action@v1` and each composite action to confirm no Docker dependency).

## Follow-ups (optional, not in this PR)
- **Restore GitHub billing** so the `liveness-check` ubuntu tier (and any future hosted need) works again.
- `claude.yml` / `claude-code-review.yml` have no `concurrency:` block — on a finite pool, bursts of `@claude` / PR-sync events will queue rather than run in parallel. Add a concurrency group if that latency matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
