### PR TITLE
Observability: content quality gate + dual-channel alerts + heartbeat

### DIFF
--- a/.github/actions/lane-content-alert/action.yml
+++ b/.github/actions/lane-content-alert/action.yml
@@ -1,0 +1,129 @@
+name: Lane content quality gate (advisory)
+description: >-
+  Run the advisory content/volume gate (scripts/check_lane_content.py): inspect
+  the most recent artifact in each research lane and flag anomalously small or
+  collapsed output that recency alone would miss (e.g. expired Twitter cookies →
+  bird returns [] → lane commits a husk → freshness stays green). On an anomaly
+  it alerts via hooker AND a direct Telegram fallback. Sibling to
+  lane-freshness-alert; stdlib Python only so it runs on both runner tiers. This
+  action NEVER fails the job — content anomalies are advisory; freshness remains
+  the hard gate.
+
+inputs:
+  hooker_url:
+    description: Hooker base URL. Hooker alert skipped if empty.
+    required: false
+    default: ""
+  hooker_token:
+    description: Hooker bearer token. Hooker alert skipped if empty.
+    required: false
+    default: ""
+  topic:
+    description: Hooker topic that relays to Telegram.
+    required: false
+    default: ara-research
+  telegram_bot_token:
+    description: Telegram bot token for the direct fallback channel. Skipped if empty.
+    required: false
+    default: ""
+  telegram_chat_id:
+    description: Telegram chat id for the direct fallback channel. Skipped if empty.
+    required: false
+    default: ""
+
+outputs:
+  anomaly:
+    description: "'true' when one or more lanes are content-anomalous."
+    value: ${{ steps.check.outputs.anomaly }}
+  anomalous_lanes:
+    description: Comma-separated anomalous lane names.
+    value: ${{ steps.check.outputs.anomalous_lanes }}
+
+runs:
+  using: composite
+  steps:
+    # Advisory: the script exits 0 even on an anomaly (no --exit-code), writing
+    # anomaly / anomalous_lanes / idempotency_key / report to $GITHUB_OUTPUT and
+    # a table to the step summary. `|| true` is belt-and-suspenders so this step
+    # can never fail the job even if the script hits an internal error.
+    - name: Check lane content
+      id: check
+      shell: bash
+      run: python3 scripts/check_lane_content.py || true
+
+    # ── Channel 1: hooker (relays to Telegram). Lower priority than the
+    #    freshness alert (3 vs 5): this is advisory, not "pipeline down". ─────
+    - name: Alert via hooker (relays to Telegram)
+      if: steps.check.outputs.anomaly == 'true'
+      shell: bash
+      continue-on-error: true
+      env:
+        HOOKER_URL: ${{ inputs.hooker_url }}
+        HOOKER_TOKEN: ${{ inputs.hooker_token }}
+        TOPIC: ${{ inputs.topic }}
+        ANOMALOUS_LANES: ${{ steps.check.outputs.anomalous_lanes }}
+        IDEMPOTENCY_KEY: ${{ steps.check.outputs.idempotency_key }}
+        REPO: ${{ github.repository }}
+        SERVER: ${{ github.server_url }}
+        RUN_ID: ${{ github.run_id }}
+      run: |
+        set -euo pipefail
+        if [ -z "${HOOKER_URL:-}" ] || [ -z "${HOOKER_TOKEN:-}" ]; then
+          echo "Hooker credentials missing — skipping hooker content alert (Telegram fallback still applies)"
+          exit 0
+        fi
+        count=$(printf '%s' "$ANOMALOUS_LANES" | tr ',' '\n' | grep -c . || true)
+        SAFE_LANES=$(printf '%s' "$ANOMALOUS_LANES" \
+          | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g')
+        TEXT=$(printf 'Content anomaly in lanes: %s\n\nThese lanes committed on time but the latest artifact is anomalously small or collapsed vs its trailing median — a likely silent upstream/source failure (e.g. expired Twitter cookies, a dead feed). Advisory: the pipeline is still running, but this output may be empty/garbage.' "$SAFE_LANES")
+        RUN_URL="${SERVER%/}/${REPO}/actions/runs/${RUN_ID}"
+        jq -n \
+          --arg title "🟠 ARA content: ${count} lane(s) anomalous (advisory)" \
+          --arg text "$TEXT" \
+          --arg btn "Inspect (Actions run)" \
+          --arg url "$RUN_URL" \
+          '{
+            title: $title,
+            text: $text,
+            priority: 3,
+            tags: ["ara", "advisory", "content"],
+            parse_mode: "HTML",
+            reply_markup: { inline_keyboard: [[{ text: $btn, url: $url }]] }
+          }' > "${RUNNER_TEMP:-/tmp}/hooker-lane-content.json"
+        curl -sS --fail-with-body -X POST "${HOOKER_URL%/}/publish/${TOPIC}" \
+          -H "Authorization: Bearer ${HOOKER_TOKEN}" \
+          -H "Content-Type: application/json" \
+          -H "Idempotency-Key: ${IDEMPOTENCY_KEY}" \
+          --data-binary "@${RUNNER_TEMP:-/tmp}/hooker-lane-content.json"
+
+    # ── Channel 2: direct Telegram fallback (bypasses hooker). ──────────────
+    - name: Alert via Telegram (direct fallback)
+      if: steps.check.outputs.anomaly == 'true'
+      shell: bash
+      continue-on-error: true
+      env:
+        TELEGRAM_BOT_TOKEN: ${{ inputs.telegram_bot_token }}
+        TELEGRAM_CHAT_ID: ${{ inputs.telegram_chat_id }}
+        ANOMALOUS_LANES: ${{ steps.check.outputs.anomalous_lanes }}
+        REPO: ${{ github.repository }}
+        SERVER: ${{ github.server_url }}
+        RUN_ID: ${{ github.run_id }}
+      run: |
+        set -euo pipefail
+        if [ -z "${TELEGRAM_BOT_TOKEN:-}" ] || [ -z "${TELEGRAM_CHAT_ID:-}" ]; then
+          echo "Telegram credentials missing — skipping direct Telegram content fallback"
+          exit 0
+        fi
+        count=$(printf '%s' "$ANOMALOUS_LANES" | tr ',' '\n' | grep -c . || true)
+        RUN_URL="${SERVER%/}/${REPO}/actions/runs/${RUN_ID}"
+        TEXT=$(printf '🟠 ARA content anomaly (advisory): %s lane(s)\n\nLanes: %s\n\nCommitted on time but the latest artifact is anomalously small / collapsed vs median — likely a silent source failure (expired cookies, dead feed). Pipeline still running; output may be empty.\n\n[Inspect](%s)' \
+          "$count" "$ANOMALOUS_LANES" "$RUN_URL")
+        if curl -sS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+          --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
+          --data-urlencode "text=${TEXT}" \
+          -d "parse_mode=Markdown" \
+          -d "disable_web_page_preview=true" >/dev/null; then
+          echo "Telegram content fallback sent"
+        else
+          echo "Telegram content fallback send failed (non-blocking)"
+        fi

--- a/.github/actions/lane-freshness-alert/action.yml
+++ b/.github/actions/lane-freshness-alert/action.yml
@@ -1,42 +1,62 @@
 name: Lane freshness alert
 description: >-
   Check research-lane freshness (git-commit recency vs per-lane cadence) and,
-  on staleness, alert via hooker (relays to Telegram) and fail the job. Stdlib
-  Python only, so it runs identically on ubuntu-latest and the self-hosted
-  runner. Intended to be invoked from both tiers so the watchdog survives
-  whichever tier an outage takes down.
+  on staleness, alert via hooker (relays to Telegram) AND a direct Telegram
+  fallback, then fail the job. Stdlib Python only, so it runs identically on
+  ubuntu-latest and the self-hosted runner. Intended to be invoked from both
+  tiers so the watchdog survives whichever tier an outage takes down. The dual
+  alert channel (hooker + direct Telegram) means a hooker outage / rotated
+  token no longer blackholes the alert.
 
 inputs:
   hooker_url:
