### PR TITLE
Drop vestigial Chromium install from daily-front-page

### DIFF
--- a/.github/workflows/daily-front-page.yml
+++ b/.github/workflows/daily-front-page.yml
@@ -26,8 +26,9 @@ concurrency:
 jobs:
   front-page:
     runs-on: [self-hosted, Linux]
-    # Cap a wedged Puppeteer/Chrome render so it can't pin a Cloud Run worker
-    # for GitHub's 6h default (mirrors the 90-min agent-lane convention).
+    # Cap a wedged render (resvg + network-bound og:image fetches) so it
+    # can't pin a Cloud Run worker for GitHub's 6h default (mirrors the
+    # 90-min agent-lane convention).
     timeout-minutes: 30
     # Only run when the digest succeeded, OR when a human dispatched us.
     # `workflow_run.conclusion` is empty on workflow_dispatch, so we must
@@ -105,27 +106,9 @@ jobs:
         with:
           enable-cache: true
 
-      # Install Chromium dependencies and puppeteer
-      - name: Install Chromium system dependencies
-        if: steps.check.outputs.exists == 'true'
-        run: |
-          if [ "${{ runner.os }}" = "Linux" ]; then
-            if ! command -v sudo >/dev/null 2>&1 || ! sudo -n true >/dev/null 2>&1; then
-              echo "sudo unavailable on this runner; assuming Chromium dependencies are already present."
-              exit 0
-            fi
-            sudo apt-get update -qq
-            sudo apt-get install -y -qq \
-              libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 \
-              libdrm2 libxkbcommon0 libxcomposite1 libxdamage1 libxrandr2 libgbm1 \
-              libpango-1.0-0 libcairo2 libasound2 libxshmfence1 \
-              libx11-6 libx11-xcb1 libxcb1 libxext6 libxfixes3 libxi6 \
-              libxrender1 libxtst6 libglib2.0-0 libdbus-1-3 \
-              fonts-liberation xdg-utils wget > /dev/null 2>&1
-          else
-            echo "Skipping Linux-only Chromium dependencies on ${{ runner.os }}"
-          fi
-
+      # resvg is the renderer's only native dependency (prebuilt napi binary,
+      # no Chromium/X11 libs). Text uses system fonts: the Cloud Run worker
+      # image carries fonts-dejavu-core via ffmpeg's fontconfig dependency.
       - name: Install PNG renderer
         if: steps.check.outputs.exists == 'true'
         run: cd /tmp && npm install @resvg/resvg-js@2.6.2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ service in `../runner`; see Load-bearing rule 5). A fresh
 `cloud-run-worker-*` instance spins up per job, so "self-hosted" no longer
 means one serial slot — jobs run in parallel, and each worker carries the
 pipeline's baked-in state (bird CLI + birdy daemon, LFS-hydrated
-`research/` checkout, Puppeteer/Chrome, pre-installed tooling). Aggregation,
+`research/` checkout, pre-installed tooling). Aggregation,
 synthesis, output, CI, and the Claude agent lanes all run here.
 
 Only **two `runs-on: ubuntu-latest`** (GitHub-hosted) jobs exist, and both
@@ -295,9 +295,10 @@ output or break the pipeline. Read them before editing.
    jobs run in PARALLEL (no single serial slot) and each carries baked-in
    state — bird CLI + warm birdy daemon (`hourly-twitter*`,
    `24h-model-timeline`), LFS-hydrated `research/` for prior-output context
-   (`daily-digest`, `daily-front-page`, `ci.yml` dashboard job),
-   Puppeteer/Chrome (`daily-front-page`), pre-installed pnpm/Oracle
-   tooling. Use `[self-hosted, Linux]` for anything touching that state,
+   (`daily-digest`, `ci.yml` dashboard job), pre-installed pnpm/Oracle
+   tooling. (`daily-front-page` checks out with `lfs: false` and renders
+   via resvg — it needs neither LFS media nor Chromium.) Use
+   `[self-hosted, Linux]` for anything touching that state,
    which is nearly everything. Reserve `ubuntu-latest` for the two
    watchdogs that must outlive a self-hosted outage (`liveness-check.yml`,
    `auto-rerun-on-runner-loss.yml`). The tradeoff of ephemeral workers: an


### PR DESCRIPTION
Follow-up to #117. The front-page PNG renderer has been resvg (a prebuilt napi binary, no X11/Chromium libs) since the "Render front page PNGs without Chromium" commit, but the workflow still carried a Chromium system-deps install step.

## Evidence it was dead weight

- **Every scheduled run executes on `cloud-run-worker-*`** (June 8–11 verified), where the step hits the no-sudo path and exits 0 in ~1s — it has never installed anything on the production tier, and the "assuming Chromium dependencies are already present" message it prints there is false (the worker image bakes no Chromium).
- Those runs still render text because **`fonts-dejavu-core` ships in the worker image** as a hard dependency of ffmpeg's fontconfig chain (`ffmpeg → libfontconfig1 → fontconfig-config → fonts-dejavu-core`) — now documented next to the "Install PNG renderer" step.
- On host-runner backfills the step spent ~6s running apt for packages resvg never loads.

## Changes

- `daily-front-page.yml`: remove the "Install Chromium system dependencies" step; fix the stale "wedged Puppeteer/Chrome render" timeout comment; document where fonts come from.
- `CLAUDE.md`: retire the Puppeteer/Chrome claims in the workflows intro and Load-bearing rule 5, and note `daily-front-page` checks out with `lfs: false` (it was also listed as an LFS-hydration consumer, which its own checkout comment contradicts).

No dispatch-test after merge (it would post a duplicate paper to Telegram); the step provably no-ops on the tier that runs the lane, and tomorrow's scheduled run is covered by the auto-rerun + liveness watchdogs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)