### PR TITLE
Deploy-health watchdog: page when ara.guzus.xyz serves a stale build (2026-06-10)

### DIFF
--- a/.github/actions/deploy-health-alert/action.yml
+++ b/.github/actions/deploy-health-alert/action.yml
@@ -1,0 +1,140 @@
+name: Deploy health check (advisory)
+description: >-
+  Run the advisory deploy-health watchdog (scripts/check_deploy_health.py):
+  fetch the LIVE site's manifest (cache-busted past Cloudflare) and compare its
+  build stamp (`generatedAt`, emitted by dashboard/scripts/prebuild.mjs) against
+  now. Catches the failure mode the repo-side watchdogs cannot see: the repo
+  commits on time, lane content looks fine, but the Railway Docker build fails
+  on every push and prod silently serves a day-old build (the 2026-06-09
+  incident). Pages only when the repo is demonstrably pushing (deploy-stale);
+  defers to lane-freshness when the repo is idle too. On an alert-class finding
+  (deploy-stale / site-unreachable / manifest-unparseable) it alerts via hooker
+  AND a direct Telegram fallback. Sibling to lane-content-alert; stdlib Python
+  only so it runs on both runner tiers. This action NEVER fails the job —
+  deploy-health findings are advisory; freshness remains the hard gate.
+
+inputs:
+  hooker_url:
+    description: Hooker base URL. Hooker alert skipped if empty.
+    required: false
+    default: ""
+  hooker_token:
+    description: Hooker bearer token. Hooker alert skipped if empty.
+    required: false
+    default: ""
+  topic:
+    description: Hooker topic that relays to Telegram.
+    required: false
+    default: ara-research
+  telegram_bot_token:
+    description: Telegram bot token for the direct fallback channel. Skipped if empty.
+    required: false
+    default: ""
+  telegram_chat_id:
+    description: Telegram chat id for the direct fallback channel. Skipped if empty.
+    required: false
+    default: ""
+
+outputs:
+  finding:
+    description: >-
+      The deploy-health state (healthy / deploy-stale / site-unreachable /
+      manifest-unparseable / legacy-build / pipeline-idle).
+    value: ${{ steps.check.outputs.finding }}
+  alert:
+    description: "'true' when the finding is alert-class (page-worthy)."
+    value: ${{ steps.check.outputs.alert }}
+
+runs:
+  using: composite
+  steps:
+    # Advisory: the script exits 0 even on a finding (no --exit-code), writing
+    # finding / alert / idempotency_key / detail / report to $GITHUB_OUTPUT and
+    # a diagnostics block to the step summary. `|| true` is belt-and-suspenders
+    # so this step can never fail the job even on an internal script error.
+    # Needs a checkout: the deploy-stale vs pipeline-idle split reads
+    # `git log -1 --format=%ct` from the working tree.
+    - name: Check deploy health
+      id: check
+      shell: bash
+      run: python3 scripts/check_deploy_health.py || true
+
+    # ── Channel 1: hooker (relays to Telegram). Priority 4: prod serving a
+    #    stale build is user-facing (worse than a content anomaly at 3) but the
+    #    pipeline itself is still running (freshness pages at 5). ─────────────
+    - name: Alert via hooker (relays to Telegram)
+      if: steps.check.outputs.alert == 'true'
+      shell: bash
+      continue-on-error: true
+      env:
+        HOOKER_URL: ${{ inputs.hooker_url }}
+        HOOKER_TOKEN: ${{ inputs.hooker_token }}
+        TOPIC: ${{ inputs.topic }}
+        FINDING: ${{ steps.check.outputs.finding }}
+        DETAIL: ${{ steps.check.outputs.detail }}
+        IDEMPOTENCY_KEY: ${{ steps.check.outputs.idempotency_key }}
+        REPO: ${{ github.repository }}
+        SERVER: ${{ github.server_url }}
+        RUN_ID: ${{ github.run_id }}
+      run: |
+        set -euo pipefail
+        if [ -z "${HOOKER_URL:-}" ] || [ -z "${HOOKER_TOKEN:-}" ]; then
+          echo "Hooker credentials missing — skipping hooker deploy-health alert (Telegram fallback still applies)"
+          exit 0
+        fi
+        # Finding/detail come from our own script, but escape defensively
+        # since the body uses parse_mode:HTML.
+        SAFE_DETAIL=$(printf '%s' "$DETAIL" \
+          | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g')
+        TEXT=$(printf '%s\n\nThe LIVE site (ara.guzus.xyz) is not serving a current build even though the repo looks healthy — likely the Railway Docker build is failing on every push (check the Railway deploy logs), or the site/manifest route is down. Advisory: the research pipeline itself is still running.' "$SAFE_DETAIL")
+        RUN_URL="${SERVER%/}/${REPO}/actions/runs/${RUN_ID}"
+        jq -n \
+          --arg title "🔴 ARA deploy health: ${FINDING} (advisory)" \
+          --arg text "$TEXT" \
+          --arg btn "Inspect (Actions run)" \
+          --arg url "$RUN_URL" \
+          '{
+            title: $title,
+            text: $text,
+            priority: 4,
+            tags: ["ara", "advisory", "deploy"],
+            parse_mode: "HTML",
+            reply_markup: { inline_keyboard: [[{ text: $btn, url: $url }]] }
+          }' > "${RUNNER_TEMP:-/tmp}/hooker-deploy-health.json"
+        curl -sS --fail-with-body -X POST "${HOOKER_URL%/}/publish/${TOPIC}" \
+          -H "Authorization: Bearer ${HOOKER_TOKEN}" \
+          -H "Content-Type: application/json" \
+          -H "Idempotency-Key: ${IDEMPOTENCY_KEY}" \
+          --data-binary "@${RUNNER_TEMP:-/tmp}/hooker-deploy-health.json"
+
+    # ── Channel 2: direct Telegram fallback (bypasses hooker). ──────────────
+    - name: Alert via Telegram (direct fallback)
+      if: steps.check.outputs.alert == 'true'
+      shell: bash
+      continue-on-error: true
+      env:
+        TELEGRAM_BOT_TOKEN: ${{ inputs.telegram_bot_token }}
+        TELEGRAM_CHAT_ID: ${{ inputs.telegram_chat_id }}
+        FINDING: ${{ steps.check.outputs.finding }}
+        DETAIL: ${{ steps.check.outputs.detail }}
+        REPO: ${{ github.repository }}
+        SERVER: ${{ github.server_url }}
+        RUN_ID: ${{ github.run_id }}
+      run: |
+        set -euo pipefail
+        if [ -z "${TELEGRAM_BOT_TOKEN:-}" ] || [ -z "${TELEGRAM_CHAT_ID:-}" ]; then
+          echo "Telegram credentials missing — skipping direct Telegram deploy-health fallback"
+          exit 0
+        fi
+        RUN_URL="${SERVER%/}/${REPO}/actions/runs/${RUN_ID}"
+        TEXT=$(printf '🔴 ARA deploy health (advisory): %s\n\n%s\n\nThe live site is not serving a current build even though the repo looks healthy — check the Railway deploy logs.\n\n[Inspect](%s)' \
+          "$FINDING" "$DETAIL" "$RUN_URL")
+        if curl -sS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+          --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
+          --data-urlencode "text=${TEXT}" \
+          -d "parse_mode=Markdown" \
+          -d "disable_web_page_preview=true" >/dev/null; then
+          echo "Telegram deploy-health fallback sent"
+        else
+          echo "Telegram deploy-health fallback send failed (non-blocking)"
+        fi

