### PR TITLE
Front page: import real article images (RSS/community) instead of the arxiv logo

### DIFF
--- a/scripts/render_front_page.mjs
+++ b/scripts/render_front_page.mjs
@@ -151,11 +151,68 @@ async function fetchWithTimeout(url, options = {}, timeoutMs = 8000) {
   }
 }
 
+// Real browser UA — many publishers/CDNs serve og:image meta only to
+// browser-like clients; a generic bot UA gets a thin or blocked response
+// (which is why non-arxiv sources previously yielded no image).
+const IMAGE_FETCH_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36";
+
+// Hosts whose pages don't yield a usable article image:
+// - arxiv.org exposes the generic arxiv LOGO as og:image, not the paper,
+// - x.com / twitter.com are auth-walled to non-browser clients,
+// - news.ycombinator.com pages are comment threads, not articles.
+function isImageCandidate(url) {
+  try {
+    const host = new URL(url).hostname.replace(/^www\./, "").toLowerCase();
+    if (/(^|\.)arxiv\.org$/.test(host)) return false;
+    if (/(^|\.)(x|twitter)\.com$/.test(host)) return false;
+    if (host === "news.ycombinator.com") return false;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// The digest links are almost entirely arxiv (Research Highlights), so its
+// only reliable og:image is the arxiv logo. Pull richer candidates from the
+// raw aggregation — RSS (news/blog articles) and community (HN/Reddit outbound
+// links) carry real article URLs with real og:images.
+async function richSourceLinks() {
+  const out = [];
+  for (const file of [
+    `research/rss/${date}.md`,
+    `research/community/${date}-hn.md`,
+    `research/community/${date}-reddit.md`,
+  ]) {
+    try {
+      const text = await readFile(file, "utf8");
+      for (const link of markdownLinks(text)) out.push({ ...link, story: link.label });
+    } catch {
+      // file may not exist for this date — skip it
+    }
+  }
+  return out;
+}
+
+// Prioritised, de-duped, filtered candidate links for the lead image:
+// rich aggregation sources first (real article images), digest links last.
+async function imageCandidateLinks() {
+  const all = [...(await richSourceLinks()), ...uniqueSourceLinks()];
+  const seen = new Set();
+  const out = [];
+  for (const link of all) {
+    if (!isImageCandidate(link.url) || seen.has(link.url)) continue;
+    seen.add(link.url);
+    out.push(link);
+  }
+  return out.slice(0, 30);
+}
+
 async function imageFromPage(link) {
   try {
     const pageResponse = await fetchWithTimeout(link.url, {
       headers: {
-        "user-agent": "ai-research-arm-front-page/1.0",
+        "user-agent": IMAGE_FETCH_UA,
         accept: "text/html,application/xhtml+xml",
       },
       redirect: "follow",
@@ -170,7 +227,7 @@ async function imageFromPage(link) {
 
     const imageResponse = await fetchWithTimeout(imageUrl, {
       headers: {
-        "user-agent": "ai-research-arm-front-page/1.0",
+        "user-agent": IMAGE_FETCH_UA,
         accept: "image/avif,image/webp,image/png,image/jpeg,image/*",
       },
       redirect: "follow",
@@ -196,7 +253,7 @@ async function imageFromPage(link) {
 
 async function resolveImages(limit = 3) {
   const images = [];
-  for (const link of uniqueSourceLinks()) {
+  for (const link of await imageCandidateLinks()) {
     const image = await imageFromPage(link);
     if (image) images.push(image);
     if (images.length >= limit) break;


### PR DESCRIPTION
## Problem
The daily front-page "newspaper" always used the **arxiv logo** as its lead image.

Before (`2026-06-09`):
```
src="https://arxiv.org/static/browse/0.3.4/images/arxiv-logo-fb.png"
source-url="https://arxiv.org/abs/2606.01495"
```

## Root cause
`scripts/render_front_page.mjs` builds image candidates from the **daily digest's** links, and the digest is almost entirely arxiv (Research Highlights). arxiv abstract pages expose the generic **arxiv logo** (`arxiv-logo-fb.png`) as their `og:image` — not the paper — and it was the only digest link that reliably yielded an image (others returned nothing to the bot UA). So `resolveImages` always landed on the arxiv logo.

## The fix (`scripts/render_front_page.mjs`, one file)
- **Source candidates from the raw aggregation** — `research/rss/<date>.md` + `research/community/<date>-{hn,reddit}.md` — which link to real news/blog articles (the-decoder, TechCrunch, Ars Technica, OpenAI, …) carrying real `og:image`s. Digest links stay as a fallback.
- **Skip** hosts that can't yield an article image: `arxiv.org` (logo), `x.com`/`twitter.com` (auth-walled), `news.ycombinator.com` (threads).
- **Browser User-Agent** for the fetches — publishers/CDNs serve `og:image` only to browser-like clients (the old bot UA is why non-arxiv sources yielded nothing).

## Verification
Re-ran the renderer on `2026-06-09`:
```
# before
src="https://arxiv.org/static/browse/0.3.4/images/arxiv-logo-fb.png"
# after
src="https://techcrunch.com/wp-content/uploads/.../GettyImages-...jpg?w=1024"
source-url="https://techcrunch.com/2026/06/08/mercors-brendan-foody-..."
```
- `node --check scripts/render_front_page.mjs` → OK.
- Both the `.png` and `.ara.md` paths go through `resolveImages` → the new candidate builder, so both select the same real image.

## Risk & rollback
Low — single file, image-selection only; no change to layout/SVG/PNG rendering. If no candidate yields an image, the renderer falls through to its existing no-image path (graceful). The og:image fetch is live/network, same as before — just over richer, browser-UA'd sources. Rollback is a one-file revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
