### PR TITLE
Pin generative research to Claude Opus 4.8

### DIFF
--- a/.github/workflows/generative-research.yml
+++ b/.github/workflows/generative-research.yml
@@ -10,7 +10,7 @@ name: Generative Research
 #      infer the research question, then expand into a full article.
 #
 # Two backends, mutually exclusive at runtime:
-#   * claude   — anthropics/claude-code-action@v1 with OAuth (model claude-opus-4-7).
+#   * claude   — anthropics/claude-code-action@v1 with OAuth (model claude-opus-4-8).
 #   * deepseek — same action, but redirected to Fireworks' Anthropic-compatible
 #                endpoint via ANTHROPIC_BASE_URL/ANTHROPIC_AUTH_TOKEN (model
 #                deepseek-v4-flash, served by Fireworks). Mirrors the
@@ -191,13 +191,13 @@ jobs:
             PROMPT="$TOPIC"
             if [ -n "${ISSUE_BODY:-}" ]; then
               CANDIDATE=$(printf '%s\n' "$ISSUE_BODY" \
-                | grep -iE '^[[:space:]]*backend[[:space:]]*:[[:space:]]*(claude|claude-opus-4-7|deepseek|deepseek-v4-flash)[[:space:]]*$' \
+                | grep -iE '^[[:space:]]*backend[[:space:]]*:[[:space:]]*(claude|claude-opus-4-8|claude-opus-4-7|deepseek|deepseek-v4-flash)[[:space:]]*$' \
                 | head -n1 \
                 | sed -E 's/^[[:space:]]*[Bb][Aa][Cc][Kk][Ee][Nn][Dd][[:space:]]*:[[:space:]]*//' \
                 | tr -d '[:space:]' \
                 | tr '[:upper:]' '[:lower:]' || true)
               case "$CANDIDATE" in
-                claude-opus-4-7) CANDIDATE="claude" ;;
+                claude-opus-4-8|claude-opus-4-7) CANDIDATE="claude" ;;
                 deepseek) CANDIDATE="deepseek-v4-flash" ;;
               esac
               if [ "$CANDIDATE" = "claude" ] || [ "$CANDIDATE" = "deepseek-v4-flash" ]; then
@@ -205,7 +205,7 @@ jobs:
               fi
               # Strip the backend: directive line out, keep the rest as the brief.
               CLEAN_BODY=$(printf '%s\n' "$ISSUE_BODY" \
-                | grep -ivE '^[[:space:]]*backend[[:space:]]*:[[:space:]]*(claude|claude-opus-4-7|deepseek|deepseek-v4-flash)[[:space:]]*$' \
+                | grep -ivE '^[[:space:]]*backend[[:space:]]*:[[:space:]]*(claude|claude-opus-4-8|claude-opus-4-7|deepseek|deepseek-v4-flash)[[:space:]]*$' \
                 | sed -E 's/[[:space:]]+$//' \
                 || true)
               # Substantive = any non-whitespace remains after the strip.
@@ -229,7 +229,7 @@ jobs:
 
           case "$BACKEND" in
             deepseek) BACKEND="deepseek-v4-flash" ;;
-            claude-opus-4-7) BACKEND="claude" ;;
+            claude-opus-4-8|claude-opus-4-7) BACKEND="claude" ;;
           esac
           if [ "$BACKEND" != "claude" ] && [ "$BACKEND" != "deepseek-v4-flash" ]; then
             echo "unsupported backend/model: $BACKEND" >&2
@@ -417,8 +417,9 @@ jobs:
 
       # ---- Claude backend ---------------------------------------------------
       # OAuth-authenticated against native Anthropic. The writer records
-      # --model claude-opus-4-7 (the actual served model), not the CLI's
-      # --model opus alias.
+      # --model claude-opus-4-8 (the actual served model). Pinning
+      # ANTHROPIC_DEFAULT_OPUS_MODEL keeps the CLI's --model opus alias from
+      # drifting under this workflow.
       # Hard wall-clock cap on the model step. The runner already lost
       # comms once when the action ran ~19m on the un-capped concurrent
       # fan-out version of the prompt; pacing fixed that, but a stuck
@@ -445,6 +446,7 @@ jobs:
           # hourly-twitter workflow.
           AUTH_TOKEN: ${{ secrets.BIRD_AUTH_TOKEN }}
           CT0: ${{ secrets.BIRD_CT0 }}
