### PR TITLE
Docs accuracy fixes 2026-06-10: catalog/allowlist truth, AGENTS.md, dead CSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,6 @@ Thumbs.db
 !.agents/commands/
 !.agents/commands/*.md
 .gstack/
-AGENTS.md
 
 # --- Node ---
 node_modules/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# AGENTS.md
+
+Agents working in this repo: read [`CLAUDE.md`](CLAUDE.md) — it is the
+full operating guide (pipeline architecture, workflows, output
+locations, authentication, and the load-bearing rules). This file is a
+short pointer plus the few genuinely agent-specific notes.
+
+## Agent-specific notes
+
+- **Claude workflows** use `anthropics/claude-code-action@v1`. Pass the
+  model via `claude_args`, never as a separate `model:` input:
+
+  ```yaml
+  # Correct (v1)
+  claude_args: "--model opus"
+
+  # Wrong (do not use a separate model input here)
+  model: <versioned-model-name>
+  ```
+
+  Reference: https://code.claude.com/docs/en/github-actions
+  (action repo: https://github.com/anthropics/claude-code-action)
+
+- **bird CLI** invocations must always pass `--json --plain` and fall
+  back gracefully (`|| echo "[]"`); the X/Twitter cookies expire and a
+  workflow must continue with empty data rather than crash.
+
+- Everything else — runner choice, the ARA DSL compile/validate
+  contract, model-ticket and wiki CRUD protocols, telemetry, atomic
+  writes — is documented in `CLAUDE.md`. Follow that.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,8 @@ and opens a PR with methodology fixes.
 | Path | What it is |
 |---|---|
 | [`ARA_DSL.md`](ARA_DSL.md) | Source format for generative-research articles. The compiler at `scripts/compile_ara.py` turns `.ara.md` into a validated `<article>` fragment. |
-| [`COMPONENTS.md`](COMPONENTS.md) | Reference for the `ara-*` component vocabulary the validator enforces. The CSS at `dashboard/src/components/ara-research.css` is the live source of truth — currently ~113 classes vs ~81 documented (see "Known drift" below). |
+| [`COMPONENTS.md`](COMPONENTS.md) | Human reference for the `ara-*` component vocabulary. The machine-readable contract the validator loads is [`ARA_CATALOG.json`](ARA_CATALOG.json); the two are kept in lockstep (CI-enforced — see "Component catalog" below). The CSS at `dashboard/src/components/ara-research.css` is the rendering source of truth and intentionally carries *more* `ara-*` classes than the article allowlist (runtime + front-page layers). |
+| [`ARA_CATALOG.json`](ARA_CATALOG.json) | Machine-readable ara-* component catalog the validator loads its class allowlist from. `scripts/ara_catalog.py` validates it stays in lockstep with COMPONENTS.md (CI-enforced; see "Component catalog" below). |
 | [`docs/generative-research-backends.md`](docs/generative-research-backends.md) | Backend matrix for the generative-research lane (Claude vs DeepSeek vs local Oracle), env mapping, comparison commands. |
 | [`docs/model-tickets.md`](docs/model-tickets.md) | Schema + lifecycle + dedup protocol for `research/models/tickets/*.md`. Read by the CRUD agent in `24h-model-timeline.yml` and enforced by `scripts/check_model_tickets.py`. |
 | [`docs/wiki-schema.md`](docs/wiki-schema.md) | Canonical schema + page conventions for the LLM Wiki (`research/wiki/`). Read at runtime by the ingest agent in `wiki-ingest.yml` and enforced by `scripts/check_wiki.py`. |
@@ -46,7 +47,7 @@ and opens a PR with methodology fixes.
 | Script | Purpose |
 |---|---|
 | `compile_ara.py` | `.ara.md` → validated HTML fragment. |
-| `decompile_ara.py` | HTML fragment → `.ara.md` source (round-trip). |
+| `ara_catalog.py` | Loads + validates `ARA_CATALOG.json` (the validator's class allowlist) and checks it stays in lockstep with COMPONENTS.md. `uv run python scripts/ara_catalog.py` (exit 0 = in sync); CI runs the same check via `test_ara_dsl.py`. |
 | `check_generative_research.py` | Pre-commit validator. Tag/class allowlist + optional `--diversity-min`, `--callout-max`, `--strict-shape` design gates. Exit 0 = safe to commit. |
 | `write_generative_research.py` | Single publisher for `research/generative/`. Validates body, writes HTML + DSL source, updates `index.json`, commits. |
 | `run_generative_research_oracle.py` | Local runner: bundles ARA docs + recent research, calls `../oracle` (GPT-5.5 Pro), extracts `.ara.md`, runs the validator with `--diversity-min 3 --callout-max 5 --strict-shape`, then hands to the writer. |
@@ -58,7 +59,25 @@ and opens a PR with methodology fixes.
 | `check_wiki.py` | Validator for `research/wiki/` pages against the schema in `docs/wiki-schema.md`. `uv run python scripts/check_wiki.py` (exit 0 = safe); `--lint` adds advisory checks. The ingest agent in `wiki-ingest.yml` runs it until exit 0; CI runs it on every PR. |
 | `wiki_search.py` | Search wrapper over `research/wiki/` (`uv run python scripts/wiki_search.py "<query>"`). The ingest agent runs it before writing any page so it UPDATEs an existing page instead of duplicating. |
 | `check_lane_freshness.py` | Freshness watchdog. Measures git-commit recency per research lane against per-lane cadence thresholds; exits 2 (and emits a hooker/Telegram alert from `liveness-check.yml`) when a lane is stale. Stdlib-only so it runs on both runner tiers. |
-| `test_ara_dsl.py`, `test_dedupe_headline_alerts.py` | Pytest-style tests run in CI. |
+| `build_wiki_index.py` | Rebuilds `research/wiki/index.json` from the wiki pages. **CI-load-bearing**: `ci.yml` runs `--check` (exit 1 if the committed index is stale or any page fails validation); `wiki-ingest.yml` regenerates it every run. |
+| `fetch_ai_blogs.py` | Per-feed AI-blog fetcher used by `daily-ai-blogs.yml`; boundary-handles bad feeds so one failure doesn't crash the run. |
+| `source_cache.py` | Runtime primary-source fetch cache under `data/source-cache/` (gitignored), used by `generative-research.yml`. |
+| `render_front_page.mjs` | Puppeteer/Chrome renderer for the daily newspaper PNG, used by `daily-front-page.yml`. |
+| `test_ara_dsl.py`, `test_dedupe_headline_alerts.py` | Pytest-style tests run in CI. (`test_ara_dsl.py` also asserts `ARA_CATALOG.json` ↔ `COMPONENTS.md` lockstep.) |
+
+#### Experimental / manually-run scripts (NOT in the automated pipeline)
+
+These exist in `scripts/` but are referenced by **zero** workflows — they
+are run by hand, not on a schedule. Tested and functional, but not
+pipeline code; don't assume the dashboard or any lane depends on them.
+
+| Script | Purpose |
+|---|---|
+| `generate_generative_article_audio.py` | Backfill TTS audio for a generative article (Gemini Flash TTS / Vertex). Run manually; needs `GEMINI_API_KEY`. |
+| `collect_viral_tweets.py`, `analyze_viral_tweets.py` | Viral-tweet collection + analysis. Write `research/twitter-viral/`. |
+| `analyze_overperformance.py`, `enrich_overperformance.py`, `experiment_overperf_cv.py` | Tweet-overperformance analysis / enrichment / cross-validation experiments. |
+| `enrich_bookmarks.py` | Enrich a bookmark export with engagement/features. |
+| `tweet_content.py`, `tweet_features.py`, `tweet_virality_verifier.py` | Tweet content/feature extraction + virality scoring helpers used by the viral/overperf cluster. |
 
 ## GitHub Actions Workflows
 
@@ -189,6 +208,7 @@ research/
 ├── twitter-deepseek/          # hourly-twitter.yml backend=deepseek-claude-code
 ├── twitter-deepseek-pi/       # hourly-twitter.yml backend=deepseek-pi
 ├── twitter-fireworks-pi/      # hourly-twitter.yml backend=fireworks-pi
+├── twitter-viral/             # experimental viral/overperf cluster (manual; see Scripts)
 └── wiki/                      # wiki-ingest.yml (compounding LLM knowledge base)
     ├── index.md                # entry point / page directory
     ├── log.md                  # append-only ingest log (one entry per run)
@@ -208,8 +228,11 @@ Secrets are configured in GitHub Actions. None are committed.
 | `FIREWORKS_API_KEY` | `generative-research backend=deepseek-v4-flash`; all `hourly-twitter.yml` non-claude lanes (`deepseek-claude-code`, `deepseek-pi`, `fireworks-pi`) | Required for the DeepSeek-V4-Flash-via-Fireworks and Kimi lanes. |
 | `BIRD_AUTH_TOKEN`, `BIRD_CT0` | All bird-CLI workflows (`hourly-twitter*`, `24h-model-timeline`) | X/Twitter cookies. |
 | `EXA_API_KEY`, `PERPLEXITY_API_KEY` | `daily-digest`, `ai-news-research`, `research-issue` | Optional; enhance MCP search. |
+| `GEMINI_API_KEY` | `daily-digest` (inline Gemini Flash TTS for digest audio); also the manual `generate_generative_article_audio.py` | Optional; without it, audio generation is skipped. |
 | `HOOKER_TOKEN` | Telemetry composite action | Optional; without it, telemetry steps no-op. |
+| `HOOKER_URL` | Hooker telemetry composite + most workflows (the hooker endpoint, distinct from `HOOKER_TOKEN`) | The `https://hooker.guzus.xyz`-style base URL the telemetry/alert steps POST to. Referenced widely across workflows/actions. |
 | `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID` | `hourly-twitter*` | For headline alert delivery. |
+| `VERCEL_DEPLOY_HOOK` | `24h-model-timeline`, `wiki-ingest` | Optional; belt-and-suspenders deploy trigger. When unset, the lane relies on Vercel's GitHub auto-deploy on push. |
 | `GITHUB_TOKEN` | All workflows | Auto-provided. |
 
 ## Load-bearing Rules
@@ -217,22 +240,28 @@ Secrets are configured in GitHub Actions. None are committed.
 These are the conventions that, if broken, will silently corrupt
 output or break the pipeline. Read them before editing.
 
-1. **ARA DSL round-trip is mandatory.** Every commit to
+1. **ARA DSL compile + validate is mandatory.** Every commit to
    `research/generative/` must go through
    `scripts/compile_ara.py` (`.ara.md` → HTML) and pass
    `scripts/check_generative_research.py` (tag/class allowlist plus
    optional `--diversity-min`, `--callout-max`, `--strict-shape`
    design gates). `scripts/write_generative_research.py` is the
    **only** committer for that directory — it re-validates at write
-   time. Workflows that bypass the writer will fail review.
+   time and persists the `.ara.md` source verbatim alongside the
+   generated HTML (there is no decompile step; the source is the
+   committed `.ara.md`, not something regenerated from the HTML).
+   Workflows that bypass the writer will fail review.
 
 2. **The validator is exact-match.** Class tokens must start with
-   `ara-` *and* be documented in `COMPONENTS.md` (or be a valid
-   `--variant` suffix of a documented class). Tags outside the
-   allowlist (`<style>`, `<script>`, `<iframe>`, `<h1>`, inline
-   `style=`, `on*=`, `javascript:` URLs) are rejected. Reach for
-   `:::raw` only when the DSL genuinely can't express the shape;
-   invented classes still fail.
+   `ara-` *and* be a base class in `ARA_CATALOG.json` (or be a valid
+   `--variant` suffix of a cataloged base class). The allowlist is
+   loaded from `ARA_CATALOG.json` (via `scripts/ara_catalog.py`), NOT
+   parsed from `COMPONENTS.md` — `COMPONENTS.md` is the human reference
+   kept in lockstep with the catalog (CI-enforced; see "Component
+   catalog"). Tags outside the allowlist (`<style>`, `<script>`,
+   `<iframe>`, `<h1>`, inline `style=`, `on*=`, `javascript:` URLs) are
+   rejected. Reach for `:::raw` only when the DSL genuinely can't
+   express the shape; invented classes still fail.
 
 3. **Dashboard deploys are git-push driven.** Vercel watches `main`
    and rebuilds on every push (root `dashboard/`). There is no
@@ -354,15 +383,42 @@ output or break the pipeline. Read them before editing.
   `env:` rather than direct `${{ }}` interpolation in `run:` blocks
   to avoid script-injection.
 
-## Known Drift
+## Component catalog
 
-- `dashboard/src/components/ara-research.css` defines ~113 `ara-*`
-  classes; `COMPONENTS.md` documents ~81. If you encounter an
-  undocumented `ara-*` class in a real article, grep the CSS (it's the
-  live source of truth) and add the missing primitive to
-  `COMPONENTS.md` in the same PR. The validator's allowlist comes from
-  `COMPONENTS.md`, so an undocumented class will be rejected at commit
-  time regardless of whether the CSS supports it.
+The article-fragment class allowlist lives in **`ARA_CATALOG.json`**
+(73 base `ara-*` classes). The validator
+(`scripts/check_generative_research.py` → `write_generative_research.py`
+→ `ara_catalog.load_catalog`/`catalog_classes`) loads its allowlist from
+that file, NOT from `COMPONENTS.md`. `COMPONENTS.md` is the human
+reference and documents the **same 73** classes;
+`scripts/ara_catalog.py` (`validate_catalog_against_components`) asserts
+the two stay in perfect lockstep and CI enforces it via
+`test_ara_dsl.py`. To add a new primitive, add it to BOTH files in the
+same PR (and ship the matching CSS); a class present in one but not the
+other fails CI.
+
+The CSS intentionally defines **more** `ara-*` classes than the article
+allowlist. The extra classes are NOT drift and are NOT a commit-time
+rejection risk — they belong to layers that live outside the
+article-fragment contract on purpose:
+
+- `dashboard/src/components/ara-research.css` defines ~98 base `ara-*`
+  classes total: the 73 cataloged article primitives (`ara-doc`,
+  `ara-callout`, `ara-figure`, …) that DO appear in `.ara.md` and ARE the
+  allowlist, **plus** ~25 **runtime/interactive extras** — table-of-
+  contents, figure lightbox, chart tooltips/axes/series (e.g.
+  `ara-chart-series-*`, built at `main.ts` ~line 3311) — injected by
+  `dashboard/src/main.ts` at runtime. The runtime extras never appear in
+  `.ara.md` source, so they don't need to be in the allowlist.
+- **Front-page template classes** (`ara-paper-*`, styled in
+  `dashboard/src/style.css`) used by the daily-front-page newspaper
+  render, which is its own template, not an ARA article.
+
+So a higher CSS class count than `COMPONENTS.md`/`ARA_CATALOG.json` is
+expected. Only worry about an undocumented class if it appears in an
+*article fragment* — and then the fix is to add it to both
+`ARA_CATALOG.json` and `COMPONENTS.md`, not to the CSS (the CSS may
+already have it).
 
 ## Historical Docs
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ flowchart TB
 
 | Source | Method | Frequency | Real-time? |
 |--------|--------|-----------|------------|
-| **Twitter/X** | bird CLI (33 accounts + 7 searches) | Every 3 hours | ✅ Yes |
+| **Twitter/X** | bird CLI (75 accounts + 7 searches) | Every 3 hours | ✅ Yes |
 | **RSS Feeds** | Direct XML fetch | Hourly | ✅ Yes |
 | **Bluesky** | Public API | Daily | ✅ Yes |
 | **Reddit** | RSS feeds | Every 4 hours | ✅ Yes |
@@ -124,7 +124,7 @@ gantt
 | `4h-community.yml` | Every 4 hours | Reddit RSS + HN MCP | `research/community/` |
 | `daily-arxiv.yml` | Daily 06:13 UTC | arXiv papers | `research/arxiv/` |
 | `daily-digest.yml` | Daily 00:00 UTC | All sources + MCP search | `research/digest/` |
-| `hourly-twitter.yml` (matrix) | claude tier every 3h (`:07`), deepseek-claude-code tier every 6h (`:37`), deepseek-pi and fireworks-pi tiers manual | Twitter/X via bird CLI (50+ accounts, 7 search queries) | `research/twitter/` (claude) + `research/twitter-deepseek/` (Claude Code) + `research/twitter-deepseek-pi/` (pi) + `research/twitter-fireworks-pi/` (Fireworks pi) |
+| `hourly-twitter.yml` (matrix) | claude tier every 3h (`:07`), deepseek-claude-code tier every 6h (`:37`), deepseek-pi and fireworks-pi tiers manual | Twitter/X via bird CLI (75 accounts, 7 search queries) | `research/twitter/` (claude) + `research/twitter-deepseek/` (Claude Code) + `research/twitter-deepseek-pi/` (pi) + `research/twitter-fireworks-pi/` (Fireworks pi) |
 | `ai-news-research.yml` | Twice daily (08:23, 20:23 UTC) | Perplexity/Exa MCP | `research/` |
 | `daily-improve.yml` | Daily 00:17 UTC | Self-improvement | PRs with improvements |
 | `research-issue.yml` | On issue label | Deep research on any topic | `research/issues/` |
@@ -283,7 +283,7 @@ dashboard/                          # Vite + Bun + TypeScript SPA
 ## Data Source Details
 
 ### Twitter/X (Every 3 hours)
-Via [bird CLI](https://github.com/steipete/bird) — 33 monitored accounts, 20 tweets each, 7 search queries.
+Via [bird CLI](https://github.com/steipete/bird) — 75 monitored accounts, 20 tweets each, 7 search queries.
 
 **AI Labs & Companies (11):**
 OpenAI, Anthropic, Google AI, DeepMind, Mistral, Meta AI, Cohere, AI21Labs, Stability AI, Hugging Face, NVIDIA AI Dev

--- a/dashboard/src/components/ara-research.css
+++ b/dashboard/src/components/ara-research.css
@@ -12,7 +12,7 @@
  *              ara-h2 (+ ara-h2-num), ara-h3, ara-h4, ara-divider
  *   Blocks:    ara-callout (+ --info|success|warn|danger),
  *              ara-callout-label, ara-quote, ara-quote-attr,
- *              ara-figure, ara-caption, ara-code
+ *              ara-figure, ara-caption
  *   Data:      ara-kv (with dt/dd inside), ara-stats, ara-stat,
  *              ara-stat-label, ara-stat-value, ara-stat-note,
  *              ara-table
@@ -687,8 +687,7 @@ body.ara-figure-modal-open {
 }
 
 /* ── Code ────────────────────────────────────────── */
