### PR TITLE
Docs hosting truth 2026-06-10: ara.guzus.xyz is served by Railway, not Vercel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ sources (Twitter/RSS/Bluesky/HN/Reddit/arXiv)
     → synthesis workflows (digest, news research, model timeline) read research/
     → output workflows (front-page, generative-research) produce shareable artifacts
     → dashboard prebuild copies research/* into dashboard/public/research/
-    → Vercel git integration auto-builds and deploys on every push to main
+    → Railway rebuilds the root Dockerfile image and deploys on every push to main
 ```
 
 Daily-improve runs at the tail of the cycle, reads yesterday's output,
@@ -38,7 +38,8 @@ and opens a PR with methodology fixes.
 | [`docs/wiki-schema.md`](docs/wiki-schema.md) | Canonical schema + page conventions for the LLM Wiki (`research/wiki/`). Read at runtime by the ingest agent in `wiki-ingest.yml` and enforced by `scripts/check_wiki.py`. |
 | [`docs/hooker-telemetry.md`](docs/hooker-telemetry.md) | Non-blocking telemetry route via `https://hooker.guzus.xyz` topic `ara-telemetry`. |
 | [`docs/archive/`](docs/archive/) | Historical improvement logs and superseded docs. |
-| `dashboard/` | Vite + Bun + TypeScript SPA. `prebuild.mjs` copies `research/*` into `public/research/` and emits `manifest.json`; Vercel auto-deploys on every push to `main`. |
+| `dashboard/` | Vite + Bun + TypeScript SPA. `prebuild.mjs` copies `research/*` into `public/research/` and emits `manifest.json`; Railway auto-deploys on every push to `main` (next row). |
+| [`Dockerfile`](Dockerfile) + [`Caddyfile`](Caddyfile) + [`railway.json`](railway.json) | The Railway deploy stack serving **ara.guzus.xyz** (behind Cloudflare — responses carry `x-railway-edge`). The root `Dockerfile` builds the dashboard with bun (`oven/bun:1-alpine`, plus `nodejs` for the pre/postbuild node scripts) and serves `dashboard/dist` with Caddy; `railway.json` pins the DOCKERFILE builder + `/` healthcheck. `dashboard/vercel.json` is the legacy Vercel config — Vercel no longer serves the domain (Load-bearing rule 3). |
 | `data/` | Static lookup data used by aggregation scripts. |
 | `research/` | All generated artifacts. Subdir map in "Output Locations" below. |
 
@@ -232,7 +233,7 @@ Secrets are configured in GitHub Actions. None are committed.
 | `HOOKER_TOKEN` | Telemetry composite action | Optional; without it, telemetry steps no-op. |
 | `HOOKER_URL` | Hooker telemetry composite + most workflows (the hooker endpoint, distinct from `HOOKER_TOKEN`) | The `https://hooker.guzus.xyz`-style base URL the telemetry/alert steps POST to. Referenced widely across workflows/actions. |
 | `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID` | `hourly-twitter*` | For headline alert delivery. |
-| `VERCEL_DEPLOY_HOOK` | `24h-model-timeline`, `wiki-ingest` | Optional; belt-and-suspenders deploy trigger. When unset, the lane relies on Vercel's GitHub auto-deploy on push. |
+| `VERCEL_DEPLOY_HOOK` | `24h-model-timeline`, `wiki-ingest`, `hourly-twitter` (claude tier) | Optional legacy nudge to a Vercel project that does NOT serve ara.guzus.xyz (prod deploys are Railway, git-push driven — Load-bearing rule 3; Vercel's last recorded deploy failed 2026-05-25). Harmless: the step no-ops when unset. |
 | `GITHUB_TOKEN` | All workflows | Auto-provided. |
 
 ## Load-bearing Rules
@@ -263,12 +264,23 @@ output or break the pipeline. Read them before editing.
    rejected. Reach for `:::raw` only when the DSL genuinely can't
    express the shape; invented classes still fail.
 
-3. **Dashboard deploys are git-push driven.** Vercel watches `main`
-   and rebuilds on every push (root `dashboard/`). There is no
-   workflow file for deploys. `dashboard/scripts/prebuild.mjs` copies
-   `research/<source>/` into `public/research/` and emits
-   `manifest.json` before Vite runs. Touching it changes what the
-   dashboard sees.
+3. **Dashboard deploys are git-push driven — Railway is the deployer.**
+   Railway watches `main` and rebuilds the Docker image on every push
+   (root `Dockerfile`: bun build → Caddy serve; `railway.json` pins
+   the builder + healthcheck). ara.guzus.xyz is served by that
+   container behind Cloudflare (responses carry `x-railway-edge`) —
+   NOT by Vercel, whose last recorded deploy failed 2026-05-25 and
+   whose leftovers (`dashboard/vercel.json`, `VERCEL_DEPLOY_HOOK`)
+   are legacy. There is still no workflow file for deploys.
+   `dashboard/scripts/prebuild.mjs` copies `research/<source>/` into
+   `public/research/` and emits `manifest.json` before Vite runs (the
+   Docker build runs the same `bun run build` lifecycle). Touching it
+   changes what the dashboard sees. Incident-learned corollary: the
+   Dockerfile's package manager MUST stay in lockstep with the
+   dashboard's (bun since #102) — a leftover `npm ci` froze prod at a
+   stale build for ~a day with CI green, because CI never runs the
+   Dockerfile. Deploy staleness is watched by
+   `scripts/check_deploy_health.py`, wired into `liveness-check.yml`.
 
 4. **Hooker telemetry is non-blocking.** Every workflow's final step
    posts to `https://hooker.guzus.xyz` via the local composite at
@@ -308,7 +320,8 @@ output or break the pipeline. Read them before editing.
 8. **Atomic file writes.** Long-running aggregation scripts that
    write into `research/` should write to a temp file in the same
    directory and `os.replace()` into place, so a half-finished file
-   never reaches Vercel's prebuild.
+   never reaches the dashboard prebuild (and thus the next deployed
+   Railway image).
 
 9. **Model tickets are CRUD'd, not regenerated.**
    `research/models/tickets/<slug>.md` is the persistent store for the

--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ flowchart TB
     Improve -->|"Creates PRs"| sources
 
     subgraph dashboard["🖥️ Dashboard"]
-        Vercel["Vercel<br/><i>ara.guzus.xyz</i>"]
+        Railway["Railway<br/><i>ara.guzus.xyz</i>"]
     end
 
-    twitter_out --> Vercel
+    twitter_out --> Railway
 ```
 
 ## Data Sources
@@ -130,7 +130,7 @@ gantt
 | `research-issue.yml` | On issue label | Deep research on any topic | `research/issues/` |
 | `generative-research.yml` | On `gen-research` issue label or `workflow_dispatch` (`topic` or `twitter_url`) | Claude or DeepSeek writes an HTML article | `research/generative/` |
 
-Dashboard deploys are handled by **Vercel's git integration**, not a workflow file — every push to `main` triggers a build automatically.
+Dashboard deploys are handled by **Railway's git integration**, not a workflow file — every push to `main` rebuilds the root `Dockerfile` (bun build → Caddy serve) automatically.
 
 `generative-research.yml` defaults to **Claude Opus 4.7** for new manual,
 issue-triggered, and auto-dispatched runs. Use `backend=deepseek-v4-flash`
@@ -213,7 +213,7 @@ A single-page dashboard that displays Twitter/X research reports with:
 - Date picker, search, and refresh controls
 - Mobile responsive with bottom nav bar
 
-Built with **Vite + Bun + TypeScript**, deployed to Vercel via the git integration (root directory: `dashboard/`). Every push to `main` triggers a Vercel build; the `prebuild` hook in `dashboard/scripts/prebuild.mjs` copies `research/<source>/` into `public/research/` and emits `manifest.json` before Vite runs.
+Built with **Vite + Bun + TypeScript**, deployed by Railway from the root `Dockerfile` (bun build → Caddy serve, behind Cloudflare; see also `Caddyfile` and `railway.json`). Every push to `main` triggers a Railway rebuild; the `prebuild` hook in `dashboard/scripts/prebuild.mjs` copies `research/<source>/` into `public/research/` and emits `manifest.json` before Vite runs.
 
 ## Setup
 
@@ -275,7 +275,7 @@ dashboard/                          # Vite + Bun + TypeScript SPA
 │   └── style.css                  # Warm cream palette, responsive styles
 ├── index.html                     # Entry point
 ├── scripts/prebuild.mjs           # Copies research/ into public/, builds manifest.json
-├── vercel.json                    # Vercel build settings (framework, install, build)
+├── vercel.json                    # Legacy Vercel config (prod is served by Railway via the root Dockerfile)
 ├── vite.config.js                 # Vite config
 └── package.json                   # Dependencies (vite, marked, dompurify)
 ```


### PR DESCRIPTION
## What

Fixes every hosting/deploy claim in `CLAUDE.md` and `README.md`: the live site **ara.guzus.xyz is served by Railway** (Caddy container built from the root `Dockerfile`, behind Cloudflare), not Vercel as both docs claimed. Follow-up to the prod-freeze incident fixed by #112.

## Verified ground truth (not taken on faith)

- `curl -sSI https://ara.guzus.xyz` → `server: cloudflare` + `x-railway-edge: railway/asia-southeast1-eqsg3a`.
- GitHub deployments API: `railway-app[bot]` creates an `ara-research / production` deployment per push to `main` (continuous through today); `vercel[bot]`'s last `Production` record is **2026-05-25T05:50Z with state `failure`** (deployment 4805991857).
- Root `Dockerfile` (post-#112): `oven/bun:1-alpine` + `apk add nodejs` (pre/postbuild are node scripts) + `bun install --frozen-lockfile` + `bun run build`, served by `caddy:2-alpine`; `railway.json` pins the DOCKERFILE builder + `/` healthcheck.
- `VERCEL_DEPLOY_HOOK` is referenced by **3** workflows (`24h-model-timeline`, `wiki-ingest`, `hourly-twitter` claude tier) — the old auth row listed only 2.
- `AGENTS.md` makes no Vercel/Railway claims — untouched.

Vercel is deliberately framed as **legacy/secondary, not deleted**: `dashboard/vercel.json` and the deploy-hook nudges still exist; the project just doesn't serve the domain.

## Changes

**CLAUDE.md**
- Pipeline diagram: Vercel auto-deploy line → Railway Dockerfile rebuild on every push to `main`.
- Key Components: `dashboard/` row corrected; new row for the Railway deploy stack (`Dockerfile` + `Caddyfile` + `railway.json`), noting `dashboard/vercel.json` is legacy.
- Load-bearing rule 3 rewritten: still git-push driven with no deploy workflow file, but Railway is the deployer; keeps the `prebuild.mjs` warning; adds the incident lesson — **the Dockerfile's package manager must stay in lockstep with the dashboard's (bun since #102)**: a leftover `npm ci` froze prod at a stale build for ~a day with CI green, because CI never runs the Dockerfile. One-line cross-ref to the deploy-health watchdog (`scripts/check_deploy_health.py` via `liveness-check.yml`, landing in a parallel PR).
- Rule 8: "never reaches Vercel's prebuild" → dashboard prebuild / next deployed Railway image.
- Auth table: `VERCEL_DEPLOY_HOOK` reframed as an optional legacy nudge to a Vercel project that does not serve prod; consuming-workflow list completed.

**README.md**
- Architecture mermaid node `Vercel` → `Railway` (ara.guzus.xyz).
- Deploy sentences (workflow section + Dashboard section) → Railway git integration, root `Dockerfile`, bun build → Caddy serve.
- `vercel.json` tree annotation marked legacy.

No code, workflow, or script changes — docs only (`git status` clean apart from these two files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)