### PR TITLE
Fix front-page PNG layout: budget-aware SVG flow + image format sniffing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ and opens a PR with methodology fixes.
 | `build_wiki_index.py` | Rebuilds `research/wiki/index.json` from the wiki pages. **CI-load-bearing**: `ci.yml` runs `--check` (exit 1 if the committed index is stale or any page fails validation); `wiki-ingest.yml` regenerates it every run. |
 | `fetch_ai_blogs.py` | Per-feed AI-blog fetcher used by `daily-ai-blogs.yml`; boundary-handles bad feeds so one failure doesn't crash the run. |
 | `source_cache.py` | Runtime primary-source fetch cache under `data/source-cache/` (gitignored), used by `generative-research.yml`. |
-| `render_front_page.mjs` | Puppeteer/Chrome renderer for the daily newspaper PNG, used by `daily-front-page.yml`. |
+| `render_front_page.mjs` | Deterministic newspaper renderer used by `daily-front-page.yml`: digest → SVG → PNG via `@resvg/resvg-js` (no Chromium/model dependency), plus the `.ara.md` source for the interactive edition. Layout is budget-aware — overflow is ellipsized/dropped, never painted over. |
 | `test_ara_dsl.py`, `test_dedupe_headline_alerts.py` | Pytest-style tests run in CI. (`test_ara_dsl.py` also asserts `ARA_CATALOG.json` ↔ `COMPONENTS.md` lockstep.) |
 
 #### Experimental / manually-run scripts (NOT in the automated pipeline)

--- a/scripts/render_front_page.mjs
+++ b/scripts/render_front_page.mjs
@@ -208,7 +208,23 @@ async function imageCandidateLinks() {
   return out.slice(0, 30);
 }
 
