### PR TITLE
Bump dompurify 3.3.1 → 3.4.8 (clear 8 moderate XSS advisories on the dashboard sanitizer trust boundary)

### DIFF
--- a/dashboard/bun.lock
+++ b/dashboard/bun.lock
@@ -1,10 +1,11 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "dashboard",
       "dependencies": {
-        "dompurify": "^3.3.1",
+        "dompurify": "^3.4.8",
         "marked": "^18.0.3",
       },
       "devDependencies": {
@@ -65,7 +66,7 @@
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
-    "dompurify": ["dompurify@3.3.1", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q=="],
+    "dompurify": ["dompurify@3.4.8", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -20,7 +20,7 @@
     "vite": "^8.0.13"
   },
   "dependencies": {
-    "dompurify": "^3.3.1",
+    "dompurify": "^3.4.8",
     "marked": "^18.0.3"
   }
 }


### PR DESCRIPTION
## Problem (with evidence)

`dashboard/bun.lock` pins **`dompurify@3.3.1`** — the version CI **and**
Vercel install via `bun install --frozen-lockfile`
(`.github/workflows/ci.yml` dashboard job; `dashboard/vercel.json`
`installCommand`). `npm audit` reports **8 moderate XSS advisories**
against it. npm's headline metadata counts these as **1 vulnerable
package** (`total: 1`) — the "8" is the advisory count, and all 8 are
severity `moderate` (none high/critical):

```
package severity: moderate
package range: <=3.3.3
advisory count: 8
advisory severities: ['moderate']
metadata vuln counts: {'moderate': 1, 'high': 0, 'critical': 0, 'total': 1}
  - GHSA-v2wj-7wpq-c8vv  range >=3.1.3 <=3.3.1   Cross-site Scripting
  - GHSA-cjmm-f4jc-qw8r  range <=3.3.1           ADD_ATTR predicate skips URI validation
  - GHSA-cj63-jhhr-wcxv  range <=3.3.1           USE_PROFILES prototype pollution allows event handlers
  - GHSA-39q2-94rc-95cp  range <=3.3.3           ADD_TAGS function form bypasses FORBID_TAGS
  - GHSA-h7mw-gpvr-xq4m  range <3.4.0            FORBID_TAGS bypassed by function-based ADD_TAGS predicate
  - GHSA-crv5-9vww-q3g8  range >=1.0.10 <3.4.0   SAFE_FOR_TEMPLATES bypass in RETURN_DOM mode
  - GHSA-v9jr-rg53-9pgp  range >=3.0.1 <3.4.0    Prototype Pollution to XSS via CUSTOM_ELEMENT_HANDLING
  - GHSA-h8r8-wccr-v5f2  range <3.3.2            mutation-XSS via Re-Contextualization
```

The highest affected ceiling is **`<3.4.0`**, so `3.4.8` clears all 8.

**Why it matters here.** `dashboard/src/main.ts` configures DOMPurify as
the dashboard's sanitizer. `setSafeWikiContent` (main.ts:1509) is the
**documented trust boundary** for *semi-trusted, LLM-authored* wiki page
bodies — the wiki/research lanes ingest external tweets and RSS that an
LLM can faithfully reproduce into a page body (its own doc comment:
*"Stricter sanitizer for LLM-authored (semi-trusted) wiki pages … LOCKS
DOWN"*). A sanitizer guarding that boundary should not run a build with
known prototype-pollution / mutation-XSS bypasses.

**Honest scoping of exploitability.** main.ts uses the **array-literal**
forms of `ADD_ATTR` / `ADD_TAGS` / `FORBID_TAGS` (sanitize calls at
main.ts:643, 704, 1509), **not** the function/predicate forms that three
of the advisories specifically target (`GHSA-cjmm-f4jc-qw8r` ADD_ATTR
predicate, `GHSA-39q2-94rc-95cp` / `GHSA-h7mw-gpvr-xq4m` function-based
ADD_TAGS) — so those particular vectors largely do not apply to this
codebase. The bump is justified by the **broadly applicable** advisories
that hit any 3.3.1 config: `USE_PROFILES` prototype pollution
(`GHSA-cj63-jhhr-wcxv`), `CUSTOM_ELEMENT_HANDLING` prototype-pollution→XSS
(`GHSA-v9jr-rg53-9pgp`), mutation-XSS (`GHSA-h8r8-wccr-v5f2`), generic XSS
(`GHSA-v2wj-7wpq-c8vv`), and the `SAFE_FOR_TEMPLATES` bypass
(`GHSA-crv5-9vww-q3g8`). The trust-boundary input is **pipeline-LLM-
generated, not attacker-supplied**, so live exploitability is lower than
"XSS" alone implies — but it is a real, in-range vulnerable dependency on
the live lockfile, on a surface the code itself documents as a trust
boundary, and worth clearing.

## Root cause

The dashboard carries **two** lockfiles: `bun.lock` (what CI + Vercel
actually use) and an orphaned `package-lock.json`. Dependabot's npm
ecosystem (`.github/dependabot.yml`, `npm` / `/dashboard`) bumps
`package.json` and regenerates **`package-lock.json`**, but **cannot
touch `bun.lock`**. So after any dependabot bump,
`bun install --frozen-lockfile` validates `package.json` against a
`bun.lock` that is still 3.3.1 → mismatch → **red on arrival**. Proven on
the lone surviving dependabot PR (#98, branch
`dependabot/npm_and_yarn/dashboard/dompurify-3.4.8`):

```
 dashboard/package-lock.json | 39 +++++++--------------------------------
 dashboard/package.json      |  2 +-
 2 files changed, 8 insertions(+), 33 deletions(-)
```

It touches `package-lock.json` + `package.json` and **never `bun.lock`** —
which is exactly why every dependabot dashboard PR fails the frozen-lockfile
gate and the security bump never lands. The pin has therefore stayed on the
vulnerable build.

## The fix

This PR manually does what dependabot can't: regenerate `bun.lock` so it
agrees with `package.json` on the patched release.

- `dashboard/package.json`: `"dompurify": "^3.3.1"` → `"^3.4.8"`
- `dashboard/bun.lock`: regenerated via `bun install` → `dompurify@3.4.8`
  (bun 1.3.13 also adds a `configVersion: 0` field; that is a legitimate
  bun-produced artifact, not a hand-edit)

Two files, **+4 / −3, dompurify only**. No source changes — the DOMPurify
API surface main.ts uses (`USE_PROFILES` / `ADD_ATTR` / `ADD_TAGS` /
`FORBID_TAGS` / `FORBID_ATTR`) is stable across 3.3 → 3.4 (typecheck +
build pass).

**Out of scope by design.** The systemic gap — dependabot's npm ecosystem
can't maintain `bun.lock`, so npm-ecosystem dashboard PRs keep arriving
dead — is real but **not fixed here** (the real fix is a dependabot-config
change or a `bun.lock`-regeneration step; tracked separately). The
orphaned `package-lock.json` is left as-is: it is read by **nothing** in
CI or Vercel (`grep package-lock` across `.github/`, `scripts/`,
`vercel.json` → zero refs; last touched in unrelated commit `a1200b2c`).
Running `npm audit` *inside* `dashboard/` reads that stale 3.3.1 lock and
re-prints the advisories even after this bump — that is a stale-file
artifact, not a live failure, and CI never runs `npm audit`.

## Verification (all run locally, bun 1.3.13 — CI's exact gates)

From `dashboard/`, mirroring the CI dashboard job and `vercel.json`
commands:

**1. `bun install --frozen-lockfile` → exit 0** (the gate every dependabot
dashboard PR fails; lock matches package.json):

```
bun install v1.3.13 (bf2e2cec)
Checked 22 installs across 53 packages (no changes) [23.00ms]
```

**2. `bunx tsc --noEmit -p tsconfig.json` → exit 0** (no output; 3.3 → 3.4
API stable for main.ts).

**3. `SKIP_LFS_POINTERS=1 bun run build` → exit 0** (CI's exact build
command — prebuild + vite + postbuild-seo, bundles `dompurify@3.4.8`):

```
$ vite build
vite v8.0.13 building client environment for production...
✓ 7 modules transformed.
dist/index.html                   8.46 kB │ gzip:  2.96 kB
dist/assets/index-D9mo_vZC.css   79.67 kB │ gzip: 14.73 kB
dist/assets/index-Dv2pXcCt.js   147.86 kB │ gzip: 46.42 kB
✓ built in 418ms
$ node scripts/postbuild-seo.mjs
postbuild-seo: 42 article pages (0 skipped), 1 digest page, 27 wiki pages
```

**4. Advisory clearance** — two authoritative signals agree 3.4.8 is clean:
- `npm audit` advisory range tops out at `<3.4.0`; `3.4.8` is outside it.
- A clean-room audit of pure `dompurify@3.4.8` (fresh dir,
  `npm install --package-lock-only` then `npm audit`) → **`found 0
  vulnerabilities`**.
- The install resolves a **single** `dompurify@3.4.8` copy
  (`node_modules/dompurify/package.json` → `"version": "3.4.8"`, no nested
  older duplicates).

## Risk & rollback

**Low.** Patch/minor bump within the 3.x line, API-stable (typecheck +
build pass). Blast radius is the dashboard sanitizer only — no pipeline,
workflow, or `research/` data changes. Production deploy reads `bun.lock`
(`vercel.json` `installCommand: bun install --frozen-lockfile`), so the
bump genuinely lands in the deployed bundle. **Rollback** = revert the
2-file commit.

**Recommended post-merge check (non-blocking).** 3.4.x intentionally
tightens `ADD_TAGS` / `ADD_ATTR` / `USE_PROFILES` handling; `tsc` and the
build prove API/type stability but not rendered DOM. On the Vercel preview,
spot-check (a) a wiki page body (the `setSafeWikiContent` path) and (b) a
page using an `iframe` / `audio` embed (the `setSafeContent` allow-list at
main.ts:706-707), to confirm the tightened sanitization did not strip the
legitimately allow-listed embeds. main.ts uses the array-literal forms
(not the function form the bypass advisories target), so no stripping is
expected.

**Merge hygiene.** Close the lone surviving dependabot dompurify PR **#98**
(`dependabot/npm_and_yarn/dashboard/dompurify-3.4.8`) — it bumps
`package-lock.json` only, leaves `bun.lock` at 3.3.1, and is therefore
dead-on-arrival under `--frozen-lockfile`. Merging it instead of this PR
would break CI/Vercel and leave 3.3.1 in the bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
