### PR TITLE
Fix Twitter birdy daemon port collisions

### DIFF
--- a/.github/actions/birdy-daemon/action.yml
+++ b/.github/actions/birdy-daemon/action.yml
@@ -1,6 +1,6 @@
 name: Birdy daemon + bird-fast wrapper
 description: >
-  Start a birdy daemon on 127.0.0.1:8080 (warm bird API for LLM follow-up
+  Start a birdy daemon on a free localhost port (warm bird API for LLM follow-up
   queries) and install bird-fast on the job PATH — a drop-in shim that
   routes the same `bird ...` args through the daemon's POST /run endpoint
   for sub-second latency. The companion stop step lives inline in each
@@ -14,9 +14,9 @@ inputs:
     description: BIRD_CT0 secret value.
     required: true
   port:
-    description: Daemon listen port (still on 127.0.0.1 only).
+    description: Daemon listen port (still on 127.0.0.1 only). Use 0 for an automatically selected free port.
     required: false
-    default: '8080'
+    default: '0'
   concurrency:
     description: Internal request concurrency.
     required: false
@@ -33,7 +33,7 @@ runs:
       shell: bash
       env:
         BIRDY_ACCOUNTS: '[{"name":"ci","auth_token":"${{ inputs.bird_auth_token }}","ct0":"${{ inputs.bird_ct0 }}"}]'
-        DAEMON_PORT: ${{ inputs.port }}
+        DAEMON_PORT_INPUT: ${{ inputs.port }}
         DAEMON_CONC: ${{ inputs.concurrency }}
         DAEMON_TTL: ${{ inputs.cache_ttl }}
       run: |
@@ -42,38 +42,65 @@ runs:
         # bird-CLI startup. The daemon holds warm auth + account-rotation,
         # so each follow-up is ~300ms (network only). Translates to
         # ~10-15s saved on busy cycles.
+        set -euo pipefail
+
+        STATE_DIR=$(mktemp -d "${RUNNER_TEMP:-/tmp}/birdy-daemon.XXXXXX")
+        LOG_PATH="$STATE_DIR/birdy-daemon.log"
+        PID_PATH="$STATE_DIR/birdy-daemon.pid"
+
+        if [ -z "${DAEMON_PORT_INPUT}" ] || [ "${DAEMON_PORT_INPUT}" = "0" ] || [ "${DAEMON_PORT_INPUT}" = "auto" ]; then
+          DAEMON_PORT=$(python3 - <<'PY'
+        import socket
+
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind(("127.0.0.1", 0))
+            print(sock.getsockname()[1])
+        PY
+          )
+        else
+          DAEMON_PORT="${DAEMON_PORT_INPUT}"
+        fi
+
+        DAEMON_URL="http://127.0.0.1:${DAEMON_PORT}"
+        {
+          echo "BIRDY_DAEMON_URL=${DAEMON_URL}"
+          echo "BIRDY_DAEMON_PID_PATH=${PID_PATH}"
+          echo "BIRDY_DAEMON_LOG_PATH=${LOG_PATH}"
+        } >> "$GITHUB_ENV"
+
         nohup birdy daemon --addr "127.0.0.1:${DAEMON_PORT}" --concurrency "${DAEMON_CONC}" --cache-ttl "${DAEMON_TTL}" \
-          > /tmp/birdy-daemon.log 2>&1 &
-        echo $! > /tmp/birdy-daemon.pid
+          > "$LOG_PATH" 2>&1 &
+        echo $! > "$PID_PATH"
 
         for attempt in 1 2 3 4 5 6 7 8 9 10; do
           sleep 1
-          if curl -fsS "http://127.0.0.1:${DAEMON_PORT}/health" 2>/dev/null | grep -q '"ok":true'; then
-            echo "birdy daemon up: $(curl -sS http://127.0.0.1:${DAEMON_PORT}/health)"
+          if curl -fsS "${DAEMON_URL}/health" 2>/dev/null | grep -q '"ok":true'; then
+            echo "birdy daemon up: $(curl -sS "${DAEMON_URL}/health")"
             exit 0
           fi
           echo "Waiting for birdy daemon, attempt ${attempt}/10"
         done
         echo "birdy daemon did not become healthy in 10s:"
-        cat /tmp/birdy-daemon.log
+        cat "$LOG_PATH"
         exit 1
 
     - name: Install bird-fast wrapper (calls daemon)
       shell: bash
-      env:
-        DAEMON_PORT: ${{ inputs.port }}
       run: |
         # bird-fast: a drop-in shim that takes the same args as `bird` but
         # forwards them to the local daemon's POST /run endpoint. Same JSON
         # output on stdout. Lets the LLM keep its existing mental model
         # ("bird search ...") while paying daemon-speed latency.
+        set -euo pipefail
+
+        DEFAULT_DAEMON_URL="${BIRDY_DAEMON_URL:?BIRDY_DAEMON_URL was not exported by the daemon start step}"
         INSTALL_DIR="$HOME/.local/bin"
         mkdir -p "$INSTALL_DIR"
         WRAPPER_PATH="$INSTALL_DIR/bird-fast"
         cat > "$WRAPPER_PATH" <<WRAPPER
         #!/bin/bash
         set -e
-        DAEMON_URL="\${BIRDY_DAEMON_URL:-http://127.0.0.1:${DAEMON_PORT}}"
+        DAEMON_URL="\${BIRDY_DAEMON_URL:-${DEFAULT_DAEMON_URL}}"
         PAYLOAD=\$(printf '%s\n' "\$@" | jq -Rs '{args: split("\n") | map(select(length > 0))}')
         RESP=\$(curl -sS -X POST "\${DAEMON_URL}/run" \\
           -H "Content-Type: application/json" \\

--- a/.github/workflows/auto-rerun-on-runner-loss.yml
+++ b/.github/workflows/auto-rerun-on-runner-loss.yml
@@ -58,7 +58,7 @@ jobs:
     steps:
       # Checkout only so the local hooker-telemetry composite action resolves.
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Re-run failed jobs if (and only if) a worker vanished
         id: decide

--- a/.github/workflows/hourly-twitter.yml
+++ b/.github/workflows/hourly-twitter.yml
@@ -446,8 +446,16 @@ jobs:
       - name: Stop birdy daemon
         if: always() && steps.const.outputs.enable_daemon == 'true'
         run: |
-          if [ -f /tmp/birdy-daemon.pid ]; then
-            PID=$(cat /tmp/birdy-daemon.pid)
+          if [ -z "${BIRDY_DAEMON_PID_PATH:-}" ]; then
+            echo "No birdy daemon state exported; nothing to stop."
+            exit 0
+          fi
+
+          PID_PATH="$BIRDY_DAEMON_PID_PATH"
+          LOG_PATH="${BIRDY_DAEMON_LOG_PATH:-}"
+
+          if [ -f "$PID_PATH" ]; then
+            PID=$(cat "$PID_PATH")
             if kill -0 "$PID" 2>/dev/null; then
               echo "Stopping daemon PID $PID..."
               kill -TERM "$PID" 2>/dev/null || true
@@ -458,11 +466,11 @@ jobs:
               done
               kill -KILL "$PID" 2>/dev/null || true
             fi
-            rm -f /tmp/birdy-daemon.pid
+            rm -f "$PID_PATH"
           fi
-          if [ -f /tmp/birdy-daemon.log ]; then
+          if [ -n "$LOG_PATH" ] && [ -f "$LOG_PATH" ]; then
             echo "--- daemon log (last 20 lines) ---"
-            tail -20 /tmp/birdy-daemon.log
+            tail -20 "$LOG_PATH"
           fi
 
       # ── claude-tier dry-run fixture (skips push) ───────────────────

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -400,11 +400,11 @@ output or break the pipeline. Read them before editing.
 ## Component catalog
 
 The article-fragment class allowlist lives in **`ARA_CATALOG.json`**
-(73 base `ara-*` classes). The validator
+(currently 87 base `ara-*` classes). The validator
 (`scripts/check_generative_research.py` → `write_generative_research.py`
 → `ara_catalog.load_catalog`/`catalog_classes`) loads its allowlist from
 that file, NOT from `COMPONENTS.md`. `COMPONENTS.md` is the human
-reference and documents the **same 73** classes;
+reference and documents the **same cataloged base classes**;
 `scripts/ara_catalog.py` (`validate_catalog_against_components`) asserts
 the two stay in perfect lockstep and CI enforces it via
 `test_ara_dsl.py`. To add a new primitive, add it to BOTH files in the
@@ -416,11 +416,12 @@ allowlist. The extra classes are NOT drift and are NOT a commit-time
 rejection risk — they belong to layers that live outside the
 article-fragment contract on purpose:
 
-- `dashboard/src/components/ara-research.css` defines ~98 base `ara-*`
-  classes total: the 73 cataloged article primitives (`ara-doc`,
+- `dashboard/src/components/ara-research.css` defines more `ara-*`
+  classes than the catalog: the cataloged article primitives (`ara-doc`,
   `ara-callout`, `ara-figure`, …) that DO appear in `.ara.md` and ARE the
-  allowlist, **plus** ~25 **runtime/interactive extras** — table-of-
-  contents, figure lightbox, chart tooltips/axes/series (e.g.
+  allowlist, **plus** **runtime/interactive extras** — table-of-
+  contents, figure lightbox, chart tooltips/axes/series, generated chart
+  internals (e.g.
   `ara-chart-series-*`, built at `main.ts` ~line 3311) — injected by
   `dashboard/src/main.ts` at runtime. The runtime extras never appear in
   `.ara.md` source, so they don't need to be in the allowlist.


### PR DESCRIPTION
## Summary
- Make the birdy daemon composite choose a free localhost port by default instead of fixed `127.0.0.1:8080`.
- Store daemon PID/log state in the per-job runner temp directory and export it through `GITHUB_ENV` for `bird-fast` and cleanup.
- Update the Twitter workflow cleanup step so it only stops the daemon started by the current job.
- Apply the remaining Dependabot checkout bump from #88 (`actions/checkout@v6`) because #88 cannot be merged by this token due workflow-file scope.
- Refresh `CLAUDE.md` component-catalog counts/wording after the current ARA catalog expansion.

## Evidence
- Latest failing Twitter runs died at `Start birdy daemon` with `listen tcp 127.0.0.1:8080: bind: address already in use`.
- Latest auto-rerun failures had zero executed steps/logs, indicating GitHub-hosted startup failure rather than rerun decision logic.

## Verification
- `actionlint -shellcheck= .github/workflows/hourly-twitter.yml .github/workflows/auto-rerun-on-runner-loss.yml`
- Extracted modified workflow/composite `run:` blocks and ran `bash -n` over 24 scripts.
- `uv run python scripts/ara_catalog.py`
- `uv run python scripts/check_model_tickets.py && uv run python scripts/check_wiki.py`
- `uv run python -m unittest discover -s scripts -p 'test_*.py'`
- `cd dashboard && bun install --frozen-lockfile && bun run build`
- `git diff --check`

## PR Triage Done
Merged safe open PRs: #86, #87, #92, #93, #94, #95, #97, #100, #104, #105, #106.
#88 remains open only because GitHub refused OAuth merge of a workflow-file change without `workflow` scope; its one-line change is included here.
