### PR TITLE
Python correctness: locked/atomic audio index write, newspaper validator, blog-resilience tests

### DIFF
--- a/scripts/compile_ara.py
+++ b/scripts/compile_ara.py
@@ -1711,6 +1711,54 @@ def compile_article_source(source: str) -> str:
     return article
 
 
+# Newspaper output is emitted by trusted directive code that html.escape()s
+# every interpolated value, so it can never produce a raw <script>/<style>/
+# <iframe> tag or an inline event handler from its (already-curated) input.
+# The check below is defense-in-depth. It reuses write_generative_research's
+# DISALLOWED_PATTERNS (style=, on*=, javascript:) AND adds the three tag
+# patterns those expressions DON'T cover: the article path blocks <script>/
+# <style>/<iframe> via the FRAGMENT_ALLOWED_TAGS *tag* allowlist, but the
+# newspaper path deliberately emits <nav>/<button>/<details>/<summary> +
+# aria-*/type/data-columns, so it has no tag allowlist — without these
+# patterns a bare `<script>...</script>` would slip straight through (the
+# three DISALLOWED_PATTERNS only match attribute/URL shapes, not tags).
+NEWSPAPER_FORBIDDEN_TAGS = [
+    re.compile(r"<\s*script\b", re.IGNORECASE),
+    re.compile(r"<\s*style\b", re.IGNORECASE),
+    re.compile(r"<\s*iframe\b", re.IGNORECASE),
+]
+
+
+def validate_newspaper_body(body: str) -> None:
+    """Defense-in-depth denylist check on compiled newspaper HTML.
+
+    compile_article_source routes its output through
+    write_generative_research.validate_body and its FRAGMENT_ALLOWED_TAGS
+    allowlist. The newspaper target can't use that allowlist because it
+    legitimately emits interactive tags (<nav>/<button>/<details>/<summary>)
+    and aria-*/type/data-columns attributes the fragment allowlist rejects.
+    Re-deriving a full per-attribute allowlist for that wider, less-exercised
+    surface risks false-rejecting a future digest shape, so this is a
+    denylist instead: it rejects the dangerous constructs the trusted
+    compiler never emits (raw <script>/<style>/<iframe> tags, inline style=,
+    on*= handlers, javascript: URLs).
+
+    Raises AraSyntaxError on a violation so compile_ara.main() / callers
+    surface a clean error rather than a traceback.
+    """
+    # Reuse the writer's canonical attribute/URL denylist so the two stay in
+    # lockstep. Imported lazily to mirror the existing deferred imports from
+    # write_generative_research below (avoids a module-load import cycle).
+    from write_generative_research import DISALLOWED_PATTERNS  # noqa: E402
+
+    for pat in (*NEWSPAPER_FORBIDDEN_TAGS, *DISALLOWED_PATTERNS):
+        m = pat.search(body)
+        if m:
+            raise AraSyntaxError(
+                f"newspaper body contains disallowed pattern: {m.group(0)!r}"
+            )
+
+
 def compile_newspaper_source(source: str) -> str:
     meta, body = parse_frontmatter(source)
     header = emit_newspaper_header(meta)
@@ -1719,7 +1767,9 @@ def compile_newspaper_source(source: str) -> str:
     body_html = compile_blocks(blocks, directive_map)
     date_attr = f' data-paper-date="{html.escape(str(meta.get("date")), quote=True)}"' if meta.get("date") else ""
     parts = [f'<article class="ara-paper"{date_attr}>', header, body_html, '</article>\n']
-    return "\n".join(parts)
+    article = "\n".join(parts)
+    validate_newspaper_body(article)
+    return article
 
 
 def compile_source(source: str, target: str = "article") -> str:

--- a/scripts/generate_generative_article_audio.py
+++ b/scripts/generate_generative_article_audio.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import fcntl
 import html
 import html.parser
 import json
@@ -24,6 +25,15 @@ import urllib.request
 import ssl
 from pathlib import Path
 from typing import Any
