### PR TITLE
Simplify-for-clarity redesign: minimalist header, global search, Models modal, wiki hovers

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -39,12 +39,11 @@
         <div class="header-top">
           <div class="brand">
             <h1 class="brand-title">ai-research-arm</h1>
+            <button class="brand-search" id="searchToggle" type="button" aria-label="Search" title="Search (/)">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>
+            </button>
           </div>
           <div class="header-actions">
-            <div class="language-switch" id="languageSwitch" aria-label="Article language">
-              <button class="language-btn active" type="button" data-language="en" title="Show English">EN</button>
-              <button class="language-btn" type="button" data-language="ko" title="Show Korean when available">한국어</button>
-            </div>
             <a class="header-link" href="https://github.com/guzus/ai-research-arm" target="_blank" rel="noopener">
               <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
               <span class="header-link-label">guzus/ai-research-arm</span>
@@ -52,19 +51,20 @@
           </div>
         </div>
         <nav class="tabs" id="tabs">
-          <button class="tab active" data-tab="today">Today</button>
+          <div class="calendar" id="calendar"></div>
           <button class="tab" data-tab="twitter">Twitter</button>
           <button class="tab" data-tab="models">Model Timeline</button>
           <button class="tab" data-tab="research">Research</button>
           <button class="tab" data-tab="wiki">Wiki</button>
         </nav>
-        <div class="calendar" id="calendar"></div>
-        <div class="controls">
+        <div class="search-overlay" id="searchOverlay" hidden>
           <div class="search-box">
             <svg class="search-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>
-            <input type="text" class="search-input" id="searchInput" placeholder="Search content... (/)">
+            <input type="text" class="search-input" id="searchInput" placeholder="Search content...">
             <span class="search-count" id="searchCount" aria-live="polite"></span>
           </div>
+        </div>
+        <div class="controls">
           <a
             class="request-btn"
             href="https://github.com/guzus/ai-research-arm/issues/new?labels=gen-research&title=%5BResearch%5D%20&body=%23%23%20Research%20request%0A%0ATopic%3A%20%0A%0AContext%3A%20%0A%0ATags%3A%20%0A%0Abackend%3A%20claude"
@@ -85,6 +85,9 @@
       <footer class="site-footer">
         <a class="footer-link" href="https://x.com/uncanny_guzus" target="_blank" rel="noopener noreferrer">
           x.com/uncanny_guzus
+        </a>
+        <a class="footer-link" href="https://t.me/robot_colosseum" target="_blank" rel="noopener noreferrer">
+          t.me/robot_colosseum
         </a>
       </footer>
     </div>

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -39,7 +39,7 @@
         <div class="header-top">
           <div class="brand">
             <h1 class="brand-title">ai-research-arm</h1>
-            <button class="brand-search" id="searchToggle" type="button" aria-label="Search" title="Search (/)">
+            <button class="brand-search" id="searchToggle" type="button" aria-label="Search" title="Search (⌘K or /)">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>
             </button>
           </div>
@@ -60,8 +60,11 @@
         <div class="search-overlay" id="searchOverlay" hidden>
           <div class="search-box">
             <svg class="search-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>
-            <input type="text" class="search-input" id="searchInput" placeholder="Search content...">
+            <input type="text" class="search-input" id="searchInput" placeholder="Search this view…" autocomplete="off" spellcheck="false">
             <span class="search-count" id="searchCount" aria-live="polite"></span>
+            <button class="search-clear" id="searchClear" type="button" aria-label="Clear search" hidden>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
+            </button>
           </div>
         </div>
         <div class="controls">

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -66,6 +66,7 @@
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
             </button>
           </div>
+          <div class="search-results" id="searchResults" role="listbox" hidden></div>
         </div>
         <div class="controls">
           <a

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -206,7 +206,7 @@ const content = document.getElementById('content')!;
 const calendarEl = document.getElementById('calendar')!;
 const searchInput = document.getElementById('searchInput') as HTMLInputElement;
 const searchCountEl = document.getElementById('searchCount')!;
-const languageSwitch = document.getElementById('languageSwitch')!;
+const languageSwitch = document.getElementById('languageSwitch');
 
 // ── Path routing ─────────────────────────────────────
 // Format (history API, no hash):
@@ -345,6 +345,7 @@ function syncTabUi(): void {
     requestAnimationFrame(revealActiveTab);
     window.setTimeout(revealActiveTab, 120);
   }
+  document.body.classList.toggle('tab-today', activeTab === 'today');
   document.body.classList.toggle('tab-research', activeTab === 'research');
   document.body.classList.toggle('tab-frontpage', activeTab === 'frontpage');
   // Models tab shows the ticket grid (no date routing); the calendar