-.ara-doc code,
-.ara-code {
+.ara-doc code {
   font-family: var(--font-mono);
   font-size: 0.86em;
   background: var(--bg-secondary);
@@ -708,8 +707,7 @@ body.ara-figure-modal-open {
   line-height: 1.55;
 }
 
-.ara-doc pre code,
-.ara-doc pre .ara-code {
+.ara-doc pre code {
   background: none;
   padding: 0;
   font-size: inherit;
@@ -1986,7 +1984,6 @@ body.ara-figure-modal-open {
   }
 
   .ara-callout,
-  .ara-card,
   .ara-quote,
   .ara-stat,
   .ara-stat-unit,

--- a/scripts/check_generative_research.py
+++ b/scripts/check_generative_research.py
@@ -2,9 +2,12 @@
 """Compile-check a generative research article body without committing.
 
 Runs the same validation rules write_generative_research.py enforces at
-commit time — tag allowlist, ara-* exact-match class allowlist parsed
-from COMPONENTS.md (modifier suffixes allowed), size cap, no inline
-style/script/JS handlers, opening/closing <article> structure.
+commit time — tag allowlist, ara-* exact-match class allowlist loaded
+from ARA_CATALOG.json (modifier suffixes allowed), size cap, no inline
+style/script/JS handlers, opening/closing <article> structure. The
+allowlist comes from ARA_CATALOG.json via write_generative_research's
+load_valid_classes(); COMPONENTS.md is the human reference kept in
+lockstep with the catalog (CI-enforced via ara_catalog.py).
 
 Optional design-system enforcement flags (off by default so check
 stays additive):


### PR DESCRIPTION
Make the docs match the code after verifying every claim against the source (counts measured, scripts/secrets grepped, build + tests run).

## Catalog / allowlist truth (was the misleading "Known Drift")
- The validator's class allowlist loads from **`ARA_CATALOG.json`** (73 base classes) via `write_generative_research.load_valid_classes()` — **not** parsed from `COMPONENTS.md`. `COMPONENTS.md` is the human reference kept in **perfect lockstep** (73 = 73), CI-enforced by `ara_catalog.validate_catalog_against_components` + `test_ara_dsl.py`.
- Rewrote `## Known Drift` → `## Component catalog`; fixed the stale `~113 vs ~81` + "live source of truth" doc-table row (l.34) and Rule 2 ("documented in COMPONENTS.md" → ARA_CATALOG.json). Added an `ARA_CATALOG.json` doc-table row + `ara_catalog.py` Scripts row.
- The CSS legitimately carries more `ara-*` classes: `ara-research.css` has ~98 base selectors = the 73 cataloged primitives **plus** ~25 runtime/interactive extras (TOC, lightbox, chart series like `ara-chart-series-*` injected by `main.ts`); the front-page `ara-paper-*` template lives in `style.css`. These are intentionally outside the article-fragment allowlist — not drift, not a rejection risk.
- `scripts/check_generative_research.py` docstring corrected to say the allowlist comes from `ARA_CATALOG.json` (docstring/comment only — **no logic change**).

## Dead CSS removal
- `ara-card` and `ara-code` have **zero** references outside `ara-research.css` and are absent from the catalog. Removed them, collapsing the two grouped code selectors so the live `.ara-doc code` / `.ara-doc pre code` rules survive. `bun run build` confirms inline-code styling intact and both classes absent from the bundle.

## decompile_ara.py (does not exist)
- Removed the Scripts-table row; softened Rule 1 "round-trip mandatory" → "compile + validate" (the `.ara.md` source is persisted verbatim by the writer; there is no decompile step).

## AGENTS.md (was corrupted + gitignored)
- Replaced the botched Claude→"Codex" find/replace with a short accurate pointer to `CLAUDE.md` (correct `anthropics/claude-code-action@v1` refs, verified doc URLs) and removed `AGENTS.md` from `.gitignore` so fresh clones track it.

## Table / output drift
- Authentication: added `HOOKER_URL`, `GEMINI_API_KEY` (optional), `VERCEL_DEPLOY_HOOK` (optional).
- Scripts: added `build_wiki_index.py` (**CI-load-bearing** via `--check`), `fetch_ai_blogs.py`, `source_cache.py`, `render_front_page.mjs`; added an "Experimental / manually-run" subsection for the audio + viral/overperf cluster (referenced by zero workflows).
- Output Locations: added `research/twitter-viral/`.
- README: reconciled the Twitter account count (was "33" twice, "50+" once) to the **verified 75** monitored handles (13 labs + 11 hyperscalers + 51 others in `.github/actions/twitter-fetch`); kept the verified "20 tweets each, 7 search queries".

## Validation
- `uv run python scripts/ara_catalog.py` → `OK: 73 ARA classes`, exit 0.
- `bun install --frozen-lockfile && bun run build` → succeeds (CSS bundle clean; live code selectors present, dead classes gone).
- `uv run python -m unittest discover -s scripts -p 'test_*.py'` → 227 tests OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)