### PR TITLE
Avoid sudo for Cloud Run birdy tools

### DIFF
--- a/.github/actions/birdy-daemon/action.yml
+++ b/.github/actions/birdy-daemon/action.yml
@@ -1,7 +1,7 @@
 name: Birdy daemon + bird-fast wrapper
 description: >
   Start a birdy daemon on 127.0.0.1:8080 (warm bird API for LLM follow-up
-  queries) and install /usr/local/bin/bird-fast — a drop-in shim that
+  queries) and install bird-fast on the job PATH — a drop-in shim that
   routes the same `bird ...` args through the daemon's POST /run endpoint
   for sub-second latency. The companion stop step lives inline in each
   workflow (kept as a separate step so it can use `if: always()`).
@@ -67,7 +67,10 @@ runs:
         # forwards them to the local daemon's POST /run endpoint. Same JSON
         # output on stdout. Lets the LLM keep its existing mental model
         # ("bird search ...") while paying daemon-speed latency.
-        sudo tee /usr/local/bin/bird-fast > /dev/null <<WRAPPER
+        INSTALL_DIR="$HOME/.local/bin"
+        mkdir -p "$INSTALL_DIR"
+        WRAPPER_PATH="$INSTALL_DIR/bird-fast"
+        cat > "$WRAPPER_PATH" <<WRAPPER
         #!/bin/bash
         set -e
         DAEMON_URL="\${BIRDY_DAEMON_URL:-http://127.0.0.1:${DAEMON_PORT}}"
@@ -87,5 +90,8 @@ runs:
           exit 1
         fi
         WRAPPER
-        sudo chmod +x /usr/local/bin/bird-fast
+        chmod +x "$WRAPPER_PATH"
+        echo "$INSTALL_DIR" >> "$GITHUB_PATH"
+        export PATH="$INSTALL_DIR:$PATH"
+
         bird-fast whoami 2>&1 | head -3 || echo "(bird-fast wrapper installed)"

--- a/.github/actions/twitter-fetch/action.yml
+++ b/.github/actions/twitter-fetch/action.yml
@@ -100,7 +100,12 @@ runs:
           exit 1
         fi
 
-        sudo install -m 755 "$BIN" /usr/local/bin/birdy
+        INSTALL_DIR="$HOME/.local/bin"
+        mkdir -p "$INSTALL_DIR"
+        install -m 755 "$BIN" "$INSTALL_DIR/birdy"
+        echo "$INSTALL_DIR" >> "$GITHUB_PATH"
+        export PATH="$INSTALL_DIR:$PATH"
+
         birdy version 2>&1 | head -3 || echo "(birdy installed)"
 
     - name: Fetch tweets, searches, and news via birdy multi-fetch


### PR DESCRIPTION
## Summary
- install birdy into `/Users/alphanonce/.local/bin` instead of `/usr/local/bin`
- install the bird-fast wrapper into the job PATH without sudo
- keep Cloud Run self-hosted runner compatibility with no-new-privileges sandboxing

## Verification
- `actionlint .github/workflows/hourly-twitter.yml`
- dry-run workflow dispatch on `codex/cloud-run-no-sudo-birdy`: https://github.com/guzus/ai-research-arm/actions/runs/26711767011