--- a/.github/workflows/liveness-check.yml
+++ b/.github/workflows/liveness-check.yml
@@ -1,14 +1,23 @@
 name: Pipeline Liveness Check
 
-# Freshness + content watchdog that makes silent pipeline outages loud. For
-# each scheduled research lane it:
+# Freshness + content + deploy watchdog that makes silent pipeline outages
+# loud. For each scheduled research lane it:
 #   1. (advisory) checks CONTENT — is the most recent artifact anomalously
 #      small / collapsed vs its trailing median? (scripts/check_lane_content.py)
 #      A lane can commit on time yet emit a husk (expired bird cookies → [] →
 #      near-empty file). This never fails the job; it just alerts.
-#   2. checks FRESHNESS — git-commit recency vs a per-lane cadence threshold
+#   2. (advisory) checks DEPLOY HEALTH — is the LIVE site serving a current
+#      build? (scripts/check_deploy_health.py) The repo can be perfectly fresh
+#      while prod is dead: the Railway Docker build broke on every push after
+#      #102 and ara.guzus.xyz silently served a day-old build for ~1 day with
+#      zero alarms, because both repo-side checks stayed green. This fetches
+#      the live manifest's `generatedAt` stamp (cache-busted past Cloudflare)
+#      and pages only when the build lags >8h while the repo is demonstrably
+#      pushing (<2h since last commit) — a big lag with an idle repo defers to
+#      the freshness page below instead of double-paging. Never fails the job.
+#   3. checks FRESHNESS — git-commit recency vs a per-lane cadence threshold
 #      (scripts/check_lane_freshness.py); on staleness it alerts AND fails.
-#   3. (healthy runs only) emits a HEARTBEAT — a dead-man's-switch success ping
+#   4. (healthy runs only) emits a HEARTBEAT — a dead-man's-switch success ping
 #      so the watchdog's / hooker's OWN silence becomes detectable downstream.
 #
 # Alerts now go out over TWO independent channels: hooker (relays to Telegram)
@@ -32,9 +41,13 @@ name: Pipeline Liveness Check
 # the two jobs (and repeat runs) collapse to one message per set per day.
 #
 # Step ORDERING is load-bearing: the freshness action ends with a `Fail if
-# stale` step that exits non-zero. GHA skips later steps in a job once a step
-# fails without continue-on-error, so:
+# stale` step that exits non-zero — it must stay the only step that can fail,
+# and it must stay LAST among the checks. GHA skips later steps in a job once
+# a step fails without continue-on-error, so:
 #   - the content gate runs BEFORE freshness (so a stale day can't skip it);
+#   - deploy health also runs BEFORE freshness: one stale lane must not mask
+#     a dead deploy (the rest of the pipeline can still be pushing hourly
+#     while prod serves a stale build);
 #   - the heartbeat runs AFTER freshness but is guarded by stale == 'false'
 #     (a stale/down pipeline must not emit an "alive" ping anyway, so being
 #     skipped on stale days is the desired behavior).
@@ -74,6 +87,19 @@ jobs:
           telegram_bot_token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           telegram_chat_id: ${{ secrets.TELEGRAM_CHAT_ID }}
 
+      # Advisory deploy-health check — is the LIVE site serving a current
+      # build? Also ahead of the freshness fail step: one stale lane must not
+      # skip the deploy probe. continue-on-error is belt-and-suspenders on top
+      # of the composite's own never-fail design (Rule 4 semantics).
+      - name: Deploy health (advisory) + alert if prod is stale
+        continue-on-error: true
+        uses: ./.github/actions/deploy-health-alert
+        with:
+          hooker_url: ${{ secrets.HOOKER_URL }}
+          hooker_token: ${{ secrets.HOOKER_TOKEN }}
+          telegram_bot_token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          telegram_chat_id: ${{ secrets.TELEGRAM_CHAT_ID }}
+
       # Freshness check + dual-channel alert; its final step fails on staleness.
       - name: Check freshness + alert on staleness
         id: freshness
@@ -107,6 +133,15 @@ jobs:
 
       - name: Content quality gate (advisory) + alert on anomaly
         uses: ./.github/actions/lane-content-alert
+        with:
+          hooker_url: ${{ secrets.HOOKER_URL }}
+          hooker_token: ${{ secrets.HOOKER_TOKEN }}
+          telegram_bot_token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          telegram_chat_id: ${{ secrets.TELEGRAM_CHAT_ID }}
+
+      - name: Deploy health (advisory) + alert if prod is stale
+        continue-on-error: true
+        uses: ./.github/actions/deploy-health-alert
         with:
           hooker_url: ${{ secrets.HOOKER_URL }}
           hooker_token: ${{ secrets.HOOKER_TOKEN }}

--- a/dashboard/scripts/prebuild.mjs
+++ b/dashboard/scripts/prebuild.mjs
@@ -239,7 +239,18 @@ function buildTicketsIndex() {
 }
 
 function buildManifest() {
-  const manifest = {};
+  const manifest = {
+    // Deploy-health stamp (scripts/check_deploy_health.py reads these from the
+    // LIVE site). `generatedAt` is the build wall-clock: on a healthy system a
+    // push to main rebuilds within minutes, so the live value should never lag
+    // far behind the latest commit. `gitSha` is best-effort diagnostic only —
+    // the Docker build context has no .git, so never shell out to git here;
+    // Railway/Vercel expose the sha via env when configured, else null.
+    // Additive only: main.ts's loadManifest() normalizes by picking known
+    // keys, so existing consumers ignore these fields.
+    generatedAt: new Date().toISOString(),
+    gitSha: process.env.RAILWAY_GIT_COMMIT_SHA || process.env.VERCEL_GIT_COMMIT_SHA || null,
+  };
   for (const [key, { dir, re }] of Object.entries(DATE_PATTERNS)) {
     manifest[key] = collectDates(join(publicResearch, dir), re);
   }
@@ -267,9 +278,14 @@ function buildManifest() {
     JSON.stringify(manifest),
   );
   const counts = Object.fromEntries(
-    Object.entries(manifest).map(([k, v]) => [k, Array.isArray(v) ? v.length : 0]),
+    Object.entries(manifest)
+      .filter(([, v]) => Array.isArray(v))
+      .map(([k, v]) => [k, v.length]),
   );
-  console.log('prebuild: manifest.json', counts);
+  console.log(
+    `prebuild: manifest.json (generatedAt=${manifest.generatedAt} gitSha=${manifest.gitSha ?? 'null'})`,
+    counts,
+  );
 }
 
 copyData();