+
+# The generative index.json is also written by write_generative_research.py
+# (the canonical committer for research/generative/). Reuse ITS atomic
+# temp-file+os.replace writer and lockfile convention so an audio backfill and
+# a concurrent article publish serialize on the same lock instead of clobbering
+# each other (Rule 8 — atomic writes). We import only the write primitive and
+# replicate the small flock dance locally; we do NOT hand-roll a third writer.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from write_generative_research import atomic_write_json  # noqa: E402
 
 
 DEFAULT_DEVELOPER_MODEL = "gemini-2.5-flash-preview-tts"
@@ -351,15 +361,38 @@ def encode_mp3(pcm_path: Path, mp3_path: Path, bitrate: str) -> None:
 
 
 def update_index(root: Path, slug: str, audio_rel: str) -> None:
+    """Set `audio_file` on the matching row in research/generative/index.json,
+    serialized against write_generative_research.py's writer.
+
+    This read-modify-write must run under the SAME advisory lock the article
+    writer uses (fcntl.flock on `index.json.lock`) so a concurrent publish and
+    an audio backfill cannot interleave their read/write and lose a row, and so
+    a reader never sees a half-written file (the write itself is atomic via
+    os.replace inside atomic_write_json). We lock a SEPARATE lockfile next to
+    index.json — never index.json itself — because atomic_write_json rotates
+    index.json to a fresh inode, so a lock held on the data file would not be
+    seen by the next writer (this mirrors append_index_atomically's rationale).
+    The on-disk snapshot is (re-)read INSIDE the critical section; any caller's
+    earlier read is stale by definition.
+    """
     path = root / "research" / "generative" / "index.json"