@@ -399,6 +400,7 @@ function hasResearchLanguage(row: GenResearchRow | null, language: ResearchLangu
 }
 
 function syncLanguageUi(row: GenResearchRow | null = null): void {
+  if (!languageSwitch) return;  // language toggle removed (English-only for now)
   languageSwitch.querySelectorAll<HTMLButtonElement>('[data-language]').forEach((btn) => {
     const language = btn.dataset.language as ResearchLanguage;
     const available = !row || hasResearchLanguage(row, language);
@@ -670,8 +672,15 @@ function handleCalendarClick(e: Event): void {
   // Toggle fold/unfold when clicking the header (but not nav buttons)
   const toggleEl = target.closest('[data-cal-toggle]') as HTMLElement | null;
   if (toggleEl && !target.closest('[data-cal-nav]') && !target.closest('[data-cal-today]')) {
-    calendarEl.classList.toggle('open');
-    renderCalendar();
+    // The calendar pill is the day-view entry: from another tab it opens the
+    // digest/newspaper; when already there it just folds the date picker.
+    if (activeTab !== 'today') {
+      activeTab = 'today';
+      load();
+    } else {
+      calendarEl.classList.toggle('open');
+      renderCalendar();
+    }
     return;
   }
 
@@ -686,6 +695,7 @@ function handleCalendarClick(e: Event): void {
   if (target.closest('[data-cal-today]')) {
     const now = new Date();
     currentDate = now;
+    activeTab = 'today';
     calendarMonth = new Date(now.getFullYear(), now.getMonth(), 1);
     probeAvailability(calendarMonth.getFullYear(), calendarMonth.getMonth());
     load();
@@ -696,6 +706,8 @@ function handleCalendarClick(e: Event): void {
   if (dayEl && dayEl.dataset.date) {
     const parts = dayEl.dataset.date.split('-');
     currentDate = new Date(+parts[0], +parts[1] - 1, +parts[2]);
+    activeTab = 'today';                 // picking a date opens that day's view
+    calendarEl.classList.remove('open');
     const clickedMonth = new Date(+parts[0], +parts[1] - 1, 1);
     if (clickedMonth.getTime() !== calendarMonth.getTime()) {
       calendarMonth = clickedMonth;
@@ -2375,7 +2387,6 @@ function ticketCard(ticket: Ticket): string {
     .map((l) => `<span class="ara-tag">${escapeHtml(l)}</span>`).join('');
   return `<article class="ticket-card ticket-card-${ticket.status}" data-slug="${escapeHtml(ticket.slug)}" tabindex="0" role="button" aria-label="${escapeHtml(ticket.title)}">
     <div class="ticket-card-top">
-      ${ticketStatusPill(ticket.status)}
       <span class="ticket-company">${escapeHtml(ticket.company)}</span>
     </div>
     <h3 class="ticket-title">${escapeHtml(ticket.title)}</h3>
@@ -5041,6 +5052,24 @@ document.getElementById('shortcutToggle')!.addEventListener('click', () => {
 
 // ── Events ────────────────────────────────────────────
 
+const searchToggle = document.getElementById('searchToggle');
+const searchOverlay = document.getElementById('searchOverlay');
+function openSearch(): void {
+  if (searchOverlay) searchOverlay.hidden = false;
+  searchInput.focus();
+  searchInput.select();
+}
+function closeSearch(): void {
+  if (searchOverlay) searchOverlay.hidden = true;
+}
+searchToggle?.addEventListener('click', () => {
+  if (searchOverlay && searchOverlay.hidden) openSearch();
+  else closeSearch();
+});
+searchInput.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape') { closeSearch(); searchInput.blur(); }
+});
+
 searchInput.addEventListener('input', () => {
   if (searchDebounceId !== null) window.clearTimeout(searchDebounceId);
   searchDebounceId = window.setTimeout(() => {
@@ -5049,7 +5078,7 @@ searchInput.addEventListener('input', () => {
   }, 180);
 });
 
-languageSwitch.addEventListener('click', (e) => {
+languageSwitch?.addEventListener('click', (e) => {
   const btn = (e.target as HTMLElement).closest('[data-language]') as HTMLButtonElement | null;
   if (!btn) return;
   const language = btn.dataset.language === 'ko' ? 'ko' : 'en';
@@ -5234,7 +5263,7 @@ document.addEventListener('keydown', (e: KeyboardEvent) => {
     }
     case '/':
       e.preventDefault();
-      searchInput.focus();
+      openSearch();
       break;
     case 'r':
     case 'R':

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -657,9 +657,30 @@ function buildCalendarHtml(): string {
   return html;
 }
 
+// The picker popover is position:fixed (so it escapes the .tabs overflow clip);
+// position it under the pill in viewport coords after each render.
+function positionCalPop(): void {
+  const pop = calendarEl.querySelector<HTMLElement>('.cal-pop');
+  const header = calendarEl.querySelector<HTMLElement>('.cal-header');
+  if (!pop || !header) return;
+  const r = header.getBoundingClientRect();
+  pop.style.top = (r.bottom + 8) + 'px';
+  pop.style.left = Math.max(8, Math.min(r.left, window.innerWidth - 296)) + 'px';
+}
+
 function renderCalendar(): void {
   setSafeCalendar(calendarEl, buildCalendarHtml());
+  if (calendarEl.classList.contains('open')) positionCalPop();
 }
+
+// Close the picker on scroll — the pill isn't sticky, so a fixed popover would
+// otherwise detach from it.
+window.addEventListener('scroll', () => {
+  if (calendarEl.classList.contains('open')) {
+    calendarEl.classList.remove('open');
+    renderCalendar();
+  }
+}, true);
 
 /** Safely set calendar content using DOMPurify */
 function setSafeCalendar(el: HTMLElement, rawHtml: string): void {

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -2524,9 +2524,6 @@ function renderFrontPage(frontPage: FrontPageAsset): void {
     content,
     [
       '<div class="content-card frontpage-card">',
-      '  <div class="content-card-header">',
-      '    <div class="content-card-title">THE AGI AWARENESS POST — ' + escapeHtml(displayDate(currentDate)) + '</div>',
-      '  </div>',
       noteHtml,
       frontPageBodyHtml(frontPage),
       '</div>',
@@ -2633,9 +2630,6 @@ function renderToday(md: string, frontPage: FrontPageAsset | null = null): void 
       : '';
     const fpCard = [
       '<div class="content-card frontpage-card today-frontpage-card">',
-      '  <div class="content-card-header">',
-      '    <div class="content-card-title">THE AGI AWARENESS POST — ' + escapeHtml(displayDate(currentDate)) + '</div>',
-      '  </div>',
       noteHtml,
       frontPageBodyHtml(frontPage),
       '</div>',

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -178,7 +178,6 @@ let researchDocCache: { slug: string; language: ResearchLanguage; body: string }
 let ticketsCache: Ticket[] | null = null;
 let ticketsPromise: Promise<Ticket[] | null> | null = null;
 // Which ticket is expanded (showing body + history). Null = grid view.
-let expandedTicketSlug: string | null = null;
 // Filter state for the tickets grid.
 const ticketFilters = { status: 'all', company: 'all' };
 const LOAD_TIMEOUT_MS = 12000;
@@ -1406,14 +1405,6 @@ function extractHandles(md: string, limit = 12): string[] {
   return Array.from(handles);
 }
 
-function hostnameOf(url: string): string {
-  try {
-    return new URL(url).hostname.replace(/^www\./, '');
-  } catch {
-    return url;
-  }
-}
-
 function renderTweetAgoFromUrl(url: string): string {
   const match = url.match(/(?:x|twitter)\.com\/[^/]+\/status\/(\d+)/);
   if (!match) return '';
@@ -2376,54 +2367,19 @@ function ticketStatusPill(status: TicketStatus): string {
   return `<span class="ticket-pill ticket-pill-${status}">${escapeHtml(labels[status])}</span>`;
 }
 
-function ticketVerificationBadge(verification: TicketVerification): string {
-  if (verification === 'confirmed') return '';
-  const label = verification === 'partial' ? '◐ partial corroboration' : '⚠ unverified';
-  return `<span class="ticket-verification ticket-verification-${verification}">${escapeHtml(label)}</span>`;
-}
-
+// Compact card — status + title + company + a few labels. Everything else
+// (note, expected, model, verification, sources, history) lives in the modal
+// that opens on click, so the board stays short and scannable.
 function ticketCard(ticket: Ticket): string {
-  const expanded = ticket.slug === expandedTicketSlug;
-  const sourcesPreview = ticket.sources.slice(0, 3).map((s) => {
-    if (s.startsWith('@')) return `<span class="ticket-source-handle">${escapeHtml(s)}</span>`;
-    return `<a class="ticket-source-link" href="${escapeHtml(s)}" target="_blank" rel="noopener">${escapeHtml(hostnameOf(s))}</a>`;
-  }).join('');
-  const extraSources = ticket.sources.length > 3 ? `<span class="ticket-source-more">+${ticket.sources.length - 3}</span>` : '';
-  const labelsHtml = (ticket.labels || []).map((l) => `<span class="ara-tag">${escapeHtml(l)}</span>`).join('');
-  const expectedRow = ticket.expected
-    ? `<div class="ticket-row"><span class="ticket-row-key">Expected</span><span class="ticket-row-val">${escapeHtml(ticket.expected)}</span></div>`
-    : '';
-  const noteRow = ticket.status_note
-    ? `<div class="ticket-row ticket-row-note">${escapeHtml(ticket.status_note)}</div>`
-    : '';
-  const closedRow = ticket.status === 'closed' && ticket.closed_reason
-    ? `<div class="ticket-row ticket-row-closed"><span class="ticket-row-key">Closed</span><span class="ticket-row-val">${escapeHtml(ticket.closed_at || '')} — ${escapeHtml(ticket.closed_reason)}</span></div>`
-    : '';
-
-  const headerHtml = [
-    `<div class="ticket-header">`,
-    `  <div class="ticket-header-top">`,
-    `    ${ticketStatusPill(ticket.status)}`,
-    `    <span class="ticket-company">${escapeHtml(ticket.company)}</span>`,
-    `    ${ticketVerificationBadge(ticket.verification)}`,
-    `  </div>`,
-    `  <h3 class="ticket-title">${escapeHtml(ticket.title)}</h3>`,
-    ticket.model ? `  <div class="ticket-model">${escapeHtml(ticket.model)}</div>` : '',
-    `</div>`,
-  ].filter(Boolean).join('\n');
-
-  const metaHtml = [
-    expectedRow,
-    noteRow,
-    closedRow,
-    labelsHtml ? `<div class="ticket-labels">${labelsHtml}</div>` : '',
-    `<div class="ticket-sources">${sourcesPreview}${extraSources}</div>`,
-    `<div class="ticket-footer"><span>updated ${escapeHtml(ticket.updated_at)}</span><span>slug: ${escapeHtml(ticket.slug)}</span></div>`,
-  ].filter(Boolean).join('\n');
-
-  return `<article class="ticket-card ticket-card-${ticket.status}${expanded ? ' ticket-card-expanded' : ''}" data-slug="${escapeHtml(ticket.slug)}">
-    ${headerHtml}
-    <div class="ticket-meta">${metaHtml}</div>
+  const labelsHtml = (ticket.labels || []).slice(0, 3)
+    .map((l) => `<span class="ara-tag">${escapeHtml(l)}</span>`).join('');
+  return `<article class="ticket-card ticket-card-${ticket.status}" data-slug="${escapeHtml(ticket.slug)}" tabindex="0" role="button" aria-label="${escapeHtml(ticket.title)}">
+    <div class="ticket-card-top">
+      ${ticketStatusPill(ticket.status)}
+      <span class="ticket-company">${escapeHtml(ticket.company)}</span>
+    </div>
+    <h3 class="ticket-title">${escapeHtml(ticket.title)}</h3>
+    ${labelsHtml ? `<div class="ticket-labels">${labelsHtml}</div>` : ''}
   </article>`;
 }
 
@@ -2520,6 +2476,45 @@ function companyKey(company: string): string {
   return company.toLowerCase().split('/')[0].trim();
 }
 
+// Ticket detail modal — clicking a card opens a larger overlay with the full
+// ticket (metadata grid, body, history timeline, sources).
+let ticketModalEl: HTMLElement | null = null;
+function openTicketModal(ticket: Ticket): void {
+  if (!ticketModalEl) {
+    ticketModalEl = document.createElement('div');
+    ticketModalEl.className = 'ticket-modal';
+    ticketModalEl.addEventListener('click', (e) => {
+      const tgt = e.target as HTMLElement;
+      if (tgt === ticketModalEl || tgt.closest('.ticket-modal-close')) closeTicketModal();
+    });
+    document.body.appendChild(ticketModalEl);
+  }
+  setSafeContent(
+    ticketModalEl,
+    '<div class="ticket-modal-card"><button class="ticket-modal-close" type="button" aria-label="Close">✕</button>' +
+      ticketExpandedPanel(ticket) + '</div>',
+  );
+  ticketModalEl.style.display = 'flex';
+  document.body.classList.add('modal-open');
+}
+function closeTicketModal(): void {
+  if (ticketModalEl) ticketModalEl.style.display = 'none';
+  document.body.classList.remove('modal-open');
+}
+document.addEventListener('keydown', (e) => {
+  if (!ticketModalEl) return;
+  if (e.key === 'Escape' && ticketModalEl.style.display === 'flex') {
+    closeTicketModal();
+    return;
+  }
+  if ((e.key === 'Enter' || e.key === ' ') && document.body.classList.contains('tab-models')) {
+    const card = (document.activeElement as HTMLElement | null)?.closest?.('.ticket-card') as HTMLElement | null;
+    const slug = card?.dataset.slug;
+    const ticket = slug && ticketsCache ? ticketsCache.find((t) => t.slug === slug) : null;
+    if (ticket) { e.preventDefault(); openTicketModal(ticket); }
+  }
+});
+
 function renderTickets(tickets: Ticket[] | null): void {
   if (!tickets || tickets.length === 0) {
     setSafeContent(
@@ -2577,10 +2572,6 @@ function renderTickets(tickets: Ticket[] | null): void {
   const emptyNote = filtered.length === 0
     ? `<div class="ticket-board-empty">No tickets match the current filters.</div>`
     : '';
-  const detailPanel = ticketExpandedPanel(
-    expandedTicketSlug ? filtered.find((ticket) => ticket.slug === expandedTicketSlug) || null : null,
-  );
-
   setSafeContent(
     content,
     `<div class="tickets-view">
@@ -2591,7 +2582,6 @@ function renderTickets(tickets: Ticket[] | null): void {
       <div class="tickets-board">
         ${board}
       </div>
-      ${detailPanel}
       ${emptyNote}
     </div>`,
   );
@@ -5167,13 +5157,11 @@ content.addEventListener('click', (e) => {
     return;
   }
   if (row && activeTab === 'models') {
-    // Don't toggle on link clicks inside the card — let them open.
+    // Don't open the modal on link clicks inside the card — let them through.
     if (target.closest('a, button')) return;
     const slug = row.dataset.slug;
-    if (slug) {
-      expandedTicketSlug = expandedTicketSlug === slug ? null : slug;
-      if (ticketsCache) renderTickets(ticketsCache);
-    }
+    const ticket = slug && ticketsCache ? ticketsCache.find((t) => t.slug === slug) : null;
+    if (ticket) openTicketModal(ticket);
   }
 });
 

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -1555,6 +1555,131 @@ async function hydrateTweetCards(root: HTMLElement): Promise<void> {
   }
 }
 
+// ── Wiki mentions (auto-link known entities to the LLM wiki) ──────────────
+// In rendered content (digest / twitter / articles) underline the FIRST
+// mention of any term that has an LLM-wiki page, link it, and show a hover
+// preview on desktop — so readers can quick-look + discover without leaving
+// the page. Clicking navigates to the wiki (cross-tab, SPA).
+let wikiIndexLoad: Promise<WikiIndex | null> | null = null;
+function loadWikiIndexCached(): Promise<WikiIndex | null> {
+  if (wikiIndexCache) return Promise.resolve(wikiIndexCache);
+  if (!wikiIndexLoad) wikiIndexLoad = loadWikiIndex(new AbortController().signal);
+  return wikiIndexLoad;
+}
+
+let wikiMatcher: { re: RegExp; map: Map<string, string> } | null = null;
+function getWikiMatcher(index: WikiIndex): { re: RegExp; map: Map<string, string> } | null {
+  if (wikiMatcher) return wikiMatcher;
+  const map = new Map<string, string>();   // lowercased term → slug
+  for (const p of index.pages) {
+    for (const term of [p.title, ...(p.aliases || [])]) {
+      const key = (term || '').trim().toLowerCase();
+      if (key.length < 3) continue;          // skip noise like "AI"
+      if (!map.has(key)) map.set(key, p.slug);
+    }
+  }
+  if (map.size === 0) return null;
+  // Longest terms first so "Claude Opus 4.8" wins over "Claude".
+  const escaped = Array.from(map.keys())
+    .sort((a, b) => b.length - a.length)
+    .map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+  wikiMatcher = {
+    re: new RegExp('(?<![A-Za-z0-9])(' + escaped.join('|') + ')(?![A-Za-z0-9])', 'gi'),
+    map,
+  };
+  return wikiMatcher;
+}
+
+// Text inside these must NOT be wikified (links, code, chips, tweet cards).
+const WIKIFY_SKIP = 'a, code, pre, kbd, mark, button, select, .tweet-card, .ara-tag, .handle, .ara-eyebrow, .twitter-source-chip, .twitter-handle-chip, [data-wiki-slug], .wiki-mention';
+
+async function wikifyContent(root: HTMLElement): Promise<void> {
+  if (document.body.classList.contains('tab-wiki')) return;  // don't self-link the wiki
+  const index = await loadWikiIndexCached();
+  if (!index) return;
+  const matcher = getWikiMatcher(index);
+  if (!matcher) return;
+  const used = new Set<string>();   // link only the FIRST mention of each entity
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+    acceptNode(node: Node): number {
+      const el = (node as Text).parentElement;
+      if (!el || el.closest(WIKIFY_SKIP)) return NodeFilter.FILTER_REJECT;
+      return node.nodeValue && node.nodeValue.trim() ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT;
+    },
+  });
+  const textNodes: Text[] = [];
+  for (let n = walker.nextNode(); n; n = walker.nextNode()) textNodes.push(n as Text);
+  for (const node of textNodes) {
+    const text = node.nodeValue || '';
+    matcher.re.lastIndex = 0;
+    const hits: Array<{ s: number; e: number; slug: string; term: string }> = [];
+    let m: RegExpExecArray | null;
+    while ((m = matcher.re.exec(text))) {
+      const slug = matcher.map.get(m[1].toLowerCase());
+      if (slug && !used.has(slug)) {
+        used.add(slug);
+        hits.push({ s: m.index, e: m.index + m[1].length, slug, term: m[1] });
+      }
+    }
+    if (hits.length === 0) continue;
+    const frag = document.createDocumentFragment();
+    let cur = 0;
+    for (const h of hits) {
+      if (h.s > cur) frag.appendChild(document.createTextNode(text.slice(cur, h.s)));
+      const a = document.createElement('a');
+      a.className = 'wiki-mention';
+      a.setAttribute('data-wiki-slug', h.slug);
+      a.setAttribute('href', '/wiki/' + h.slug);
+      a.textContent = h.term;
+      frag.appendChild(a);
+      cur = h.e;
+    }
+    if (cur < text.length) frag.appendChild(document.createTextNode(text.slice(cur)));
+    node.parentNode?.replaceChild(frag, node);
+  }
+  ensureWikiHover();
+}
+
+// Shared desktop hover-preview card (one element, repositioned per mention).
+let wikiHoverEl: HTMLElement | null = null;
+let wikiHoverReady = false;
+function ensureWikiHover(): void {
+  if (wikiHoverReady) return;
+  wikiHoverReady = true;
+  document.addEventListener('mouseover', (e) => {
+    const el = (e.target as HTMLElement)?.closest?.('.wiki-mention') as HTMLElement | null;
+    if (el) showWikiHover(el);
+  });
+  document.addEventListener('mouseout', (e) => {
+    if ((e.target as HTMLElement)?.closest?.('.wiki-mention')) hideWikiHover();
+  });
+  window.addEventListener('scroll', hideWikiHover, true);
+}
+function showWikiHover(el: HTMLElement): void {
+  const slug = el.getAttribute('data-wiki-slug');
+  const page = slug ? wikiPageMap.get(slug) : null;
+  if (!page) return;
+  if (!wikiHoverEl) {
+    wikiHoverEl = document.createElement('div');
+    wikiHoverEl.className = 'wiki-hover';
+    document.body.appendChild(wikiHoverEl);
+  }
+  setSafeContent(
+    wikiHoverEl,
+    '<span class="wiki-hover-type">' + escapeHtml(String(page.type)) + '</span>' +
+    '<span class="wiki-hover-title">' + escapeHtml(page.title) + '</span>' +
+    '<span class="wiki-hover-summary">' + escapeHtml(page.summary || '') + '</span>',
+  );
+  const r = el.getBoundingClientRect();
+  const left = Math.max(12, Math.min(r.left, window.innerWidth - 320 - 12));
+  wikiHoverEl.style.display = 'block';
+  wikiHoverEl.style.left = left + 'px';
+  wikiHoverEl.style.top = (r.bottom + 8) + 'px';
+}
+function hideWikiHover(): void {
+  if (wikiHoverEl) wikiHoverEl.style.display = 'none';
+}
+
 // ── Wiki (LLM Wiki) ───────────────────────────────────
 //
 // The wiki is a compounding knowledge base under research/wiki/. The Python
@@ -1841,10 +1966,6 @@ function renderWikiIndex(index: WikiIndex): void {
     content,
     [
       '<div class="content-card wiki-index-card">',
-      '  <div class="wiki-index-header">',
-      '    <h1 class="wiki-index-title">LLM Wiki</h1>',
-      '    <span class="wiki-index-count">' + pages.length + ' pages</span>',
-      '  </div>',
       '  <div class="wiki-index-main">',
       emptyNote,
       sections.join('\n'),
@@ -2152,12 +2273,18 @@ function renderTwitterReport(md: string, fallbackDate: string | null = null): vo
     const displayTime = timeInfo
       ? '<span class="twitter-cycle-time">' + escapeHtml(timeInfo.utc) + '</span><span class="local-time">' + escapeHtml(timeInfo.local) + '</span>'
       : '<span class="twitter-cycle-time">' + escapeHtml(title) + '</span>';
+    // Show the full cycle summary in the Signal Brief — it's the only place
+    // the summary lives now, so don't cut it mid-sentence.
     const leadText = cycleSummary
-      ? truncateText(cleanPublicLeadText(stripMarkdown(cycleSummary)), 620)
+      ? cleanPublicLeadText(stripMarkdown(cycleSummary))
       : truncateText(cleanPublicLeadText(stripMarkdown(section.body)), 620);
-    // Storyless cycles fall back to the cycle markdown — minus the Cycle
-    // summary paragraph, which the Signal Brief above already shows verbatim.
-    const fallbackBody = section.body.replace(/\*\*Cycle summary\*\*:[\s\S]*?(?=\n#{1,3}\s|$)/i, '').trim();
+    // Storyless cycles fall back to the cycle markdown — minus the parts shown
+    // separately above (Cycle summary → Signal Brief; Skeptic's corner → its
+    // own callout) so nothing renders twice.
+    const fallbackBody = section.body
+      .replace(/\*\*Cycle summary\*\*:[\s\S]*?(?=\n#{1,3}\s|$)/i, '')
+      .replace(/###\s+[^\n]*[Ss]keptic[^\n]*\n[\s\S]*?(?=\n#{2,3}\s|$)/i, '')
+      .trim();
     const structuredStoryCards = renderStructuredTwitterStories(section.body);
     const storyCards = structuredStoryCards || stories.map((story) => {
       const verification = truncateText(stripMarkdown(extractSectionText(story.body, 'Verification')), 210);
@@ -2216,6 +2343,7 @@ function renderTwitterReport(md: string, fallbackDate: string | null = null): vo
 
   setSafeContent(content, '<div class="twitter-report">' + cards.join('\n') + '</div>');
   void hydrateTweetCards(content);
+  void wikifyContent(content);
 }
 
 function loadTickets(): Promise<Ticket[] | null> {
@@ -2456,9 +2584,6 @@ function renderTickets(tickets: Ticket[] | null): void {
   setSafeContent(
     content,
     `<div class="tickets-view">
-      <div class="tickets-heading">
-        <h2>Model release timeline</h2>
-      </div>
       <div class="tickets-controls">
         <div class="ticket-filters">${statusBar}</div>
         <select class="ticket-company-select" data-filter-company>${companyOptions}</select>
@@ -2553,15 +2678,10 @@ function renderToday(md: string, frontPage: FrontPageAsset | null = null): void 
     const audioUrl = `${AUDIO_BASE}/audio/${dateStr}-digest.mp3`;
     cards.push(
       [
-        '<div class="content-card today-audio-card">',
-        '  <div class="content-card-header">',
-        '    <div class="content-card-title">🎧 Audio digest</div>',
-        '  </div>',
-        '  <div class="content-card-body">',
-        '    <audio controls preload="metadata" style="width:100%;" src="' + audioUrl + '">',
-        '      Your browser does not support the audio element.',
-        '    </audio>',
-        '  </div>',
+        '<div class="today-audio">',
+        '  <audio controls preload="metadata" style="width:100%;" src="' + audioUrl + '">',
+        '    Your browser does not support the audio element.',
+        '  </audio>',
         '</div>',
       ].join('\n'),
     );
@@ -2592,9 +2712,6 @@ function renderToday(md: string, frontPage: FrontPageAsset | null = null): void 
       cards.push(
         [
           '<div class="content-card today-card">',
-          '  <div class="content-card-header">',
-          '    <div class="content-card-title">' + escapeHtml(displayDate(currentDate)) + '</div>',
-          '  </div>',
           '  <div class="content-card-body">',
           '    <div class="today-tldr">',
           '      <span class="today-tldr-label">TL;DR</span>',
@@ -2641,9 +2758,11 @@ function renderToday(md: string, frontPage: FrontPageAsset | null = null): void 
       ].join('\n'),
     );
     enhanceNewspaper();
+    void wikifyContent(content);
     return;
   }
   setSafeContent(content, todayCards);
+  void wikifyContent(content);
 }
 
 // ── Generative research ───────────────────────────────
@@ -2786,6 +2905,7 @@ function renderResearchDoc(row: GenResearchRow, body: string): void {
     applyAraTooltips(article);
     renderResearchTOC(article);
     addSectionAnchors(article);
+    void wikifyContent(article);
     scrollToHashIfPresent();
   } else {
     hideResearchTOC();
@@ -5012,6 +5132,19 @@ content.addEventListener('click', (e) => {
   // for instant SPA nav so a click never triggers a full page reload. Mirror the
   // research [data-slug] branch. Placed before the [data-slug] lookup; they use
   // distinct attributes so there's no collision, but ordering keeps intent clear.
+  // Wiki mentions (auto-linked entities in digest/twitter/articles) navigate
+  // to the wiki from ANY tab — distinct from the wiki-tab-only links below.
+  const wikiMention = target.closest('.wiki-mention') as HTMLElement | null;
+  if (wikiMention) {
+    const slug = wikiMention.dataset.wikiSlug;
+    if (slug) {
+      e.preventDefault();
+      activeTab = 'wiki';
+      selectedSlug = slug;
+      load();
+    }
+    return;
+  }
   const wikiAnchor = target.closest('[data-wiki-slug]') as HTMLElement | null;
   if (wikiAnchor && activeTab === 'wiki') {
     const slug = wikiAnchor.dataset.wikiSlug;

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -677,16 +677,10 @@ function handleCalendarClick(e: Event): void {
   // Toggle fold/unfold when clicking the header (but not nav buttons)
   const toggleEl = target.closest('[data-cal-toggle]') as HTMLElement | null;
   if (toggleEl && !target.closest('[data-cal-nav]') && !target.closest('[data-cal-today]')) {
-    // The calendar pill is the day-view entry: from another tab it opens the
-    // digest/newspaper; when already there it just folds the date picker.
-    if (activeTab !== 'today') {
-      activeTab = 'today';
-      syncTabUi();
-      load();
-    } else {
-      calendarEl.classList.toggle('open');
-      renderCalendar();
-    }
+    // The pill is a date picker: clicking it opens the calendar from any tab;
+    // picking a day (cal-day handler) then opens that day's digest/newspaper.
+    calendarEl.classList.toggle('open');
+    renderCalendar();
     return;
   }
 
@@ -2638,6 +2632,10 @@ function enhanceNewspaper(root: ParentNode = content): void {
       toggle.dataset.bound = 'true';
       const controlledId = toggle.getAttribute('aria-controls');
       const panel = controlledId ? paper.querySelector<HTMLElement>('#' + CSS.escape(controlledId)) : null;
+      // Unfold by default — sections (Departments, lead, etc.) start expanded so
+      // the content reads without a click; clicking still collapses.
+      toggle.setAttribute('aria-expanded', 'true');
+      if (panel) panel.hidden = false;
       toggle.addEventListener('click', () => {
         const expanded = toggle.getAttribute('aria-expanded') !== 'false';
         toggle.setAttribute('aria-expanded', expanded ? 'false' : 'true');

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -5079,23 +5079,49 @@ document.getElementById('shortcutToggle')!.addEventListener('click', () => {
 
 const searchToggle = document.getElementById('searchToggle');
 const searchOverlay = document.getElementById('searchOverlay');
+const searchClear = document.getElementById('searchClear');
+function syncSearchClear(): void {
+  if (searchClear) (searchClear as HTMLElement).hidden = searchInput.value.length === 0;
+}
 function openSearch(): void {
   if (searchOverlay) searchOverlay.hidden = false;
+  syncSearchClear();
   searchInput.focus();
   searchInput.select();
 }
 function closeSearch(): void {
   if (searchOverlay) searchOverlay.hidden = true;
 }
+function clearSearch(): void {
+  searchInput.value = '';
+  searchTerm = '';
+  syncSearchClear();
+  load();
+  searchInput.focus();
+}
 searchToggle?.addEventListener('click', () => {
   if (searchOverlay && searchOverlay.hidden) openSearch();
   else closeSearch();
 });
+searchClear?.addEventListener('click', clearSearch);
 searchInput.addEventListener('keydown', (e) => {
   if (e.key === 'Escape') { closeSearch(); searchInput.blur(); }
 });
+// ⌘K / Ctrl+K opens search from anywhere; click outside the panel closes it.
+document.addEventListener('keydown', (e) => {
+  if ((e.metaKey || e.ctrlKey) && (e.key === 'k' || e.key === 'K')) {
+    e.preventDefault();
+    openSearch();
+  }
+});
+document.addEventListener('mousedown', (e) => {
+  if (!searchOverlay || searchOverlay.hidden) return;
+  const t = e.target as Node;
+  if (!searchOverlay.contains(t) && !(searchToggle && searchToggle.contains(t))) closeSearch();
+});
 
 searchInput.addEventListener('input', () => {
+  syncSearchClear();
   if (searchDebounceId !== null) window.clearTimeout(searchDebounceId);
   searchDebounceId = window.setTimeout(() => {
     searchTerm = searchInput.value.trim();

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -2406,14 +2406,12 @@ function ticketStatusPill(status: TicketStatus): string {
 // (note, expected, model, verification, sources, history) lives in the modal
 // that opens on click, so the board stays short and scannable.
 function ticketCard(ticket: Ticket): string {
-  const labelsHtml = (ticket.labels || []).slice(0, 3)
-    .map((l) => `<span class="ara-tag">${escapeHtml(l)}</span>`).join('');
+  // Bird's-eye board = company + title only; labels/details live in the modal.
   return `<article class="ticket-card ticket-card-${ticket.status}" data-slug="${escapeHtml(ticket.slug)}" tabindex="0" role="button" aria-label="${escapeHtml(ticket.title)}">
     <div class="ticket-card-top">
       <span class="ticket-company">${escapeHtml(ticket.company)}</span>
     </div>
     <h3 class="ticket-title">${escapeHtml(ticket.title)}</h3>
-    ${labelsHtml ? `<div class="ticket-labels">${labelsHtml}</div>` : ''}
   </article>`;
 }
 

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -2155,7 +2155,9 @@ function renderTwitterReport(md: string, fallbackDate: string | null = null): vo
     const leadText = cycleSummary
       ? truncateText(cleanPublicLeadText(stripMarkdown(cycleSummary)), 620)
       : truncateText(cleanPublicLeadText(stripMarkdown(section.body)), 620);
-    const leadHtml = twitterMarkdownToHtml(section.body);
+    // Storyless cycles fall back to the cycle markdown — minus the Cycle
+    // summary paragraph, which the Signal Brief above already shows verbatim.
+    const fallbackBody = section.body.replace(/\*\*Cycle summary\*\*:[\s\S]*?(?=\n#{1,3}\s|$)/i, '').trim();
     const structuredStoryCards = renderStructuredTwitterStories(section.body);
     const storyCards = structuredStoryCards || stories.map((story) => {
       const verification = truncateText(stripMarkdown(extractSectionText(story.body, 'Verification')), 210);
@@ -2205,11 +2207,7 @@ function renderTwitterReport(md: string, fallbackDate: string | null = null): vo
         '      <p class="twitter-brief-text">' + highlightPlainText(leadText) + '</p>',
         '    </div>',
         '  </div>',
-        '  <details class="twitter-cycle-summary">',
-        '    <summary>Full cycle text</summary>',
-        '    <div class="md-content twitter-summary-body">' + leadHtml + '</div>',
-        '  </details>',
-        storyCards ? '  <div class="twitter-story-grid">' + storyCards + '</div>' : '  <div class="md-content twitter-story-body twitter-cycle-fallback">' + twitterMarkdownToHtml(section.body) + '</div>',
+        storyCards ? '  <div class="twitter-story-grid">' + storyCards + '</div>' : '  <div class="md-content twitter-story-body twitter-cycle-fallback">' + twitterMarkdownToHtml(fallbackBody) + '</div>',
         skepticHtml,
         '</section>',
       ].join('\n'),
@@ -2464,7 +2462,6 @@ function renderTickets(tickets: Ticket[] | null): void {
       <div class="tickets-controls">
         <div class="ticket-filters">${statusBar}</div>
         <select class="ticket-company-select" data-filter-company>${companyOptions}</select>
-        <div class="ticket-summary">${filtered.length} of ${tickets.length} tickets</div>
       </div>
       <div class="tickets-board">
         ${board}

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -5080,6 +5080,105 @@ document.getElementById('shortcutToggle')!.addEventListener('click', () => {
 const searchToggle = document.getElementById('searchToggle');
 const searchOverlay = document.getElementById('searchOverlay');
 const searchClear = document.getElementById('searchClear');
+const searchResultsEl = document.getElementById('searchResults');
+
+// ── Global search ─────────────────────────────────────
+// Search across ALL content — research articles, wiki pages, model tickets —
+// from any tab; a result jumps straight to the item. The corpus is built lazily
+// from the already-loaded indexes and cached.
+type SearchHit = { type: 'research' | 'wiki' | 'model'; title: string; subtitle: string; slug: string; hay: string };
+let searchCorpus: SearchHit[] | null = null;
+let searchHits: SearchHit[] = [];
+let searchSel = -1;
+const SEARCH_TYPE_LABEL: Record<SearchHit['type'], string> = { research: 'Research', wiki: 'Wiki', model: 'Model' };
+
+async function buildSearchCorpus(): Promise<SearchHit[]> {
+  if (searchCorpus) return searchCorpus;
+  const [m, wiki, tickets] = await Promise.all([loadManifest(), loadWikiIndexCached(), loadTickets()]);
+  const hits: SearchHit[] = [];
+  if (wiki) for (const p of wiki.pages) {
+    hits.push({ type: 'wiki', title: p.title, subtitle: (p.aliases || []).slice(0, 3).join(', ') || String(p.type),
+      slug: p.slug, hay: (p.title + ' ' + (p.aliases || []).join(' ') + ' ' + (p.summary || '') + ' ' + (p.tags || []).join(' ')).toLowerCase() });
+  }
+  if (m) for (const r of (m.generative || [])) {
+    hits.push({ type: 'research', title: r.title, subtitle: (r.tags || []).slice(0, 4).join(', '),
+      slug: r.slug, hay: (r.title + ' ' + (r.tags || []).join(' ') + ' ' + (r.prompt || '')).toLowerCase() });
+  }
+  if (tickets) for (const t of tickets) {
+    hits.push({ type: 'model', title: t.title, subtitle: t.company + (t.model ? ' · ' + t.model : ''),
+      slug: t.slug, hay: (t.title + ' ' + t.company + ' ' + (t.model || '') + ' ' + (t.labels || []).join(' ')).toLowerCase() });
+  }
+  searchCorpus = hits;
+  return hits;
+}
+
+function renderSearchHits(): void {
+  if (!searchResultsEl) return;
+  if (searchHits.length === 0) {
+    setSafeContent(searchResultsEl, '<div class="search-empty">No matches</div>');
+    searchResultsEl.hidden = false;
+    return;
+  }
+  const rows = searchHits.map((h, i) =>
+    '<button class="search-result' + (i === searchSel ? ' is-sel' : '') + '" type="button" role="option" data-sr-index="' + i + '">' +
+    '<span class="search-result-type">' + SEARCH_TYPE_LABEL[h.type] + '</span>' +
+    '<span class="search-result-title">' + escapeHtml(h.title) + '</span>' +
+    (h.subtitle ? '<span class="search-result-sub">' + escapeHtml(h.subtitle) + '</span>' : '') +
+    '</button>',
+  ).join('');
+  setSafeContent(searchResultsEl, rows);
+  searchResultsEl.hidden = false;
+}
+
+async function runGlobalSearch(query: string): Promise<void> {
+  const q = query.trim().toLowerCase();
+  if (!q) {
+    searchHits = [];
+    searchSel = -1;
+    if (searchResultsEl) searchResultsEl.hidden = true;
+    if (searchCountEl) searchCountEl.textContent = '';
+    return;
+  }
+  const corpus = await buildSearchCorpus();
+  searchHits = corpus
+    .map((h) => {
+      const t = h.title.toLowerCase();
+      const score = t.startsWith(q) ? 3 : t.includes(q) ? 2 : h.hay.includes(q) ? 1 : 0;
+      return { h, score };
+    })
+    .filter((x) => x.score > 0)
+    .sort((a, b) => b.score - a.score || a.h.title.length - b.h.title.length)
+    .slice(0, 24)
+    .map((x) => x.h);
+  searchSel = searchHits.length ? 0 : -1;
+  if (searchCountEl) searchCountEl.textContent = searchHits.length ? String(searchHits.length) : '';
+  renderSearchHits();
+}
+
+function moveSearchSel(d: number): void {
+  if (searchHits.length === 0) return;
+  searchSel = (searchSel + d + searchHits.length) % searchHits.length;
+  renderSearchHits();
+  (searchResultsEl?.querySelector('.search-result.is-sel') as HTMLElement | null)?.scrollIntoView({ block: 'nearest' });
+}
+
+function activateSearchHit(h: SearchHit): void {
+  closeSearch();
+  if (h.type === 'model') {
+    activeTab = 'models';
+    selectedSlug = null;
+    syncTabUi();
+    load();
+    const t = ticketsCache ? ticketsCache.find((x) => x.slug === h.slug) : null;
+    if (t) window.setTimeout(() => openTicketModal(t), 60);
+    return;
+  }
+  activeTab = h.type; // 'research' | 'wiki'
+  selectedSlug = h.slug;
+  syncTabUi();
+  load();
+}
+
 function syncSearchClear(): void {
   if (searchClear) (searchClear as HTMLElement).hidden = searchInput.value.length === 0;
 }
@@ -5091,12 +5190,12 @@ function openSearch(): void {
 }
 function closeSearch(): void {
   if (searchOverlay) searchOverlay.hidden = true;
+  if (searchResultsEl) searchResultsEl.hidden = true;
 }
 function clearSearch(): void {
   searchInput.value = '';
-  searchTerm = '';
   syncSearchClear();
-  load();
+  void runGlobalSearch('');
   searchInput.focus();
 }
 searchToggle?.addEventListener('click', () => {
@@ -5104,8 +5203,17 @@ searchToggle?.addEventListener('click', () => {
   else closeSearch();
 });
 searchClear?.addEventListener('click', clearSearch);
+searchResultsEl?.addEventListener('click', (e) => {
+  const btn = (e.target as HTMLElement).closest('.search-result') as HTMLElement | null;
+  if (!btn) return;
+  const i = Number(btn.dataset.srIndex);
+  if (searchHits[i]) activateSearchHit(searchHits[i]);
+});
 searchInput.addEventListener('keydown', (e) => {
   if (e.key === 'Escape') { closeSearch(); searchInput.blur(); }
+  else if (e.key === 'ArrowDown') { e.preventDefault(); moveSearchSel(1); }
+  else if (e.key === 'ArrowUp') { e.preventDefault(); moveSearchSel(-1); }
+  else if (e.key === 'Enter') { e.preventDefault(); if (searchHits[searchSel]) activateSearchHit(searchHits[searchSel]); }
 });
 // ⌘K / Ctrl+K opens search from anywhere; click outside the panel closes it.
 document.addEventListener('keydown', (e) => {
@@ -5123,10 +5231,7 @@ document.addEventListener('mousedown', (e) => {
 searchInput.addEventListener('input', () => {
   syncSearchClear();
   if (searchDebounceId !== null) window.clearTimeout(searchDebounceId);
-  searchDebounceId = window.setTimeout(() => {
-    searchTerm = searchInput.value.trim();
-    load();
-  }, 180);
+  searchDebounceId = window.setTimeout(() => { void runGlobalSearch(searchInput.value); }, 120);
 });
 
 languageSwitch?.addEventListener('click', (e) => {

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -611,11 +611,15 @@ function buildCalendarHtml(): string {
   const coverageHint = coverage > 0 ? ' · ' + coverage + (coverage === 1 ? ' day' : ' days') : '';
   let html = '<div class="cal-header" data-cal-toggle>';
   html += '<span class="cal-header-label">' + monthLabel + '<span class="cal-coverage">' + coverageHint + '</span> <span class="cal-chevron">' + (open ? '&#9650;' : '&#9660;') + '</span></span>';
+  html += '</div>';
+
+  // Month nav + day grid live in a popover so the pill keeps a fixed size.
+  html += '<div class="cal-pop">';
   html += '<div class="cal-header-nav">';
   html += '<button class="cal-nav-btn" data-cal-nav="-1">&lsaquo;</button>';
   html += '<button class="cal-today-btn" data-cal-today>Today</button>';
   html += '<button class="cal-nav-btn" data-cal-nav="1">&rsaquo;</button>';
-  html += '</div></div>';
+  html += '</div>';
 
   html += '<div class="cal-grid">';
   for (const dow of dows) {
@@ -649,6 +653,7 @@ function buildCalendarHtml(): string {
   }
 
   html += '</div>';
+  html += '</div>';
   return html;
 }
 
@@ -676,6 +681,7 @@ function handleCalendarClick(e: Event): void {
     // digest/newspaper; when already there it just folds the date picker.
     if (activeTab !== 'today') {
       activeTab = 'today';
+      syncTabUi();
       load();
     } else {
       calendarEl.classList.toggle('open');
@@ -696,6 +702,7 @@ function handleCalendarClick(e: Event): void {
     const now = new Date();
     currentDate = now;
     activeTab = 'today';
+    syncTabUi();
     calendarMonth = new Date(now.getFullYear(), now.getMonth(), 1);
     probeAvailability(calendarMonth.getFullYear(), calendarMonth.getMonth());
     load();
@@ -707,6 +714,7 @@ function handleCalendarClick(e: Event): void {
     const parts = dayEl.dataset.date.split('-');
     currentDate = new Date(+parts[0], +parts[1] - 1, +parts[2]);
     activeTab = 'today';                 // picking a date opens that day's view
+    syncTabUi();
     calendarEl.classList.remove('open');
     const clickedMonth = new Date(+parts[0], +parts[1] - 1, 1);
     if (clickedMonth.getTime() !== calendarMonth.getTime()) {

--- a/dashboard/src/style.css
+++ b/dashboard/src/style.css
@@ -72,6 +72,7 @@ body {
   background: var(--bg-secondary);
   color: var(--text);
   line-height: 1.6;
+  letter-spacing: -0.012em;  /* tighter tracking overall for faster reading */
   -webkit-font-smoothing: antialiased;
   min-height: 100vh;
 }
@@ -451,6 +452,74 @@ body {
 .shortcut-guide,
 .refresh-btn {
   display: none !important;
+}
+
+/* "Request research" is a research-tab action — only show it on /research. */
+body:not(.tab-research) .request-btn { display: none; }
+
+/* Audio digest: bare player, no card chrome / "Audio digest" label. */
+.today-audio { margin: 0 0 18px; }
+.today-audio audio { width: 100%; display: block; }
+
+/* Tidy list margins inside callouts (e.g. Skeptic's corner) so bullets sit
+ * close to the colored edge instead of deeply indented. */
+.ara-callout ul,
+.ara-callout ol { margin: 8px 0 0; padding-left: 18px; }
+.ara-callout li { margin: 4px 0; }
+.ara-callout li::marker { color: var(--text-tertiary); }
+
+/* Wiki mentions: underline entities that have an LLM-wiki page; hover (desktop)
+ * shows a quick-look preview, click navigates to the page. */
+.wiki-mention {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px dotted var(--accent-warm);
+  cursor: pointer;
+  transition: color 0.1s ease, border-color 0.1s ease;
+}
+.wiki-mention:hover {
+  color: var(--accent-warm);
+  border-bottom-color: var(--accent-warm);
+  border-bottom-style: solid;
+}
+.wiki-hover {
+  position: fixed;
+  z-index: 1200;
+  display: none;
+  width: 320px;
+  max-width: calc(100vw - 24px);
+  padding: 12px 14px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: var(--shadow-lg);
+  pointer-events: none;
+}
+.wiki-hover-type {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ara-royal);
+  margin-bottom: 5px;
+}
+.wiki-hover-title {
+  display: block;
+  font-weight: 650;
+  font-size: 0.95rem;
+  color: var(--text);
+  margin-bottom: 5px;
+}
+.wiki-hover-summary {
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  font-size: 0.82rem;
+  line-height: 1.5;
+  color: var(--text-secondary);
 }
 
 .cal-header {

--- a/dashboard/src/style.css
+++ b/dashboard/src/style.css
@@ -164,12 +164,33 @@ body {
   gap: 16px;
 }
 
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
 .brand-title {
   font-size: 1.15rem;
   font-weight: 700;
   letter-spacing: -0.02em;
   font-family: var(--font-mono);
 }
+.brand-search {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  flex: 0 0 auto;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+.brand-search:hover { background: var(--bg-hover); color: var(--text); }
 
 .header-actions {
   display: flex;
@@ -429,21 +450,27 @@ body {
 }
 
 /* ── Calendar ──────────────────────────────────────── */
+/* The calendar pill is the first nav item — the "day view" entry that replaced
+ * the Today tab. Collapsed = a pill; the date grid pops over when opened. It
+ * goes navy/active when the day view is showing (like an active tab). */
 .calendar {
-  /* Compact affordance: a small pill when collapsed; expands only when opened. */
-  display: inline-block;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
   background: var(--bg);
-  border: 1px solid var(--border-light);
-  border-radius: 10px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
   box-shadow: var(--shadow-sm);
-  padding: 7px 13px;
-  margin-bottom: 12px;
+  padding: 7px 14px;
 }
-.calendar.open {
-  display: block;
-  padding: 14px 16px;
-  border-radius: 14px;
+body.tab-today .calendar {
+  background: var(--accent);
+  border-color: var(--accent);
 }
+body.tab-today .cal-header-label { color: var(--on-accent); }
+body.tab-today .cal-coverage,
+body.tab-today .cal-chevron { color: var(--on-accent); opacity: 0.75; }
 
 /* Aggressive-minimalism chrome cuts: drop the floating section-nav widget, the
  * keyboard-shortcut guide, and the manual refresh button — content-first.
@@ -456,6 +483,12 @@ body {
 
 /* "Request research" is a research-tab action — only show it on /research. */
 body:not(.tab-research) .request-btn { display: none; }
+/* The controls row now holds only Request research → hide it off /research. */
+body:not(.tab-research) .controls { display: none; }
+
+/* Search overlay — revealed by the magnifier button next to the wordmark. */
+.search-overlay { margin-bottom: 12px; }
+.search-overlay[hidden] { display: none; }
 
 /* Audio digest: bare player, no card chrome / "Audio digest" label. */
 .today-audio { margin: 0 0 18px; }
@@ -542,6 +575,16 @@ body:not(.tab-research) .request-btn { display: none; }
   display: grid;
   grid-template-columns: repeat(7, 1fr);
   gap: 2px;
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  z-index: 60;
+  width: 280px;
+  padding: 12px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: var(--shadow-lg);
 }
 
 .cal-chevron {
@@ -2069,11 +2112,7 @@ body.has-toc .section-nav { display: none; }
 }
 
 /* ── Generative Research ────────────────────────────── */
-body.tab-research #calendar,
-body.tab-models #calendar,
-body.tab-wiki #calendar {
-  display: none;
-}
+/* (The calendar is now the day-view nav pill — visible on every tab.) */
 
 /* The floating section-nav (prev/next ## section, "1/1") is meaningless on the
    wiki catalog and single-page newspaper editions. */
@@ -2992,13 +3031,16 @@ body.tab-frontpage .section-nav {
 
 .ticket-company-select {
   font-size: 12px;
-  padding: 6px 10px;
+  font-weight: 500;
+  padding: 6px 12px;
   border: 1px solid var(--border);
-  border-radius: 3px;
+  border-radius: 8px;
   background: var(--bg);
   color: var(--text);
   cursor: pointer;
+  transition: background 0.12s ease, border-color 0.12s ease;
 }
+.ticket-company-select:hover { background: var(--bg-hover); }
 
 .ticket-summary {
   font-size: 12px;
@@ -3031,8 +3073,15 @@ body.tab-frontpage .section-nav {
   min-width: 0;
   background: var(--bg-secondary);
   border: 1px solid var(--border-light);
+  border-top: 3px solid var(--border);
   border-radius: 8px;
 }
+/* Status lives on the column top accent (cards no longer carry a pill). */
+.ticket-column-rumored    { border-top-color: #9aa0ac; }
+.ticket-column-in-testing { border-top-color: #d99a2b; }
+.ticket-column-confirmed  { border-top-color: #2ba8e0; }
+.ticket-column-released   { border-top-color: #2fa86a; }
+.ticket-column-closed     { border-top-color: #b6bcc6; }
 
 .ticket-column-header {
   height: 30px;

--- a/dashboard/src/style.css
+++ b/dashboard/src/style.css
@@ -1758,6 +1758,7 @@ body.has-toc .section-nav { display: none; }
 .ara-paper-kicker,
 .ara-paper-deck,
 .ara-paper-index,
+.ara-paper-meter,
 .ara-paper-meta > span:last-child {
   /* !important: the template's own .ara-paper-index { display: flex } rule
    * is defined later in this file and would otherwise win. */
@@ -3103,6 +3104,60 @@ body.tab-frontpage .section-nav {
 
 /* Per-status left-border accent — quick visual triage. */
 .ticket-card-closed     { border-left-color: var(--text-tertiary); opacity: 0.72; }
+
+/* Compact card top row (status + company). */
+.ticket-card-top {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+/* Ticket detail modal — opens on click with the full ticket. */
+.ticket-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1300;
+  display: none;
+  align-items: flex-start;
+  justify-content: center;
+  background: rgba(8, 12, 20, 0.55);
+  padding: 48px 16px;
+  overflow-y: auto;
+}
+.ticket-modal-card {
+  position: relative;
+  width: 100%;
+  max-width: 720px;
+  background: var(--bg);
+  border: 1px solid var(--border-light);
+  border-radius: 16px;
+  box-shadow: var(--shadow-lg);
+  padding: 28px 30px;
+}
+.ticket-modal-close {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 13px;
+}
+.ticket-modal-close:hover { background: var(--bg-hover); color: var(--text); }
+.ticket-modal .ticket-detail-panel {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-shadow: none;
+}
+body.modal-open { overflow: hidden; }
 .ticket-card-closed:hover { opacity: 0.95; }
 
 .ticket-header-top {

--- a/dashboard/src/style.css
+++ b/dashboard/src/style.css
@@ -559,12 +559,7 @@ body:not(.tab-research) .controls { display: none; }
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 0;
   cursor: pointer;
-}
-
-.calendar.open .cal-header {
-  margin-bottom: 12px;
 }
 
 .cal-grid {

--- a/dashboard/src/style.css
+++ b/dashboard/src/style.css
@@ -568,13 +568,18 @@ body:not(.tab-research) .controls { display: none; }
 }
 
 .cal-grid {
-  display: none;
-}
-
-.calendar.open .cal-grid {
   display: grid;
   grid-template-columns: repeat(7, 1fr);
   gap: 2px;
+}
+
+/* The opened picker (month nav + grid) is a popover so the pill keeps a fixed
+ * size and never shoves the tabs when toggled. */
+.cal-pop {
+  display: none;
+}
+.calendar.open .cal-pop {
+  display: block;
   position: absolute;
   top: calc(100% + 8px);
   left: 0;
@@ -608,13 +613,11 @@ body:not(.tab-research) .controls { display: none; }
 }
 
 .cal-header-nav {
-  display: none;
-  align-items: center;
-  gap: 4px;
-}
-
-.calendar.open .cal-header-nav {
   display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 4px;
+  margin-bottom: 8px;
 }
 
 .cal-nav-btn {

--- a/dashboard/src/style.css
+++ b/dashboard/src/style.css
@@ -410,10 +410,10 @@ body {
   background: var(--bg);
   border: 1px solid var(--border);
   color: var(--text);
-  padding: 7px 12px 7px 34px;
-  border-radius: 9px;
+  padding: 9px 58px 9px 36px;
+  border-radius: 10px;
   font-family: var(--font);
-  font-size: 0.84rem;
+  font-size: 0.9rem;
   outline: none;
   transition: all 0.15s;
 }
@@ -431,7 +431,7 @@ body {
 
 .search-count {
   position: absolute;
-  right: 10px;
+  right: 38px;
   top: 50%;
   transform: translateY(-50%);
   font-family: var(--font-mono);
@@ -487,8 +487,26 @@ body:not(.tab-research) .request-btn { display: none; }
 body:not(.tab-research) .controls { display: none; }
 
 /* Search overlay — revealed by the magnifier button next to the wordmark. */
-.search-overlay { margin-bottom: 12px; }
+.search-overlay { margin-bottom: 12px; max-width: 480px; }
 .search-overlay[hidden] { display: none; }
+.search-clear {
+  position: absolute;
+  right: 6px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 26px;
+  height: 26px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  background: transparent;
+  color: var(--text-tertiary);
+  border-radius: 6px;
+  cursor: pointer;
+}
+.search-clear:hover { background: var(--bg-hover); color: var(--text); }
+.search-clear[hidden] { display: none; }
 
 /* Audio digest: bare player, no card chrome / "Audio digest" label. */
 .today-audio { margin: 0 0 18px; }

--- a/dashboard/src/style.css
+++ b/dashboard/src/style.css
@@ -3073,15 +3073,14 @@ body.tab-frontpage .section-nav {
   min-width: 0;
   background: var(--bg-secondary);
   border: 1px solid var(--border-light);
-  border-top: 3px solid var(--border);
   border-radius: 8px;
 }
-/* Status lives on the column top accent (cards no longer carry a pill). */
-.ticket-column-rumored    { border-top-color: #9aa0ac; }
-.ticket-column-in-testing { border-top-color: #d99a2b; }
-.ticket-column-confirmed  { border-top-color: #2ba8e0; }
-.ticket-column-released   { border-top-color: #2fa86a; }
-.ticket-column-closed     { border-top-color: #b6bcc6; }
+/* Status reads from the column-header label color (no top bar / card pill). */
+.ticket-column-rumored    .ticket-column-header { color: #8a92a0; }
+.ticket-column-in-testing .ticket-column-header { color: #c77f1a; }
+.ticket-column-confirmed  .ticket-column-header { color: #1f93cc; }
+.ticket-column-released   .ticket-column-header { color: #2a9560; }
+.ticket-column-closed     .ticket-column-header { color: #8a92a0; }
 
 .ticket-column-header {
   height: 30px;

--- a/dashboard/src/style.css
+++ b/dashboard/src/style.css
@@ -2930,6 +2930,17 @@ body.tab-frontpage .section-nav {
   padding-bottom: 10px;
 }
 
+@media (max-width: 640px) {
+  /* Kanban lanes are unusable on a phone (cramped horizontal scroll) — stack
+   * the status columns into one vertical list instead. */
+  .tickets-board {
+    grid-auto-flow: row;
+    grid-auto-columns: auto;
+    grid-template-columns: 1fr;
+    overflow-x: visible;
+  }
+}
+
 .ticket-column {
   min-width: 0;
   background: var(--bg-secondary);

--- a/dashboard/src/style.css
+++ b/dashboard/src/style.css
@@ -2983,60 +2983,67 @@ body.tab-frontpage .section-nav {
 
 /* (The non-functional "Release"/"•••" Jira chrome buttons were removed.) */
 
+/* Unified filter bar: status segments + company dropdown share one bordered
+ * toolbar with consistent type/height and a divider between the two facets. */
 .tickets-controls {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 10px;
-  margin-bottom: 14px;
+  gap: 4px;
+  margin-bottom: 16px;
+  padding: 4px;
+  background: var(--bg);
+  border: 1px solid var(--border-light);
+  border-radius: 12px;
 }
 
 .ticket-filters {
-  display: flex;
+  display: inline-flex;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: 2px;
 }
 
 .ticket-filter-pill {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 5px 10px;
+  padding: 5px 11px;
   font-size: 12px;
   font-weight: 600;
-  color: #42526e;
+  color: var(--text-secondary);
   background: transparent;
-  border: 1px solid transparent;
-  border-radius: 3px;
+  border: 0;
+  border-radius: 8px;
   cursor: pointer;
   text-transform: capitalize;
-  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+  transition: background 120ms ease, color 120ms ease;
 }
-.ticket-filter-pill:hover { background: var(--bg-hover); }
+.ticket-filter-pill:hover { background: var(--bg-hover); color: var(--text); }
 .ticket-filter-pill.active {
   background: var(--accent-warm-bg);
   color: var(--accent-warm);
-  border-color: var(--accent-warm-bg);
 }
 .ticket-filter-count {
   font-variant-numeric: tabular-nums;
   font-size: 11px;
   opacity: 0.7;
 }
-.ticket-filter-pill.active .ticket-filter-count { opacity: 0.85; }
+.ticket-filter-pill.active .ticket-filter-count { opacity: 0.9; }
 
 .ticket-company-select {
   font-size: 12px;
   font-weight: 500;
-  padding: 6px 12px;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  background: var(--bg);
-  color: var(--text);
+  padding: 5px 8px 5px 12px;
+  margin-left: 4px;
+  border: 0;
+  border-left: 1px solid var(--border-light);
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-secondary);
   cursor: pointer;
-  transition: background 0.12s ease, border-color 0.12s ease;
+  transition: color 0.12s ease;
 }
-.ticket-company-select:hover { background: var(--bg-hover); }
+.ticket-company-select:hover { color: var(--text); }
 
 .ticket-summary {
   font-size: 12px;

--- a/dashboard/src/style.css
+++ b/dashboard/src/style.css
@@ -487,7 +487,7 @@ body:not(.tab-research) .request-btn { display: none; }
 body:not(.tab-research) .controls { display: none; }
 
 /* Search overlay — revealed by the magnifier button next to the wordmark. */
-.search-overlay { margin-bottom: 12px; max-width: 480px; }
+.search-overlay { margin-bottom: 12px; max-width: 560px; }
 .search-overlay[hidden] { display: none; }
 .search-clear {
   position: absolute;
@@ -507,6 +507,67 @@ body:not(.tab-research) .controls { display: none; }
 }
 .search-clear:hover { background: var(--bg-hover); color: var(--text); }
 .search-clear[hidden] { display: none; }
+
+/* Global search results (command-palette style). */
+.search-results {
+  margin-top: 6px;
+  max-height: 380px;
+  overflow-y: auto;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: var(--shadow-lg);
+  padding: 6px;
+}
+.search-results[hidden] { display: none; }
+.search-result {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 10px;
+  border: 0;
+  background: transparent;
+  border-radius: 8px;
+  cursor: pointer;
+  text-align: left;
+  color: var(--text);
+}
+.search-result:hover,
+.search-result.is-sel { background: var(--bg-hover); }
+.search-result-type {
+  flex: 0 0 56px;
+  font-family: var(--font-mono);
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--accent-warm);
+}
+.search-result-title {
+  flex: 1;
+  min-width: 0;
+  font-size: 0.86rem;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.search-result-sub {
+  flex: 0 0 auto;
+  max-width: 38%;
+  font-size: 0.72rem;
+  color: var(--text-tertiary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.search-empty {
+  padding: 16px;
+  text-align: center;
+  font-size: 0.82rem;
+  color: var(--text-tertiary);
+}
 
 /* Audio digest: bare player, no card chrome / "Audio digest" label. */
 .today-audio { margin: 0 0 18px; }

--- a/dashboard/src/style.css
+++ b/dashboard/src/style.css
@@ -580,10 +580,8 @@ body:not(.tab-research) .controls { display: none; }
 }
 .calendar.open .cal-pop {
   display: block;
-  position: absolute;
-  top: calc(100% + 8px);
-  left: 0;
-  z-index: 60;
+  position: fixed;          /* fixed so it escapes the .tabs overflow-x clip */
+  z-index: 1100;
   width: 280px;
   padding: 12px;
   background: var(--bg);

--- a/dashboard/src/style.css
+++ b/dashboard/src/style.css
@@ -429,12 +429,28 @@ body {
 
 /* ── Calendar ──────────────────────────────────────── */
 .calendar {
+  /* Compact affordance: a small pill when collapsed; expands only when opened. */
+  display: inline-block;
   background: var(--bg);
   border: 1px solid var(--border-light);
-  border-radius: 16px;
+  border-radius: 10px;
   box-shadow: var(--shadow-sm);
-  padding: 16px;
+  padding: 7px 13px;
   margin-bottom: 12px;
+}
+.calendar.open {
+  display: block;
+  padding: 14px 16px;
+  border-radius: 14px;
+}
+
+/* Aggressive-minimalism chrome cuts: drop the floating section-nav widget, the
+ * keyboard-shortcut guide, and the manual refresh button — content-first.
+ * Keyboard shortcuts still work; only the visual widgets are removed. */
+.section-nav,
+.shortcut-guide,
+.refresh-btn {
+  display: none !important;
 }
 
 .cal-header {


### PR DESCRIPTION
## What

The aggressive simplify-toward-clarity pass across every section (follows #126 unify-spine and #127 component-native). Dashboard-only (HTML/CSS/TS); no data/schema/validator changes.

### Header — minimalist, content-first
- **Calendar pill replaces the Today tab** as the day-view entry (navy/active on today; click opens a fixed-size date-picker popover; pick a day → that day's digest). Fixed-size pill, escapes the nav's overflow clip.
- Removed the EN/한국어 toggle (English-only), the always-on search bar, the floating section-nav + shortcut "?" + refresh chrome.
- **Magnifier button** by the wordmark; footer gains `t.me/robot_colosseum`.

### Global search (⌘K)
- Command palette across **research articles + wiki pages + model tickets** from any tab; ranked title-first, type-badged results; click or ↑/↓+Enter jumps to the item. Clear (×), Esc, outside-click dismiss.

### Wiki-mention hover links
- Entities in the digest/Twitter/articles are underlined; desktop hover shows a quick-look preview; click → the wiki page (cross-tab).

### Model Timeline
- Compact cards (company + title); status reads from **color-coded column headers** (no card pill). Click → a **detail modal** (ara-kv metadata + history timeline + body + sources). **Unified filter bar** (status segments + company dropdown). Mobile kanban stacks.

### Declutter / dedup
- Newspaper: dropped the kicker tagline, "All Sources Edition", deck blurb, "In this edition" nav, and the "Signal Mix" meters; departments unfold by default.
- Twitter: Skeptic's-corner no longer doubles; Signal Brief shows in full (no mid-sentence cut).
- Removed redundant "Model release timeline" / "LLM Wiki / N pages" headings and the duplicate Today date; bare audio player.
- Tighter global letter-spacing.

## Safety
- `tsc --noEmit` clean; `vite build` succeeds; verified across all tabs (light + dark, mobile), no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)