### PR TITLE
Add runner-loss auto-rerun watchdog + fix stale runner docs

### DIFF
--- a/.github/workflows/auto-rerun-on-runner-loss.yml
+++ b/.github/workflows/auto-rerun-on-runner-loss.yml
@@ -1,0 +1,122 @@
+name: Auto-rerun on runner loss
+
+# Self-healing watchdog for the ephemeral self-hosted (Cloud Run autoscaler)
+# fleet. When a covered run FAILS because its worker vanished mid-job —
+# preemption / maintenance / OOM, which GitHub records as a job that died at
+# "Set up job" or with steps stuck `in_progress` and NO step that genuinely
+# failed — this re-runs only the failed jobs of that run.
+#
+# Load-bearing invariants (CLAUDE.md Load-bearing rule 11) — preserve all three:
+#   1. Runs on ubuntu-latest, NOT self-hosted. A recovery path for dead
+#      self-hosted workers must not depend on (or share the fate of) them.
+#   2. This workflow's own name is intentionally ABSENT from `workflows:`
+#      below, so it can never trigger itself.
+#   3. `run_attempt` is capped (< 3 => at most 2 auto re-runs) to bound loops,
+#      and only the "worker vanished" signature qualifies — a run with a
+#      genuinely failed step (real red CI) is left alone.
+
+on:
+  workflow_run:
+    # Unattended, main-branch pipelines worth auto-recovering. PR-scoped CI /
+    # code-review are intentionally excluded (their author re-runs those).
+    workflows:
+      - "Hourly RSS Official Announcements"
+      - "Twitter AI News (matrix — claude / deepseek-claude-code / deepseek-pi / fireworks-pi)"
+      - "Daily AI Expert Blogs"
+      - "Bluesky AI Researcher Feed (Twice Daily)"
+      - "Community AI Digest (HN + Reddit)"
+      - "Daily arXiv AI Research"
+      - "Daily AI Digest (All Sources)"
+      - "AI News Research Agent"
+      - "Hyperscaler Model Release Timeline (Every 24 Hours)"
+      - "LLM Wiki Ingest (After Daily Digest)"
+      - "Daily Front Page"
+      - "Generative Research"
+    types: [completed]
+    # Filters the TRIGGERING run's head_branch. Scheduled, issue-, and
+    # workflow_run-chained runs all resolve to the default branch, so every
+    # covered lane is admitted; this only scopes out stray non-main runs.
+    branches: [main]
+
+permissions:
+  actions: write # required to call rerun-failed-jobs
+  contents: read
+
+# One reconcile per (run, attempt); don't cancel an in-flight decision.
+concurrency:
+  group: auto-rerun-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}
+  cancel-in-progress: false
+
+jobs:
+  rerun:
+    name: Re-run jobs killed by worker loss
+    runs-on: ubuntu-latest
+    # Only failures, and only within the retry cap (<= 2 auto re-runs).
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.run_attempt < 3
+    steps:
+      # Checkout only so the local hooker-telemetry composite action resolves.
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Re-run failed jobs if (and only if) a worker vanished
+        id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_NAME: ${{ github.event.workflow_run.name }}
+          RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+        run: |
+          set -euo pipefail
+          echo "Inspecting run '$RUN_NAME' (#$RUN_ID, attempt $RUN_ATTEMPT)"
+
+          # Pull every job's steps (job counts are small; one page of 100 is plenty).
+          gh api "repos/$REPO/actions/runs/$RUN_ID/jobs?per_page=100" > jobs.json
+
+          # Worker-loss signature: >=1 failed/incomplete/cancelled job that has NO
+          # step with conclusion == "failure". A genuinely failed step (a non-zero
+          # exit, e.g. a content-guard step) means a real failure -> leave it red.
+          # A preempted worker can surface as a "cancelled" job inside a run-level
+          # failure, so cancelled jobs count too; a USER-cancelled run never reaches
+          # here because the job `if` requires run-level conclusion == 'failure'.
+          # jq -e exit codes: 0 = matched (rerun), 1 = false/null (skip),
+          # >=2 = jq/parse error (skip, don't turn the recovery lane red).
+          set +e
+          jq -e '
+              [ .jobs[]
+                | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == null)
+              ] as $failed
+              | ($failed | length) > 0
+                and ( $failed
+                      | map( ([ .steps[]? | select(.conclusion == "failure") ] | length) == 0 )
+                      | any )
+            ' jobs.json > /dev/null
+          rc=$?
+          set -e
+          case "$rc" in
+            0)
+              echo "Worker-loss signature detected -> re-running failed jobs."
+              gh api -X POST "repos/$REPO/actions/runs/$RUN_ID/rerun-failed-jobs"
+              echo "decision=rerun" >> "$GITHUB_OUTPUT" ;;
+            1)
+              echo "No worker-loss signature (genuine failure) -> leaving run alone."
+              echo "decision=skip" >> "$GITHUB_OUTPUT" ;;
+            *)
+              echo "::warning::could not evaluate jobs.json (jq rc=$rc) -> skipping."
+              echo "decision=skip" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+      # Non-blocking telemetry so silent retry storms stay visible (rule 4).
+      - name: Publish Hooker workflow telemetry
+        if: always()
+        uses: ./.github/actions/hooker-telemetry
+        with:
+          status: ${{ job.status }}
+          title: "auto-rerun (${{ steps.decide.outputs.decision || 'error' }})"
+          text: "${{ github.event.workflow_run.name }} #${{ github.event.workflow_run.id }} attempt ${{ github.event.workflow_run.run_attempt }}"
+          tags: "auto-rerun,runner-loss"
+        env:
+          HOOKER_URL: ${{ secrets.HOOKER_URL }}
+          HOOKER_TOKEN: ${{ secrets.HOOKER_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,27 +62,30 @@ and opens a PR with methodology fixes.
 
 ## GitHub Actions Workflows
 
-Workflows split between two runners:
+Almost every workflow runs on **`runs-on: [self-hosted, Linux]`** — an
+autoscaled fleet of ephemeral Cloud Run workers (the `runner-autoscaler`
+service in `../runner`; see Load-bearing rule 5). A fresh
+`cloud-run-worker-*` instance spins up per job, so "self-hosted" no longer
+means one serial slot — jobs run in parallel, and each worker carries the
+pipeline's baked-in state (bird CLI + birdy daemon, LFS-hydrated
+`research/` checkout, Puppeteer/Chrome, pre-installed tooling). Aggregation,
+synthesis, output, CI, and the Claude agent lanes all run here.
 
-- **`runs-on: ubuntu-latest`** — stateless workflows (no bird-CLI state,
-  no LFS hydration, no Puppeteer/Chrome, no warm caches). These run on
-  GitHub-hosted runners so they don't queue behind the single self-hosted
-  job slot. Currently: `hourly-rss.yml`, `daily-arxiv.yml`,
-  `2h-bluesky.yml`, `daily-improve.yml`, `claude-code-review.yml`,
-  `claude.yml`.
-- **`runs-on: [self-hosted, Linux]`** — workflows that genuinely need
-  the self-hosted runner's persistent state (bird CLI + birdy daemon,
-  LFS-hydrated `research/` checkout, Puppeteer/Chrome, large agent
-  pipelines). Currently: `hourly-twitter.yml`, `daily-digest.yml`,
-  `daily-front-page.yml`, `generative-research.yml`,
-  `24h-model-timeline.yml`, `ai-news-research.yml`, `ci.yml`,
-  `research-issue.yml`, `4h-community.yml`, `wiki-ingest.yml`.
-- **Both tiers** — `liveness-check.yml` (the freshness watchdog) runs one
-  job on each runner. No single runner survives both failure modes — an
-  `ubuntu-latest` billing/spending-limit block (kills the GitHub-hosted
-  tier) vs. a self-hosted outage — so the watchdog must run on both;
-  whichever tier is alive emits the hooker/Telegram alert. See the
-  workflow header for the rationale.
+Only **two `runs-on: ubuntu-latest`** (GitHub-hosted) jobs exist, and both
+are watchdogs that must survive a self-hosted/Cloud Run outage — a watchdog
+that runs on the runners it is watching is useless:
+- `liveness-check.yml` runs one job on EACH tier (its `ubuntu` job + its
+  `self-hosted` job). No single runner survives both failure modes — a
+  GitHub-hosted billing/spending-limit block vs. a self-hosted outage — so
+  whichever tier is alive emits the hooker/Telegram staleness alert.
+- `auto-rerun-on-runner-loss.yml` re-runs jobs whose ephemeral worker
+  vanished mid-run (Load-bearing rule 11).
+
+The per-workflow `ubuntu-latest` vs. `self-hosted` lists that used to live
+here are gone on purpose: the answer is now "self-hosted unless it's one of
+those two watchdogs." **Always read the workflow's actual `runs-on:` —
+never trust a cached list** (the old list here drifted to 100% wrong once
+the autoscaler landed and the stateless lanes moved back to self-hosted).
 
 Claude workflows use `anthropics/claude-code-action@v1` with the model
 passed via `claude_args: "--model opus"` (never as a separate `model:`
@@ -244,21 +247,23 @@ output or break the pipeline. Read them before editing.
    `continue-on-error: true` style. Don't add hard dependencies on
    telemetry success.
 
-5. **Runner choice is load-bearing — pick by state dependency.** Two
-   runners, two rules:
-   - **Self-hosted** for workflows that depend on baked-in state: bird
-     CLI + warm birdy daemon (`hourly-twitter*`, `24h-model-timeline`),
-     LFS-hydrated `research/` for prior-output context
-     (`daily-digest`, `daily-front-page`, `ci.yml` dashboard job),
-     Puppeteer/Chrome (`daily-front-page`), or pre-installed
-     pnpm/Oracle tooling.
-   - **`ubuntu-latest`** for stateless workflows. The self-hosted runner
-     processes one job at a time; stateless work on `ubuntu-latest`
-     frees that queue. See the "GitHub Actions Workflows" section for
-     the current split. Before flipping a workflow from self-hosted to
-     `ubuntu-latest`, verify it doesn't read pre-populated dirs, depend
-     on warm caches, or need bird/birdy state — the cost of getting
-     this wrong is a silently-broken pipeline.
+5. **Runner choice is load-bearing — default to self-hosted.** The
+   self-hosted tier is an autoscaled Cloud Run worker fleet
+   (`runner-autoscaler` in `../runner`): a fresh ephemeral
+   `cloud-run-worker-*` registers per job, runs it, then deregisters, so
+   jobs run in PARALLEL (no single serial slot) and each carries baked-in
+   state — bird CLI + warm birdy daemon (`hourly-twitter*`,
+   `24h-model-timeline`), LFS-hydrated `research/` for prior-output context
+   (`daily-digest`, `daily-front-page`, `ci.yml` dashboard job),
+   Puppeteer/Chrome (`daily-front-page`), pre-installed pnpm/Oracle
+   tooling. Use `[self-hosted, Linux]` for anything touching that state,
+   which is nearly everything. Reserve `ubuntu-latest` for the two
+   watchdogs that must outlive a self-hosted outage (`liveness-check.yml`,
+   `auto-rerun-on-runner-loss.yml`). The tradeoff of ephemeral workers: an
+   instance can vanish mid-job (preemption / maintenance / OOM), failing
+   the run with no error in the log — rule 11 auto-recovers that. Before
+   moving a job to `ubuntu-latest`, verify it needs neither the warm state
+   nor bird/birdy — getting this wrong silently breaks the pipeline.
 
 6. **bird CLI calls must be graceful.** Always pass `--json --plain`
    and pipe to a fallback (`|| echo "[]"`). The Twitter cookies expire;
@@ -310,6 +315,27 @@ output or break the pipeline. Read them before editing.
     validator (or vice versa) silently corrupts the lane. The agent
     iterates `check_wiki.py` until exit 0 before committing; CI runs it
     on every PR.
+
+11. **Worker-death auto-rerun must stay loop-safe.**
+    `.github/workflows/auto-rerun-on-runner-loss.yml` watches the
+    unattended self-hosted pipelines via `workflow_run` and, when one fails
+    because its ephemeral worker vanished (a failed/incomplete job with NO
+    genuinely-failed step — "died at Set up job", or steps stuck
+    `in_progress`/`null`), re-runs only the failed jobs. Three invariants
+    keep it from becoming a retry storm or masking real red CI, and MUST be
+    preserved if you edit it:
+    (a) **Cap on `run_attempt`** — it only fires when
+    `github.event.workflow_run.run_attempt < 3` (≤ 2 auto re-runs). This is
+    the single load-bearing guard against infinite loops.
+    (b) **Gate on the lost-runner signature** — never re-run a run whose
+    failed job has a step with `conclusion == "failure"` (a genuine
+    failure), nor a `cancelled` run. Only the "worker vanished" shape
+    qualifies.
+    (c) **Not self-referential, and `ubuntu-latest`** — the watchdog's own
+    name is absent from its `workflows:` trigger list (so it can't
+    self-trigger) and it runs GitHub-hosted (so a Cloud Run blip can't take
+    out the recovery path too). Adding its name to the trigger list, or
+    moving it to self-hosted, breaks both protections.
 
 ## Code Style
 


### PR DESCRIPTION
## Why

Today a batch of self-hosted **Cloud Run autoscaler workers died mid-job** (~12:37–13:13 UTC), failing 4 scheduled/PR runs (Twitter, Community, Bluesky, Claude Code Review) — and Community died **again** at 16:41 on the same Claude-agent step. The signature is unmistakable: a job stuck `in_progress`/at "Set up job" with **no `##[error]` in the log** — an ephemeral instance vanished (preemption / maintenance / OOM), so GitHub fails the run server-side. The autoscaler *controller* stayed healthy; only worker *instances* died. Today these just wait for the next schedule (or a human re-run).

## What this PR does

**1. `auto-rerun-on-runner-loss.yml` — a self-healing watchdog.** Triggers on `workflow_run: completed` for the unattended self-hosted pipelines and re-runs only the failed jobs **iff** the failure looks like a worker death.

Loop-safety / correctness invariants (also documented in CLAUDE.md rule 11):
- **Capped** at `run_attempt < 3` → at most **2** auto re-runs.
- **Gated on the lost-runner signature** — a failed/incomplete/cancelled job with **no** step whose `conclusion == "failure"`. A genuine red step (e.g. the `Fail DeepSeek run without article` guard) is **never** auto-rerun. Verified against the real failure shapes.
- **Not self-referential** (its own name is absent from the trigger list) and runs on **`ubuntu-latest`** so a Cloud Run blip can't take out the recovery path too.
- Non-blocking hooker telemetry so retry activity stays visible.

**2. Fix the stale CLAUDE.md runner table.** The doc claimed 6 workflows run on `ubuntu-latest`; on `main` **all of them are `[self-hosted, Linux]`**. The autoscaler era moved ~everything to self-hosted (parallel ephemeral workers removed the old single-slot bottleneck). Now only `liveness-check.yml`'s `ubuntu` job — and this new watchdog — use `ubuntu-latest`. Updates the GitHub-Actions section + Load-bearing rule 5, and adds rule 11.

## Validation

- `actionlint` ✅ and `shellcheck -x` ✅ on the new workflow.
- Adversarial review (independent agent): verdict **SHIP-WITH-FIXES**, no blockers; the two safety-critical invariants (never auto-rerun a genuine failure; never infinite-loop) hold under tracing. All SHOULD-FIXes applied (include `cancelled` jobs; explicit jq exit-status handling; clarifying comments).
- Workflow names in the trigger list are byte-exact against `main` (em-dash included).

## Notes

- `workflow_run` only fires from the **default branch**, so this is inert until merged to `main`.
- **Root cause measured — NOT OOM.** Across today's death window, worker-pool memory peaked at **26%** of 8Gi (CPU 38%) via Cloud Monitoring — the workers were healthy when they vanished. The lost-communication annotation confirms the runner dropped, but the cause is **Cloud Run instance preemption/maintenance (or an autoscaler scale-down race), not resource starvation** — so bumping `RUNNER_MEMORY` would not help. This is inherent to ephemeral Cloud Run compute, which is exactly why **recovery (this watchdog) is the right fix** rather than prevention.