--- a/scripts/check_deploy_health.py
+++ b/scripts/check_deploy_health.py
@@ -1,0 +1,610 @@
+#!/usr/bin/env python3
+"""Deploy-health watchdog (advisory): is the artifact users see current?
+
+The other two watchdogs measure the REPOSITORY: check_lane_freshness.py
+asks "did each lane commit recently?", check_lane_content.py asks "was the
+latest artifact non-empty?". Neither can see the failure mode that actually
+happened (2026-06-09→10): the Railway Docker build broke on every push
+after #102, so ara.guzus.xyz silently served a day-old build while the repo
+stayed perfectly fresh and green. Repo healthy, deploy dead, zero alarms.
+
+This script closes that gap by reading the LIVE site, not the repo:
+dashboard/scripts/prebuild.mjs stamps the manifest it emits with
+`generatedAt` (build wall-clock, ISO-8601 UTC). We fetch the deployed
+manifest and compute `lag = now - generatedAt`.
+
+Why the lag threshold works for THIS repo (no false positives in quiet
+periods): the pipeline pushes to main around the clock — over the trailing
+10 days, 367 commits with a MAXIMUM gap of ~3.4h between pushes (hourly
+RSS is the floor; lane-freshness pages rss at 4h idle anyway). Railway
+rebuilds on every push, so on a healthy system lag stays under ~1h and can
+never legitimately reach the default 8h threshold (>2x the worst observed
+push gap) without something being wrong.
+
+Distinguishing deploy-stale from pipeline-dead (don't double-page): if the
+whole pipeline froze, lag grows too — but lane-freshness already owns that
+page. So the page-worthy finding requires the repo to be DEMONSTRABLY
+alive: `deploy-stale` fires only when lag > threshold AND the last commit
+in the checkout is < 2h old (`git log -1 --format=%ct`; the liveness-check
+checkout always exists). Big lag + idle repo is reported as
+`pipeline-idle (deferring to lane-freshness)` and does not alert.
+
+Defeating the CDN cache (the read must be the ORIGIN's manifest):
+Cloudflare fronts the site. Every request appends a unique `cb=<epoch>`
+query param (CF's cache key includes the query string by default) and
+sends Cache-Control: no-cache; the response's `cf-cache-status` / `age`
+headers are captured and reported so a cached read is visible in the
+diagnostics (a `HIT` despite the buster gets an explicit warning).
+Observed live (2026-06-10): `cf-cache-status: DYNAMIC` — the JSON is not
+edge-cached today, but the busting keeps the check correct if a cache rule
+ever changes that.
+
+URL choice (verified live, 2026-06-10): the manifest users' dashboards
+consume is `/research/manifest.json` (main.ts fetches `${DATA_BASE}/
+manifest.json`). The root `/manifest.json` is a trap: the Caddyfile's
+`try_files {path} /index.html` SPA fallback serves it as index.html with
+HTTP 200, which would JSON-parse-fail forever. Default accordingly;
+`--url` overrides.
+
+Findings (state machine):
+  healthy                 lag <= threshold (or generatedAt in the future —
+                          clock skew is not an outage).
+  deploy-stale            ALERT. lag > threshold AND repo alive (< 2h since
+                          last commit). The incident this watchdog exists
+                          for: pushes flow, builds don't.
+  site-unreachable        ALERT. Fetch failed after one retry, or non-200.
+  manifest-unparseable    ALERT. Body is not a JSON object (e.g. the SPA
+                          fallback served HTML for the manifest path) or
+                          `generatedAt` is present but not a timestamp.
+  legacy-build            note, NOT a page. Manifest parses but has no
+                          `generatedAt` — the live build predates the
+                          stamping feature. Disappears after the first
+                          successful post-feature deploy.
+  pipeline-idle           note, NOT a page. lag > threshold but the repo is
+                          idle too — lane-freshness owns that page.
+
+Stdlib-only (urllib.request/json/argparse/datetime) so it runs identically
+on both watchdog tiers. All external effects (fetch, git, clock) are
+injectable for tests, mirroring check_lane_freshness/check_lane_content.
+
+Exit codes:
+  0  default — even on findings (advisory). Findings still surface via
+     $GITHUB_OUTPUT (`alert=true`) and the step summary.
+  2  an ALERT-class finding, AND --exit-code was passed.
+  1  internal error (e.g. malformed --now).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Callable, Optional
+
+# The manifest the dashboard actually consumes (see docstring: root
+# /manifest.json is the SPA fallback and serves HTML with HTTP 200).
+DEFAULT_URL = "https://ara.guzus.xyz/research/manifest.json"
+
+# lag > this is anomalous. Calibrated to the repo's real push cadence:
+# max observed push gap over 10 days is ~3.4h, builds finish in minutes,
+# so 8h is >2x the worst legitimate quiet period.
+DEFAULT_MAX_LAG_HOURS = 8.0
+
+# The repo counts as "demonstrably alive and pushing" when its last commit
+# is younger than this. Under that bound, a healthy deploy chain MUST have
+# produced a recent build (pushes flow hourly), so big lag = broken deploys.
+DEFAULT_REPO_ALIVE_HOURS = 2.0
+
+DEFAULT_TIMEOUT_SECONDS = 15.0
+RETRY_DELAY_SECONDS = 5.0
+MAX_BODY_BYTES = 5_000_000  # manifest is ~50KB; cap pathological responses
+USER_AGENT = "ara-deploy-health/1.0 (+https://github.com/guzus/ai-research-arm)"
+
+HEALTHY = "healthy"
+DEPLOY_STALE = "deploy-stale"
+SITE_UNREACHABLE = "site-unreachable"
+MANIFEST_UNPARSEABLE = "manifest-unparseable"
+LEGACY_BUILD = "legacy-build"
+PIPELINE_IDLE = "pipeline-idle"
+
+# Findings that should route an alert. legacy-build and pipeline-idle are
+# diagnostic notes by design (see docstring).
+ALERTING_STATES = frozenset({DEPLOY_STALE, SITE_UNREACHABLE, MANIFEST_UNPARSEABLE})
+
+
+class FetchError(Exception):
+    """Total fetch failure (after retries). Message carries the last error."""
+
+
+@dataclass
+class FetchResult:
+    """A completed HTTP exchange. Header keys are lower-cased."""
+
+    status: int
+    headers: dict[str, str]
+    body: str
+
+
+@dataclass
+class DeployHealth:
+    state: str
+    detail: str                              # single line, alert-body ready
+    lag_hours: Optional[float] = None
+    repo_idle_hours: Optional[float] = None
+    generated_at: Optional[str] = None
+    git_sha: Optional[str] = None
+    cache_status: Optional[str] = None       # cf-cache-status header (or None)
+    age: Optional[str] = None                # age header (or None)
+    http_status: Optional[int] = None
+    url: str = ""
+
+    @property
+    def alerting(self) -> bool:
+        return self.state in ALERTING_STATES
+
+
+def with_cache_buster(url: str, epoch: int) -> str:
+    """Append a unique cb=<epoch> param (CF's cache key includes the query)."""
+    sep = "&" if "?" in url else "?"
+    return f"{url}{sep}cb={epoch}"
+
+
+def fetch_manifest(
+    url: str,
+    *,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    retries: int = 1,
+    opener_fn: Callable = urllib.request.urlopen,
+    sleep_fn: Callable[[float], None] = time.sleep,
+    epoch_fn: Callable[[], float] = time.time,
+) -> FetchResult:
+    """Fetch the live manifest with a cache-busting param. One retry.
+
+    Returns a FetchResult on HTTP success; raises FetchError once every
+    attempt (initial + `retries`) has failed. HTTP error statuses (urlopen
+    raises HTTPError for non-2xx) are retried like network errors — a 502
+    from a mid-restart edge is transient — and the final error message
+    carries the status code so the finding's detail is diagnosable.
+    """
+    target = with_cache_buster(url, int(epoch_fn()))
+    request = urllib.request.Request(
+        target,
+        headers={
+            "User-Agent": USER_AGENT,
+            # CF mostly ignores client cache-control, but it is free and
+            # correct to ask; the cb param is the real cache defeat.
+            "Cache-Control": "no-cache",
+            "Pragma": "no-cache",
+        },
+    )
+    last_error: Optional[BaseException] = None
+    for attempt in range(retries + 1):
+        if attempt > 0:
+            sleep_fn(RETRY_DELAY_SECONDS)
+        try:
+            with opener_fn(request, timeout=timeout) as resp:
+                body = resp.read(MAX_BODY_BYTES).decode("utf-8", "replace")
+                headers = {str(k).lower(): str(v) for k, v in resp.headers.items()}
+                status = getattr(resp, "status", None)
+                if status is None:  # pre-3.9 compat shim; harmless elsewhere
+                    status = resp.getcode()
+                return FetchResult(status=int(status), headers=headers, body=body)
+        except urllib.error.HTTPError as exc:  # non-2xx IS a response; keep code
+            last_error = exc
+        except Exception as exc:  # URLError, socket timeout, DNS, TLS, ...
+            last_error = exc
+    attempts = retries + 1
+    if isinstance(last_error, urllib.error.HTTPError):
+        raise FetchError(
+            f"HTTP {last_error.code} after {attempts} attempt(s) for {target}"
+        ) from last_error
+    raise FetchError(
+        f"fetch failed after {attempts} attempt(s) for {target}: {last_error}"
+    ) from last_error
+
+
+def repo_last_commit_epoch(repo_root: str) -> Optional[int]:
+    """Epoch of the last commit in the checkout, or None when unavailable.
+
+    `git log -1 --format=%ct` works even on a depth-1 checkout (it only
+    needs the tip), so this is robust on both watchdog tiers.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "log", "-1", "--format=%ct"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return None
+    raw = out.stdout.strip()
+    try:
+        return int(raw)
+    except ValueError:
+        return None
+
+
+def parse_iso8601(value: str) -> Optional[datetime]:
+    """Parse an ISO-8601 timestamp; tolerate the trailing 'Z' that
+    `Date.prototype.toISOString()` emits (Python <3.11 fromisoformat
+    rejects it). Naive values are assumed UTC."""
+    if not isinstance(value, str) or not value:
+        return None
+    raw = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _fmt_hours(hours: Optional[float]) -> str:
+    if hours is None:
+        return "?"
+    if hours < 48:
+        return f"{hours:.1f}h"
+    return f"{hours / 24:.1f}d"
+
+
+def cache_note(headers: dict[str, str]) -> str:
+    """Single-line CDN-cache diagnostic. Must not crash on absent headers."""
+    status = headers.get("cf-cache-status", "absent")
+    age = headers.get("age", "absent")
+    note = f"cf-cache-status={status} age={age}"
+    if status.upper() == "HIT":
+        note += (
+            " (WARNING: cache HIT despite the cb cache-buster — this read may"
+            " be a stale edge copy; check Cloudflare cache rules)"
+        )
+    return note
+
+
+def evaluate(
+    *,
+    url: str = DEFAULT_URL,
+    max_lag_hours: float = DEFAULT_MAX_LAG_HOURS,
+    repo_alive_hours: float = DEFAULT_REPO_ALIVE_HOURS,
+    now: Optional[datetime] = None,
+    fetch_fn: Callable[[str], FetchResult],
+    git_time_fn: Callable[[], Optional[int]],
+) -> DeployHealth:
+    """Classify the live deploy. fetch_fn/git_time_fn/now are injectable so
+    the logic is unit-testable without network or a repository (mirrors the
+    age_fn/sizes_fn seams in the sibling watchdogs)."""
+    now = now or datetime.now(timezone.utc)
+
+    # 1) Reach the site. Any exception out of the fetch seam (the real
+    #    impl already retried) means users may not be reaching it either.
+    try:
+        result = fetch_fn(url)
+    except Exception as exc:
+        return DeployHealth(
+            state=SITE_UNREACHABLE,
+            detail=f"could not fetch live manifest: {exc}",
+            url=url,
+        )
+
+    cache_status = result.headers.get("cf-cache-status")
+    age = result.headers.get("age")
+    base = dict(cache_status=cache_status, age=age, http_status=result.status, url=url)
+
+    if result.status != 200:
+        return DeployHealth(
+            state=SITE_UNREACHABLE,
+            detail=f"live manifest returned HTTP {result.status} (expected 200)",
+            **base,
+        )
+
+    # 2) Parse. The SPA fallback serves index.html with HTTP 200 for missing
+    #    paths (Caddyfile try_files), so "200 but HTML" is a real deployed-
+    #    artifact failure shape, not a transport error.
+    try:
+        manifest = json.loads(result.body)
+    except ValueError:
+        snippet = result.body[:60].replace("\n", " ")
+        content_type = result.headers.get("content-type", "absent")
+        return DeployHealth(
+            state=MANIFEST_UNPARSEABLE,
+            detail=(
+                f"live manifest is not JSON (content-type={content_type}; "
+                f"body starts {snippet!r}) — is the static file route broken?"
+            ),
+            **base,
+        )
+    if not isinstance(manifest, dict):
+        return DeployHealth(
+            state=MANIFEST_UNPARSEABLE,
+            detail=f"live manifest is JSON but not an object (got {type(manifest).__name__})",
+            **base,
+        )
+
+    git_sha = manifest.get("gitSha")
+    base["git_sha"] = git_sha if isinstance(git_sha, str) else None
+
+    # 3) The stamp. Absent => the live build predates this feature: an
+    #    expected, self-resolving state right after this PR ships — note it,
+    #    never page on it.
+    if "generatedAt" not in manifest:
+        return DeployHealth(
+            state=LEGACY_BUILD,
+            detail=(
+                "live manifest has no generatedAt — the deployed build predates "
+                "the deploy-health stamp; this resolves on the first successful "
+                "post-feature deploy (advisory note, not a page)"
+            ),
+            **base,
+        )
+
+    raw_generated_at = manifest.get("generatedAt")
+    generated_at = parse_iso8601(raw_generated_at)
+    if generated_at is None:
+        return DeployHealth(
+            state=MANIFEST_UNPARSEABLE,
+            detail=(
+                f"live manifest generatedAt is not a parseable ISO-8601 "
+                f"timestamp: {raw_generated_at!r}"
+            ),
+            **base,
+        )
+    base["generated_at"] = generated_at.isoformat()
+
+    # 4) The signal: how old is the artifact users see?
+    lag_hours = (now - generated_at).total_seconds() / 3600.0
+    base["lag_hours"] = lag_hours
+
+    if lag_hours < 0:
+        return DeployHealth(
+            state=HEALTHY,
+            detail=(
+                f"live build generatedAt is {_fmt_hours(-lag_hours)} in the "
+                "future (clock skew between builder and checker) — treating as fresh"
+            ),
+            **base,
+        )
+    if lag_hours <= max_lag_hours:
+        return DeployHealth(
+            state=HEALTHY,
+            detail=(
+                f"live build is {_fmt_hours(lag_hours)} old "
+                f"(within the {max_lag_hours:g}h threshold)"
+            ),
+            **base,
+        )
+
+    # 5) lag is anomalous. Page only when the repo is demonstrably pushing —
+    #    otherwise lane-freshness owns the page (premise c: don't double-page).
+    last_commit_epoch = git_time_fn()
+    repo_idle_hours: Optional[float] = None
+    if last_commit_epoch is not None:
+        repo_idle_hours = (now.timestamp() - last_commit_epoch) / 3600.0
+    base["repo_idle_hours"] = repo_idle_hours
+
+    if repo_idle_hours is None:
+        # Only reachable outside the wired environment (liveness-check always
+        # has a checkout). The lag is real; surface it with the caveat rather
+        # than swallowing a genuine deploy outage.
+        return DeployHealth(
+            state=DEPLOY_STALE,
+            detail=(
+                f"live build is {_fmt_hours(lag_hours)} old (> {max_lag_hours:g}h) "
+                "and repo liveness is UNKNOWN (git unavailable) — cannot apply "
+                "the pipeline-idle deferral; treat as deploy-stale"
+            ),
+            **base,
+        )
+    if repo_idle_hours < repo_alive_hours:
+        return DeployHealth(
+            state=DEPLOY_STALE,
+            detail=(
+                f"live build is {_fmt_hours(lag_hours)} old (> {max_lag_hours:g}h) "
+                f"while the repo pushed {_fmt_hours(repo_idle_hours)} ago — "
+                "pushes are flowing but deploys are not (check the Railway "
+                "build: Dockerfile / bun build / Caddy image)"
+            ),
+            **base,
+        )
+    return DeployHealth(
+        state=PIPELINE_IDLE,
+        detail=(
+            f"live build is {_fmt_hours(lag_hours)} old but the repo has also "
+            f"been idle {_fmt_hours(repo_idle_hours)} (>= {repo_alive_hours:g}h) "
+            "— pipeline-idle (deferring to lane-freshness, which owns that page)"
+        ),
+        **base,
+    )
+
+
+def format_report(health: DeployHealth) -> str:
+    """Multi-line diagnostics block for the step summary / alert context."""
+    icon = {
+        HEALTHY: "✅",
+        DEPLOY_STALE: "🔴",
+        SITE_UNREACHABLE: "🔴",
+        MANIFEST_UNPARSEABLE: "🔴",
+        LEGACY_BUILD: "⚪",
+        PIPELINE_IDLE: "🟡",
+    }
+    headers: dict[str, str] = {}
+    if health.cache_status is not None:
+        headers["cf-cache-status"] = health.cache_status
+    if health.age is not None:
+        headers["age"] = health.age
+    lines = [
+        f"{icon.get(health.state, '?')} {health.state}: {health.detail}",
+        f"- url: {health.url or '?'}",
+        f"- http_status: {health.http_status if health.http_status is not None else '?'}",
+        f"- generatedAt: {health.generated_at or 'absent'}",
+        f"- lag: {_fmt_hours(health.lag_hours)}",
+        f"- repo idle: {_fmt_hours(health.repo_idle_hours)}",
+        f"- gitSha: {health.git_sha or 'absent'}",
+        f"- cache: {cache_note(headers)}",
+    ]
+    return "\n".join(lines)
+
+
+def idempotency_key(state: str, now: datetime) -> str:
+    """Per-day, per-finding key so both watchdog tiers (and repeat runs the
+    same day) collapse to one delivered alert; a different finding the same
+    day produces a new key. Distinct prefix so deploy-health alerts never
+    collide with lane-freshness/lane-content keys."""
+    return f"deploy-health-{now.strftime('%Y-%m-%d')}-{state}"
+
+
+def _emit_github_output(health: DeployHealth, report: str, key: str) -> None:
+    out_path = os.environ.get("GITHUB_OUTPUT")
+    if not out_path:
+        return
+    delim = "__ARA_DEPLOY_HEALTH_EOF__"
+    with open(out_path, "a", encoding="utf-8") as fh:
+        fh.write(f"finding={health.state}\n")
+        fh.write(f"alert={'true' if health.alerting else 'false'}\n")
+        fh.write(f"idempotency_key={key}\n")
+        fh.write(f"detail={health.detail}\n")
+        fh.write(f"report<<{delim}\n{report}\n{delim}\n")
+
+
+def _emit_step_summary(report: str, health: DeployHealth) -> None:
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    if health.alerting:
+        header = f"### 🔴 Deploy health: {health.state} (advisory)\n\n"
+    elif health.state == HEALTHY:
+        header = "### ✅ Deploy health: live build is current\n\n"
+    else:
+        header = f"### ⚪ Deploy health: {health.state} (note)\n\n"
+    with open(summary_path, "a", encoding="utf-8") as fh:
+        fh.write(header + report + "\n")
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Deploy-health watchdog: is the live site serving a current build? (advisory)",
+    )
+    parser.add_argument(
+        "--url",
+        default=DEFAULT_URL,
+        help=f"Live manifest URL (default: {DEFAULT_URL}; root /manifest.json "
+        "is the SPA fallback and serves HTML — do not point there).",
+    )
+    parser.add_argument(
+        "--max-lag-hours",
+        type=float,
+        default=DEFAULT_MAX_LAG_HOURS,
+        help=f"Max tolerated build age before the lag is anomalous (default: {DEFAULT_MAX_LAG_HOURS:g}).",
+    )
+    parser.add_argument(
+        "--repo-alive-hours",
+        type=float,
+        default=DEFAULT_REPO_ALIVE_HOURS,
+        help="Repo counts as alive-and-pushing when its last commit is younger "
+        f"than this; gates the deploy-stale page (default: {DEFAULT_REPO_ALIVE_HOURS:g}).",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=DEFAULT_TIMEOUT_SECONDS,
+        help=f"Per-attempt fetch timeout in seconds (default: {DEFAULT_TIMEOUT_SECONDS:g}).",
+    )
+    parser.add_argument(
+        "--now",
+        help="ISO-8601 UTC timestamp to evaluate against (default: now). For testing.",
+    )
+    parser.add_argument(
+        "--repo",
+        default=None,
+        help="Repository root for the repo-liveness probe (default: git toplevel of CWD, else CWD).",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of the report.")
+    parser.add_argument(
+        "--exit-code",
+        action="store_true",
+        help="Exit 2 on an alert-class finding (default: always exit 0 — advisory).",
+    )
+    args = parser.parse_args(argv)
+
+    if args.now:
+        # Python <3.11's fromisoformat rejects a trailing 'Z'; normalize it.
+        now_dt = parse_iso8601(args.now)
+        if now_dt is None:
+            print(f"error: --now is not a valid ISO-8601 timestamp: {args.now}", file=sys.stderr)
+            return 1
+    else:
+        now_dt = datetime.now(timezone.utc)
+
+    repo_root = args.repo
+    if repo_root is None:
+        try:
+            top = subprocess.run(
+                ["git", "rev-parse", "--show-toplevel"],
+                capture_output=True, text=True, check=True,
+            ).stdout.strip()
+            repo_root = top or os.getcwd()
+        except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+            repo_root = os.getcwd()
+
+    health = evaluate(
+        url=args.url,
+        max_lag_hours=args.max_lag_hours,
+        repo_alive_hours=args.repo_alive_hours,
+        now=now_dt,
+        fetch_fn=lambda url: fetch_manifest(url, timeout=args.timeout),
+        git_time_fn=lambda: repo_last_commit_epoch(repo_root),
+    )
+    report = format_report(health)
+    key = idempotency_key(health.state, now_dt)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "now": now_dt.isoformat(),
+                    "finding": health.state,
+                    "alert": health.alerting,
+                    "detail": health.detail,
+                    "idempotency_key": key,
+                    "url": health.url,
+                    "http_status": health.http_status,
+                    "generated_at": health.generated_at,
+                    "lag_hours": health.lag_hours,
+                    "repo_idle_hours": health.repo_idle_hours,
+                    "git_sha": health.git_sha,
+                    "cf_cache_status": health.cache_status,
+                    "age": health.age,
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(report)
+
+    _emit_github_output(health, report, key)
+    _emit_step_summary(report, health)
+
+    if health.alerting:
+        print(
+            f"\n::warning::deploy-health finding: {health.state} "
+            "(advisory — does not fail the job)",
+            file=sys.stderr,
+        )
+        return 2 if args.exit_code else 0
+    if health.state in (LEGACY_BUILD, PIPELINE_IDLE):
+        print(f"\ndeploy-health note: {health.state} (no alert)", file=sys.stderr)
+    else:
+        print("\nlive deploy is current", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_check_deploy_health.py
+++ b/scripts/test_check_deploy_health.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+
+import json
+import unittest
+from datetime import datetime, timedelta, timezone
+
+import check_deploy_health as cdh
+
+NOW = datetime(2026, 6, 10, 12, 0, 0, tzinfo=timezone.utc)
+URL = "https://ara.example.test/research/manifest.json"
+
+FULL_HEADERS = {
+    "content-type": "application/json",
+    "cf-cache-status": "DYNAMIC",
+    "age": "0",
+}
+
+
+def _manifest_body(generated_at=None, *, omit_stamp=False, git_sha="abc1234"):
+    body = {"today": [], "twitter": [], "models": [], "frontpage": [], "audio": [], "generative": []}
+    if not omit_stamp:
+        body["generatedAt"] = generated_at
+        body["gitSha"] = git_sha
+    return json.dumps(body)
+
+
+def _result(body, status=200, headers=None):
+    return cdh.FetchResult(
+        status=status,
+        headers=dict(FULL_HEADERS if headers is None else headers),
+        body=body,
+    )
+
+
+def _iso_hours_ago(hours):
+    return (NOW - timedelta(hours=hours)).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def _epoch_hours_ago(hours):
+    return int((NOW - timedelta(hours=hours)).timestamp())
+
+
+def _evaluate(fetch_fn, git_time_fn=lambda: _epoch_hours_ago(0.5), **kwargs):
+    return cdh.evaluate(
+        url=URL,
+        max_lag_hours=8.0,
+        repo_alive_hours=2.0,
+        now=NOW,
+        fetch_fn=fetch_fn,
+        git_time_fn=git_time_fn,
+        **kwargs,
+    )
+
+
+class EvaluateTest(unittest.TestCase):
+    def test_healthy_small_lag(self):
+        # Built 1h ago, repo pushing — the steady state.
+        health = _evaluate(lambda url: _result(_manifest_body(_iso_hours_ago(1.0))))
+        self.assertEqual(health.state, cdh.HEALTHY)
+        self.assertFalse(health.alerting)
+        self.assertAlmostEqual(health.lag_hours, 1.0, places=2)
+
+    def test_deploy_stale_big_lag_repo_alive(self):
+        # THE incident shape: pushes flow (repo idle 0.5h) but the live build
+        # is 26h old — Railway builds are failing on every push.
+        health = _evaluate(
+            lambda url: _result(_manifest_body(_iso_hours_ago(26.0))),
+            git_time_fn=lambda: _epoch_hours_ago(0.5),
+        )
+        self.assertEqual(health.state, cdh.DEPLOY_STALE)
+        self.assertTrue(health.alerting)
+        self.assertAlmostEqual(health.lag_hours, 26.0, places=2)
+        self.assertAlmostEqual(health.repo_idle_hours, 0.5, places=2)
+        self.assertIn("deploy", health.detail)
+
+    def test_big_lag_repo_idle_defers_to_lane_freshness(self):
+        # Pipeline froze 10h ago: lag is big BUT the repo is idle too —
+        # lane-freshness owns that page; we must not double-page.
+        health = _evaluate(
+            lambda url: _result(_manifest_body(_iso_hours_ago(26.0))),
+            git_time_fn=lambda: _epoch_hours_ago(10.0),
+        )
+        self.assertEqual(health.state, cdh.PIPELINE_IDLE)
+        self.assertFalse(health.alerting)
+        self.assertIn("lane-freshness", health.detail)
+
+    def test_missing_generated_at_is_legacy_build(self):
+        # The live build predates the stamping feature: note, never a page.
+        health = _evaluate(lambda url: _result(_manifest_body(omit_stamp=True)))
+        self.assertEqual(health.state, cdh.LEGACY_BUILD)
+        self.assertFalse(health.alerting)
+
+    def test_fetch_failure_is_site_unreachable(self):
+        def boom(url):
+            raise cdh.FetchError("fetch failed after 2 attempt(s): connection refused")
+
+        health = _evaluate(boom)
+        self.assertEqual(health.state, cdh.SITE_UNREACHABLE)
+        self.assertTrue(health.alerting)
+        self.assertIn("connection refused", health.detail)
+
+    def test_unexpected_fetch_exception_is_site_unreachable(self):
+        # The fetch seam is a network boundary: ANY exception out of it must
+        # classify, not crash the watchdog.
+        def boom(url):
+            raise RuntimeError("totally unexpected")
+
+        health = _evaluate(boom)
+        self.assertEqual(health.state, cdh.SITE_UNREACHABLE)
+        self.assertTrue(health.alerting)
+
+    def test_non_200_is_site_unreachable(self):
+        health = _evaluate(lambda url: _result("oops", status=503))
+        self.assertEqual(health.state, cdh.SITE_UNREACHABLE)
+        self.assertTrue(health.alerting)
+        self.assertIn("503", health.detail)
+
+    def test_html_body_is_manifest_unparseable(self):
+        # Observed live: the Caddy SPA fallback serves index.html with HTTP
+        # 200 for a missing path — JSON parsing fails, and that means the
+        # deployed artifact users need is gone.
+        health = _evaluate(
+            lambda url: _result(
+                "<!doctype html>\n<html>...</html>",
+                headers={"content-type": "text/html; charset=utf-8"},
+            )
+        )
+        self.assertEqual(health.state, cdh.MANIFEST_UNPARSEABLE)
+        self.assertTrue(health.alerting)
+        self.assertIn("text/html", health.detail)
+
+    def test_non_object_json_is_manifest_unparseable(self):
+        health = _evaluate(lambda url: _result("[]"))
+        self.assertEqual(health.state, cdh.MANIFEST_UNPARSEABLE)
+        self.assertTrue(health.alerting)
+
+    def test_garbage_generated_at_is_manifest_unparseable(self):
+        health = _evaluate(lambda url: _result(_manifest_body("not-a-timestamp")))
+        self.assertEqual(health.state, cdh.MANIFEST_UNPARSEABLE)
+        self.assertTrue(health.alerting)
+
+    def test_threshold_boundary_exactly_at_threshold_is_healthy(self):
+        # lag must be STRICTLY greater than the threshold to be anomalous.
+        health = _evaluate(lambda url: _result(_manifest_body(_iso_hours_ago(8.0))))
+        self.assertEqual(health.state, cdh.HEALTHY)
+        self.assertFalse(health.alerting)
+
+    def test_threshold_boundary_just_over_flags(self):
+        health = _evaluate(
+            lambda url: _result(_manifest_body(_iso_hours_ago(8.01))),
+            git_time_fn=lambda: _epoch_hours_ago(0.1),
+        )
+        self.assertEqual(health.state, cdh.DEPLOY_STALE)
+        self.assertTrue(health.alerting)
+
+    def test_repo_alive_boundary_exactly_two_hours_defers(self):
+        # repo_idle must be STRICTLY under repo_alive_hours to page.
+        health = _evaluate(
+            lambda url: _result(_manifest_body(_iso_hours_ago(26.0))),
+            git_time_fn=lambda: _epoch_hours_ago(2.0),
+        )
+        self.assertEqual(health.state, cdh.PIPELINE_IDLE)
+        self.assertFalse(health.alerting)
+
+    def test_git_time_unavailable_still_flags_with_caveat(self):
+        # Outside the wired environment (no checkout) we cannot apply the
+        # deferral; surface the real lag rather than swallowing it.
+        health = _evaluate(
+            lambda url: _result(_manifest_body(_iso_hours_ago(26.0))),
+            git_time_fn=lambda: None,
+        )
+        self.assertEqual(health.state, cdh.DEPLOY_STALE)
+        self.assertTrue(health.alerting)
+        self.assertIn("UNKNOWN", health.detail)
+
+    def test_future_generated_at_is_healthy_clock_skew(self):
+        health = _evaluate(lambda url: _result(_manifest_body(_iso_hours_ago(-0.5))))
+        self.assertEqual(health.state, cdh.HEALTHY)
+        self.assertFalse(health.alerting)
+        self.assertIn("future", health.detail)
+
+    def test_absent_cache_headers_do_not_crash(self):
+        # The contract: diagnostics must tolerate cf-cache-status/age absence
+        # (origin reads outside Cloudflare, or header changes).
+        health = _evaluate(
+            lambda url: _result(
+                _manifest_body(_iso_hours_ago(1.0)),
+                headers={"content-type": "application/json"},
+            )
+        )
+        self.assertEqual(health.state, cdh.HEALTHY)
+        self.assertIsNone(health.cache_status)
+        self.assertIsNone(health.age)
+        report = cdh.format_report(health)
+        self.assertIn("cf-cache-status=absent", report)
+        self.assertIn("age=absent", report)
+
+    def test_cache_hit_despite_buster_is_warned(self):
+        health = _evaluate(
+            lambda url: _result(
+                _manifest_body(_iso_hours_ago(1.0)),
+                headers={"cf-cache-status": "HIT", "age": "5400"},
+            )
+        )
+        report = cdh.format_report(health)
+        self.assertIn("cf-cache-status=HIT", report)
+        self.assertIn("WARNING", report)
+
+
+class FetchManifestTest(unittest.TestCase):
+    class _FakeResponse:
+        def __init__(self, body=b"{}", status=200, headers=None):
+            self._body = body
+            self.status = status
+            self.headers = headers or {"Content-Type": "application/json"}
+
+        def read(self, n=-1):
+            return self._body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    def test_cache_buster_appended(self):
+        seen = {}
+
+        def opener(request, timeout):
+            seen["url"] = request.full_url
+            seen["timeout"] = timeout
+            return self._FakeResponse()
+
+        result = cdh.fetch_manifest(
+            URL, timeout=7.0, opener_fn=opener, sleep_fn=lambda s: None,
+            epoch_fn=lambda: 1781000000,
+        )
+        self.assertEqual(result.status, 200)
+        self.assertEqual(seen["url"], URL + "?cb=1781000000")
+        self.assertEqual(seen["timeout"], 7.0)
+
+    def test_cache_buster_respects_existing_query(self):
+        self.assertEqual(
+            cdh.with_cache_buster("https://x.test/m.json?a=1", 42),
+            "https://x.test/m.json?a=1&cb=42",
+        )
+
+    def test_retry_succeeds_on_second_attempt(self):
+        calls = {"n": 0}
+        sleeps = []
+
+        def opener(request, timeout):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise OSError("connection reset")
+            return self._FakeResponse(body=b'{"ok": true}')
+
+        result = cdh.fetch_manifest(
+            URL, retries=1, opener_fn=opener, sleep_fn=sleeps.append,
+            epoch_fn=lambda: 1,
+        )
+        self.assertEqual(calls["n"], 2)
+        self.assertEqual(sleeps, [cdh.RETRY_DELAY_SECONDS])
+        self.assertEqual(result.body, '{"ok": true}')
+
+    def test_retries_exhausted_raises_fetch_error(self):
+        def opener(request, timeout):
+            raise OSError("no route to host")
+
+        with self.assertRaises(cdh.FetchError) as ctx:
+            cdh.fetch_manifest(
+                URL, retries=1, opener_fn=opener, sleep_fn=lambda s: None,
+                epoch_fn=lambda: 1,
+            )
+        self.assertIn("2 attempt(s)", str(ctx.exception))
+        self.assertIn("no route to host", str(ctx.exception))
+
+    def test_header_keys_lowercased(self):
+        def opener(request, timeout):
+            return self._FakeResponse(
+                headers={"CF-Cache-Status": "DYNAMIC", "Age": "3"},
+            )
+
+        result = cdh.fetch_manifest(URL, opener_fn=opener, sleep_fn=lambda s: None, epoch_fn=lambda: 1)
+        self.assertEqual(result.headers.get("cf-cache-status"), "DYNAMIC")
+        self.assertEqual(result.headers.get("age"), "3")
+
+
+class HelpersTest(unittest.TestCase):
+    def test_idempotency_key_format(self):
+        self.assertEqual(
+            cdh.idempotency_key(cdh.DEPLOY_STALE, NOW),
+            "deploy-health-2026-06-10-deploy-stale",
+        )
+        self.assertEqual(
+            cdh.idempotency_key(cdh.HEALTHY, NOW),
+            "deploy-health-2026-06-10-healthy",
+        )
+
+    def test_parse_iso8601_variants(self):
+        # toISOString() shape (trailing Z + millis) must parse on Python <3.11.
+        parsed = cdh.parse_iso8601("2026-06-10T01:28:50.123Z")
+        self.assertIsNotNone(parsed)
+        self.assertEqual(parsed.tzinfo, timezone.utc)
+        # Naive timestamps are assumed UTC.
+        naive = cdh.parse_iso8601("2026-06-10T01:28:50")
+        self.assertIsNotNone(naive.tzinfo)
+        # Garbage and non-strings are None, not exceptions.
+        self.assertIsNone(cdh.parse_iso8601("yesterday-ish"))
+        self.assertIsNone(cdh.parse_iso8601(""))
+        self.assertIsNone(cdh.parse_iso8601(None))
+
+    def test_alerting_states_are_exactly_the_page_worthy_set(self):
+        self.assertEqual(
+            cdh.ALERTING_STATES,
+            {cdh.DEPLOY_STALE, cdh.SITE_UNREACHABLE, cdh.MANIFEST_UNPARSEABLE},
+        )
+        for state in (cdh.HEALTHY, cdh.LEGACY_BUILD, cdh.PIPELINE_IDLE):
+            self.assertNotIn(state, cdh.ALERTING_STATES)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The incident this prevents

ara.guzus.xyz (Railway: Caddy container rebuilt from the root Dockerfile on every push to `main`) silently stopped deploying for ~1 day — the Docker build failed on every commit since #102 (fixed in #112). Nothing noticed, because both existing watchdogs measure the **repository**:

- `check_lane_freshness.py` — git-commit recency: commits were perfectly fresh.
- `check_lane_content.py` (#111) — artifact volume: artifacts were perfectly healthy.

Repo green, prod dead. This PR adds the missing signal: **is the artifact users actually see current?**

## Signal design

**1. Build stamp** (`dashboard/scripts/prebuild.mjs`): the emitted `manifest.json` now carries `generatedAt` (build wall-clock, `new Date().toISOString()`) and best-effort `gitSha` (`RAILWAY_GIT_COMMIT_SHA || VERCEL_GIT_COMMIT_SHA || null` — never shells out to git; the Docker build context has no `.git`). Additive only: `main.ts`'s `loadManifest()` normalizes by picking known keys, so the SPA ignores the new fields.

**2. Live probe** (`scripts/check_deploy_health.py`, stdlib-only): fetches the deployed manifest and computes `lag = now − generatedAt`.

- **URL choice (premise stress-tested):** the default is `https://ara.guzus.xyz/research/manifest.json` — the file the dashboard actually fetches. Root `/manifest.json` is a trap: the Caddyfile's `try_files {path} /index.html` SPA fallback serves it as **HTML with HTTP 200** (verified live). Pointing there would JSON-parse-fail forever; that shape is classified as its own alerting finding (`manifest-unparseable`) since it equals "the artifact users need is gone".
- **Cache-busting (premise b):** every request appends a unique `cb=<epoch>` param (Cloudflare's cache key includes the query string) plus `Cache-Control: no-cache`, with a 15s timeout, UA header, and one retry. The response's `cf-cache-status`/`age` headers are captured in the diagnostics; a `HIT` despite the buster gets an explicit warning. Verified live: `cf-cache-status: DYNAMIC` (origin-fresh read), absent `age` handled without crashing.
- **Threshold can't false-positive in quiet periods (premise a):** measured the real push cadence — 367 commits over the trailing 10 days with a **maximum gap of 3.4h** (hourly RSS is the floor; lane-freshness pages rss at 4h idle anyway). Railway rebuilds in minutes, so healthy lag stays ~1h; the default 8h threshold (`--max-lag-hours`) is >2x the worst legitimate quiet stretch.

**3. Deferral — deploy-stale vs pipeline-dead (premise c):** a frozen pipeline also freezes `generatedAt`, but that page belongs to lane-freshness. So:

| condition | finding | alert? |
|---|---|---|
| `lag <= 8h` | `healthy` | no |
| `lag > 8h` AND last commit `< 2h` old | `deploy-stale` | **yes — THE page** (pushes flow, builds don't) |
| `lag > 8h` AND repo idle too | `pipeline-idle (deferring to lane-freshness)` | no (no double-page) |
| manifest has no `generatedAt` | `legacy-build` | no — expected until this PR's first deploy ships the stamp |
| fetch fails after retry / non-200 | `site-unreachable` | yes |
| HTTP 200 but not a JSON object / bad stamp | `manifest-unparseable` | yes |

Advisory semantics throughout: exit 0 always by default; `--exit-code` opts into exit 2 on alert-class findings (mirrors `check_lane_content.py`). `fetch_fn`/`git_time_fn`/`now` are injectable for tests, mirroring the sibling watchdogs' seams.

**4. Alerting** (`.github/actions/deploy-health-alert/action.yml`, new): dual-channel hooker (priority 4, between content's 3 and freshness's 5) + direct Telegram fallback, per-day idempotency key `deploy-health-<date>-<finding>` so both watchdog tiers collapse to one message, `continue-on-error` everywhere — never fails the job (Rule 4). A **new** composite rather than parameterizing `lane-content-alert`: the repo's pattern is one composite per check (freshness/content/heartbeat), and genericizing would push script paths, output names, and message templates through a shared path another lane depends on.

**5. Wiring** (`.github/workflows/liveness-check.yml`): the advisory step runs on BOTH tiers (ubuntu-latest + self-hosted — whichever survives an outage alerts), after the content gate and **before** the freshness composite whose final step hard-fails — one stale lane must not mask a dead deploy. Ordering invariants preserved: the only non-zero-exit step stays last; heartbeat gating unchanged.

## Validation

- `uv run python -m unittest discover -s scripts -p 'test_*.py'` (CI command): **289 tests, OK** (25 new: healthy / deploy-stale / pipeline-idle deferral / legacy-build / unreachable / SPA-fallback HTML / threshold boundaries at exactly 8h and 2h / absent cache headers / retry mechanics / idempotency key).
- `cd dashboard && bun install --frozen-lockfile && SKIP_LFS_POINTERS=1 bun run build`: built `manifest.json` (both `public/research/` and `dist/research/`) now contains `generatedAt: 2026-06-10T01:40:02.929Z`, `gitSha: null` (no Railway env locally — expected).
- **Live dry-run** `uv run python scripts/check_deploy_health.py`: reports `legacy-build` — the correct result today, since the current prod build predates the stamp; this finding disappears after this PR's first successful deploy. Diagnostics show `http_status: 200`, `cf-cache-status=DYNAMIC age=absent` (origin-fresh, cache-bust effective).
- Trap probe `--url https://ara.guzus.xyz/manifest.json --exit-code`: correctly flags `manifest-unparseable` (content-type=text/html SPA fallback), exit 2.
- `actionlint .github/workflows/liveness-check.yml`: pass (repo-wide run shows only pre-existing SC2086 info-level notes in other workflows; CI runs actionlint with `shellcheck: false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)