-async function imageFromPage(link) {
+// Content-type headers lie often enough (CDN error pages, mislabeled
+// formats) that the downloaded bytes are the only trustworthy signal.
+function sniffImageFormat(bytes) {
+  if (bytes.length >= 4 && bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47) return "image/png";
+  if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) return "image/jpeg";
+  if (bytes.length >= 4 && bytes.toString("ascii", 0, 4) === "GIF8") return "image/gif";
+  if (bytes.length >= 12 && bytes.toString("ascii", 0, 4) === "RIFF" && bytes.toString("ascii", 8, 12) === "WEBP") return "image/webp";
+  if (bytes.length >= 12 && bytes.toString("ascii", 4, 8) === "ftyp" && /^av(if|is)/.test(bytes.toString("ascii", 8, 12))) return "image/avif";
+  return null;
+}
+
+const ALL_IMAGE_FORMATS = ["image/png", "image/jpeg", "image/gif", "image/webp", "image/avif"];
+// resvg cannot decode webp/avif — embedding one paints an empty frame on
+// the rendered PNG, so the SVG path must stick to this set.
+const SVG_SAFE_FORMATS = ["image/png", "image/jpeg", "image/gif"];
+
+async function imageFromPage(link, allowedFormats) {
   try {
     const pageResponse = await fetchWithTimeout(link.url, {
       headers: {
@@ -239,8 +255,10 @@ async function imageFromPage(link) {
     if (contentLength > 2500000) return null;
     const bytes = Buffer.from(await imageResponse.arrayBuffer());
     if (bytes.length > 2500000) return null;
+    const format = sniffImageFormat(bytes);
+    if (!format || !allowedFormats.includes(format)) return null;
     return {
-      src: `data:${contentType};base64,${bytes.toString("base64")}`,
+      src: `data:${format};base64,${bytes.toString("base64")}`,
       imageUrl,
       alt: link.label || link.story,
       caption: link.story,
@@ -251,10 +269,10 @@ async function imageFromPage(link) {
   }
 }
 
-async function resolveImages(limit = 3) {
+async function resolveImages(limit = 3, allowedFormats = ALL_IMAGE_FORMATS) {
   const images = [];
   for (const link of await imageCandidateLinks()) {
-    const image = await imageFromPage(link);
+    const image = await imageFromPage(link, allowedFormats);
     if (image) images.push(image);
     if (images.length >= limit) break;
   }
@@ -354,7 +372,7 @@ function renderAraSource(images = []) {
   return source.join("\n");
 }
 
-function wrapText(text, maxChars, maxLines = 99) {
+function wrapText(text, maxChars) {
   const words = text.split(/\s+/).filter(Boolean);
   const lines = [];
   let line = "";
@@ -363,13 +381,36 @@ function wrapText(text, maxChars, maxLines = 99) {
     if (next.length > maxChars && line) {
       lines.push(line);
       line = word;
-      if (lines.length >= maxLines) break;
     } else {
       line = next;
     }
   }
-  if (line && lines.length < maxLines) lines.push(line);
+  if (line) lines.push(line);
   return lines;
+}
+
+// Truncation must stay visible: a clamp that drops words silently produces
+// mid-sentence headlines on the rendered page.
+function clampText(text, maxChars, maxLines) {
+  const lines = wrapText(text, maxChars);
+  if (lines.length <= maxLines) return lines;
+  const kept = lines.slice(0, maxLines);
+  const last = kept[maxLines - 1].slice(0, Math.max(1, maxChars - 1));
+  kept[maxLines - 1] = `${last.replace(/[\s,;:.—–-]+$/, "")}…`;
+  return kept;
+}
+
+// The digest's lead bullet is a full paragraph; only its first sentence is
+// headline-sized. Requiring a following capital/figure and a 30-char minimum
+// avoids false splits on decimals ("$19.2B") and short abbreviations.
+function splitFirstSentence(text) {
+  for (const match of text.matchAll(/[.!?]["”')\]]*\s+(?=["“(]?[A-Z0-9~$€£#@])/g)) {
+    const head = text.slice(0, match.index + match[0].length).trimEnd();
+    if (head.length < 30) continue;
+    if (/\b(?:vs|Mr|Mrs|Ms|Dr|Prof|St|Vol|No|Inc|Corp|Co|Ltd|Jr|Sr|etc)\.$/i.test(head.replace(/["”')\]]+$/, ""))) continue;
+    return [head, text.slice(match.index + match[0].length)];
+  }
+  return [text.trim(), ""];
 }
 
 function svgText(x, y, lines, options = {}) {
@@ -420,18 +461,30 @@ function renderSvg(images = []) {
   parts.push(`<line x1="62" x2="1138" y1="242" y2="242" stroke="#1f1a14" stroke-width="3"/>`);
   parts.push(`<line x1="62" x2="1138" y1="248" y2="248" stroke="#1f1a14" stroke-width="1"/>`);
 
+  // Lead column geometry: text flows from y=305 and must stop above the
+  // image slot (fixed at 690..900) or, with no image, above the 930 rule.
+  // Every block fits its remaining vertical budget — content that doesn't
+  // fit is ellipsized or dropped, never painted over by a later element.
+  const imageTop = 690;
+  const leadBottom = images[0] ? imageTop - 18 : 906;
   let y = 305;
-  const headlineLines = wrapText(lead, 25, 5);
-  parts.push(svgText(62, y, headlineLines, { size: 44, weight: "700", lineHeight: 48 }));
-  y += headlineLines.length * 48 + 24;
-  for (const item of leadDeck) {
-    const lines = wrapText(item, 56, 4);
+  const [headlineText, headlineRest] = splitFirstSentence(lead);
+  const headlineSize = headlineText.length > 130 ? 36 : 44;
+  const headlineWrap = headlineSize === 36 ? 31 : 25;
+  const headlineLineHeight = headlineSize === 36 ? 40 : 48;
+  const headlineLines = clampText(headlineText, headlineWrap, 5);
+  parts.push(svgText(62, y, headlineLines, { size: headlineSize, weight: "700", lineHeight: headlineLineHeight }));
+  y += headlineLines.length * headlineLineHeight + 24;
+  for (const item of [headlineRest, ...leadDeck].filter(Boolean)) {
+    const linesThatFit = Math.floor((leadBottom - y) / 29) + 1;
+    if (linesThatFit < 2) break;
+    const lines = clampText(item, 54, Math.min(4, linesThatFit));
     parts.push(svgText(62, y, lines, { size: 22, lineHeight: 29 }));
     y += lines.length * 29 + 14;
   }
   if (images[0]) {
-    parts.push(svgImage(images[0], 62, 690, 650, 210));
-    parts.push(svgText(62, 924, wrapText(images[0].alt, 72, 1), {
+    parts.push(svgImage(images[0], 62, imageTop, 650, 210));
+    parts.push(svgText(62, 924, clampText(images[0].alt, 72, 1), {
       size: 13,
       weight: "700",
       family: "Arial, sans-serif",
@@ -439,13 +492,20 @@ function renderSvg(images = []) {
   }
 
   parts.push(`<line x1="760" x2="760" y1="282" y2="900" stroke="#2b251d" stroke-width="2"/>`);
+  const sidebarBottom = 906;
   let sideY = 305;
   for (const [label, items] of [["Breaking", breaking], ["Policy Watch", policy]]) {
+    // Section label plus at least two lines of its first item must fit,
+    // otherwise the whole section is dropped rather than spilling over
+    // the 930 rule into the departments grid.
+    if (items.length === 0 || sideY + 31 + 22 > sidebarBottom) continue;
     parts.push(`<line x1="790" x2="1138" y1="${sideY - 22}" y2="${sideY - 22}" stroke="#1f1a14" stroke-width="7"/>`);
     parts.push(svgText(790, sideY, [label.toUpperCase()], { size: 16, weight: "800", family: "Arial, sans-serif" }));
     sideY += 31;
     for (const item of items.slice(0, 3)) {
-      const lines = wrapText(item, 38, 4);
+      const linesThatFit = Math.floor((sidebarBottom - sideY) / 22) + 1;
+      if (linesThatFit < 2) break;
+      const lines = clampText(item, 38, Math.min(4, linesThatFit));
       parts.push(svgText(790, sideY, lines, { size: 17, lineHeight: 22 }));
       sideY += lines.length * 22 + 14;
     }
@@ -462,16 +522,19 @@ function renderSvg(images = []) {
     const x = 62 + i * 365;
     if (i > 0) parts.push(`<line x1="${x - 22}" x2="${x - 22}" y1="958" y2="1360" stroke="#7d725f" stroke-width="1"/>`);
     parts.push(svgText(x, 982, [columns[i][0]], { size: 26, weight: "700" }));
+    const columnBottom = 1360;
     let columnY = 1022;
     for (const item of columns[i][1].slice(0, i === 1 ? 4 : 3)) {
-      const lines = wrapText(`• ${item}`, 35, 4);
+      const linesThatFit = Math.floor((columnBottom - columnY) / 22) + 1;
+      if (linesThatFit < 2) break;
+      const lines = clampText(`• ${item}`, 35, Math.min(4, linesThatFit));
       parts.push(svgText(x, columnY, lines, { size: 17, lineHeight: 22 }));
       columnY += lines.length * 22 + 12;
     }
   }
 
   parts.push(`<rect x="62" y="1390" width="1076" height="106" fill="#fffaf2" stroke="#2b251d" stroke-width="2"/>`);
-  parts.push(svgText(84, 1426, wrapText(quote || "No quote of the day was available in the digest.", 100, 3), {
+  parts.push(svgText(84, 1426, clampText(quote || "No quote of the day was available in the digest.", 100, 3), {
     size: 18,
     lineHeight: 25,
     italic: true,
@@ -494,7 +557,7 @@ function renderSvg(images = []) {
 
 if (output.endsWith(".png")) {
   const { Resvg } = await import("/tmp/node_modules/@resvg/resvg-js/index.js");
-  const images = await resolveImages(1);
+  const images = await resolveImages(1, SVG_SAFE_FORMATS);
   const png = new Resvg(renderSvg(images), {
     fitTo: { mode: "width", value: 2400 },
     font: {


### PR DESCRIPTION
## Problem

The 2026-06-10 and 2026-06-11 front pages rendered visibly broken:

- **Headline clipped mid-sentence** ("…FY26-Q4 topped every") — `wrapText(lead, 25, 5)` silently dropped everything past 5 lines, and the digest's lead bullet is a ~500-char paragraph.
- **Lede text painted over by the photo** — the image is stamped at a fixed slot (y 690–900) *after* the text, so any paragraph flowing past y=690 was buried, with fragments peeking out at the edges.
- **Sidebar crossed the y=930 rule** — the horizontal rule drew straight through "summaries as Google's own speech…" on June 11; no section enforced its vertical budget.
- **Latent: empty picture frame** — webp/avif og:images were embedded as data URIs that resvg cannot decode (reproduced on a June 9 re-render).

## Fix (`scripts/render_front_page.mjs`, SVG/PNG path only)

- Headline = **first sentence** of the lead bullet (abbreviation-guarded splitter: `vs.` / `Inc.` / `Mr.` etc.), adaptive 44px/36px sizing; the remainder flows into the lede column.
- Every section now fits its **vertical budget** (lede stops above the image slot or y=906; sidebar above 906; department columns above 1360): content that doesn't fit is **ellipsized via `clampText`** — truncation stays visible — or dropped, never overdrawn. Empty sidebar sections are skipped instead of stacking labels.
- Downloaded images are **magic-byte sniffed**; the PNG path embeds only resvg-decodable formats (png/jpeg/gif), and the data-URI mime comes from sniffed bytes instead of the content-type header. `.ara.md`/HTML modes keep all formats (`.ara.md` embeds the remote URL anyway) — behavior unchanged.
- CLAUDE.md scripts row updated: the renderer has been resvg (not Puppeteer/Chrome) since the "Render front page PNGs without Chromium" commit.

## Verification

- Re-rendered 2026-06-09/10/11 locally: full headline sentences, clean ellipses, no text under the photo, all rules clear, June 9 gets a real decoded image instead of an empty frame.
- `.ara.md` generation + `compile_ara.py --target newspaper` still pass.
- Budget invariant brute-forced over all reachable layout states (4 section configs): last painted baseline never exceeds its budget; worst ink depth past a budget is descender-only (~6px) against ≥18px slack.
- Reviewer-agent pass: helpers, sniffing, and mode isolation confirmed sound.

Follow-up candidates (not in this PR): `daily-front-page.yml` still installs Chromium system deps the renderer no longer uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)