+          ANTHROPIC_DEFAULT_OPUS_MODEL: claude-opus-4-8
         with: &claude_with
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # The hourly Twitter lane auto-dispatches this workflow with
@@ -1497,7 +1499,7 @@ jobs:
                     --tags "$(cat .gen-input/tags.txt)" \
                     --source "$GEN_SOURCE" \
                     --prompt "$(cat .gen-input/prompt.txt)" \
-                    --model claude-opus-4-7 \
+                    --model claude-opus-4-8 \
                     --cite-density-min 10 --refs-min 20 \
                     --qsanity \
                     --html-body "$GEN_DRAFT"
@@ -1509,7 +1511,7 @@ jobs:
                     --tags "$(cat .gen-input/tags.txt)" \
                     --source "$GEN_SOURCE" \
                     --prompt "$(cat .gen-input/prompt.txt)" \
-                    --model claude-opus-4-7 \
+                    --model claude-opus-4-8 \
                     --cite-density-min 10 --refs-min 20 \
                     --qsanity \
                     --html-body "$GEN_DRAFT"

--- a/.github/workflows/generative-research.yml
+++ b/.github/workflows/generative-research.yml
@@ -191,21 +191,25 @@ jobs:
             PROMPT="$TOPIC"
             if [ -n "${ISSUE_BODY:-}" ]; then
               CANDIDATE=$(printf '%s\n' "$ISSUE_BODY" \
-                | grep -iE '^[[:space:]]*backend[[:space:]]*:[[:space:]]*(claude|claude-opus-4-8|claude-opus-4-7|deepseek|deepseek-v4-flash)[[:space:]]*$' \
+                | grep -iE '^[[:space:]]*backend[[:space:]]*:[[:space:]]*[^[:space:]]+[[:space:]]*$' \
                 | head -n1 \
                 | sed -E 's/^[[:space:]]*[Bb][Aa][Cc][Kk][Ee][Nn][Dd][[:space:]]*:[[:space:]]*//' \
                 | tr -d '[:space:]' \
                 | tr '[:upper:]' '[:lower:]' || true)
               case "$CANDIDATE" in
-                claude-opus-4-8|claude-opus-4-7) CANDIDATE="claude" ;;
+                claude-opus-4-8) CANDIDATE="claude" ;;
                 deepseek) CANDIDATE="deepseek-v4-flash" ;;
               esac
-              if [ "$CANDIDATE" = "claude" ] || [ "$CANDIDATE" = "deepseek-v4-flash" ]; then
+              if [ -n "${CANDIDATE:-}" ]; then
+                if [ "$CANDIDATE" != "claude" ] && [ "$CANDIDATE" != "deepseek-v4-flash" ]; then
+                  echo "unsupported backend/model: $CANDIDATE" >&2
+                  exit 1
+                fi
                 BACKEND="$CANDIDATE"
               fi
               # Strip the backend: directive line out, keep the rest as the brief.
               CLEAN_BODY=$(printf '%s\n' "$ISSUE_BODY" \
-                | grep -ivE '^[[:space:]]*backend[[:space:]]*:[[:space:]]*(claude|claude-opus-4-8|claude-opus-4-7|deepseek|deepseek-v4-flash)[[:space:]]*$' \
+                | grep -ivE '^[[:space:]]*backend[[:space:]]*:[[:space:]]*[^[:space:]]+[[:space:]]*$' \
                 | sed -E 's/[[:space:]]+$//' \
                 || true)
               # Substantive = any non-whitespace remains after the strip.
@@ -229,7 +233,7 @@ jobs:
 
           case "$BACKEND" in
             deepseek) BACKEND="deepseek-v4-flash" ;;
-            claude-opus-4-8|claude-opus-4-7) BACKEND="claude" ;;
+            claude-opus-4-8) BACKEND="claude" ;;
           esac
           if [ "$BACKEND" != "claude" ] && [ "$BACKEND" != "deepseek-v4-flash" ]; then
             echo "unsupported backend/model: $BACKEND" >&2
@@ -665,7 +669,7 @@ jobs:
                 ONLY if all three ambiguity conditions hold, take the
                 scope-clarification path:
                   a. Pick 3 specific sub-topics the user could research