-    description: Hooker base URL (e.g. https://hooker.guzus.xyz). Alert is skipped if empty.
+    description: Hooker base URL (e.g. https://hooker.guzus.xyz). Hooker alert skipped if empty.
     required: false
     default: ""
   hooker_token:
-    description: Hooker bearer token. Alert is skipped if empty.
+    description: Hooker bearer token. Hooker alert skipped if empty.
     required: false
     default: ""
   topic:
     description: Hooker topic that relays to Telegram.
     required: false
     default: ara-research
+  telegram_bot_token:
+    description: Telegram bot token for the direct fallback channel. Telegram alert skipped if empty.
+    required: false
+    default: ""
+  telegram_chat_id:
+    description: Telegram chat id for the direct fallback channel. Telegram alert skipped if empty.
+    required: false
+    default: ""
+
+outputs:
+  stale:
+    description: "'true' when one or more lanes are stale (lets the caller gate a heartbeat)."
+    value: ${{ steps.check.outputs.stale }}
+  stale_lanes:
+    description: Comma-separated stale lane names.
+    value: ${{ steps.check.outputs.stale_lanes }}
 
 runs:
   using: composite
   steps:
     # The script writes stale / stale_lanes / idempotency_key / report to
     # $GITHUB_OUTPUT (registered as this step's outputs) and a table to the
-    # job step summary. `|| true` keeps this step green so the alert step can
-    # still fire on staleness; the explicit "Fail if stale" step sets the
-    # job's final red status. (Avoids relying on composite continue-on-error.)
+    # job step summary. `|| true` keeps this step green so the alert steps can
+    # still fire on staleness; the explicit "Fail if stale" step (LAST) sets
+    # the job's final red status. (Avoids relying on composite continue-on-error.)
     - name: Check lane freshness
       id: check
       shell: bash
       run: python3 scripts/check_lane_freshness.py || true
 
-    # Loud alert that reaches a human. Idempotency-Key is a per-day hash over
-    # the stale set, so the ubuntu-latest and self-hosted jobs (and repeat runs
-    # the same day) collapse to a single delivered message; a change in the
-    # stale set produces a new key and re-alerts.
+    # ── Channel 1: hooker (relays to Telegram) ─────────────────────────────
+    # Idempotency-Key is a per-day hash over the stale set, so the ubuntu-latest
+    # and self-hosted jobs (and repeat runs the same day) collapse to a single
+    # delivered message; a change in the stale set produces a new key and
+    # re-alerts. continue-on-error so a hooker outage cannot fail the job and
+    # cannot prevent the Telegram fallback below from firing.
     - name: Alert via hooker (relays to Telegram)
       if: steps.check.outputs.stale == 'true'
       shell: bash
@@ -52,7 +72,7 @@ runs:
       run: |
         set -euo pipefail
         if [ -z "${HOOKER_URL:-}" ] || [ -z "${HOOKER_TOKEN:-}" ]; then
-          echo "Hooker credentials missing — skipping alert (staleness still fails the job)"
+          echo "Hooker credentials missing — skipping hooker alert (Telegram fallback + staleness fail still apply)"
           exit 0
         fi
         count=$(printf '%s' "$STALE_LANES" | tr ',' '\n' | grep -c . || true)
@@ -81,6 +101,53 @@ runs:
           -H "Idempotency-Key: ${IDEMPOTENCY_KEY}" \
           --data-binary "@${RUNNER_TEMP:-/tmp}/hooker-lane-freshness.json"
 
+    # ── Channel 2: direct Telegram fallback (bypasses hooker entirely) ──────
+    # Independent of hooker so a hooker outage / rotated HOOKER_TOKEN cannot
+    # blackhole the alert. Mirrors the proven sendMessage call in
+    # daily-digest.yml (endpoint, --data-urlencode, parse_mode=Markdown,
+    # disable_web_page_preview). The two watchdog tiers can each send one
+    # Telegram message here — an acceptable belt-and-suspenders for the failure
+    # mode we are guarding (better a duplicate page than a missed outage).
+    # continue-on-error so a malformed/limited send can never fail the job.
+    - name: Alert via Telegram (direct fallback)
+      if: steps.check.outputs.stale == 'true'
+      shell: bash
+      continue-on-error: true
+      env:
+        TELEGRAM_BOT_TOKEN: ${{ inputs.telegram_bot_token }}
+        TELEGRAM_CHAT_ID: ${{ inputs.telegram_chat_id }}
+        STALE_LANES: ${{ steps.check.outputs.stale_lanes }}
+        REPO: ${{ github.repository }}
+        SERVER: ${{ github.server_url }}
+        RUN_ID: ${{ github.run_id }}
+      run: |
+        set -euo pipefail
+        if [ -z "${TELEGRAM_BOT_TOKEN:-}" ] || [ -z "${TELEGRAM_CHAT_ID:-}" ]; then
+          echo "Telegram credentials missing — skipping direct Telegram fallback"
+          exit 0
+        fi
+        count=$(printf '%s' "$STALE_LANES" | tr ',' '\n' | grep -c . || true)
+        RUN_URL="${SERVER%/}/${REPO}/actions/runs/${RUN_ID}"
+        # Plain text + a Markdown link. Lane names are a controlled allowlist
+        # (no Markdown metacharacters), so keeping the body metachar-free is
+        # what prevents a silent Telegram parse error under continue-on-error.
+        TEXT=$(printf '🚨 ARA pipeline: %s lane(s) STALE\n\nStale lanes: %s\n\nNo commit within the expected cadence — likely a workflow outage (check GitHub Actions billing/spending limit + the self-hosted runner).\n\n[Investigate](%s)' \
+          "$count" "$STALE_LANES" "$RUN_URL")
+        if curl -sS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+          --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
+          --data-urlencode "text=${TEXT}" \
+          -d "parse_mode=Markdown" \
+          -d "disable_web_page_preview=true" >/dev/null; then
+          echo "Telegram fallback sent"
+        else
+          echo "Telegram fallback send failed (non-blocking)"
+        fi
+
+    # MUST remain the LAST step: it is the only step allowed to exit non-zero.
+    # Any step placed after it would be skipped on stale days (GHA skips
+    # subsequent steps once one fails without continue-on-error), which is why
+    # the alert channels above run first and why the heartbeat is wired in the
+    # caller AFTER this action with an `if: stale == 'false'` guard.
     - name: Fail if stale
       if: steps.check.outputs.stale == 'true'
       shell: bash

--- a/.github/actions/liveness-heartbeat/action.yml
+++ b/.github/actions/liveness-heartbeat/action.yml
@@ -1,0 +1,79 @@
+name: Liveness heartbeat (dead-man's switch)
+description: >-
+  Emit a tiny success "the watchdog ran and the pipeline is healthy" ping to
+  hooker on every healthy liveness run. This is the dead-man's-switch half of
+  the watchdog: the freshness/content alerts fire when something is WRONG, but
+  if the whole watchdog stops running (or hooker itself goes silent) there is no
+  alert to miss — so a downstream monitor that expects this heartbeat on a fixed
+  cadence can detect the watchdog's / hooker's OWN silence. Caller gates this on
+  freshness `stale == 'false'` so a "down" pipeline never emits an "alive" ping.
+  NEVER fails the job (telemetry semantics, Rule 4). NOTE: a heartbeat *to*
+  hooker cannot detect hooker's own silence by itself — that detection lives in
+  whatever downstream consumes the heartbeat.
+
+inputs:
+  hooker_url:
+    description: Hooker base URL. Heartbeat skipped if empty.
+    required: false
+    default: ""
+  hooker_token:
+    description: Hooker bearer token. Heartbeat skipped if empty.
+    required: false
+    default: ""
+  topic:
+    description: >-
+      Hooker topic for the heartbeat. Defaults to ara-telemetry (not the
+      alerting topic) so the heartbeat does not relay to the human Telegram
+      channel as a notification.
+    required: false
+    default: ara-telemetry
+
+runs:
+  using: composite
+  steps:
+    - name: Heartbeat ping to hooker
+      shell: bash
+      continue-on-error: true
+      env:
+        HOOKER_URL: ${{ inputs.hooker_url }}
+        HOOKER_TOKEN: ${{ inputs.hooker_token }}
+        TOPIC: ${{ inputs.topic }}
+        REPO: ${{ github.repository }}
+        SERVER: ${{ github.server_url }}
+        RUN_ID: ${{ github.run_id }}
+        JOB: ${{ github.job }}
+      run: |
+        set -euo pipefail
+        if [ -z "${HOOKER_URL:-}" ] || [ -z "${HOOKER_TOKEN:-}" ]; then
+          echo "Hooker credentials missing — skipping heartbeat (non-blocking)"
+          exit 0
+        fi
+        # Per-day + per-tier idempotency so the two tiers (ubuntu + self-hosted)
+        # and any repeat runs collapse to one heartbeat marker per tier per day —
+        # a downstream monitor only needs to see "at least one tier checked in
+        # today", and dedup keeps hooker history clean.
+        DATE=$(date -u +%Y-%m-%d)
+        KEY="ara-liveness-heartbeat-${DATE}-${JOB}"
+        RUN_URL="${SERVER%/}/${REPO}/actions/runs/${RUN_ID}"
+        jq -n \
+          --arg title "💓 ARA liveness heartbeat (${JOB})" \
+          --arg text "Watchdog ran and all lanes are fresh. If this heartbeat stops arriving on its ~6h cadence, the liveness watchdog or hooker itself has gone silent." \
+          --arg run "$RUN_URL" \
+          --arg tier "$JOB" \
+          --arg date "$DATE" \
+          '{
+            title: $title,
+            text: $text,
+            priority: 1,
+            tags: ["ara", "heartbeat", "liveness"],
+            payload: { kind: "liveness-heartbeat", tier: $tier, date: $date, run_url: $run }
+          }' > "${RUNNER_TEMP:-/tmp}/hooker-heartbeat.json"
+        if curl -sS --fail-with-body -X POST "${HOOKER_URL%/}/publish/${TOPIC}" \
+          -H "Authorization: Bearer ${HOOKER_TOKEN}" \
+          -H "Content-Type: application/json" \
+          -H "Idempotency-Key: ${KEY}" \
+          --data-binary "@${RUNNER_TEMP:-/tmp}/hooker-heartbeat.json"; then
+          echo "Heartbeat sent (${KEY})"
+        else
+          echo "Heartbeat send failed (non-blocking)"
+        fi

--- a/.github/workflows/liveness-check.yml
+++ b/.github/workflows/liveness-check.yml
@@ -1,9 +1,21 @@
 name: Pipeline Liveness Check
 
-# Freshness watchdog that makes silent pipeline outages loud. For each
-# scheduled research lane it measures git-commit recency against a per-lane
-# cadence threshold (see scripts/check_lane_freshness.py) and, on staleness,
-# alerts via hooker (relays to Telegram) AND fails the job.
+# Freshness + content watchdog that makes silent pipeline outages loud. For
+# each scheduled research lane it:
+#   1. (advisory) checks CONTENT — is the most recent artifact anomalously
+#      small / collapsed vs its trailing median? (scripts/check_lane_content.py)
+#      A lane can commit on time yet emit a husk (expired bird cookies → [] →
+#      near-empty file). This never fails the job; it just alerts.
+#   2. checks FRESHNESS — git-commit recency vs a per-lane cadence threshold
+#      (scripts/check_lane_freshness.py); on staleness it alerts AND fails.
+#   3. (healthy runs only) emits a HEARTBEAT — a dead-man's-switch success ping
+#      so the watchdog's / hooker's OWN silence becomes detectable downstream.
+#
+# Alerts now go out over TWO independent channels: hooker (relays to Telegram)
+# AND a direct Telegram sendMessage. Previously hooker was a single point of
+# failure for all alerting — a hooker outage / rotated token silently
+# black-holed every alert (Rule 4 makes telemetry non-blocking). The direct
+# Telegram fallback closes that gap.
 #
 # Two-tier by design. No single runner survives both failure modes:
 #   - A GitHub Actions billing/spending-limit block kills *ubuntu-latest*
@@ -12,12 +24,20 @@ name: Pipeline Liveness Check
 #     ubuntu-only watchdog was killed by the same block.
 #   - A self-hosted runner outage kills the *self-hosted* tier.
 # So we run the identical check on BOTH tiers: whichever tier is alive does
-# the alerting. The alert goes out over hooker (an external endpoint), NOT via
-# GitHub's native workflow-failure email — that email requires the job to run,
-# which is exactly what a billing block prevents.
+# the alerting. The alert goes out over hooker + direct Telegram (external
+# endpoints), NOT via GitHub's native workflow-failure email — that email
+# requires the job to run, which is exactly what a billing block prevents.
 #
-# Alerts dedupe via a per-day Idempotency-Key over the stale set, so the two
-# jobs (and repeat runs) collapse to one Telegram message per stale set per day.
+# Alerts dedupe via per-day Idempotency-Keys over the anomalous/stale set, so
+# the two jobs (and repeat runs) collapse to one message per set per day.
+#
+# Step ORDERING is load-bearing: the freshness action ends with a `Fail if
+# stale` step that exits non-zero. GHA skips later steps in a job once a step
+# fails without continue-on-error, so:
+#   - the content gate runs BEFORE freshness (so a stale day can't skip it);
+#   - the heartbeat runs AFTER freshness but is guarded by stale == 'false'
+#     (a stale/down pipeline must not emit an "alive" ping anyway, so being
+#     skipped on stale days is the desired behavior).
 
 on:
   schedule:
@@ -42,9 +62,32 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0   # git log needs full history; depth:1 breaks it
-          lfs: false       # we only read commit metadata, not file contents
+          lfs: false       # commit metadata + non-LFS text artifacts only
+
+      # Advisory content/volume gate FIRST (never fails the job, and must not
+      # be skipped on a stale day — hence ahead of the freshness fail step).
+      - name: Content quality gate (advisory) + alert on anomaly
+        uses: ./.github/actions/lane-content-alert
+        with:
+          hooker_url: ${{ secrets.HOOKER_URL }}
+          hooker_token: ${{ secrets.HOOKER_TOKEN }}
+          telegram_bot_token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          telegram_chat_id: ${{ secrets.TELEGRAM_CHAT_ID }}
+
+      # Freshness check + dual-channel alert; its final step fails on staleness.
       - name: Check freshness + alert on staleness
+        id: freshness
         uses: ./.github/actions/lane-freshness-alert
+        with:
+          hooker_url: ${{ secrets.HOOKER_URL }}
+          hooker_token: ${{ secrets.HOOKER_TOKEN }}
+          telegram_bot_token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          telegram_chat_id: ${{ secrets.TELEGRAM_CHAT_ID }}
+
+      # Dead-man's-switch heartbeat — only on a healthy (non-stale) run.
+      - name: Heartbeat (healthy runs only)
+        if: steps.freshness.outputs.stale == 'false'
+        uses: ./.github/actions/liveness-heartbeat
         with:
           hooker_url: ${{ secrets.HOOKER_URL }}
           hooker_token: ${{ secrets.HOOKER_TOKEN }}
@@ -61,8 +104,27 @@ jobs:
         with:
           fetch-depth: 0
           lfs: false
+
+      - name: Content quality gate (advisory) + alert on anomaly
+        uses: ./.github/actions/lane-content-alert
+        with:
+          hooker_url: ${{ secrets.HOOKER_URL }}
+          hooker_token: ${{ secrets.HOOKER_TOKEN }}
+          telegram_bot_token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          telegram_chat_id: ${{ secrets.TELEGRAM_CHAT_ID }}
+
       - name: Check freshness + alert on staleness
+        id: freshness
         uses: ./.github/actions/lane-freshness-alert
+        with:
+          hooker_url: ${{ secrets.HOOKER_URL }}
+          hooker_token: ${{ secrets.HOOKER_TOKEN }}
+          telegram_bot_token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          telegram_chat_id: ${{ secrets.TELEGRAM_CHAT_ID }}
+
+      - name: Heartbeat (healthy runs only)
+        if: steps.freshness.outputs.stale == 'false'
+        uses: ./.github/actions/liveness-heartbeat
         with:
           hooker_url: ${{ secrets.HOOKER_URL }}
           hooker_token: ${{ secrets.HOOKER_TOKEN }}

--- a/scripts/check_lane_content.py
+++ b/scripts/check_lane_content.py
@@ -1,0 +1,456 @@
+#!/usr/bin/env python3
+"""Pipeline content/volume quality gate (advisory).
+
+The freshness watchdog (scripts/check_lane_freshness.py) answers "did this
+lane commit recently?" — but a lane can commit *on time* and still be
+broken: bird cookies expire, an upstream feed 500s, an agent emits an empty
+shell. The lane writes a near-empty file, the commit lands, freshness stays
+green, and the digest synthesizes from nothing. Nothing alerts.
+
+This script closes that gap. For each lane it inspects the MOST RECENT
+artifact on disk and flags it when it is anomalously small relative to the
+lane's own history. Two independent, deliberately conservative checks:
+
+  1. Absolute floor (`min_bytes`): the latest artifact is smaller than a
+     hard per-lane floor. The floors sit *well below* every legitimately
+     committed day we have on record (see the calibration note on each
+     lane), so a genuinely quiet day never trips this — only a near-empty
+     or `[]`-shaped artifact does.
+
+  2. Relative drop: the latest artifact is below `drop_ratio` of the
+     trailing MEDIAN of the previous N artifacts AND below a soft floor
+     (`min_bytes * soft_floor_mult`). Median (not mean) is used because
+     real lanes are extremely bursty — twitter ranges 1.7KB–318KB, rss
+     1.1KB–392KB day to day — and a mean is dragged around by those spikes.
+     The two conditions are ANDed: a lane only flags when output has both
+     collapsed relative to typical *and* fallen into "suspiciously small"
+     territory. A quiet-but-normal day (e.g. bluesky dropping to a third of
+     its median) clears the soft floor and is NOT flagged.
+
+Why this design avoids alert fatigue:
+  - Findings are ADVISORY. The script exits 0 even when it flags something
+    (unless `--exit-code` is passed); the workflow routes anomalies to the
+    alert channel without failing the job. Freshness remains the hard gate.
+  - Empirically tuned: with the shipped defaults, a backtest over the full
+    research/ history flags only the handful of genuinely near-dead days
+    (rss at 4% of median, bluesky at 2-3%) and zero normal days.
+  - The drop check needs `--history-min` (default 4) prior samples before it
+    will fire, so a brand-new or sparse lane is never flagged on thin data.
+
+Like the freshness watchdog this is stdlib-only, so it runs identically on
+both the ubuntu-latest and self-hosted runner tiers. It reads files from the
+working tree (the checkout the watchdog already has), not git history, so it
+does not need full history or LFS blobs. (All inspected artifacts are
+non-LFS text — the front-page lane deliberately reads the `.html` render, not
+the LFS-tracked `.png`, so `lfs: false` checkouts still see real bytes.)
+
+Known limitations (conscious MVP scope):
+  - The gate measures BYTES, not item/line counts. It cannot catch a
+    "template present but zero items" artifact that still clears the byte
+    floor (e.g. a digest with section headers but no stories). Byte volume is
+    a strong, cheap proxy that catches the dominant failure mode (empty/[]
+    output); an item-count check could be layered on per lane later.
+  - The wiki lane is effectively floor-only (log.md only ever grows, so the
+    relative-drop arm is disabled). It catches a truncated/empty log, not a
+    semantically-garbage ingest — acceptable given the CRUD-not-regenerate
+    wiki semantics, where bytes are not a reliable signal of ingest quality.
+  - The watchdog inspects the working-tree copy of *today's* file for
+    sub-daily lanes (rss/twitter/community), which is partially accumulated.
+    Verified non-issue: the schedule (00/06/12/18 UTC) means the 00:00 run
+    predates today's first sub-daily write, and every lane's first daily cycle
+    already commits well above its soft floor (twitter ~12KB, rss/community
+    ~2.6KB vs soft floors 1.8KB/1.2KB), so a partial-day file never trips the
+    drop arm.
+
+Exit codes:
+  0  default — even when anomalies are found (advisory). Anomalies are still
+     surfaced via $GITHUB_OUTPUT (`anomaly=true`) and the step summary.
+  2  one or more lanes anomalous, AND --exit-code was passed.
+  1  internal error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import statistics
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Callable, Optional
+
+
+@dataclass(frozen=True)
+class LaneSpec:
+    """Per-lane content policy.
+
+    glob:           shell glob (relative to repo root) selecting the lane's
+                    canonical *primary* artifact across all dates. The most
+                    recent match (lexical sort — the YYYY-MM-DD prefix makes
+                    this chronological) is the artifact under inspection.
+    min_bytes:      hard floor. Below this the latest artifact is flagged
+                    regardless of history. Set below every real committed day.
+    drop_ratio:     latest < drop_ratio * trailing-median triggers the
+                    relative-drop arm (when also below the soft floor).
+    soft_floor_mult: soft floor = min_bytes * this. The relative-drop arm
+                    only fires when latest is ALSO below this, so a large lane
+                    halving on a quiet day does not page.
+    """
+
+    glob: str
+    min_bytes: int
+    drop_ratio: float = 0.10
+    soft_floor_mult: float = 3.0
+
+
+# Per-lane content policy. Floors are calibrated from the real history in
+# research/ (the inline "obs min" is the smallest legitimately committed
+# artifact seen for that lane; the floor sits comfortably under it). The
+# lane set mirrors check_lane_freshness.py: on-demand lanes (generative,
+# issues) and experimental A/B lanes (twitter-deepseek*, twitter-fireworks*)
+# are excluded — they have no steady cadence, so "small" is not a signal.
+LANE_SPECS: dict[str, LaneSpec] = {
+    # hourly RSS roundup.            obs min ~1.1KB
+    "rss": LaneSpec("research/rss/[0-9]*.md", min_bytes=400),
+    # 3-hourly twitter report.       obs min ~1.7KB; hugely bursty (→318KB)
+    "twitter": LaneSpec("research/twitter/[0-9]*.md", min_bytes=600),
+    # 4-hourly community (HN is the canonical primary; reddit runs parallel).
+    #                                obs min ~1.5KB
+    "community": LaneSpec("research/community/[0-9]*-hn.md", min_bytes=400),
+    # twice-daily bluesky.           obs min ~165B (genuinely thin some days)
+    "bluesky": LaneSpec("research/bluesky/[0-9]*.md", min_bytes=80),
+    # daily arxiv papers.            obs min ~6KB
+    "arxiv": LaneSpec("research/arxiv/[0-9]*-papers.md", min_bytes=1500),
+    # daily synthesized digest.      obs min ~8.4KB
+    "digest": LaneSpec("research/digest/[0-9]*-digest.md", min_bytes=2000),
+    # daily model-timeline diff.     obs min ~455B (slow news days)
+    "models": LaneSpec("research/models/[0-9]*-timeline.md", min_bytes=150),
+    # daily front-page (HTML render is the stable text artifact; the PNG can
+    # be an LFS pointer on read-only checkouts so we avoid it). obs min ~6.5KB
+    "front-page": LaneSpec("research/front-page/[0-9]*-front-page.html", min_bytes=1500),
+    # daily wiki ingest. The per-page slugs are CRUD'd (an UPDATE may not grow
+    # bytes), but log.md is append-only — one entry per run — so it is the
+    # reliable "the ingest ran and did something" signal. It only ever grows,
+    # so the relative-drop arm is disabled (drop_ratio=0) and only the floor
+    # applies.
+    "wiki": LaneSpec("research/wiki/log.md", min_bytes=300, drop_ratio=0.0),
+}
+
+HEALTHY = "healthy"
+EMPTY = "empty"          # below the absolute floor
+DROP = "drop"            # collapsed vs trailing median
+MISSING = "missing"      # no artifact found at all
+INSUFFICIENT = "insufficient-history"  # too few samples to judge a drop
+
+# States that should route an alert.
+ANOMALOUS_STATES = frozenset({EMPTY, DROP, MISSING})
+
+
+@dataclass
+class LaneContent:
+    lane: str
+    spec: LaneSpec
+    artifact: Optional[str]          # basename of the inspected artifact
+    size: Optional[int]              # bytes of the latest artifact
+    median: Optional[float]          # trailing median of prior samples
+    sample_count: int                # number of prior samples available
+    state: str
+    detail: str = ""
+    ratio: Optional[float] = field(default=None)
+
+    @property
+    def anomalous(self) -> bool:
+        return self.state in ANOMALOUS_STATES
+
+
+def lane_artifact_sizes(spec: LaneSpec, repo_root: str) -> list[tuple[str, int]]:
+    """All artifacts matching the lane glob, oldest→newest, as (basename, bytes).
+
+    Lexical sort is chronological because every artifact name is
+    `YYYY-MM-DD-...` (or, for wiki, a single fixed file). Symlinks and
+    non-files are skipped defensively.
+    """
+    pattern = os.path.join(repo_root, spec.glob)
+    out: list[tuple[str, int]] = []
+    for path in sorted(glob.glob(pattern)):
+        if not os.path.isfile(path):
+            continue
+        try:
+            out.append((os.path.basename(path), os.path.getsize(path)))
+        except OSError:
+            continue
+    return out
+
+
+def classify(
+    sizes: list[tuple[str, int]],
+    spec: LaneSpec,
+    *,
+    history_min: int,
+    trailing_n: int,
+) -> LaneContent:
+    """Pure classification over a list of (name, size) samples for one lane.
+
+    Kept free of IO so it is trivially unit-testable; lane_artifact_sizes is
+    the injectable IO seam used by callers and tests. The lane name is filled
+    in by the caller (evaluate) after construction.
+    """
+    if not sizes:
+        return LaneContent(
+            lane="", spec=spec, artifact=None, size=None, median=None,
+            sample_count=0, state=MISSING, detail="no artifact matched glob",
+        )
+
+    latest_name, latest_size = sizes[-1]
+    prior = [s for _, s in sizes[:-1]]
+    trail = prior[-trailing_n:]
+    median = statistics.median(trail) if trail else None
+    soft_floor = spec.min_bytes * spec.soft_floor_mult
+    ratio = (latest_size / median) if median else None
+
+    # 1) Absolute floor — the strongest signal, evaluated first and
+    #    independent of history. A truly empty / `[]`-shaped artifact.
+    if latest_size < spec.min_bytes:
+        return LaneContent(
+            lane="", spec=spec, artifact=latest_name, size=latest_size,
+            median=median, sample_count=len(trail), state=EMPTY, ratio=ratio,
+            detail=f"{latest_size}B < floor {spec.min_bytes}B",
+        )
+
+    # 2) Relative drop — only when we have enough history to trust a median,
+    #    the lane opts in (drop_ratio > 0), and the artifact is BOTH a small
+    #    fraction of typical AND below the soft floor.
+    if (
+        spec.drop_ratio > 0
+        and median is not None
+        and len(trail) >= history_min
+        and latest_size < spec.drop_ratio * median
+        and latest_size < soft_floor
+    ):
+        return LaneContent(
+            lane="", spec=spec, artifact=latest_name, size=latest_size,
+            median=median, sample_count=len(trail), state=DROP, ratio=ratio,
+            detail=(
+                f"{latest_size}B is {ratio:.0%} of trailing median "
+                f"{median:.0f}B (< {spec.drop_ratio:.0%}) and < soft floor "
+                f"{soft_floor:.0f}B"
+            ),
+        )
+
+    # Healthy, but note when we simply lacked the history to judge a drop so
+    # the report is honest rather than implying we checked.
+    if spec.drop_ratio > 0 and len(trail) < history_min:
+        state = INSUFFICIENT
+        detail = f"{latest_size}B (only {len(trail)} prior sample(s); drop check skipped)"
+    else:
+        state = HEALTHY
+        detail = f"{latest_size}B" + (f" ({ratio:.0%} of median)" if ratio else "")
+
+    return LaneContent(
+        lane="", spec=spec, artifact=latest_name, size=latest_size,
+        median=median, sample_count=len(trail), state=state, ratio=ratio,
+        detail=detail,
+    )
+
+
+def evaluate(
+    specs: dict[str, LaneSpec],
+    repo_root: str,
+    *,
+    history_min: int = 4,
+    trailing_n: int = 8,
+    sizes_fn: Callable[[LaneSpec, str], list[tuple[str, int]]] = lane_artifact_sizes,
+) -> list[LaneContent]:
+    """Evaluate every configured lane. sizes_fn is injectable so the logic can
+    be unit-tested without a real repository (mirrors check_lane_freshness.py's
+    age_fn/dir_exists_fn pattern)."""
+    results: list[LaneContent] = []
+    for lane, spec in specs.items():
+        sizes = sizes_fn(spec, repo_root)
+        status = classify(sizes, spec, history_min=history_min, trailing_n=trailing_n)
+        status.lane = lane
+        results.append(status)
+    return results
+
+
+def _fmt_bytes(n: Optional[float]) -> str:
+    if n is None:
+        return "?"
+    n = float(n)
+    if n < 1024:
+        return f"{n:.0f}B"
+    if n < 1024 * 1024:
+        return f"{n / 1024:.1f}KB"
+    return f"{n / (1024 * 1024):.1f}MB"
+
+
+def format_report(statuses: list[LaneContent]) -> str:
+    """Markdown-friendly table. Anomalous lanes first."""
+    icon = {
+        HEALTHY: "✅",
+        EMPTY: "🔴",
+        DROP: "🟠",
+        MISSING: "❓",
+        INSUFFICIENT: "⚪",
+    }
+    order = {EMPTY: 0, DROP: 1, MISSING: 2, INSUFFICIENT: 3, HEALTHY: 4}
+    rows = sorted(statuses, key=lambda s: (order.get(s.state, 9), s.lane))
+    lines = ["| lane | state | latest | median | detail |", "|---|---|---|---|---|"]
+    for s in rows:
+        lines.append(
+            f"| `{s.lane}` | {icon.get(s.state, '?')} {s.state} "
+            f"| {_fmt_bytes(s.size)} | {_fmt_bytes(s.median)} | {s.detail} |"
+        )
+    return "\n".join(lines)
+
+
+def idempotency_key(anomalous_lanes: list[str], now: datetime) -> str:
+    """Stable per-day key over the anomalous set, so the same anomaly reported
+    by both the ubuntu-latest and self-hosted watchdog jobs (and by repeat runs
+    the same day) collapses to a single delivered alert. A change in the
+    anomalous set produces a new key. Mirrors check_lane_freshness.idempotency_key
+    with a distinct prefix so content and freshness alerts never collide."""
+    date = now.strftime("%Y-%m-%d")
+    part = "-".join(sorted(anomalous_lanes)) if anomalous_lanes else "none"
+    return f"lane-content-{date}-{part}"
+
+
+def _emit_github_output(anomalous_lanes: list[str], report: str, key: str) -> None:
+    out_path = os.environ.get("GITHUB_OUTPUT")
+    if not out_path:
+        return
+    anomaly = "true" if anomalous_lanes else "false"
+    delim = "__ARA_CONTENT_REPORT_EOF__"
+    with open(out_path, "a", encoding="utf-8") as fh:
+        fh.write(f"anomaly={anomaly}\n")
+        fh.write(f"anomalous_lanes={','.join(sorted(anomalous_lanes))}\n")
+        fh.write(f"idempotency_key={key}\n")
+        fh.write(f"report<<{delim}\n{report}\n{delim}\n")
+
+
+def _emit_step_summary(report: str, anomalous_lanes: list[str]) -> None:
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    header = (
+        f"### 🟠 Lane content: {len(anomalous_lanes)} lane(s) anomalous (advisory)\n\n"
+        if anomalous_lanes
+        else "### ✅ Lane content: all lanes look healthy\n\n"
+    )
+    with open(summary_path, "a", encoding="utf-8") as fh:
+        fh.write(header + report + "\n")
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Research lane content/volume quality gate (advisory).",
+    )
+    parser.add_argument(
+        "--now",
+        help="ISO-8601 UTC timestamp for the idempotency key (default: now). For testing.",
+    )
+    parser.add_argument(
+        "--repo",
+        default=None,
+        help="Repository root (default: git toplevel of CWD, else CWD).",
+    )
+    parser.add_argument(
+        "--trailing-n",
+        type=int,
+        default=8,
+        help="How many prior artifacts to take the median over (default: 8).",
+    )
+    parser.add_argument(
+        "--history-min",
+        type=int,
+        default=4,
+        help="Minimum prior samples before the drop check fires (default: 4).",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of a table.")
+    parser.add_argument(
+        "--exit-code",
+        action="store_true",
+        help="Exit 2 when any lane is anomalous (default: always exit 0 — advisory).",
+    )
+    args = parser.parse_args(argv)
+
+    if args.now:
+        raw = args.now[:-1] + "+00:00" if args.now.endswith("Z") else args.now
+        try:
+            now_dt = datetime.fromisoformat(raw)
+        except ValueError:
+            print(f"error: --now is not a valid ISO-8601 timestamp: {args.now}", file=sys.stderr)
+            return 1
+        if now_dt.tzinfo is None:
+            now_dt = now_dt.replace(tzinfo=timezone.utc)
+    else:
+        now_dt = datetime.now(timezone.utc)
+
+    repo_root = args.repo
+    if repo_root is None:
+        import subprocess
+
+        try:
+            top = subprocess.run(
+                ["git", "rev-parse", "--show-toplevel"],
+                capture_output=True, text=True, check=True,
+            ).stdout.strip()
+            repo_root = top or os.getcwd()
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            repo_root = os.getcwd()
+
+    statuses = evaluate(
+        LANE_SPECS,
+        repo_root,
+        history_min=args.history_min,
+        trailing_n=args.trailing_n,
+    )
+    anomalous_lanes = [s.lane for s in statuses if s.anomalous]
+    report = format_report(statuses)
+    key = idempotency_key(anomalous_lanes, now_dt)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "now": now_dt.isoformat(),
+                    "anomalous_lanes": sorted(anomalous_lanes),
+                    "idempotency_key": key,
+                    "lanes": [
+                        {
+                            "lane": s.lane,
+                            "state": s.state,
+                            "artifact": s.artifact,
+                            "size": s.size,
+                            "median": s.median,
+                            "sample_count": s.sample_count,
+                            "ratio": s.ratio,
+                            "detail": s.detail,
+                        }
+                        for s in statuses
+                    ],
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(report)
+
+    _emit_github_output(anomalous_lanes, report, key)
+    _emit_step_summary(report, anomalous_lanes)
+
+    if anomalous_lanes:
+        print(
+            f"\n::warning::content anomaly in lane(s): {', '.join(sorted(anomalous_lanes))} "
+            "(advisory — does not fail the job)",
+            file=sys.stderr,
+        )
+        return 2 if args.exit_code else 0
+    print("\nall lanes look healthy", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_check_lane_content.py
+++ b/scripts/test_check_lane_content.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+
+import check_lane_content as clc
+
+
+def _spec(min_bytes=400, drop_ratio=0.10, soft_floor_mult=3.0, glob="research/x/[0-9]*.md"):
+    return clc.LaneSpec(
+        glob=glob,
+        min_bytes=min_bytes,
+        drop_ratio=drop_ratio,
+        soft_floor_mult=soft_floor_mult,
+    )
+
+
+def _series(sizes, prefix="2026-01-"):
+    """Build an oldest->newest (name, size) list from a list of byte sizes."""
+    return [(f"{prefix}{i + 1:02d}.md", s) for i, s in enumerate(sizes)]
+
+
+class ClassifyTest(unittest.TestCase):
+    def test_no_artifact_is_missing(self):
+        status = clc.classify([], _spec(), history_min=4, trailing_n=8)
+        self.assertEqual(status.state, clc.MISSING)
+        self.assertTrue(status.anomalous)
+
+    def test_empty_artifact_below_floor_is_flagged(self):
+        # Plenty of healthy history, then a near-empty latest file.
+        sizes = _series([10000, 11000, 9000, 12000, 10500, 9800, 11200, 50])
+        status = clc.classify(sizes, _spec(min_bytes=400), history_min=4, trailing_n=8)
+        self.assertEqual(status.state, clc.EMPTY)
+        self.assertTrue(status.anomalous)
+        self.assertEqual(status.size, 50)
+
+    def test_empty_floor_fires_even_without_history(self):
+        # A floor breach is independent of history — no prior samples needed.
+        status = clc.classify(_series([20]), _spec(min_bytes=400), history_min=4, trailing_n=8)
+        self.assertEqual(status.state, clc.EMPTY)
+        self.assertTrue(status.anomalous)
+
+    def test_healthy_artifact_not_flagged(self):
+        sizes = _series([10000, 11000, 9000, 12000, 10500, 9800, 11200, 10300])
+        status = clc.classify(sizes, _spec(min_bytes=400), history_min=4, trailing_n=8)
+        self.assertEqual(status.state, clc.HEALTHY)
+        self.assertFalse(status.anomalous)
+
+    def test_sudden_drop_flagged(self):
+        # ~10KB typical, latest collapses to 900B: ABOVE the 400B floor (so it
+        # is not caught as EMPTY) but only ~9% of the median AND below the soft
+        # floor (400 * 3 = 1200). This is the "lane still committed something,
+        # but it's a near-dead husk" shape the relative arm exists to catch.
+        sizes = _series([10000, 11000, 9000, 12000, 10500, 9800, 11200, 900])
+        status = clc.classify(sizes, _spec(min_bytes=400), history_min=4, trailing_n=8)
+        self.assertEqual(status.state, clc.DROP)
+        self.assertTrue(status.anomalous)
+        self.assertLess(status.size, status.median)
+
+    def test_floor_takes_precedence_over_drop(self):
+        # When a collapse is severe enough to breach the floor too, the
+        # stronger EMPTY signal wins (floor is checked first).
+        sizes = _series([10000, 11000, 9000, 12000, 10500, 9800, 11200, 100])
+        status = clc.classify(sizes, _spec(min_bytes=400), history_min=4, trailing_n=8)
+        self.assertEqual(status.state, clc.EMPTY)
+        self.assertTrue(status.anomalous)
+
+    def test_quiet_but_normal_day_not_flagged(self):
+        # bluesky-shaped: median ~8KB, latest drops to ~1.3KB (a real quiet
+        # day). That is 16% of median — above the 10% drop ratio — AND well
+        # above the soft floor, so it must NOT page.
+        sizes = _series([8686, 4814, 2928, 2776, 2616, 9000, 8000, 1276])
+        status = clc.classify(sizes, _spec(min_bytes=80), history_min=4, trailing_n=8)
+        self.assertEqual(status.state, clc.HEALTHY)
+        self.assertFalse(status.anomalous)
+
+    def test_big_lane_halving_not_flagged(self):
+        # A large, bursty lane (twitter-shaped) halving from its median is
+        # normal variance — clears the soft floor, so not flagged.
+        sizes = _series([286736, 90434, 120884, 38290, 78832, 100000, 95000, 47000])
+        status = clc.classify(sizes, _spec(min_bytes=600), history_min=4, trailing_n=8)
+        self.assertEqual(status.state, clc.HEALTHY)
+        self.assertFalse(status.anomalous)
+
+    def test_drop_requires_below_soft_floor(self):
+        # Latest is < 10% of a huge median but ABOVE the soft floor: the AND
+        # condition is not met, so it is NOT a drop. (Guards against paging a
+        # big lane that merely shrank a lot but still produced real content.)
+        sizes = _series([100000, 100000, 100000, 100000, 100000, 100000, 100000, 2000])
+        status = clc.classify(sizes, _spec(min_bytes=400, soft_floor_mult=3.0),
+                              history_min=4, trailing_n=8)
+        # 2000 < 0.10*100000 (=10000) but 2000 > soft floor (1200) -> healthy.
+        self.assertEqual(status.state, clc.HEALTHY)
+        self.assertFalse(status.anomalous)
+
+    def test_insufficient_history_skips_drop(self):
+        # Only 2 prior samples (< history_min) and latest small-but-above-floor:
+        # we must not call it a drop on thin data.
+        sizes = _series([10000, 12000, 500])
+        status = clc.classify(sizes, _spec(min_bytes=400), history_min=4, trailing_n=8)
+        self.assertEqual(status.state, clc.INSUFFICIENT)
+        self.assertFalse(status.anomalous)
+
+    def test_insufficient_history_still_flags_floor(self):
+        # Thin history does not suppress the absolute floor.
+        sizes = _series([10000, 12000, 50])
+        status = clc.classify(sizes, _spec(min_bytes=400), history_min=4, trailing_n=8)
+        self.assertEqual(status.state, clc.EMPTY)
+        self.assertTrue(status.anomalous)
+
+    def test_drop_ratio_zero_disables_drop_arm(self):
+        # wiki-shaped: drop_ratio=0 means only the floor applies. A small but
+        # above-floor latest is healthy even if it collapsed vs history.
+        sizes = _series([10000, 11000, 9000, 12000, 10500, 9800, 11200, 400])
+        status = clc.classify(sizes, _spec(min_bytes=300, drop_ratio=0.0),
+                              history_min=4, trailing_n=8)
+        self.assertEqual(status.state, clc.HEALTHY)
+        self.assertFalse(status.anomalous)
+
+
+class EvaluateTest(unittest.TestCase):
+    def _evaluate_with(self, series_by_lane, specs=None):
+        specs = specs or {
+            "rss": _spec(min_bytes=400, glob="research/rss/[0-9]*.md"),
+            "twitter": _spec(min_bytes=600, glob="research/twitter/[0-9]*.md"),
+            "wiki": _spec(min_bytes=300, drop_ratio=0.0, glob="research/wiki/log.md"),
+            "gone": _spec(min_bytes=400, glob="research/gone/[0-9]*.md"),
+        }
+
+        def sizes_fn(spec, repo_root):
+            return series_by_lane.get(spec.glob, [])
+
+        return clc.evaluate(
+            specs,
+            repo_root="/nonexistent",
+            history_min=4,
+            trailing_n=8,
+            sizes_fn=sizes_fn,
+        )
+
+    def test_mixed_states(self):
+        statuses = self._evaluate_with(
+            {
+                # healthy
+                "research/rss/[0-9]*.md": _series(
+                    [10000, 11000, 9000, 12000, 10500, 9800, 11200, 10300]
+                ),
+                # sudden drop: still above the 600B floor but a husk (~900B
+                # vs ~100KB median) -> DROP, not EMPTY.
+                "research/twitter/[0-9]*.md": _series(
+                    [100000, 90000, 110000, 95000, 105000, 98000, 102000, 900]
+                ),
+                # wiki present and healthy
+                "research/wiki/log.md": [("log.md", 5000)],
+                # "gone" returns no files -> missing
+            }
+        )
+        by_lane = {s.lane: s for s in statuses}
+        self.assertEqual(by_lane["rss"].state, clc.HEALTHY)
+        self.assertEqual(by_lane["twitter"].state, clc.DROP)
+        self.assertEqual(by_lane["wiki"].state, clc.HEALTHY)
+        self.assertEqual(by_lane["gone"].state, clc.MISSING)
+
+        anomalous = sorted(s.lane for s in statuses if s.anomalous)
+        self.assertEqual(anomalous, ["gone", "twitter"])
+
+    def test_all_healthy(self):
+        statuses = self._evaluate_with(
+            {
+                "research/rss/[0-9]*.md": _series([10000] * 8),
+                "research/twitter/[0-9]*.md": _series([50000] * 8),
+                "research/wiki/log.md": [("log.md", 5000)],
+                "research/gone/[0-9]*.md": _series([10000] * 8),
+            }
+        )
+        self.assertEqual([s for s in statuses if s.anomalous], [])
+
+    def test_lane_label_is_attached(self):
+        statuses = self._evaluate_with(
+            {"research/rss/[0-9]*.md": _series([10000] * 8)}
+        )
+        # every status carries its configured lane key
+        self.assertEqual({s.lane for s in statuses}, {"rss", "twitter", "wiki", "gone"})
+
+
+class IdempotencyKeyTest(unittest.TestCase):
+    def setUp(self):
+        self.now = datetime(2026, 6, 10, 6, 0, tzinfo=timezone.utc)
+
+    def test_order_independent(self):
+        a = clc.idempotency_key(["twitter", "rss"], self.now)
+        b = clc.idempotency_key(["rss", "twitter"], self.now)
+        self.assertEqual(a, b)
+
+    def test_includes_date_and_set(self):
+        self.assertEqual(
+            clc.idempotency_key(["rss", "twitter"], self.now),
+            "lane-content-2026-06-10-rss-twitter",
+        )
+
+    def test_empty_set(self):
+        self.assertEqual(
+            clc.idempotency_key([], self.now),
+            "lane-content-2026-06-10-none",
+        )
+
+    def test_prefix_distinct_from_freshness(self):
+        # Content and freshness alerts must never collide on the dedup key.
+        self.assertTrue(clc.idempotency_key(["rss"], self.now).startswith("lane-content-"))
+
+
+class FilesystemIntegrationTest(unittest.TestCase):
+    """Exercises the real glob/stat IO path against a temp tree."""
+
+    def setUp(self):
+        self.repo = tempfile.mkdtemp(prefix="lane-content-")
+
+    def tearDown(self):
+        import shutil
+
+        shutil.rmtree(self.repo, ignore_errors=True)
+
+    def _write(self, rel, content):
+        path = os.path.join(self.repo, rel)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(content)
+
+    def test_picks_most_recent_and_measures_real_bytes(self):
+        # Two dated files; lexical max is the "latest".
+        self._write("research/rss/2026-06-08.md", "x" * 5000)
+        self._write("research/rss/2026-06-09.md", "y" * 4800)
+        spec = _spec(min_bytes=400, glob="research/rss/[0-9]*.md")
+        sizes = clc.lane_artifact_sizes(spec, self.repo)
+        self.assertEqual([n for n, _ in sizes], ["2026-06-08.md", "2026-06-09.md"])
+        self.assertEqual(sizes[-1], ("2026-06-09.md", 4800))
+
+    def test_empty_file_on_disk_flags_via_evaluate(self):
+        # Healthy history then an empty newest file -> EMPTY end to end.
+        for i in range(1, 9):
+            self._write(f"research/rss/2026-06-{i:02d}.md", "x" * 5000)
+        self._write("research/rss/2026-06-09.md", "")  # 0 bytes, newest
+        specs = {"rss": _spec(min_bytes=400, glob="research/rss/[0-9]*.md")}
+        statuses = clc.evaluate(specs, self.repo, history_min=4, trailing_n=8)
+        self.assertEqual(statuses[0].state, clc.EMPTY)
+
+    def test_no_dir_is_missing(self):
+        specs = {"bluesky": _spec(min_bytes=80, glob="research/bluesky/[0-9]*.md")}
+        statuses = clc.evaluate(specs, self.repo, history_min=4, trailing_n=8)
+        self.assertEqual(statuses[0].state, clc.MISSING)
+
+
+class RealRepoSmokeTest(unittest.TestCase):
+    """Print-only diagnostic against the live history.
+
+    Deliberately makes NO assertion on the live data. The content gate is
+    ADVISORY by contract — a genuinely near-empty lane day (e.g. an upstream
+    outage) is exactly when a real anomaly should surface, and this test runs
+    inside `unittest discover` on the self-hosted CI runner where research/ IS
+    present. Asserting `anomalous == []` here would turn the advisory gate into
+    a hard CI gate that fails every open PR on such a day — the opposite of the
+    design. Threshold validation lives in the offline dry-run
+    (`python scripts/check_lane_content.py`), not in CI. We only print the live
+    verdict so a human reading CI logs can eyeball it."""
+
+    def test_live_lanes_diagnostic_only(self):
+        import subprocess
+
+        try:
+            repo = subprocess.run(
+                ["git", "rev-parse", "--show-toplevel"],
+                capture_output=True, text=True, check=True,
+            ).stdout.strip()
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            self.skipTest("not in a git repo")
+
+        if not os.path.isdir(os.path.join(repo, "research", "rss")):
+            self.skipTest("research/ tree not present in this checkout")
+
+        statuses = clc.evaluate(clc.LANE_SPECS, repo)
+        anomalous = [f"{s.lane}:{s.state}" for s in statuses if s.anomalous]
+        # Print, never assert. (No failure, no flakiness gating CI on data.)
+        print(
+            "\n[lane-content live diagnostic] "
+            + ("all healthy" if not anomalous else "advisory anomalies: " + ", ".join(anomalous))
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

The pipeline's only health signal today is git-commit **recency**
(`check_lane_freshness.py`) routed through a **single** channel (hooker).
Two silent-failure gaps (from the 2026-06-10 audit, T1-1 + T1-2):

1. **A lane can commit on time and stay green while emitting empty/garbage.**
   Expired bird cookies → `bird ... || echo "[]"` → near-empty file → commit
   lands → freshness ✅ → digest synthesizes from nothing. Nothing alerts.
2. **Hooker is a single point of failure for *all* alerting.** Compute is
   dual-tier (ubuntu + self-hosted) but both tiers alert only via hooker with
   the same `HOOKER_TOKEN`. A pipeline outage *during* a hooker outage / after
   a token rotation is invisible.

## What

### 1. Content/volume quality gate (advisory) — `scripts/check_lane_content.py`
Inspects the **most recent artifact** per lane and flags it when:
- **Absolute floor**: below a per-lane byte floor (catches empty / `[]` output), or
- **Relative drop**: below `drop_ratio` (default 10%) of the trailing **median**
  of the prior N artifacts **AND** below a soft floor (`min_bytes * 3`).

**Why it won't false-positive (the explicit design goal):**
- **Median, not mean** — real lanes are extremely bursty (twitter 1.7KB–318KB,
  rss 1.1KB–392KB day to day); a mean is dragged around by spikes, a median
  isn't.
- **ANDed soft-floor** — a big lane halving on a quiet day clears the soft
  floor and is *not* flagged; only a collapse that is *both* a tiny fraction of
  typical *and* suspiciously small pages. (Verified: bluesky dropping to 33% of
  median today is correctly healthy.)
- **Backtested over the full `research/` history**: with shipped defaults the
  drop arm flags only the handful of genuinely near-dead days (rss 1/79 at 4%
  of median, bluesky 2/93 at 2–3%) and **zero** normal days.
- **Partial-day files verified safe**: the watchdog runs 00/06/12/18 UTC; the
  00:00 run predates today's first sub-daily write, and every sub-daily lane's
  first daily cycle already commits well above its soft floor (twitter ~12KB,
  rss/community ~2.6KB vs floors 1.8KB/1.2KB) — so a partially-accumulated file
  never trips the drop arm.
- **ADVISORY**: the script exits 0 even on an anomaly (`--exit-code` opts into
  exit 2 for non-watchdog use). Freshness stays the only hard gate.

Stdlib-only (runs on both runner tiers), injectable `sizes_fn`, mirrors
`check_lane_freshness.py`. **Dry-run against the live repo today: all lanes
healthy.** Tests (`scripts/test_check_lane_content.py`, 23 cases) cover empty
flagged, healthy not flagged, sudden drop flagged, quiet-but-normal NOT
flagged, floor-precedence, insufficient-history, and a print-only live
diagnostic (deliberately **non-asserting** so an advisory gate never becomes a
hard CI gate that fails PRs on a genuinely-empty day).

### 2. Second alert channel + heartbeat
- `lane-freshness-alert` now posts to **hooker AND a direct Telegram
  `sendMessage`** (mirrors the proven call in `daily-digest.yml`) — a hooker
  outage / rotated token no longer black-holes alerts. New `lane-content-alert`
  sibling routes content anomalies through the same two channels.
- `liveness-heartbeat`: dead-man's-switch success ping to hooker on healthy
  runs (per-day/per-tier idempotency) so the watchdog's/hooker's **own** silence
  is detectable by a downstream monitor.
- **All alert/heartbeat steps are non-blocking** (`continue-on-error`, Rule 4).
  **Step ordering preserves the invariant** that the only non-zero-exit step
  (`fail-if-stale`) is **last**: the content gate runs *before* it (so a stale
  day can't skip it), the heartbeat runs *after* it gated on `stale == 'false'`
  (a down pipeline must not emit an "alive" ping). **Two-tier (ubuntu +
  self-hosted) structure intact.**

## Files
- `scripts/check_lane_content.py` (new) · `scripts/test_check_lane_content.py` (new)
- `.github/actions/lane-content-alert/action.yml` (new) · `.github/actions/liveness-heartbeat/action.yml` (new)
- `.github/actions/lane-freshness-alert/action.yml` (Telegram fallback + `stale` output)
- `.github/workflows/liveness-check.yml` (wire content gate + heartbeat into both tiers)

## Validation
- `uv run python -m unittest discover -s scripts -p 'test_*.py'` → **250 OK** (23 new).
- `actionlint .github/workflows/liveness-check.yml` → clean; all 4 YAML files parse.
- `uv run python scripts/check_lane_content.py` (live dry-run) → all lanes healthy, exit 0.
- Advisory contract verified: anomaly → exit 0 by default, exit 2 with `--exit-code`.

## Known limitations (conscious MVP scope)
- Measures **bytes**, not item/line counts — can't catch "template present,
  zero items" that still clears the byte floor. Strong cheap proxy for the
  dominant empty-output failure mode; per-lane item checks can layer on later.
- The **wiki** lane is floor-only (`log.md` only grows) — catches a truncated
  log, not a semantically-garbage ingest. Defensible given CRUD-not-regenerate
  wiki semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)