### PR TITLE
Global search over digest sections + twitter cycles; header refinements

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -38,12 +38,12 @@
       <header class="header">
         <div class="header-top">
           <div class="brand">
-            <h1 class="brand-title">ai-research-arm</h1>
-            <button class="brand-search" id="searchToggle" type="button" aria-label="Search" title="Search (⌘K or /)">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>
-            </button>
+            <h1 class="brand-title" id="brandHome" role="button" tabindex="0" title="Home">ai-research-arm</h1>
           </div>
           <div class="header-actions">
+            <button class="brand-search" id="searchToggle" type="button" aria-label="Search" title="Search (⌘F or /)">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>
+            </button>
             <a class="header-link" href="https://github.com/guzus/ai-research-arm" target="_blank" rel="noopener">
               <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
               <span class="header-link-label">guzus/ai-research-arm</span>

--- a/dashboard/scripts/prebuild.mjs
+++ b/dashboard/scripts/prebuild.mjs
@@ -395,7 +395,102 @@ async function hydrateTweets() {
   );
 }
 
+// ── Search index (digest sections + twitter cycles) ─────────
+// A small, bounded JSON the SPA loads once so digest sections and twitter
+// cycles become searchable jump targets in the global command palette. Bounded
+// to recent dates (older sections/cycles aren't worth searching) and fully
+// best-effort so a malformed file never fails the build.
+const DIGEST_RECENT_FILES = 14;
+
+function buildSearchIndex() {
+  const out = { digestSections: [], twitter: [] };
+  // Digest sections: split each recent digest on `## ` headings (mirrors
+  // splitSections() in main.ts). Skip "Executive Summary" — it renders as the
+  // tldr card with no .content-card-title to scroll to.
+  try {
+    const dir = join(researchSrc, 'digest');
+    if (existsSync(dir)) {
+      const re = /^(\d{4}-\d{2}-\d{2})-digest\.md$/;
+      const dates = readdirSync(dir)
+        .map((n) => (re.exec(n) || [])[1])
+        .filter(Boolean)
+        .sort()
+        .reverse()
+        .slice(0, DIGEST_RECENT_FILES);
+      const SKIP = new Set(['Executive Summary']);
+      for (const date of dates) {
+        const md = readFileSync(join(dir, `${date}-digest.md`), 'utf8');
+        let title = null;
+        let buf = [];
+        const flush = () => {
+          if (title && !SKIP.has(title)) {
+            const snippet = buf
+              .join(' ')
+              .replace(/[#>*_`~|\[\]()]/g, ' ')
+              .replace(/https?:\/\/\S+/g, ' ')
+              .replace(/\s+/g, ' ')
+              .trim()
+              .slice(0, 140);
+            out.digestSections.push({ date, sectionTitle: title, snippet });
+          }
+        };
+        for (const line of md.split('\n')) {
+          const mm = line.match(/^## (.+)/);
+          if (mm) {
+            flush();
+            title = mm[1].trim();
+            buf = [];
+          } else if (title) {
+            buf.push(line);
+          }
+        }
+        flush();
+      }
+    }
+  } catch (e) {
+    console.warn('prebuild: digest search index skipped:', e?.message || e);
+  }
+  // Twitter cycles: split each recent twitter file on `## HH:MM UTC` cycle
+  // headings; index the Cycle summary (Signal Brief) + story titles. The anchor
+  // MUST match the id assigned in renderTwitterReport (cycle-HHMMutc).
+  try {
+    const dir = join(researchSrc, 'twitter');
+    if (existsSync(dir)) {
+      const files = readdirSync(dir)
+        .filter((n) => /^\d{4}-\d{2}-\d{2}\.md$/.test(n))
+        .sort()
+        .reverse()
+        .slice(0, TWEET_RECENT_FILES);
+      for (const name of files) {
+        const date = name.slice(0, 10);
+        const text = readFileSync(join(dir, name), 'utf8');
+        const parts = text.split(/^## (\d{2}:\d{2} UTC)\s*$/m);
+        for (let i = 1; i < parts.length; i += 2) {
+          const cycleTime = parts[i];
+          const body = parts[i + 1] || '';
+          const sum = body.match(/\*\*Cycle summary\*\*:\s*([\s\S]*?)(?=\n#{1,3}\s|\n\*\*|\n## |$)/i);
+          const summary = (sum ? sum[1] : '').replace(/\s+/g, ' ').trim().slice(0, 200);
+          const storyTitles = [
+            ...[...body.matchAll(/^####\s+\d+\.\s+(.+)$/gm)].map((m) => m[1].trim()),
+            ...[...body.matchAll(/class="twitter-story-title"[^>]*>([^<]+)</g)].map((m) => m[1].trim()),
+          ];
+          if (!summary && storyTitles.length === 0) continue;
+          const anchor = 'cycle-' + cycleTime.replace(/[:\s]/g, '').toLowerCase();
+          out.twitter.push({ date, cycleTime, anchor, summary, storyTitles });
+        }
+      }
+    }
+  } catch (e) {
+    console.warn('prebuild: twitter search index skipped:', e?.message || e);
+  }
+  writeFileSync(join(publicResearch, 'search-index.json'), JSON.stringify(out));
+  console.log(
+    `prebuild: search-index.json (${out.digestSections.length} digest sections, ${out.twitter.length} twitter cycles)`,
+  );
+}
+
 copyData();
 buildTicketsIndex();
 buildManifest();
+buildSearchIndex();
 await hydrateTweets().catch((e) => console.warn('prebuild: tweet hydration skipped:', e?.message || e));

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -2294,6 +2294,9 @@ function renderTwitterReport(md: string, fallbackDate: string | null = null): vo
     const title = section.title || displayDate(currentDate);
     const dateStr = fmtDate(currentDate);
     const timeInfo = parseUtcTime(section.title, dateStr);
+    // Stable per-cycle anchor for search-driven deep links — must match the
+    // anchor prebuild writes into search-index.json (cycle-HHMMutc).
+    const cycleAnchor = 'cycle-' + section.title.replace(/[:\s]/g, '').toLowerCase();
     const cycleSummary = extractCycleSummary(section.body);
     const stories = parseTwitterStories(section.body);
     const displayTime = timeInfo
@@ -2350,7 +2353,7 @@ function renderTwitterReport(md: string, fallbackDate: string | null = null): vo
 
     cards.push(
       [
-        '<section class="content-card twitter-cycle-card">',
+        '<section id="' + cycleAnchor + '" class="content-card twitter-cycle-card">',
         '  <div class="twitter-cycle-header">',
         '    <div class="twitter-cycle-kicker">' + (timeInfo ? clockIcon(timeInfo.localHours, timeInfo.localMinutes) : '') + displayTime + '</div>',
         '  </div>',
@@ -4985,6 +4988,12 @@ async function load(): Promise<void> {
           showEmpty(dateStr);
         }
       }
+      // Search-driven deep link into a specific digest section.
+      if (pendingDigestSection) {
+        const want = pendingDigestSection;
+        pendingDigestSection = null;
+        requestAnimationFrame(() => scrollToDigestSection(want));
+      }
     } else {
       const result = await withTimeout(fetchTwitter(dateStr, controller.signal), LOAD_TIMEOUT_MS, controller);
       if (requestId !== loadRequestId) return;
@@ -5005,6 +5014,14 @@ async function load(): Promise<void> {
         } else {
           showEmpty(dateStr);
         }
+      }
+      // Search-driven deep link into a specific twitter cycle (by id anchor).
+      if (pendingTwitterAnchor) {
+        const id = pendingTwitterAnchor;
+        pendingTwitterAnchor = null;
+        requestAnimationFrame(() =>
+          document.getElementById(id)?.scrollIntoView({ behavior: 'smooth', block: 'start' }),
+        );
       }
     }
 
@@ -5065,6 +5082,21 @@ function scrollToSection(index: number): void {
   updateNavCounter();
 }
 
+// Deferred scroll targets for search-driven navigation into the today/twitter
+// views — set by activateSearchHit, consumed post-render in load().
+let pendingDigestSection: string | null = null;
+let pendingTwitterAnchor: string | null = null;
+
+// Digest section cards carry no id, so match by the rendered .content-card-title
+// (textContent decodes &amp; back to &, so a literal-& title compares equal).
+function scrollToDigestSection(title: string): void {
+  const want = title.trim();
+  const idx = getCards().findIndex(
+    (c) => (c.querySelector('.content-card-title')?.textContent || '').trim() === want,
+  );
+  if (idx >= 0) scrollToSection(idx);
+}
+
 document.getElementById('navUp')!.addEventListener('click', () => scrollToSection(currentSection - 1));
 document.getElementById('navDown')!.addEventListener('click', () => scrollToSection(currentSection + 1));
 window.addEventListener('beforeunload', () => stopResearchAudio());
@@ -5077,6 +5109,19 @@ document.getElementById('shortcutToggle')!.addEventListener('click', () => {
 
 // ── Events ────────────────────────────────────────────
 
+// Clicking the wordmark returns to the home (today) view.
+function goHome(): void {
+  activeTab = 'today';
+  selectedSlug = null;
+  syncTabUi();
+  load();
+}
+const brandHome = document.getElementById('brandHome');
+brandHome?.addEventListener('click', goHome);
+brandHome?.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); goHome(); }
+});
+
 const searchToggle = document.getElementById('searchToggle');
 const searchOverlay = document.getElementById('searchOverlay');
 const searchClear = document.getElementById('searchClear');
@@ -5086,15 +5131,44 @@ const searchResultsEl = document.getElementById('searchResults');
 // Search across ALL content — research articles, wiki pages, model tickets —
 // from any tab; a result jumps straight to the item. The corpus is built lazily
 // from the already-loaded indexes and cached.
-type SearchHit = { type: 'research' | 'wiki' | 'model'; title: string; subtitle: string; slug: string; hay: string };
+type SearchHit = { type: 'research' | 'wiki' | 'model' | 'digest' | 'twitter'; title: string; subtitle: string; slug: string; hay: string; date?: string; anchor?: string; sectionTitle?: string };
 let searchCorpus: SearchHit[] | null = null;
 let searchHits: SearchHit[] = [];
 let searchSel = -1;
-const SEARCH_TYPE_LABEL: Record<SearchHit['type'], string> = { research: 'Research', wiki: 'Wiki', model: 'Model' };
+const SEARCH_TYPE_LABEL: Record<SearchHit['type'], string> = { research: 'Research', wiki: 'Wiki', model: 'Model', digest: 'Digest', twitter: 'Twitter' };
+
+// Build-time content index (digest sections + twitter cycles) — see
+// scripts/prebuild.mjs:buildSearchIndex. Loaded once, cached, best-effort.
+type SearchIndexFile = {
+  digestSections?: { date: string; sectionTitle: string; snippet?: string }[];
+  twitter?: { date: string; cycleTime: string; anchor: string; summary?: string; storyTitles?: string[] }[];
+};
+let searchIndexCache: SearchIndexFile | null = null;
+let searchIndexPromise: Promise<SearchIndexFile | null> | null = null;
+function loadSearchIndex(): Promise<SearchIndexFile | null> {
+  if (searchIndexCache) return Promise.resolve(searchIndexCache);
+  if (searchIndexPromise) return searchIndexPromise;
+  searchIndexPromise = (async () => {
+    try {
+      const r = await fetch(`${DATA_BASE}/search-index.json`);
+      if (!r.ok) return null;
+      const j = (await r.json()) as SearchIndexFile;
+      searchIndexCache = j;
+      return j;
+    } catch {
+      return null; // missing file / SPA-shell HTML / parse error → no content hits
+    }
+  })();
+  return searchIndexPromise;
+}
+function ymdToDate(s: string): Date {
+  const [y, m, d] = s.split('-').map(Number);
+  return new Date(y, (m || 1) - 1, d || 1);
+}
 
 async function buildSearchCorpus(): Promise<SearchHit[]> {
   if (searchCorpus) return searchCorpus;
-  const [m, wiki, tickets] = await Promise.all([loadManifest(), loadWikiIndexCached(), loadTickets()]);
+  const [m, wiki, tickets, idx] = await Promise.all([loadManifest(), loadWikiIndexCached(), loadTickets(), loadSearchIndex()]);
   const hits: SearchHit[] = [];
   if (wiki) for (const p of wiki.pages) {
     hits.push({ type: 'wiki', title: p.title, subtitle: (p.aliases || []).slice(0, 3).join(', ') || String(p.type),
@@ -5107,6 +5181,19 @@ async function buildSearchCorpus(): Promise<SearchHit[]> {
   if (tickets) for (const t of tickets) {
     hits.push({ type: 'model', title: t.title, subtitle: t.company + (t.model ? ' · ' + t.model : ''),
       slug: t.slug, hay: (t.title + ' ' + t.company + ' ' + (t.model || '') + ' ' + (t.labels || []).join(' ')).toLowerCase() });
+  }
+  const ds = idx?.digestSections;
+  if (ds) for (const s of ds) {
+    hits.push({ type: 'digest', title: s.sectionTitle, subtitle: displayDate(ymdToDate(s.date)) + ' digest',
+      slug: '', date: s.date, sectionTitle: s.sectionTitle,
+      hay: (s.date + ' ' + s.sectionTitle + ' ' + (s.snippet || '')).toLowerCase() });
+  }
+  const tw = idx?.twitter;
+  if (tw) for (const c of tw) {
+    const titleText = c.summary || c.storyTitles?.[0] || (c.cycleTime + ' cycle');
+    hits.push({ type: 'twitter', title: titleText, subtitle: displayDate(ymdToDate(c.date)) + ' · ' + c.cycleTime,
+      slug: '', date: c.date, anchor: c.anchor,
+      hay: (c.date + ' ' + c.cycleTime + ' ' + (c.summary || '') + ' ' + (c.storyTitles || []).join(' ')).toLowerCase() });
   }
   searchCorpus = hits;
   return hits;
@@ -5173,6 +5260,30 @@ function activateSearchHit(h: SearchHit): void {
     if (t) window.setTimeout(() => openTicketModal(t), 60);
     return;
   }
+  if (h.type === 'digest') {
+    if (h.date) {
+      activeTab = 'today';
+      selectedSlug = null;
+      currentDate = ymdToDate(h.date);
+      calendarMonth = new Date(currentDate.getFullYear(), currentDate.getMonth(), 1);
+      pendingDigestSection = h.sectionTitle || null;
+      syncTabUi();
+      load();
+    }
+    return;
+  }
+  if (h.type === 'twitter') {
+    if (h.date) {
+      activeTab = 'twitter';
+      selectedSlug = null;
+      currentDate = ymdToDate(h.date);
+      calendarMonth = new Date(currentDate.getFullYear(), currentDate.getMonth(), 1);
+      pendingTwitterAnchor = h.anchor || null;
+      syncTabUi();
+      load();
+    }
+    return;
+  }
   activeTab = h.type; // 'research' | 'wiki'
   selectedSlug = h.slug;
   syncTabUi();
@@ -5215,9 +5326,10 @@ searchInput.addEventListener('keydown', (e) => {
   else if (e.key === 'ArrowUp') { e.preventDefault(); moveSearchSel(-1); }
   else if (e.key === 'Enter') { e.preventDefault(); if (searchHits[searchSel]) activateSearchHit(searchHits[searchSel]); }
 });
-// ⌘K / Ctrl+K opens search from anywhere; click outside the panel closes it.
+// ⌘F / Ctrl+F opens search from anywhere (overrides native find); click outside
+// the panel closes it.
 document.addEventListener('keydown', (e) => {
-  if ((e.metaKey || e.ctrlKey) && (e.key === 'k' || e.key === 'K')) {
+  if ((e.metaKey || e.ctrlKey) && (e.key === 'f' || e.key === 'F')) {
     e.preventDefault();
     openSearch();
   }

--- a/dashboard/src/style.css
+++ b/dashboard/src/style.css
@@ -72,7 +72,7 @@ body {
   background: var(--bg-secondary);
   color: var(--text);
   line-height: 1.6;
-  letter-spacing: -0.012em;  /* tighter tracking overall for faster reading */
+  letter-spacing: -0.022em;  /* tight tracking overall for faster reading */
   -webkit-font-smoothing: antialiased;
   min-height: 100vh;
 }
@@ -175,7 +175,9 @@ body {
   font-weight: 700;
   letter-spacing: -0.02em;
   font-family: var(--font-mono);
+  cursor: pointer;
 }
+.brand-title:hover { color: var(--accent-warm); }
 .brand-search {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
Extends the global command palette to index **digest sections** and **twitter cycles** as jump targets, plus three header/typography refinements.

## Global search content indexing
- `prebuild.mjs` now builds a bounded `search-index.json` (one file, two keys: `digestSections` + `twitter`): the 14 most-recent digests (one entry per `##` section, Executive Summary excluded) and the 21 most-recent twitter days (one entry per `## HH:MM UTC` cycle — the Signal Brief summary + story titles). Best-effort: a malformed file never fails the build.
- `buildSearchCorpus` loads it (cached) and folds it into the existing corpus, so a single query now matches Research / Wiki / Model / **Digest** / **Twitter**.
- Clicking a hit navigates to that date and scrolls to the target: digest sections scroll by matching `.content-card-title`; twitter cycles get a stable `id="cycle-HHMMutc"` (matching the prebuilt anchor) and scroll into view.

## Header / typography
- Search button moved to the top-right `header-actions`; shortcut is now **⌘F / Ctrl+F** (overrides native find).
- The `ai-research-arm` wordmark is now a **Home** link (returns to the today view from any deep view).
- Tightened global letter-spacing (`-0.012em` → `-0.022em`).

## Verification
- `tsc --noEmit` clean; `bun run build` green.
- prebuild emits `search-index.json (112 digest sections, 133 twitter cycles)`.
- Headless QA (vite preview): "Breaking News" → 5 dated Digest hits → click → `/today/2026-06-16`, scrolled to the section. "Anthropic" → click Twitter hit → `/twitter/2026-06-10` with `cycle-1900utc` scrolled to top. Mixed "GPT" query returns Model/Twitter/Wiki/Digest. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)