-                     instead (e.g. for "AI" → "Anthropic Claude 4.7
+                     instead (e.g. for "AI" → "Anthropic Claude 4.8
                      enterprise adoption Q1 2026", "GPU supply
                      constraints from TSMC CoWoS-L capacity 2026",
                      "EU AI Act Article 6 enforcement timeline").
@@ -1851,7 +1855,7 @@ jobs:
                 ONLY if all three ambiguity conditions hold, take the
                 scope-clarification path:
                   a. Pick 3 specific sub-topics the user could research
-                     instead (e.g. for "AI" → "Anthropic Claude 4.7
+                     instead (e.g. for "AI" → "Anthropic Claude 4.8
                      enterprise adoption Q1 2026", "GPU supply
                      constraints from TSMC CoWoS-L capacity 2026",
                      "EU AI Act Article 6 enforcement timeline").

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,7 +157,7 @@ opus everywhere.
 
 | Backend | When | Auth | Notes |
 |---|---|---|---|
-| **Claude (default)** | All Claude workflows; `generative-research backend=claude` | `CLAUDE_CODE_OAUTH_TOKEN` | Native Anthropic. `claude-opus-4-7` for generative-research. |
+| **Claude (default)** | All Claude workflows; `generative-research backend=claude` | `CLAUDE_CODE_OAUTH_TOKEN` | Native Anthropic. `claude-opus-4-8` for generative-research. |
 | **DeepSeek V4 Flash (via Fireworks)** | `generative-research backend=deepseek-v4-flash`; `hourly-twitter.yml` DeepSeek lanes | `FIREWORKS_API_KEY` | Uses Fireworks' Anthropic-compatible endpoint at `https://api.fireworks.ai/inference` with model `accounts/fireworks/models/deepseek-v4-flash` (base URL omits `/v1`; the client appends `/v1/messages`). Overrides `ANTHROPIC_BASE_URL`/`ANTHROPIC_AUTH_TOKEN`/`ANTHROPIC_MODEL` so the Claude Code action transparently calls Fireworks. The direct DeepSeek API (`api.deepseek.com`) is retired (billing/credits). Selector token: `deepseek-v4-flash` (or `deepseek`). Generative-research retries up to 2x on socket drops before commit. |
 | **Fireworks pi** | `hourly-twitter.yml backend=fireworks-pi` manual comparison lane | `FIREWORKS_API_KEY` | Uses pi's built-in Fireworks provider with `accounts/fireworks/models/kimi-k2p6`; writes `research/twitter-fireworks-pi/` plus a Telegram summary. |
 | **Local Oracle (GPT-5.5 Pro)** | `scripts/run_generative_research_oracle.py` | Local `../oracle` checkout (browser engine by default) | Runs entirely on the developer machine; outputs go through the same `check_generative_research.py` → `write_generative_research.py` contract. Source metadata: `local-oracle`. |

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Dashboard deploys are handled by **Railway's git integration**, not a workflow f
 
 `generative-research.yml` defaults to **Claude Opus 4.8** for new manual,
 issue-triggered, and auto-dispatched runs. Use `backend=deepseek-v4-flash`
-for the DeepSeek V4 Pro comparison path. See
+for the DeepSeek V4 Flash comparison path. See
 [Generative Research Backends](docs/generative-research-backends.md)
 for the exact env mapping and comparison commands.
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ gantt
 
 Dashboard deploys are handled by **Railway's git integration**, not a workflow file — every push to `main` rebuilds the root `Dockerfile` (bun build → Caddy serve) automatically.
 
-`generative-research.yml` defaults to **Claude Opus 4.7** for new manual,
+`generative-research.yml` defaults to **Claude Opus 4.8** for new manual,
 issue-triggered, and auto-dispatched runs. Use `backend=deepseek-v4-flash`
 for the DeepSeek V4 Pro comparison path. See
 [Generative Research Backends](docs/generative-research-backends.md)

--- a/docs/generative-research-backends.md
+++ b/docs/generative-research-backends.md
@@ -5,7 +5,7 @@ research pipeline:
 
 | Dispatch value | Served model | Auth path | Notes |
 |---|---|---|---|
-| `claude` | `claude-opus-4-7` | `CLAUDE_CODE_OAUTH_TOKEN` | Default for manual and issue-triggered generative research. Native Anthropic Claude Code path. |
+| `claude` | `claude-opus-4-8` | `CLAUDE_CODE_OAUTH_TOKEN` | Default for manual and issue-triggered generative research. Native Anthropic Claude Code path. The workflow pins `ANTHROPIC_DEFAULT_OPUS_MODEL=claude-opus-4-8`, so the Claude Code `opus` alias resolves to Opus 4.8 for this lane. |
 | `deepseek-v4-flash` | `deepseek-v4-flash` via Fireworks | `FIREWORKS_API_KEY` via Fireworks' Anthropic-compatible endpoint | Optional comparison backend. Routes through Fireworks (`accounts/fireworks/models/deepseek-v4-flash`); the direct DeepSeek API is retired (billing/credits). The `--model opus` passed to Claude Code is ignored — `ANTHROPIC_MODEL` env governs the served model. All model slots (incl. subagents) use the Fireworks model id. Retries up to two times if the Anthropic-compatible socket drops before an article commit is produced. |
 
 ## Local Oracle / GPT-5.5 Pro
@@ -173,7 +173,7 @@ The expected difference is the model backend:
   limited to the workflow's run-scoped `$GEN_DRAFT` path, so a self-hosted
   runner cannot reuse stale `/tmp/gen-research*.ara.md` content from another
   backend or run.
-- Claude: native Anthropic endpoint, `claude-opus-4-7` metadata in
+- Claude: native Anthropic endpoint, `claude-opus-4-8` metadata in
   `research/generative/index.json`.
 
 After both runs finish, compare:

--- a/scripts/test_generate_generative_article_audio.py
+++ b/scripts/test_generate_generative_article_audio.py
@@ -36,7 +36,7 @@ def _sample_rows() -> list[dict]:
             "kind": "fragment",
             "language": "en",
             "title": "First Article — détail",  # non-ASCII to lock ensure_ascii=False
-            "model": "claude-opus-4-7",
+            "model": "claude-opus-4-8",
             "created_at": "2026-05-01T00:00:00Z",
             "source": "workflow_dispatch",
             "prompt": "first",
@@ -48,7 +48,7 @@ def _sample_rows() -> list[dict]:
             "kind": "fragment",
             "language": "en",
             "title": "Second Article",
-            "model": "claude-opus-4-7",
+            "model": "claude-opus-4-8",
             "created_at": "2026-05-02T00:00:00Z",
             "source": "workflow_dispatch",
             "prompt": "second",
@@ -80,7 +80,7 @@ class UpdateIndexTest(unittest.TestCase):
         self.assertNotIn("audio_file", by_slug["first-article"])
         # Every other field on the mutated row is preserved.
         self.assertEqual(by_slug["second-article"]["title"], "Second Article")
-        self.assertEqual(by_slug["second-article"]["model"], "claude-opus-4-7")
+        self.assertEqual(by_slug["second-article"]["model"], "claude-opus-4-8")
 
     def test_shape_byte_identical_to_writer(self):
         # Capture the exact bytes the old hand-rolled writer would have produced

--- a/scripts/write_generative_research.py
+++ b/scripts/write_generative_research.py
@@ -598,7 +598,7 @@ def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--topic", required=True, help="user-supplied topic; default title source")
     p.add_argument("--html-body", required=True, help="path to <article> fragment, or '-' for stdin")
-    p.add_argument("--model", required=True, help="model identifier, e.g. claude-opus-4-7")
+    p.add_argument("--model", required=True, help="model identifier, e.g. claude-opus-4-8")
     p.add_argument("--title", default=None, help="explicit title; falls back to first <h2> then topic")
     p.add_argument("--slug", default=None, help="url slug; falls back to slugify(topic)")
     p.add_argument("--prompt", default=None, help="original user prompt (stored in index)")


### PR DESCRIPTION
## Summary
- pin the generative-research Claude backend to Claude Opus 4.8 via ANTHROPIC_DEFAULT_OPUS_MODEL
- update writer metadata in the workflow from claude-opus-4-7 to claude-opus-4-8
- refresh backend docs and model examples/tests to match the new standard

## Verification
- actionlint .github/workflows/generative-research.yml
- uv run python -m unittest scripts.test_generate_generative_article_audio