-    rows = json.loads(path.read_text(encoding="utf-8"))
-    for row in rows:
-        if row.get("slug") == slug:
-            row["audio_file"] = audio_rel
-            break
-    else:
-        raise SystemExit(f"cannot update audio_file, slug not found: {slug}")
-    path.write_text(json.dumps(rows, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    lock_fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
+    try:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        rows = json.loads(path.read_text(encoding="utf-8"))
+        for row in rows:
+            if row.get("slug") == slug:
+                row["audio_file"] = audio_rel
+                break
+        else:
+            raise SystemExit(f"cannot update audio_file, slug not found: {slug}")
+        atomic_write_json(path, rows)
+    finally:
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        finally:
+            os.close(lock_fd)
 
 
 def estimate_cost(text_chars: int, duration_seconds: float, model: str) -> str:

--- a/scripts/test_ara_dsl.py
+++ b/scripts/test_ara_dsl.py
@@ -288,6 +288,106 @@ title: Bad Paper
 """
             )
 
+    # --- Newspaper defense-in-depth validator (validate_newspaper_body) ---
+    # compile_newspaper_source returns WITHOUT the article path's
+    # FRAGMENT_ALLOWED_TAGS allowlist (it legitimately emits
+    # <nav>/<button>/<details>/aria-*), so a denylist guards against the
+    # dangerous constructs the trusted compiler never emits.
+
+    def test_real_front_page_sources_still_compile(self):
+        # Strongest non-breaking guard: compile EVERY committed front-page
+        # newspaper source and assert the validator passes it. The front-page
+        # output legitimately uses <nav>/<button>/<details>/<summary> +
+        # aria-*/type/data-columns; the validator must not reject any of it.
+        repo_root = Path(compile_ara.__file__).resolve().parent.parent
+        sources = sorted((repo_root / "research" / "front-page").glob("*.ara.md"))
+        self.assertGreater(len(sources), 0, "expected committed front-page .ara.md sources")
+        for src in sources:
+            with self.subTest(source=src.name):
+                html = compile_ara.compile_source(
+                    src.read_text(encoding="utf-8"), target="newspaper"
+                )
+                # Sanity: the legitimate interactive tags are present and kept.
+                self.assertIn("<nav", html)
+                self.assertIn("<button", html)
+                self.assertIn("<details", html)
+                self.assertIn('aria-expanded="true"', html)
+
+    def test_newspaper_validator_passes_clean_interactive_output(self):
+        # The full interactive newspaper fixture must pass end to end.
+        html = compile_newspaper_ok(
+            """---
+title: Clean Paper
+date: May 28, 2026
+---
+
+:::paper-index
+- {label: Lead, target: "#lead-top"}
+:::
+
+:::lead(id="lead-top", label="Top Story", title="Models move into production")
+The day opens with ==production AI== pressure.
+:::
+
+:::briefs(title="Breaking", columns=2)
+- {headline: New model ships, tag: Models, body: Lower latency.}
+:::
+
+:::news-meter(title="Signal Mix")
+- {label: Breaking, value: 75, display: "3 items", tone: hot}
+:::
+"""
+        )
+        self.assertIn('class="ara-paper"', html)
+        # Idempotent: re-validating the already-compiled output is a no-op.
+        compile_ara.validate_newspaper_body(html)
+
+    def test_newspaper_validator_rejects_script_tag(self):
+        # The gap the denylist closes: DISALLOWED_PATTERNS (style=/on*=/
+        # javascript:) does NOT match a bare <script> tag. The tag patterns do.
+        with self.assertRaisesRegex(compile_ara.AraSyntaxError, "disallowed pattern"):
+            compile_ara.validate_newspaper_body(
+                '<article class="ara-paper"><script>alert(1)</script></article>'
+            )
+
+    def test_newspaper_validator_rejects_style_and_iframe_tags(self):
+        with self.assertRaises(compile_ara.AraSyntaxError):
+            compile_ara.validate_newspaper_body(
+                '<article class="ara-paper"><style>x{}</style></article>'
+            )
+        with self.assertRaises(compile_ara.AraSyntaxError):
+            compile_ara.validate_newspaper_body(
+                '<article class="ara-paper"><iframe src="x"></iframe></article>'
+            )
+
+    def test_newspaper_validator_rejects_inline_style_and_handlers(self):
+        with self.assertRaises(compile_ara.AraSyntaxError):
+            compile_ara.validate_newspaper_body(
+                '<article class="ara-paper"><div style="color:red">x</div></article>'
+            )
+        with self.assertRaises(compile_ara.AraSyntaxError):
+            compile_ara.validate_newspaper_body(
+                '<article class="ara-paper"><button onclick="x()">x</button></article>'
+            )
+        with self.assertRaises(compile_ara.AraSyntaxError):
+            compile_ara.validate_newspaper_body(
+                '<article class="ara-paper"><a href="javascript:void(0)">x</a></article>'
+            )
+
+    def test_newspaper_validator_allows_legit_interactive_markup(self):
+        # The exact tag/attribute shapes the compiler emits must NOT trip the
+        # denylist: <nav aria-label>, <button type aria-expanded aria-controls>,
+        # <details>/<summary>, <section data-columns>, data-paper-date.
+        compile_ara.validate_newspaper_body(
+            '<article class="ara-paper" data-paper-date="June 9, 2026">'
+            '<nav class="ara-paper-index" aria-label="In this edition"></nav>'
+            '<button class="ara-paper-toggle" type="button" aria-expanded="true" '
+            'aria-controls="x-body"><span aria-hidden="true">v</span></button>'
+            '<section class="ara-paper-briefs" data-columns="2">'
+            '<details class="ara-paper-brief"><summary>x</summary></details>'
+            "</section></article>"
+        )
+
     def test_bar_chart_horizontal_diverging_keeps_negative(self):
         html = compile_ok(
             """---

--- a/scripts/test_fetch_ai_blogs.py
+++ b/scripts/test_fetch_ai_blogs.py
@@ -9,6 +9,8 @@ import sys
 import tempfile
 import unittest
 import unittest.mock
+import urllib.error
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(__file__))
@@ -88,6 +90,103 @@ class FeedParserTest(unittest.TestCase):
         high = blogs.FeedItem(SOURCE, "High", "https://example.com/a", None, "", 2, "high")
 
         self.assertEqual(blogs.dedupe_items([low, high]), [high])
+
+
+class CollectItemsResilienceTest(unittest.TestCase):
+    """The hourly lane must survive a single bad feed: collect_items catches
+    per-feed fetch/parse failures, records them, and keeps going so one dead
+    upstream can't crash the whole run. test_main_writes_markdown mocks
+    collect_items wholesale, so the real per-feed except handler
+    (fetch_ai_blogs.py: collect_items + fetch_url) would otherwise be untested.
+    """
+
+    def test_url_error_recorded_not_raised(self):
+        # A feed whose fetch raises urllib.error.URLError (e.g. DNS failure,
+        # connection refused) must be recorded in `errors`, not propagated.
+        with unittest.mock.patch.object(
+            blogs, "fetch_url", side_effect=urllib.error.URLError("name resolution failed")
+        ):
+            items, errors = blogs.collect_items([SOURCE], dt.date(2026, 5, 25), False)
+
+        self.assertEqual(items, [])
+        self.assertEqual(len(errors), 1)
+        err_source, err_text = errors[0]
+        self.assertIs(err_source, SOURCE)
+        self.assertTrue(err_text.startswith("URLError:"), err_text)
+        self.assertIn("name resolution failed", err_text)
+
+    def test_parse_error_recorded_not_raised(self):
+        # A feed that returns malformed XML must surface as a recorded error
+        # via the real parse_feed -> ET.fromstring path, not crash the run.
+        with unittest.mock.patch.object(blogs, "fetch_url", return_value=b"<not-valid-xml"):
+            items, errors = blogs.collect_items([SOURCE], dt.date(2026, 5, 25), False)
+
+        self.assertEqual(items, [])
+        self.assertEqual(len(errors), 1)
+        err_source, err_text = errors[0]
+        self.assertIs(err_source, SOURCE)
+        self.assertTrue(err_text.startswith("ParseError:"), err_text)
+        # Sanity: a real ET.ParseError is what we're exercising here.
+        with self.assertRaises(ET.ParseError):
+            blogs.parse_feed(SOURCE, b"<not-valid-xml")
+
+    def test_one_bad_feed_does_not_drop_a_healthy_one(self):
+        # Two sources: one fetches fine, one raises. The healthy item must
+        # still come through and the bad feed must be recorded as an error.
+        good = blogs.Source(
+            id="good",
+            name="Good Blog",
+            url="https://good.example/",
+            feed_url="https://good.example/feed.xml",
+            type="expert_blog",
+            priority="P0",
+            cadence="daily",
+            tags=("agents",),
+            include_in_digest=True,
+            notes="",
+        )
+        good_feed = b"""<?xml version="1.0"?>
+        <rss version="2.0">
+          <channel>
+            <item>
+              <title>Healthy post</title>
+              <link>https://good.example/post</link>
+              <pubDate>Mon, 25 May 2026 08:00:00 GMT</pubDate>
+              <description>Body.</description>
+            </item>
+          </channel>
+        </rss>"""
+
+        def fake_fetch(url: str) -> bytes:
+            if url == good.feed_url:
+                return good_feed
+            raise urllib.error.URLError("boom")
+
+        with unittest.mock.patch.object(blogs, "fetch_url", side_effect=fake_fetch):
+            items, errors = blogs.collect_items([good, SOURCE], dt.date(2026, 5, 25), False)
+
+        self.assertEqual([i.title for i in items], ["Healthy post"])
+        self.assertEqual([s.id for s, _ in errors], ["example"])
+
+    def test_render_markdown_emits_fetch_errors_section(self):
+        # The recorded errors must surface in the report so a silent stream of
+        # empty digests is visible. render_markdown owns the "## Fetch Errors"
+        # section.
+        with unittest.mock.patch.object(
+            blogs, "fetch_url", side_effect=urllib.error.URLError("connection refused")
+        ):
+            items, errors = blogs.collect_items([SOURCE], dt.date(2026, 5, 25), False)
+
+        markdown = blogs.render_markdown(
+            target_date=dt.date(2026, 5, 25),
+            sources=[SOURCE],
+            items=items,
+            errors=errors,
+        )
+        self.assertIn("## Fetch Errors", markdown)
+        self.assertIn("- Fetch errors: 1", markdown)
+        self.assertIn(SOURCE.name, markdown)
+        self.assertIn("connection refused", markdown)
 
 
 class MainTest(unittest.TestCase):

--- a/scripts/test_generate_generative_article_audio.py
+++ b/scripts/test_generate_generative_article_audio.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Tests for scripts/generate_generative_article_audio.py.
+
+Focused on update_index, which mutates the shared research/generative/
+index.json — the same file write_generative_research.py owns. The mutation
+must run under that writer's lock and use its atomic temp-file+os.replace
+writer so a concurrent publish and an audio backfill can't clobber each other
+(Rule 8). These tests pin two invariants:
+
+  * the audio_file field is set on the right row and other rows are untouched;
+  * the on-disk shape (2-space indent, ensure_ascii=False, trailing newline)
+    is byte-identical to what the writer produces — so routing through
+    atomic_write_json did not change index.json's serialized form.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import generate_generative_article_audio as audio  # noqa: E402
+import write_generative_research as writer  # noqa: E402
+
+
+def _sample_rows() -> list[dict]:
+    return [
+        {
+            "slug": "first-article",
+            "file": "2026-05-01T000000--first-article.html",
+            "kind": "fragment",
+            "language": "en",
+            "title": "First Article — détail",  # non-ASCII to lock ensure_ascii=False
+            "model": "claude-opus-4-7",
+            "created_at": "2026-05-01T00:00:00Z",
+            "source": "workflow_dispatch",
+            "prompt": "first",
+            "tags": ["a", "b"],
+        },
+        {
+            "slug": "second-article",
+            "file": "2026-05-02T000000--second-article.html",
+            "kind": "fragment",
+            "language": "en",
+            "title": "Second Article",
+            "model": "claude-opus-4-7",
+            "created_at": "2026-05-02T00:00:00Z",
+            "source": "workflow_dispatch",
+            "prompt": "second",
+            "tags": [],
+        },
+    ]
+
+
+class UpdateIndexTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.gen_dir = self.root / "research" / "generative"
+        self.gen_dir.mkdir(parents=True)
+        self.index_path = self.gen_dir / "index.json"
+        # Seed using the writer's own serializer so "before" reflects the
+        # canonical on-disk shape.
+        writer.atomic_write_json(self.index_path, _sample_rows())
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_sets_audio_file_on_matching_row_only(self):
+        audio.update_index(self.root, "second-article", "audio/second-article.mp3")
+        rows = json.loads(self.index_path.read_text(encoding="utf-8"))
+        by_slug = {r["slug"]: r for r in rows}
+        self.assertEqual(by_slug["second-article"]["audio_file"], "audio/second-article.mp3")
+        # The other row is untouched — no stray audio_file key.
+        self.assertNotIn("audio_file", by_slug["first-article"])
+        # Every other field on the mutated row is preserved.
+        self.assertEqual(by_slug["second-article"]["title"], "Second Article")
+        self.assertEqual(by_slug["second-article"]["model"], "claude-opus-4-7")
+
+    def test_shape_byte_identical_to_writer(self):
+        # Capture the exact bytes the old hand-rolled writer would have produced
+        # (json.dumps(..., indent=2, ensure_ascii=False) + "\n") and confirm the
+        # locked atomic path produces the same bytes.
+        rows = json.loads(self.index_path.read_text(encoding="utf-8"))
+        for row in rows:
+            if row["slug"] == "first-article":
+                row["audio_file"] = "audio/first-article.mp3"
+        expected_bytes = (
+            json.dumps(rows, indent=2, ensure_ascii=False) + "\n"
+        ).encode("utf-8")
+
+        audio.update_index(self.root, "first-article", "audio/first-article.mp3")
+        actual_bytes = self.index_path.read_bytes()
+        self.assertEqual(actual_bytes, expected_bytes)
+        # Belt-and-suspenders: trailing newline present, non-ASCII kept literal.
+        self.assertTrue(actual_bytes.endswith(b"\n"))
+        self.assertIn("détail", actual_bytes.decode("utf-8"))
+
+    def test_unknown_slug_raises_and_leaves_index_unchanged(self):
+        before = self.index_path.read_bytes()
+        with self.assertRaises(SystemExit):
+            audio.update_index(self.root, "does-not-exist", "audio/x.mp3")
+        # The file must be unchanged: the slug check happens before any write.
+        self.assertEqual(self.index_path.read_bytes(), before)
+
+    def test_uses_writer_lockfile_path(self):
+        # The lock must be the SAME file the article writer locks, or the two
+        # writers wouldn't serialize. append_index_atomically locks
+        # index.json + ".lock"; assert update_index creates exactly that file.
+        lock_path = self.index_path.with_suffix(self.index_path.suffix + ".lock")
+        self.assertFalse(lock_path.exists())
+        audio.update_index(self.root, "first-article", "audio/first-article.mp3")
+        self.assertTrue(lock_path.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Three first-principles correctness fixes from the 2026-06-10 audit (T3-6, T4). All changes are scoped to `scripts/`; no workflow, dashboard, or doc changes. Full `scripts/` test suite is green.

## 1. Atomic + locked `index.json` write (T3-6, Rule 8)
`generate_generative_article_audio.py::update_index` did a non-atomic, unlocked `read → mutate → write_text` on `research/generative/index.json` — the exact file `write_generative_research.py` serializes writers to via `fcntl.flock` on `index.json.lock` + an atomic temp-file+`os.replace` writer. A concurrent article publish and an audio backfill could clobber each other, and a reader between truncate/write could see corrupt JSON.

**Fix:** route the read-modify-write through the SAME lockfile and reuse the writer's `atomic_write_json` primitive (imported, not reimplemented — no third writer). Re-reads inside the critical section. **Verified the serialized `index.json` shape is byte-identical** to the previous output (19000 → 19000 bytes on the live file; a unit test pins the byte-for-byte equality).

## 2. Newspaper allowlist defense-in-depth (T4)
`compile_ara.py::compile_newspaper_source` returned without any tag/attribute check, unlike the article path which routes through `validate_body`. The newspaper target legitimately emits `<nav>/<button>/<details>/<summary>` + `aria-*`/`type`/`data-columns`, so it can't reuse the fragment tag allowlist.

**Fix:** new `validate_newspaper_body()` denylist. It reuses `write_generative_research.DISALLOWED_PATTERNS` (`style=`, `on*=`, `javascript:`) AND adds `<script>`/`<style>`/`<iframe>` tag patterns — those three DISALLOWED_PATTERNS only match attribute/URL shapes, so a bare `<script>` tag would otherwise slip through. Raises `AraSyntaxError` (caught by `main()` → clean exit, no traceback).

**Non-breaking verified:** the modified compiler produces byte-identical newspaper HTML for the live front-page source, and a test compiles EVERY committed `research/front-page/*.ara.md` through the validator (all pass, interactive tags preserved). Rejection tested for script/style/iframe/inline-style/handlers/javascript-URLs.

_Known characteristic (unchanged from the article path): the reused `javascript:` rule is a case-insensitive substring match, so literal prose like "JavaScript: A Guide" would trip it. This is identical to the existing `validate_body` behavior on the same patterns; all current inputs pass._

## 3. Test the resilience path (T4)
`test_fetch_ai_blogs.py` mocked `collect_items` wholesale, leaving the real per-feed exception handler ("one bad feed doesn't crash the hourly run") untested.

**Fix:** new `CollectItemsResilienceTest` mocks `fetch_url` (not `collect_items`) to raise `urllib.error.URLError` and to return malformed XML (real `xml.etree.ElementTree.ParseError`), asserting `collect_items` returns `([], [(source, err)])`, that one bad feed doesn't drop a healthy one, and that `render_markdown` emits the `## Fetch Errors` section.

## Validation
- CI command `uv run python -m unittest discover -s scripts -p 'test_*.py'` → all pass (241, `OK skipped=6`).
- `uv run python scripts/check_generative_research.py <existing article>` → "Safe to commit".
- `uv run python scripts/compile_ara.py --target newspaper <live front-page>` → exit 0, output byte-identical to pre-change.

## Files
- `scripts/generate_generative_article_audio.py`, `scripts/compile_ara.py`, `scripts/test_fetch_ai_blogs.py` (owned)
- `scripts/test_generate_generative_article_audio.py` (new test file)
- `scripts/test_ara_dsl.py` (existing — newspaper-validator tests added to the canonical home for `compile_ara` tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)