### PR TITLE
Fix Railway Docker build: bun instead of npm ci (prod stale since #102)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,18 @@
-FROM node:22-alpine AS build
+FROM oven/bun:1-alpine AS build
 
 WORKDIR /app
 
-COPY dashboard/package*.json ./dashboard/
-RUN cd dashboard && npm ci
+# The dashboard's package manager is bun (package-lock.json was dropped in #102,
+# so `npm ci` can no longer run). Its pre/postbuild lifecycle scripts shell out
+# to `node` (node scripts/prebuild.mjs, postbuild-seo.mjs), so install nodejs too.
+RUN apk add --no-cache nodejs
+
+COPY dashboard/package.json dashboard/bun.lock ./dashboard/
+RUN cd dashboard && bun install --frozen-lockfile
 
 COPY . .
 
-RUN cd dashboard && SKIP_LFS_POINTERS=1 npm run build
+RUN cd dashboard && SKIP_LFS_POINTERS=1 bun run build
 
 FROM caddy:2-alpine
 


### PR DESCRIPTION
## Problem: production has been silently stale since #102

`ara.guzus.xyz` is served by **Railway** (Caddy container behind Cloudflare — `x-railway-edge` header), not Vercel as `CLAUDE.md` states. The root `Dockerfile` builds `dashboard/dist` and serves it.

The build step ran `npm ci`, which **requires `package-lock.json`** — but that file was deleted in **#102 (`2ab20be8`, "drop orphaned package-lock.json")** when the dashboard moved to bun. So every Railway build has hard-failed at the install step since then, freezing the live site at the last pre-#102 build.

**Impact:** live manifest's newest date is `2026-06-09`; today's pipeline output **and the dashboard security/quality fixes from #109/#110 are not live.** It went unnoticed because the freshness watchdog tracks *git-commit* recency (which is fine) — **deploy success is unmonitored.**

Repro of the break:
```
$ npm --prefix dashboard ci
npm error code EUSAGE
npm error The `npm ci` command can only install with an existing package-lock.json ...
```

## Fix

Build with **bun** (the dashboard's package manager since #102) instead of `npm ci`. `nodejs` is installed because the pre/postbuild lifecycle scripts shell out to `node` (`node scripts/prebuild.mjs`, `postbuild-seo.mjs`).

## Validation — real `docker build` (reproduces Railway's environment)

```
bun install --frozen-lockfile           -> ok
prebuild.mjs (manifest)                  -> ok (frontpage:14 today:93 audio:32 generative:42)
tsc --noEmit && vite build               -> ok (built in 167ms, index-ZtnKCB0K.css)
postbuild-seo.mjs                        -> ok (share image: .../2026-06-10-front-page.png)
COPY dist -> caddy /srv                  -> image built
```
The produced bundle contains **today's (2026-06-10) content** and reflects current `main` (0 `ara-card`/`ara-code` hits → #110 is in the build).

## Follow-ups (not in this PR)
- `CLAUDE.md` still says deploys are Vercel-driven — stale; the canonical host is Railway. Worth correcting.
- No **deploy-health** signal exists (a stale/failed deploy is invisible). Suggest a check comparing the live `manifest.json` date to `HEAD`.
- Decide whether to keep Railway or cut the domain over to Vercel (which `CLAUDE.md` already assumes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
