### PR TITLE
[codex] Make ARA wiki OKF-native

### DIFF
--- a/.github/workflows/wiki-ingest.yml
+++ b/.github/workflows/wiki-ingest.yml
@@ -212,9 +212,10 @@ jobs:
                    the canonical name AND likely aliases). Inspect the hits.
                 b) IF a page already covers this subject → UPDATE it in
                    place: fold today's development into the body, add or
-                   refine `[[links]]` and `aliases`, and bump `updated_at`
-                   to the ingested date per the schema. Do NOT create a
-                   second page. Do NOT change its slug.
+                   refine `[[links]]` and `aliases`, and bump `timestamp`
+                   to the ingested date as `<ingested-date>T00:00:00Z` per
+                   the schema. Do NOT create a second page. Do NOT change
+                   its slug.
                 c) ONLY IF no existing page covers it → CREATE a new page in
                    the correct subdir (entities/ vs concepts/ vs themes/)
                    with a slug per the schema conventions, full frontmatter,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ and opens a PR with methodology fixes.
 | [`COMPONENTS.md`](COMPONENTS.md) | Human reference for the `ara-*` component vocabulary. The machine-readable contract the validator loads is [`ARA_CATALOG.json`](ARA_CATALOG.json); the two are kept in lockstep (CI-enforced — see "Component catalog" below). The CSS at `dashboard/src/components/ara-research.css` is the rendering source of truth and intentionally carries *more* `ara-*` classes than the article allowlist (runtime + front-page layers). |
 | [`ARA_CATALOG.json`](ARA_CATALOG.json) | Machine-readable ara-* component catalog the validator loads its class allowlist from. `scripts/ara_catalog.py` validates it stays in lockstep with COMPONENTS.md (CI-enforced; see "Component catalog" below). |
 | [`docs/generative-research-backends.md`](docs/generative-research-backends.md) | Backend matrix for the generative-research lane (Claude vs DeepSeek vs local Oracle), env mapping, comparison commands. |
+| [`docs/okf.md`](docs/okf.md) | Open Knowledge Format export contract for sharing `research/wiki/` as a portable Markdown/YAML knowledge bundle. |
 | [`docs/model-tickets.md`](docs/model-tickets.md) | Schema + lifecycle + dedup protocol for `research/models/tickets/*.md`. Read by the CRUD agent in `24h-model-timeline.yml` and enforced by `scripts/check_model_tickets.py`. |
 | [`docs/wiki-schema.md`](docs/wiki-schema.md) | Canonical schema + page conventions for the LLM Wiki (`research/wiki/`). Read at runtime by the ingest agent in `wiki-ingest.yml` and enforced by `scripts/check_wiki.py`. |
 | [`docs/hooker-telemetry.md`](docs/hooker-telemetry.md) | Non-blocking telemetry route via `https://hooker.guzus.xyz` topic `ara-telemetry`. |
@@ -59,6 +60,7 @@ and opens a PR with methodology fixes.
 | `check_model_tickets.py` | Validator for `research/models/tickets/*.md` against the schema in `docs/model-tickets.md`. The CRUD agent in `24h-model-timeline.yml` runs it after every pass; CI runs it on every PR. |
 | `check_wiki.py` | Validator for `research/wiki/` pages against the schema in `docs/wiki-schema.md`. `uv run python scripts/check_wiki.py` (exit 0 = safe); `--lint` adds advisory checks. The ingest agent in `wiki-ingest.yml` runs it until exit 0; CI runs it on every PR. |
 | `wiki_search.py` | Search wrapper over `research/wiki/` (`uv run python scripts/wiki_search.py "<query>"`). The ingest agent runs it before writing any page so it UPDATEs an existing page instead of duplicating. |
+| `export_wiki_okf.py` | Export `research/wiki/` as a portable Open Knowledge Format bundle: validates the OKF-native wiki pages and rewrites `[[wikilinks]]` to standard Markdown links. |
 | `check_lane_freshness.py` | Freshness watchdog. Measures git-commit recency per research lane against per-lane cadence thresholds; exits 2 (and emits a hooker/Telegram alert from `liveness-check.yml`) when a lane is stale. Stdlib-only so it runs on both runner tiers. |
 | `build_wiki_index.py` | Rebuilds `research/wiki/index.json` from the wiki pages. **CI-load-bearing**: `ci.yml` runs `--check` (exit 1 if the committed index is stale or any page fails validation); `wiki-ingest.yml` regenerates it every run. |
 | `fetch_ai_blogs.py` | Per-feed AI-blog fetcher used by `daily-ai-blogs.yml`; boundary-handles bad feeds so one failure doesn't crash the run. |
@@ -345,7 +347,7 @@ output or break the pipeline. Read them before editing.
     The `wiki-ingest.yml` agent runs daily *after the digest*
     (`workflow_run`), reads the schema doc, and for each subject runs
     `scripts/wiki_search.py` to find an existing page and UPDATE it
-    (bump `updated_at`, refine `[[links]]`/`aliases`) rather than
+    (bump the OKF `timestamp`, refine `[[links]]`/`aliases`) rather than
     duplicating — it creates a new page only when none exists. Update is
     the default; creation is the exception. **Slugs are immutable** (a
     rename updates the title + aliases, never the filename); pages are

--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ Agents command: `.agents/commands/gen-research-tweet.md`.
 For a concise framework on which AI industry areas matter most, see
 [AI Industry Map](docs/ai-industry-map.md).
 
+For portable data sharing from the ARA wiki, see
+[Open Knowledge Format for ARA](docs/okf.md).
+
 ## On-Demand Research Agent
 
 Request deep research on any topic by creating a GitHub Issue with the `research` label.

--- a/docs/okf.md
+++ b/docs/okf.md
@@ -1,0 +1,103 @@
+# Open Knowledge Format for ARA
+
+ARA adopts the Open Knowledge Format (OKF) for portable knowledge sharing from
+the persistent wiki at `research/wiki/`.
+
+OKF v0.1 is an open Google Cloud specification for representing knowledge as a
+directory of Markdown files with YAML frontmatter. See Google's introduction:
+<https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing>
+and the draft spec:
+<https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md>.
+Its core interoperability surface is deliberately small: each concept is one
+Markdown file, the frontmatter has a required `type` field, and recommended
+fields such as `title`, `description`, `resource`, `tags`, and `timestamp` make
+the bundle easy for humans, agents, search indexes, and graph viewers to
+consume.
+
+ARA already has the same underlying mechanics: a git-versioned wiki of
+interlinked Markdown pages with strict frontmatter and a generated dashboard
+index. The maintained wiki pages now use OKF-native frontmatter fields at the
+source, with a few ARA extension fields where the pipeline needs stricter local
+behavior.
+
+## Source Bundle
+
+The source of truth remains:
+
+```
+research/wiki/
+├── index.md
+├── log.md
+├── entities/
+├── concepts/
+└── themes/
+```
+
+Every non-reserved page under `entities/`, `concepts/`, and `themes/` is an OKF
+concept document. `index.md` and `log.md` remain reserved navigation/history
+files.
+
+The ARA wiki is stricter than baseline OKF:
+
+- It has exactly three canonical concept types: `entity`, `concept`, `theme`.
+- Every page carries stable `slug`, `title`, `description`, `created_at`, and
+  `timestamp` fields.
+- Internal links use ARA wikilinks (`[[slug]]`, `[[slug|Label]]`) so the
+  validator can resolve aliases and catch missing pages before publishing.
+- `scripts/check_wiki.py` remains the source validator for the maintained wiki.
+
+## OKF Export
+
+Generate a portable OKF bundle from the maintained wiki:
+
+```bash
+uv run python scripts/export_wiki_okf.py --out /tmp/ara-okf
+```
+
+The exporter validates the wiki first, then writes a clean bundle containing:
+
+- `index.md` — OKF-style bundle index grouped by entity, concept, and theme.
+- `entities/*.md`, `concepts/*.md`, `themes/*.md` — one OKF concept document per
+  wiki page.
+
+The generated bundle is intended for sharing with agents and external tools.
+It is not committed by default because `research/wiki/` is the canonical source
+and the export is deterministic from that source.
+
+## Field Mapping
+
+| ARA wiki field | OKF export field | Notes |
+|---|---|---|
+| `type` | `type` | Preserved as `entity`, `concept`, or `theme`; OKF consumers must tolerate unknown producer-defined types. |
+| `title` | `title` | Preserved unchanged. |
+| `description` | `description` | OKF's one-line preview field. |
+| `tags` | `tags` | Preserved unchanged. |
+| `timestamp` | `timestamp` | Preserved as the OKF last-meaningful-change timestamp. |
+| `slug` | `ara_slug` | Preserved as an ARA extension field. |
+| `aliases` | `aliases` | Preserved as an extension field for agent lookup. |
+| `created_at` | `created_at` | Preserved as an extension field. |
+| `sources` | `sources` | Preserved as an extension field. |
+
+ARA does not force `resource` on wiki pages because many pages describe abstract
+entities, concepts, or themes rather than a single underlying data asset.
+
+## Link Mapping
+
+ARA source pages use `[[wikilinks]]` because the local validator resolves slugs
+and aliases. OKF consumers expect normal Markdown links, so the exporter rewrites
+resolved wikilinks:
+
+```markdown
+[[openai]]              -> [OpenAI](../entities/openai.md)
+[[openai|OpenAI lab]]   -> [OpenAI lab](../entities/openai.md)
+[[An Alias]]            -> [Canonical Title](../entities/openai.md)
+```
+
+Unresolved wikilinks cannot reach the exporter because `scripts/check_wiki.py`
+rejects them first.
+
+## Compatibility Boundary
+
+Baseline OKF consumers must tolerate ARA extension fields. ARA consumers should
+not assume every OKF bundle has ARA fields such as `ara_slug`, `aliases`, or
+`sources`; those are local affordances layered on top of the open format.

--- a/docs/wiki-schema.md
+++ b/docs/wiki-schema.md
@@ -7,6 +7,11 @@ markdown pages — one per entity, concept, or theme — that a daily Claude age
 model-release tickets), **not** the raw firehose. Each page accretes detail and
 cross-links over time; pages are updated and interlinked, rarely deleted.
 
+The wiki is also the source bundle for ARA's Open Knowledge Format (OKF) export.
+See [`docs/okf.md`](okf.md) for the field mapping and export command. OKF is the
+portable sharing shape; this schema remains the stricter source-of-truth
+contract enforced inside the repo.
+
 This doc is the **contract**: the maintenance agent reads it each run, and the
 validator (`scripts/check_wiki.py`) enforces it. Keep this doc and the validator
 in lockstep — every field and rule described here is checked there, and vice
@@ -61,9 +66,9 @@ title: Nebius Group                # required; human-readable display name
 type: entity                       # required; one of: entity | concept | theme
 aliases: [Nebius, NBIS, "Nebius Group N.V."]   # optional; list of strings (other names this page answers to)
 tags: [neocloud, gpu-cloud, ai-infrastructure] # optional; list of strings (free-text facets)
-summary: Amsterdam-based AI cloud ("neocloud") provider spun out of Yandex.  # required; ONE line
+description: Amsterdam-based AI cloud ("neocloud") provider spun out of Yandex.  # required; ONE line
 created_at: 2026-05-24             # required; YYYY-MM-DD (ISO date)
-updated_at: 2026-05-24             # required; YYYY-MM-DD (>= created_at)
+timestamp: 2026-05-24T00:00:00Z    # required; ISO 8601 timestamp (>= created_at)
 sources:                           # optional; list of mappings, each with a title (req)
   - {title: "ARA daily digest 2026-05-24", path: research/digest/2026-05-24-digest.md}
   - {title: "Nebius Q1 2026 results", url: "https://example.com/nebius-q1", date: 2026-05-20}
@@ -81,9 +86,9 @@ Field reference:
 | `type` | yes | enum | `entity` \| `concept` \| `theme`. Must match the subdir (see taxonomy). |
 | `aliases` | no | list[str] | Alternate names. **Each alias joins the wikilink resolver namespace** (see slug rules). |
 | `tags` | no | list[str] | Free-text facets used by search/lint. |
-| `summary` | yes | string | A single line (no embedded newlines). |
+| `description` | yes | string | OKF preview field; a single line (no embedded newlines). |
 | `created_at` | yes | date | ISO `YYYY-MM-DD`. |
-| `updated_at` | yes | date | ISO `YYYY-MM-DD`; must be `>= created_at`. |
+| `timestamp` | yes | datetime | OKF last-meaningful-change timestamp; use ISO 8601 UTC (`YYYY-MM-DDT00:00:00Z` for date-granular updates); must be `>= created_at`. |
 | `sources` | no | list[map] | Each item is a mapping with `title` (req) and optional `url` (http(s)), `path` (repo-relative), `date` (ISO). No other keys. |
 
 Both flow style (`aliases: [a, b]`, `sources: - {title: ...}`) and block style
@@ -159,19 +164,19 @@ Rules:
 # Wiki Index
 
 ## Entities
-- [[slug]] — one-line summary
+- [[slug]] — one-line description
 - ...
 
 ## Concepts
-- [[slug]] — one-line summary
+- [[slug]] — one-line description
 
 ## Themes
-- [[slug]] — one-line summary
+- [[slug]] — one-line description
 ```
 
 - First line must be exactly `# Wiki Index`.
 - One `##` section per type (`Entities` / `Concepts` / `Themes`).
-- Each catalog line is `- [[slug]] — one-line summary` (em dash `—`).
+- Each catalog line is `- [[slug]] — one-line description` (em dash `—`).
 - **Every page must be listed exactly once**, under the section matching its
   `type`. **Every listed slug must have a page file.** The validator checks both
   directions and the section↔type match.
@@ -226,13 +231,13 @@ On each daily run:
      wikilink resolution working).
    - Add new citations to `sources`.
    - Add new cross-links (`[[...]]`) to other pages the update touches.
-   - Bump `updated_at` to today. **Do not** change `slug` or `created_at`.
+   - Bump `timestamp` to the ingested date as `YYYY-MM-DDT00:00:00Z`. **Do not** change `slug` or `created_at`.
 
 5. **If no match → CREATE a page.**
    - Choose the correct `type` and put the file in the matching subdir.
    - Pick a slug per the slug rules; ensure it is unique across all subdirs and
      that its aliases don't collide with any existing slug or alias.
-   - Set `created_at = updated_at = today`.
+   - Set `created_at = today` and `timestamp = <today>T00:00:00Z`.
    - Write a non-empty body with at least the "why it matters" framing and
      source citations, and cross-link it to related pages.
    - Add it to `index.md` under the right section.
@@ -261,7 +266,7 @@ On each daily run:
 
 - **Orphans** — pages with no inbound links from any other page. Candidates for
   better cross-linking.
-- **Stale pages** — `updated_at` older than ~30 days. Candidates for a refresh
+- **Stale pages** — `timestamp` older than ~30 days. Candidates for a refresh
   pass.
 - **Missing reciprocal links** — page A links B but B does not link back to A.
   Often a cheap, high-value link to add.
@@ -279,11 +284,11 @@ consistency. Exit 0 on success, exit 1 on any failure with `FAIL <relpath>:
 Hard-fail checks:
 
 - Frontmatter schema: required fields present and correctly typed; `sources`
-  mappings well-formed; `summary` single-line.
+  mappings well-formed; `description` single-line.
 - Slug: matches the pattern, equals the filename stem, globally unique; aliases
   don't collide (the resolver namespace is slugs ∪ aliases).
 - `type`: in the enum and matching the subdir.
-- Dates: ISO `YYYY-MM-DD`; `updated_at >= created_at`.
+- Dates: ISO `YYYY-MM-DD` / ISO 8601 UTC timestamp; `timestamp >= created_at`.
 - Body: non-empty.
 - Wikilinks: every `[[target]]` (outside fenced code) resolves to a slug or
   alias.

--- a/research/wiki/concepts/agent-lifespan-engineering.md
+++ b/research/wiki/concepts/agent-lifespan-engineering.md
@@ -4,9 +4,9 @@ title: Agent Lifespan Engineering
 type: concept
 aliases: ["Agent Lifespan Engineering", "agent half-life", "AgingBench", "Your Agents Are Aging Too"]
 tags: [agents, evaluation, benchmarks, memory, deployment]
-summary: Treating deployed agentic systems as objects whose effectiveness degrades over a deployment horizon, with memory policy — not model strength — as the dominant variable; the underlying frame of the 2026-05-29 AgingBench paper.
+description: Treating deployed agentic systems as objects whose effectiveness degrades over a deployment horizon, with memory policy — not model strength — as the dominant variable; the underlying frame of the 2026-05-29 AgingBench paper.
 created_at: 2026-05-29
-updated_at: 2026-05-30
+timestamp: 2026-05-30T00:00:00Z
 sources:
   - {title: "ARA daily digest 2026-05-29", path: research/digest/2026-05-29-digest.md}
   - {title: "ARA daily digest 2026-05-30", path: research/digest/2026-05-30-digest.md}

--- a/research/wiki/concepts/artificial-general-engineer.md
+++ b/research/wiki/concepts/artificial-general-engineer.md
@@ -4,9 +4,9 @@ title: Artificial General Engineer
 type: concept
 aliases: ["artificial general engineer", "AGE", "industrial AI", "AI-for-manufacturing"]
 tags: [industrial-ai, manufacturing, design, agents]
-summary: The thesis that an AI system can take complex physical products from concept through production — extending AI's reach from software and chatbots into hardware design and manufacturing.
+description: The thesis that an AI system can take complex physical products from concept through production — extending AI's reach from software and chatbots into hardware design and manufacturing.
 created_at: 2026-06-12
-updated_at: 2026-06-12
+timestamp: 2026-06-12T00:00:00Z
 sources:
   - {title: "ARA daily digest 2026-06-12", path: research/digest/2026-06-12-digest.md}
 ---

--- a/research/wiki/concepts/dynamic-workflows.md
+++ b/research/wiki/concepts/dynamic-workflows.md
@@ -4,9 +4,9 @@ title: Dynamic Workflows
 type: concept
 aliases: ["Dynamic Workflows", "Claude Code Dynamic Workflows", "parallel subagents"]
 tags: [agentic, claude-code, anthropic, subagents, codebase-migration]
-summary: Anthropic's 2026-05-28 Claude Code feature in which Claude writes a JavaScript orchestrator that fans a single session out to up to 1,000 parallel subagents per run, gated to Enterprise / Team / Max tiers and aimed at codebase-scale migrations.
+description: Anthropic's 2026-05-28 Claude Code feature in which Claude writes a JavaScript orchestrator that fans a single session out to up to 1,000 parallel subagents per run, gated to Enterprise / Team / Max tiers and aimed at codebase-scale migrations.
 created_at: 2026-05-29
-updated_at: 2026-05-30
+timestamp: 2026-05-30T00:00:00Z
 sources:
   - {title: "ARA daily digest 2026-05-29", path: research/digest/2026-05-29-digest.md}
   - {title: "ARA daily digest 2026-05-30", path: research/digest/2026-05-30-digest.md}

--- a/research/wiki/concepts/neocloud.md
+++ b/research/wiki/concepts/neocloud.md
@@ -4,9 +4,9 @@ title: Neocloud
 type: concept
 aliases: [neocloud, "neo-cloud", "GPU-as-a-service", GPUaaS]
 tags: [ai-infrastructure, gpu-cloud, business-model, take-or-pay]
-summary: Business model where a specialized provider buys GPUs on debt and rents the capacity back under multi-year take-or-pay contracts, distinct from general-purpose hyperscalers.
+description: Business model where a specialized provider buys GPUs on debt and rents the capacity back under multi-year take-or-pay contracts, distinct from general-purpose hyperscalers.
 created_at: 2026-05-24
-updated_at: 2026-05-24
+timestamp: 2026-05-24T00:00:00Z
 sources:
   - {title: "ARA generative research — CoreWeave GPU-as-a-service unit economics", path: research/generative/2026-05-16T103712--coreweave-gpu-as-a-service-unit-economics-and-customer-conce.html}
   - {title: "ARA daily digest 2026-05-20", path: research/digest/2026-05-20-digest.md}

--- a/research/wiki/entities/amazon.md
+++ b/research/wiki/entities/amazon.md
@@ -4,9 +4,9 @@ title: Amazon
 type: entity
 aliases: [Amazon, "Amazon.com", AWS, "Amazon Web Services", "Andy Jassy"]
 tags: [hyperscaler, cloud, investor, ai-infrastructure, bedrock]
-summary: Hyperscaler, Anthropic's single largest investor, and — per WSJ/Axios reporting — the trigger of the June 2026 Fable 5 / Mythos 5 export crackdown after CEO Andy Jassy briefed Treasury that Amazon researchers had jailbroken the model.
+description: Hyperscaler, Anthropic's single largest investor, and — per WSJ/Axios reporting — the trigger of the June 2026 Fable 5 / Mythos 5 export crackdown after CEO Andy Jassy briefed Treasury that Amazon researchers had jailbroken the model.
 created_at: 2026-06-14
-updated_at: 2026-06-15
+timestamp: 2026-06-15T00:00:00Z
 sources:
   - {title: "ARA daily digest 2026-06-15", path: research/digest/2026-06-15-digest.md}
   - {title: "ARA daily digest 2026-06-14", path: research/digest/2026-06-14-digest.md}

--- a/research/wiki/entities/anthropic.md
+++ b/research/wiki/entities/anthropic.md
@@ -4,9 +4,9 @@ title: Anthropic
 type: entity
 aliases: [Anthropic, "Anthropic PBC", "@AnthropicAI"]
 tags: [frontier-lab, claude, ai-safety, foundation-models]
-summary: AI safety company and frontier lab behind the Claude model family; shipped its first public Mythos-class model (Fable 5 / Mythos 5) on 2026-06-09 and closed a $65B Series H at $965B post-money on 2026-05-28 — first time eclipsing OpenAI on private valuation — with an October 2026 IPO target.
+description: AI safety company and frontier lab behind the Claude model family; shipped its first public Mythos-class model (Fable 5 / Mythos 5) on 2026-06-09 and closed a $65B Series H at $965B post-money on 2026-05-28 — first time eclipsing OpenAI on private valuation — with an October 2026 IPO target.
 created_at: 2026-05-24
-updated_at: 2026-06-16
+timestamp: 2026-06-16T00:00:00Z
 sources:
   - {title: "ARA daily digest 2026-06-16", path: research/digest/2026-06-16-digest.md}
   - {title: "ARA daily digest 2026-06-15", path: research/digest/2026-06-15-digest.md}

--- a/research/wiki/entities/apple.md
+++ b/research/wiki/entities/apple.md
@@ -4,9 +4,9 @@ title: Apple
 type: entity
 aliases: [Apple, "Apple Inc.", Siri, "Apple Intelligence", "Private Cloud Compute", PCC]
 tags: [consumer-tech, on-device-ai, apple-intelligence, siri, wwdc]
-summary: Consumer-hardware giant whose long-delayed Siri rebuild — reportedly powered by a custom Google Gemini model with a user-selectable "Extensions" layer — is the marquee AI item at WWDC 2026 (keynote 2026-06-08).
+description: Consumer-hardware giant whose long-delayed Siri rebuild — reportedly powered by a custom Google Gemini model with a user-selectable "Extensions" layer — is the marquee AI item at WWDC 2026 (keynote 2026-06-08).
 created_at: 2026-06-08
-updated_at: 2026-06-10
+timestamp: 2026-06-10T00:00:00Z
 sources:
   - {title: "ARA daily digest 2026-06-10", path: research/digest/2026-06-10-digest.md}
   - {title: "ARA daily digest 2026-06-08", path: research/digest/2026-06-08-digest.md}

--- a/research/wiki/entities/claude-fable-5.md
+++ b/research/wiki/entities/claude-fable-5.md
@@ -4,9 +4,9 @@ title: Claude Fable 5 / Mythos 5
 type: entity
 aliases: ["Claude Fable 5", "Fable 5", "Claude Mythos 5", "Mythos 5", "Mythos-class", "claude-fable-5", "claude-mythos-5"]
 tags: [model-release, anthropic, claude, frontier-model, mythos-class, alignment]
-summary: Anthropic's 2026-06-09 frontier release — one Mythos-class model sold as two products, the safeguarded GA Fable 5 (auto-routing high-risk queries to Opus 4.8) and the restricted, unsafeguarded Mythos 5 for Glasswing/critical-infra partners.
+description: Anthropic's 2026-06-09 frontier release — one Mythos-class model sold as two products, the safeguarded GA Fable 5 (auto-routing high-risk queries to Opus 4.8) and the restricted, unsafeguarded Mythos 5 for Glasswing/critical-infra partners.
 created_at: 2026-06-10
-updated_at: 2026-06-16
+timestamp: 2026-06-16T00:00:00Z
 sources:
   - {title: "ARA daily digest 2026-06-16", path: research/digest/2026-06-16-digest.md}
   - {title: "ARA daily digest 2026-06-15", path: research/digest/2026-06-15-digest.md}

--- a/research/wiki/entities/claude-opus-4-8.md
+++ b/research/wiki/entities/claude-opus-4-8.md
@@ -4,9 +4,9 @@ title: Claude Opus 4.8
 type: entity
 aliases: ["Claude Opus 4.8", "Opus 4.8", "claude-opus-4-8"]
 tags: [model-release, anthropic, claude, frontier-model, alignment]
-summary: Anthropic's 2026-05-28 frontier flagship, succeeding Opus 4.7 at flat pricing with a +4.9pp agentic-coding lift, +137 knowledge-work Elo, and a Fast Mode that runs ~2.5× faster and 3× cheaper.
+description: Anthropic's 2026-05-28 frontier flagship, succeeding Opus 4.7 at flat pricing with a +4.9pp agentic-coding lift, +137 knowledge-work Elo, and a Fast Mode that runs ~2.5× faster and 3× cheaper.
 created_at: 2026-05-29
-updated_at: 2026-06-10
+timestamp: 2026-06-10T00:00:00Z
 sources:
   - {title: "ARA daily digest 2026-06-10", path: research/digest/2026-06-10-digest.md}
   - {title: "ARA daily digest 2026-05-29", path: research/digest/2026-05-29-digest.md}

--- a/research/wiki/entities/cognition-ai.md
+++ b/research/wiki/entities/cognition-ai.md
@@ -4,9 +4,9 @@ title: Cognition AI
 type: entity
 aliases: ["Cognition", "Cognition AI", "Cognition Labs", "Devin"]
 tags: [agentic, coding-agent, startup, ai-engineering]
-summary: Maker of the Devin autonomous coding agent; raised $1B+ at a $26B post-money valuation in May 2026 against $492M ARR (~13× YoY), with 89% of Cognition's own code now written by Devin.
+description: Maker of the Devin autonomous coding agent; raised $1B+ at a $26B post-money valuation in May 2026 against $492M ARR (~13× YoY), with 89% of Cognition's own code now written by Devin.
 created_at: 2026-05-29
-updated_at: 2026-05-29
+timestamp: 2026-05-29T00:00:00Z
 sources:
   - {title: "ARA daily digest 2026-05-29", path: research/digest/2026-05-29-digest.md}
   - {title: "ARA daily digest 2026-05-27", path: research/digest/2026-05-27-digest.md}

--- a/research/wiki/entities/coreweave.md
+++ b/research/wiki/entities/coreweave.md
@@ -4,9 +4,9 @@ title: CoreWeave
 type: entity
 aliases: [CoreWeave, CRWV, "CoreWeave, Inc."]
 tags: [neocloud, gpu-cloud, ai-infrastructure, take-or-pay]
-summary: NASDAQ-listed GPU-as-a-service neocloud with a ~$99B contracted backlog, ~$25B debt, and revenue concentrated in Microsoft, OpenAI, and Meta.
+description: NASDAQ-listed GPU-as-a-service neocloud with a ~$99B contracted backlog, ~$25B debt, and revenue concentrated in Microsoft, OpenAI, and Meta.
 created_at: 2026-05-24
-updated_at: 2026-05-24
+timestamp: 2026-05-24T00:00:00Z
 sources:
   - {title: "ARA generative research — CoreWeave GPU-as-a-service unit economics", path: research/generative/2026-05-16T103712--coreweave-gpu-as-a-service-unit-economics-and-customer-conce.html}
   - {title: "ARA daily digest 2026-05-20", path: research/digest/2026-05-20-digest.md}

--- a/research/wiki/entities/deepseek.md
+++ b/research/wiki/entities/deepseek.md
@@ -4,9 +4,9 @@ title: DeepSeek
 type: entity
 aliases: [DeepSeek, "DeepSeek AI", "深度求索", "DeepSeek-V4", "DeepSeek V4 Pro", "Liang Wenfeng"]
 tags: [frontier-lab, chinese-llm, open-weights, foundation-models, commercialization]
-summary: Hangzhou-based Chinese frontier lab; on 2026-06-04 disclosed its first-ever external round (~$7.4B / ~50B yuan at up to a $59B valuation, Tencent + CATL leading), marking its pivot from research to commercialization.
+description: Hangzhou-based Chinese frontier lab; on 2026-06-04 disclosed its first-ever external round (~$7.4B / ~50B yuan at up to a $59B valuation, Tencent + CATL leading), marking its pivot from research to commercialization.
 created_at: 2026-06-04
-updated_at: 2026-06-05
+timestamp: 2026-06-05T00:00:00Z
 sources:
   - {title: "ARA daily digest 2026-06-05", path: research/digest/2026-06-05-digest.md}
   - {title: "ARA daily digest 2026-06-04", path: research/digest/2026-06-04-digest.md}

--- a/research/wiki/entities/dell.md
+++ b/research/wiki/entities/dell.md
@@ -4,9 +4,9 @@ title: Dell Technologies
 type: entity
 aliases: [Dell, "Dell Technologies", "Dell Inc.", "DELL", "@MichaelDell"]
 tags: [oem, server-vendor, enterprise-ai, capital-markets]
-summary: US enterprise-IT OEM; Q1 FY27 (reported 2026-05-29) printed $43.8B revenue (+88% YoY) with AI-Optimized Servers at $16.1B (+757% YoY), $24.4B AI orders booked, FY27 AI-server outlook raised to $60B; stock +32% on the print, the best single day in company history.
+description: US enterprise-IT OEM; Q1 FY27 (reported 2026-05-29) printed $43.8B revenue (+88% YoY) with AI-Optimized Servers at $16.1B (+757% YoY), $24.4B AI orders booked, FY27 AI-server outlook raised to $60B; stock +32% on the print, the best single day in company history.
 created_at: 2026-06-01
-updated_at: 2026-06-01
+timestamp: 2026-06-01T00:00:00Z
 sources:
   - {title: "ARA daily digest 2026-06-01", path: research/digest/2026-06-01-digest.md}
   - {title: "Dell Q1 FY27 results", date: 2026-05-29}

--- a/research/wiki/entities/figure-ai.md
+++ b/research/wiki/entities/figure-ai.md
@@ -4,9 +4,9 @@ title: Figure AI
 type: entity
 aliases: [Figure, "Figure AI", "Figure Robotics", "Figure 03", "Figure 4", "Helix", "Helix-02", "@adcock_brett", "Brett Adcock"]
 tags: [humanoid-robotics, vla, robotics, brett-adcock]
-summary: US humanoid-robotics company whose Helix-02 in-house VLA ran a 200-hour fully autonomous package-sort shift (249,560 packages, zero hardware failures, zero teleop) on its Figure 03 fleet at Sunnyvale on 2026-05-30, ~10× the previous public envelope on MTBI.
+description: US humanoid-robotics company whose Helix-02 in-house VLA ran a 200-hour fully autonomous package-sort shift (249,560 packages, zero hardware failures, zero teleop) on its Figure 03 fleet at Sunnyvale on 2026-05-30, ~10× the previous public envelope on MTBI.
 created_at: 2026-06-01
-updated_at: 2026-06-01
+timestamp: 2026-06-01T00:00:00Z
 sources:
   - {title: "ARA daily digest 2026-06-01", path: research/digest/2026-06-01-digest.md}
   - {title: "Humanoids Daily — Figure 200-hour Helix-02 marathon", date: 2026-05-30}

--- a/research/wiki/entities/gemini-3-5-flash.md
+++ b/research/wiki/entities/gemini-3-5-flash.md
@@ -4,9 +4,9 @@ title: Gemini 3.5 Flash
 type: entity
 aliases: ["Gemini 3.5 Flash", "Gemini 3.2 Flash", "Gemini 3.5 Live Translate"]
 tags: [model-release, google-deepmind, flash-tier, agentic]
-summary: Google's fast, low-cost frontier model shipped GA at Google I/O 2026, positioned for agents rather than chatbots; gained a real-time speech-to-speech Live Translate variant (70+ languages) on 2026-06-09.
+description: Google's fast, low-cost frontier model shipped GA at Google I/O 2026, positioned for agents rather than chatbots; gained a real-time speech-to-speech Live Translate variant (70+ languages) on 2026-06-09.
 created_at: 2026-05-24
-updated_at: 2026-06-10
+timestamp: 2026-06-10T00:00:00Z
 sources:
   - {title: "ARA daily digest 2026-06-10", path: research/digest/2026-06-10-digest.md}
   - {title: "ARA daily digest 2026-05-20", path: research/digest/2026-05-20-digest.md}

--- a/research/wiki/entities/gemini-spark.md
+++ b/research/wiki/entities/gemini-spark.md
@@ -4,9 +4,9 @@ title: Gemini Spark
 type: entity
 aliases: ["Gemini Spark", "Google Gemini Spark", "Spark agent"]
 tags: [agents, google, gemini, consumer-agent, product]
-summary: Google's persistent consumer agent for Gemini, hit GA on 2026-05-29 for US AI Ultra subscribers at $99.99/mo — the first GA paid frontier-lab persistent consumer agent, running on dedicated Google Cloud VMs so state persists with the phone off.
+description: Google's persistent consumer agent for Gemini, hit GA on 2026-05-29 for US AI Ultra subscribers at $99.99/mo — the first GA paid frontier-lab persistent consumer agent, running on dedicated Google Cloud VMs so state persists with the phone off.
 created_at: 2026-06-01
-updated_at: 2026-06-01
+timestamp: 2026-06-01T00:00:00Z
 sources:
   - {title: "ARA daily digest 2026-06-01", path: research/digest/2026-06-01-digest.md}
   - {title: "9to5Google — Gemini Spark GA", date: 2026-05-29}

--- a/research/wiki/entities/gemma-4.md
+++ b/research/wiki/entities/gemma-4.md
@@ -4,9 +4,9 @@ title: Gemma 4
 type: entity
 aliases: ["Gemma 4", "Gemma 4 12B", "Gemma-4", "Gemma 4 family", "Gemma"]
 tags: [open-weights, model, multimodal, google-deepmind, apache-2-0, on-device]
-summary: Google DeepMind's open-weights (Apache 2.0) multimodal model family; the 2026-06-04 cycle surfaced an encoder-free 12B variant that runs locally on 16 GB RAM as Gemma crossed 150M+ cumulative downloads.
+description: Google DeepMind's open-weights (Apache 2.0) multimodal model family; the 2026-06-04 cycle surfaced an encoder-free 12B variant that runs locally on 16 GB RAM as Gemma crossed 150M+ cumulative downloads.
 created_at: 2026-06-04
-updated_at: 2026-06-05
+timestamp: 2026-06-05T00:00:00Z
 sources:
   - {title: "ARA daily digest 2026-06-05", path: research/digest/2026-06-05-digest.md}
   - {title: "ARA daily digest 2026-06-04", path: research/digest/2026-06-04-digest.md}

--- a/research/wiki/entities/liquid-ai.md
+++ b/research/wiki/entities/liquid-ai.md
@@ -4,9 +4,9 @@ title: Liquid AI
 type: entity
 aliases: ["Liquid AI", "LiquidAI", "Liquid Foundation Models", "LFM"]
 tags: [open-weights, on-device, hybrid-models, mit-spinout]
-summary: MIT-spinout foundation model lab focused on on-device hybrid (non-pure-transformer) architectures; shipped LFM2.5-8B-A1B (8B/1B-active MoE, 128K context, 38T pre-training tokens) with day-one llama.cpp / MLX / vLLM / SGLang support on 2026-05-29.
+description: MIT-spinout foundation model lab focused on on-device hybrid (non-pure-transformer) architectures; shipped LFM2.5-8B-A1B (8B/1B-active MoE, 128K context, 38T pre-training tokens) with day-one llama.cpp / MLX / vLLM / SGLang support on 2026-05-29.
 created_at: 2026-05-29
-updated_at: 2026-05-30
+timestamp: 2026-05-30T00:00:00Z
 sources:
   - {title: "ARA daily digest 2026-05-29", path: research/digest/2026-05-29-digest.md}
   - {title: "ARA daily digest 2026-05-30", path: research/digest/2026-05-30-digest.md}

--- a/research/wiki/entities/meta.md
+++ b/research/wiki/entities/meta.md
@@ -4,9 +4,9 @@ title: Meta
 type: entity
 aliases: [Meta, "Meta Platforms", Facebook, "Meta AI", Llama, "AI Mode"]
 tags: [hyperscaler, frontier-lab, consumer-ai, open-weights, social]
-summary: Social-platform hyperscaler and frontier-model builder (Llama); on 2026-06-16 launched "AI Mode" on Facebook, pulling from public info across its platforms as it races to catch up in the AI-assistant race.
+description: Social-platform hyperscaler and frontier-model builder (Llama); on 2026-06-16 launched "AI Mode" on Facebook, pulling from public info across its platforms as it races to catch up in the AI-assistant race.
 created_at: 2026-06-16
-updated_at: 2026-06-16
+timestamp: 2026-06-16T00:00:00Z
 sources:
   - {title: "ARA daily digest 2026-06-16", path: research/digest/2026-06-16-digest.md}
 ---

--- a/research/wiki/entities/microsoft.md
+++ b/research/wiki/entities/microsoft.md
@@ -4,9 +4,9 @@ title: Microsoft
 type: entity
 aliases: [Microsoft, MSFT, "Microsoft Corporation", "@Microsoft", MAI, "Microsoft AI", "MAI-Thinking-1", "MAI-Code-1-Flash", "Project Polaris", "MAIA 200"]
 tags: [hyperscaler, frontier-lab, copilot, azure, foundation-models, custom-silicon]
-summary: Hyperscaler and frontier-model builder; at Build 2026 shipped a full first-party MAI model stack and made Project Polaris the default GitHub Copilot engine, the clearest move yet to cut its dependence on OpenAI.
+description: Hyperscaler and frontier-model builder; at Build 2026 shipped a full first-party MAI model stack and made Project Polaris the default GitHub Copilot engine, the clearest move yet to cut its dependence on OpenAI.
 created_at: 2026-06-03
-updated_at: 2026-06-04
+timestamp: 2026-06-04T00:00:00Z
 sources:
   - {title: "ARA daily digest 2026-06-03", path: research/digest/2026-06-03-digest.md}
   - {title: "ARA daily digest 2026-06-04", path: research/digest/2026-06-04-digest.md}

--- a/research/wiki/entities/minimax-m3.md
+++ b/research/wiki/entities/minimax-m3.md
@@ -4,9 +4,9 @@ title: MiniMax M3
 type: entity
 aliases: ["MiniMax M3", "M3", "MiniMax-M3", MiniMax]
 tags: [open-weights, model, agentic-coding, chinese-llm, long-context]
-summary: MiniMax's open-weights model with 1M context and 59% SWE-Bench Pro — the strongest open-weights agentic-coding model of the cycle.
+description: MiniMax's open-weights model with 1M context and 59% SWE-Bench Pro — the strongest open-weights agentic-coding model of the cycle.
 created_at: 2026-06-03
-updated_at: 2026-06-04
+timestamp: 2026-06-04T00:00:00Z
 sources:
   - {title: "ARA daily digest 2026-06-03", path: research/digest/2026-06-03-digest.md}
   - {title: "ARA daily digest 2026-06-04", path: research/digest/2026-06-04-digest.md}

--- a/research/wiki/entities/nebius.md
+++ b/research/wiki/entities/nebius.md
@@ -4,9 +4,9 @@ title: Nebius Group
 type: entity
 aliases: [Nebius, NBIS, "Nebius Group N.V."]
 tags: [neocloud, gpu-cloud, ai-infrastructure, nvidia-partner]
-summary: Amsterdam-based AI cloud ("neocloud") provider spun out of Yandex, scaling GPU capacity for AI training and inference.
+description: Amsterdam-based AI cloud ("neocloud") provider spun out of Yandex, scaling GPU capacity for AI training and inference.
 created_at: 2026-05-24
-updated_at: 2026-05-24
+timestamp: 2026-05-24T00:00:00Z
 sources:
   - {title: "ARA daily digest 2026-05-20", path: research/digest/2026-05-20-digest.md}
   - {title: "ARA daily digest 2026-05-21 (Google × Blackstone neocloud JV targets CoreWeave/Nebius)", path: research/digest/2026-05-21-digest.md}

--- a/research/wiki/entities/nvidia.md
+++ b/research/wiki/entities/nvidia.md
@@ -4,9 +4,9 @@ title: NVIDIA
 type: entity
 aliases: [NVIDIA, Nvidia, NVDA, "@nvidia", "@nvidianewsroom", "Jensen Huang", "Nemotron", "Nemotron-3-Ultra", "Nemotron-3-Ultra-550B", "Nemotron 3 Ultra"]
 tags: [gpu, ai-chips, accelerators, open-weights, datacenter, semiconductors]
-summary: The dominant AI accelerator supplier; its GPUs underwrite the AI-capex buildout, and on 2026-06-05 it released the open-weights Nemotron-3-Ultra-550B that dominated developer mindshare alongside Gemma 4.
+description: The dominant AI accelerator supplier; its GPUs underwrite the AI-capex buildout, and on 2026-06-05 it released the open-weights Nemotron-3-Ultra-550B that dominated developer mindshare alongside Gemma 4.
 created_at: 2026-06-05
-updated_at: 2026-06-05
+timestamp: 2026-06-05T00:00:00Z
 sources:
   - {title: "ARA daily digest 2026-06-05", path: research/digest/2026-06-05-digest.md}
   - {title: "ARA daily digest 2026-05-21", path: research/digest/2026-05-21-digest.md}

--- a/research/wiki/entities/openai.md
+++ b/research/wiki/entities/openai.md
@@ -4,9 +4,9 @@ title: OpenAI
 type: entity
 aliases: ["OpenAI", "OpenAI OpCo", "@OpenAI", "OpenAI Inc."]
 tags: [frontier-lab, gpt, foundation-models, ai-policy]
-summary: AI lab behind the GPT family; March 2026 private valuation of $852B (now exceeded by Anthropic's $965B); ChatGPT crossed 600M MAU as OpenAI pivots to an agent-first "super app" ("chat is dead").
+description: AI lab behind the GPT family; March 2026 private valuation of $852B (now exceeded by Anthropic's $965B); ChatGPT crossed 600M MAU as OpenAI pivots to an agent-first "super app" ("chat is dead").
 created_at: 2026-05-30
-updated_at: 2026-06-15
+timestamp: 2026-06-15T00:00:00Z
 sources:
   - {title: "ARA daily digest 2026-06-15", path: research/digest/2026-06-15-digest.md}
   - {title: "ARA daily digest 2026-06-14", path: research/digest/2026-06-14-digest.md}

--- a/research/wiki/entities/openrouter.md
+++ b/research/wiki/entities/openrouter.md
@@ -4,9 +4,9 @@ title: OpenRouter
 type: entity
 aliases: ["OpenRouter", "openrouter.ai", "@OpenRouterAI"]
 tags: [llm-router, inference, infrastructure, capital-markets]
-summary: LLM-routing API serving 400+ models to 8M+ developers; closed a $113M Series B at $1.3B post-money on 2026-05-30 (CapitalG led, NVentures participated); weekly volume jumped 5× to 25T tokens, on track for >1 quadrillion tokens in 2026.
+description: LLM-routing API serving 400+ models to 8M+ developers; closed a $113M Series B at $1.3B post-money on 2026-05-30 (CapitalG led, NVentures participated); weekly volume jumped 5× to 25T tokens, on track for >1 quadrillion tokens in 2026.
 created_at: 2026-06-01
-updated_at: 2026-06-01
+timestamp: 2026-06-01T00:00:00Z
 sources:
   - {title: "ARA daily digest 2026-06-01", path: research/digest/2026-06-01-digest.md}
   - {title: "OpenRouter Series B announcement", date: 2026-05-30}

--- a/research/wiki/entities/prometheus.md
+++ b/research/wiki/entities/prometheus.md
@@ -4,9 +4,9 @@ title: Prometheus
 type: entity
 aliases: [Prometheus, "Prometheus AI", "Bezos Prometheus"]
 tags: [industrial-ai, megaround, manufacturing, funding, jeff-bezos]
-summary: Jeff Bezos's industrial-AI startup building an "artificial general engineer"; disclosed a $12B Series B at a ~$41B valuation on 2026-06-11 — industrial AI's first megaround.
+description: Jeff Bezos's industrial-AI startup building an "artificial general engineer"; disclosed a $12B Series B at a ~$41B valuation on 2026-06-11 — industrial AI's first megaround.
 created_at: 2026-06-12
-updated_at: 2026-06-12
+timestamp: 2026-06-12T00:00:00Z
 sources:
   - {title: "ARA daily digest 2026-06-12", path: research/digest/2026-06-12-digest.md}
 ---

--- a/research/wiki/entities/sakana-ai.md
+++ b/research/wiki/entities/sakana-ai.md
@@ -4,9 +4,9 @@ title: Sakana AI
 type: entity
 aliases: ["Sakana AI", Sakana, Marlin, "Sakana Marlin"]
 tags: [ai-lab, japan, deep-research, agents, ab-mcts]
-summary: Tokyo-based AI lab shipping Marlin — an autonomous "Ultra Deep Research" agent ("Virtual CSO") built on its AB-MCTS multi-model reasoning — a non-US entrant into the deep-research category dominated by OpenAI/Google.
+description: Tokyo-based AI lab shipping Marlin — an autonomous "Ultra Deep Research" agent ("Virtual CSO") built on its AB-MCTS multi-model reasoning — a non-US entrant into the deep-research category dominated by OpenAI/Google.
 created_at: 2026-06-16
-updated_at: 2026-06-16
+timestamp: 2026-06-16T00:00:00Z
 sources:
   - {title: "ARA daily digest 2026-06-16", path: research/digest/2026-06-16-digest.md}
 ---

--- a/research/wiki/entities/salesforce.md
+++ b/research/wiki/entities/salesforce.md
@@ -4,9 +4,9 @@ title: Salesforce
 type: entity
 aliases: [Salesforce, "Salesforce Inc", CRM, Agentforce]
 tags: [enterprise-software, agentic-ai, crm, m-and-a, claude-code]
-summary: Enterprise CRM giant betting its AI future on agentic software (Agentforce); acquired AI customer-service platform Fin (formerly Intercom) for $3.6B on 2026-06-15 — the day's largest confirmed AI M&A.
+description: Enterprise CRM giant betting its AI future on agentic software (Agentforce); acquired AI customer-service platform Fin (formerly Intercom) for $3.6B on 2026-06-15 — the day's largest confirmed AI M&A.
 created_at: 2026-06-16
-updated_at: 2026-06-16
+timestamp: 2026-06-16T00:00:00Z
 sources:
   - {title: "ARA daily digest 2026-06-16", path: research/digest/2026-06-16-digest.md}
   - {title: "Salesforce acquires Fin for $3.6B (CNBC)", url: "https://www.cnbc.com/amp/2026/06/15/salesforce-ai-customer-service-fin-acquistion.html", date: 2026-06-15}

--- a/research/wiki/entities/spacex.md
+++ b/research/wiki/entities/spacex.md
@@ -4,9 +4,9 @@ title: SpaceX
 type: entity
 aliases: [SpaceX, "@SpaceX", SPCX, "Space Exploration Technologies", Starlink]
 tags: [ipo, capital-markets, ai-infrastructure, space, public-listing]
-summary: "Aerospace company whose record IPO (Nasdaq SPCX, pricing 2026-06-11 at $135/share, ~$1.75T valuation, ~$74.4B net raise) anchors the 2026 AI-financing issuance wave on the public-markets side."
+description: "Aerospace company whose record IPO (Nasdaq SPCX, pricing 2026-06-11 at $135/share, ~$1.75T valuation, ~$74.4B net raise) anchors the 2026 AI-financing issuance wave on the public-markets side."
 created_at: 2026-06-05
-updated_at: 2026-06-15
+timestamp: 2026-06-15T00:00:00Z
 sources:
   - {title: "ARA daily digest 2026-06-15", path: research/digest/2026-06-15-digest.md}
   - {title: "ARA daily digest 2026-06-14", path: research/digest/2026-06-14-digest.md}

--- a/research/wiki/entities/xai.md
+++ b/research/wiki/entities/xai.md
@@ -4,9 +4,9 @@ title: xAI
 type: entity
 aliases: [xAI, "x.AI", "@xai", Grok, Colossus, "Colossus 1"]
 tags: [frontier-lab, grok, compute-landlord, elon-musk, ai-infrastructure]
-summary: Elon Musk's frontier lab behind Grok; increasingly defined by its compute-landlord business — renting Colossus capacity to rival labs at $2B+/month (Anthropic ~$1.25B, Google ~$920M).
+description: Elon Musk's frontier lab behind Grok; increasingly defined by its compute-landlord business — renting Colossus capacity to rival labs at $2B+/month (Anthropic ~$1.25B, Google ~$920M).
 created_at: 2026-06-08
-updated_at: 2026-06-08
+timestamp: 2026-06-08T00:00:00Z
 sources:
   - {title: "ARA daily digest 2026-06-08", path: research/digest/2026-06-08-digest.md}
   - {title: "ARA model ticket — xAI Grok Build", path: research/models/tickets/xai-grok-build-2026-05.md}

--- a/research/wiki/index.json
+++ b/research/wiki/index.json
@@ -12,8 +12,10 @@
         "deployment"
       ],
       "summary": "Treating deployed agentic systems as objects whose effectiveness degrades over a deployment horizon, with memory policy — not model strength — as the dominant variable; the underlying frame of the 2026-05-29 AgingBench paper.",
+      "description": "Treating deployed agentic systems as objects whose effectiveness degrades over a deployment horizon, with memory policy — not model strength — as the dominant variable; the underlying frame of the 2026-05-29 AgingBench paper.",
       "created_at": "2026-05-29",
       "updated_at": "2026-05-30",
+      "timestamp": "2026-05-30T00:00:00Z",
       "file": "concepts/agent-lifespan-engineering.md",
       "aliases": [
         "Agent Lifespan Engineering",
@@ -44,8 +46,10 @@
         "governance"
       ],
       "summary": "The 2026 storyline of agentic AI systems — MCP servers, agent frameworks, and integrated runtimes — surfacing a new class of supply-chain and capability-misuse vulnerabilities at scale.",
+      "description": "The 2026 storyline of agentic AI systems — MCP servers, agent frameworks, and integrated runtimes — surfacing a new class of supply-chain and capability-misuse vulnerabilities at scale.",
       "created_at": "2026-05-29",
       "updated_at": "2026-06-15",
+      "timestamp": "2026-06-15T00:00:00Z",
       "file": "themes/agentic-ai-security.md",
       "aliases": [
         "agentic AI security",
@@ -86,8 +90,10 @@
         "capital-markets"
       ],
       "summary": "The cross-cutting narrative of a historically large, debt- and equity-financed buildout of GPU/TPU compute capacity, and the question of whether demand justifies it.",
+      "description": "The cross-cutting narrative of a historically large, debt- and equity-financed buildout of GPU/TPU compute capacity, and the question of whether demand justifies it.",
       "created_at": "2026-05-24",
       "updated_at": "2026-06-12",
+      "timestamp": "2026-06-12T00:00:00Z",
       "file": "themes/ai-capex.md",
       "aliases": [
         "AI capex",
@@ -153,8 +159,10 @@
         "bedrock"
       ],
       "summary": "Hyperscaler, Anthropic's single largest investor, and — per WSJ/Axios reporting — the trigger of the June 2026 Fable 5 / Mythos 5 export crackdown after CEO Andy Jassy briefed Treasury that Amazon researchers had jailbroken the model.",
+      "description": "Hyperscaler, Anthropic's single largest investor, and — per WSJ/Axios reporting — the trigger of the June 2026 Fable 5 / Mythos 5 export crackdown after CEO Andy Jassy briefed Treasury that Amazon researchers had jailbroken the model.",
       "created_at": "2026-06-14",
       "updated_at": "2026-06-15",
+      "timestamp": "2026-06-15T00:00:00Z",
       "file": "entities/amazon.md",
       "aliases": [
         "Amazon",
@@ -188,8 +196,10 @@
         "foundation-models"
       ],
       "summary": "AI safety company and frontier lab behind the Claude model family; shipped its first public Mythos-class model (Fable 5 / Mythos 5) on 2026-06-09 and closed a $65B Series H at $965B post-money on 2026-05-28 — first time eclipsing OpenAI on private valuation — with an October 2026 IPO target.",
+      "description": "AI safety company and frontier lab behind the Claude model family; shipped its first public Mythos-class model (Fable 5 / Mythos 5) on 2026-06-09 and closed a $65B Series H at $965B post-money on 2026-05-28 — first time eclipsing OpenAI on private valuation — with an October 2026 IPO target.",
       "created_at": "2026-05-24",
       "updated_at": "2026-06-16",
+      "timestamp": "2026-06-16T00:00:00Z",
       "file": "entities/anthropic.md",
       "aliases": [
         "Anthropic",
@@ -253,8 +263,10 @@
         "wwdc"
       ],
       "summary": "Consumer-hardware giant whose long-delayed Siri rebuild — reportedly powered by a custom Google Gemini model with a user-selectable \"Extensions\" layer — is the marquee AI item at WWDC 2026 (keynote 2026-06-08).",
+      "description": "Consumer-hardware giant whose long-delayed Siri rebuild — reportedly powered by a custom Google Gemini model with a user-selectable \"Extensions\" layer — is the marquee AI item at WWDC 2026 (keynote 2026-06-08).",
       "created_at": "2026-06-08",
       "updated_at": "2026-06-10",
+      "timestamp": "2026-06-10T00:00:00Z",
       "file": "entities/apple.md",
       "aliases": [
         "Apple",
@@ -288,8 +300,10 @@
         "agents"
       ],
       "summary": "The thesis that an AI system can take complex physical products from concept through production — extending AI's reach from software and chatbots into hardware design and manufacturing.",
+      "description": "The thesis that an AI system can take complex physical products from concept through production — extending AI's reach from software and chatbots into hardware design and manufacturing.",
       "created_at": "2026-06-12",
       "updated_at": "2026-06-12",
+      "timestamp": "2026-06-12T00:00:00Z",
       "file": "concepts/artificial-general-engineer.md",
       "aliases": [
         "artificial general engineer",
@@ -319,8 +333,10 @@
         "frontier-ai"
       ],
       "summary": "The 2026 storyline of California acting as the operative US AI regulator while the federal AI executive order remains pulled — anchored by the Transparency in Frontier AI Act and a ~30-bill package that cleared the May 29 chamber-of-origin crossover.",
+      "description": "The 2026 storyline of California acting as the operative US AI regulator while the federal AI executive order remains pulled — anchored by the Transparency in Frontier AI Act and a ~30-bill package that cleared the May 29 chamber-of-origin crossover.",
       "created_at": "2026-05-30",
       "updated_at": "2026-06-03",
+      "timestamp": "2026-06-03T00:00:00Z",
       "file": "themes/california-ai-regulation.md",
       "aliases": [
         "California AI regulation",
@@ -357,8 +373,10 @@
         "alignment"
       ],
       "summary": "Anthropic's 2026-06-09 frontier release — one Mythos-class model sold as two products, the safeguarded GA Fable 5 (auto-routing high-risk queries to Opus 4.8) and the restricted, unsafeguarded Mythos 5 for Glasswing/critical-infra partners.",
+      "description": "Anthropic's 2026-06-09 frontier release — one Mythos-class model sold as two products, the safeguarded GA Fable 5 (auto-routing high-risk queries to Opus 4.8) and the restricted, unsafeguarded Mythos 5 for Glasswing/critical-infra partners.",
       "created_at": "2026-06-10",
       "updated_at": "2026-06-16",
+      "timestamp": "2026-06-16T00:00:00Z",
       "file": "entities/claude-fable-5.md",
       "aliases": [
         "Claude Fable 5",
@@ -403,8 +421,10 @@
         "alignment"
       ],
       "summary": "Anthropic's 2026-05-28 frontier flagship, succeeding Opus 4.7 at flat pricing with a +4.9pp agentic-coding lift, +137 knowledge-work Elo, and a Fast Mode that runs ~2.5× faster and 3× cheaper.",
+      "description": "Anthropic's 2026-05-28 frontier flagship, succeeding Opus 4.7 at flat pricing with a +4.9pp agentic-coding lift, +137 knowledge-work Elo, and a Fast Mode that runs ~2.5× faster and 3× cheaper.",
       "created_at": "2026-05-29",
       "updated_at": "2026-06-10",
+      "timestamp": "2026-06-10T00:00:00Z",
       "file": "entities/claude-opus-4-8.md",
       "aliases": [
         "Claude Opus 4.8",
@@ -436,8 +456,10 @@
         "ai-engineering"
       ],
       "summary": "Maker of the Devin autonomous coding agent; raised $1B+ at a $26B post-money valuation in May 2026 against $492M ARR (~13× YoY), with 89% of Cognition's own code now written by Devin.",
+      "description": "Maker of the Devin autonomous coding agent; raised $1B+ at a $26B post-money valuation in May 2026 against $492M ARR (~13× YoY), with 89% of Cognition's own code now written by Devin.",
       "created_at": "2026-05-29",
       "updated_at": "2026-05-29",
+      "timestamp": "2026-05-29T00:00:00Z",
       "file": "entities/cognition-ai.md",
       "aliases": [
         "Cognition",
@@ -469,8 +491,10 @@
         "take-or-pay"
       ],
       "summary": "NASDAQ-listed GPU-as-a-service neocloud with a ~$99B contracted backlog, ~$25B debt, and revenue concentrated in Microsoft, OpenAI, and Meta.",
+      "description": "NASDAQ-listed GPU-as-a-service neocloud with a ~$99B contracted backlog, ~$25B debt, and revenue concentrated in Microsoft, OpenAI, and Meta.",
       "created_at": "2026-05-24",
       "updated_at": "2026-05-24",
+      "timestamp": "2026-05-24T00:00:00Z",
       "file": "entities/coreweave.md",
       "aliases": [
         "CoreWeave",
@@ -502,8 +526,10 @@
         "commercialization"
       ],
       "summary": "Hangzhou-based Chinese frontier lab; on 2026-06-04 disclosed its first-ever external round (~$7.4B / ~50B yuan at up to a $59B valuation, Tencent + CATL leading), marking its pivot from research to commercialization.",
+      "description": "Hangzhou-based Chinese frontier lab; on 2026-06-04 disclosed its first-ever external round (~$7.4B / ~50B yuan at up to a $59B valuation, Tencent + CATL leading), marking its pivot from research to commercialization.",
       "created_at": "2026-06-04",
       "updated_at": "2026-06-05",
+      "timestamp": "2026-06-05T00:00:00Z",
       "file": "entities/deepseek.md",
       "aliases": [
         "DeepSeek",
@@ -540,8 +566,10 @@
         "capital-markets"
       ],
       "summary": "US enterprise-IT OEM; Q1 FY27 (reported 2026-05-29) printed $43.8B revenue (+88% YoY) with AI-Optimized Servers at $16.1B (+757% YoY), $24.4B AI orders booked, FY27 AI-server outlook raised to $60B; stock +32% on the print, the best single day in company history.",
+      "description": "US enterprise-IT OEM; Q1 FY27 (reported 2026-05-29) printed $43.8B revenue (+88% YoY) with AI-Optimized Servers at $16.1B (+757% YoY), $24.4B AI orders booked, FY27 AI-server outlook raised to $60B; stock +32% on the print, the best single day in company history.",
       "created_at": "2026-06-01",
       "updated_at": "2026-06-01",
+      "timestamp": "2026-06-01T00:00:00Z",
       "file": "entities/dell.md",
       "aliases": [
         "Dell",
@@ -571,8 +599,10 @@
         "codebase-migration"
       ],
       "summary": "Anthropic's 2026-05-28 Claude Code feature in which Claude writes a JavaScript orchestrator that fans a single session out to up to 1,000 parallel subagents per run, gated to Enterprise / Team / Max tiers and aimed at codebase-scale migrations.",
+      "description": "Anthropic's 2026-05-28 Claude Code feature in which Claude writes a JavaScript orchestrator that fans a single session out to up to 1,000 parallel subagents per run, gated to Enterprise / Team / Max tiers and aimed at codebase-scale migrations.",
       "created_at": "2026-05-29",
       "updated_at": "2026-05-30",
+      "timestamp": "2026-05-30T00:00:00Z",
       "file": "concepts/dynamic-workflows.md",
       "aliases": [
         "Dynamic Workflows",
@@ -609,8 +639,10 @@
         "frontier-ai"
       ],
       "summary": "The 2026 storyline of US federal AI governance — culminating in Trump's June 2 executive order mandating 30-day government pre-release access to frontier models for cybersecurity review.",
+      "description": "The 2026 storyline of US federal AI governance — culminating in Trump's June 2 executive order mandating 30-day government pre-release access to frontier models for cybersecurity review.",
       "created_at": "2026-06-03",
       "updated_at": "2026-06-16",
+      "timestamp": "2026-06-16T00:00:00Z",
       "file": "themes/federal-ai-policy.md",
       "aliases": [
         "federal AI policy",
@@ -651,8 +683,10 @@
         "brett-adcock"
       ],
       "summary": "US humanoid-robotics company whose Helix-02 in-house VLA ran a 200-hour fully autonomous package-sort shift (249,560 packages, zero hardware failures, zero teleop) on its Figure 03 fleet at Sunnyvale on 2026-05-30, ~10× the previous public envelope on MTBI.",
+      "description": "US humanoid-robotics company whose Helix-02 in-house VLA ran a 200-hour fully autonomous package-sort shift (249,560 packages, zero hardware failures, zero teleop) on its Figure 03 fleet at Sunnyvale on 2026-05-30, ~10× the previous public envelope on MTBI.",
       "created_at": "2026-06-01",
       "updated_at": "2026-06-01",
+      "timestamp": "2026-06-01T00:00:00Z",
       "file": "entities/figure-ai.md",
       "aliases": [
         "Figure",
@@ -687,8 +721,10 @@
         "agentic"
       ],
       "summary": "Google's fast, low-cost frontier model shipped GA at Google I/O 2026, positioned for agents rather than chatbots; gained a real-time speech-to-speech Live Translate variant (70+ languages) on 2026-06-09.",
+      "description": "Google's fast, low-cost frontier model shipped GA at Google I/O 2026, positioned for agents rather than chatbots; gained a real-time speech-to-speech Live Translate variant (70+ languages) on 2026-06-09.",
       "created_at": "2026-05-24",
       "updated_at": "2026-06-10",
+      "timestamp": "2026-06-10T00:00:00Z",
       "file": "entities/gemini-3-5-flash.md",
       "aliases": [
         "Gemini 3.5 Flash",
@@ -721,8 +757,10 @@
         "product"
       ],
       "summary": "Google's persistent consumer agent for Gemini, hit GA on 2026-05-29 for US AI Ultra subscribers at $99.99/mo — the first GA paid frontier-lab persistent consumer agent, running on dedicated Google Cloud VMs so state persists with the phone off.",
+      "description": "Google's persistent consumer agent for Gemini, hit GA on 2026-05-29 for US AI Ultra subscribers at $99.99/mo — the first GA paid frontier-lab persistent consumer agent, running on dedicated Google Cloud VMs so state persists with the phone off.",
       "created_at": "2026-06-01",
       "updated_at": "2026-06-01",
+      "timestamp": "2026-06-01T00:00:00Z",
       "file": "entities/gemini-spark.md",
       "aliases": [
         "Gemini Spark",
@@ -753,8 +791,10 @@
         "on-device"
       ],
       "summary": "Google DeepMind's open-weights (Apache 2.0) multimodal model family; the 2026-06-04 cycle surfaced an encoder-free 12B variant that runs locally on 16 GB RAM as Gemma crossed 150M+ cumulative downloads.",
+      "description": "Google DeepMind's open-weights (Apache 2.0) multimodal model family; the 2026-06-04 cycle surfaced an encoder-free 12B variant that runs locally on 16 GB RAM as Gemma crossed 150M+ cumulative downloads.",
       "created_at": "2026-06-04",
       "updated_at": "2026-06-05",
+      "timestamp": "2026-06-05T00:00:00Z",
       "file": "entities/gemma-4.md",
       "aliases": [
         "Gemma 4",
@@ -788,8 +828,10 @@
         "mit-spinout"
       ],
       "summary": "MIT-spinout foundation model lab focused on on-device hybrid (non-pure-transformer) architectures; shipped LFM2.5-8B-A1B (8B/1B-active MoE, 128K context, 38T pre-training tokens) with day-one llama.cpp / MLX / vLLM / SGLang support on 2026-05-29.",
+      "description": "MIT-spinout foundation model lab focused on on-device hybrid (non-pure-transformer) architectures; shipped LFM2.5-8B-A1B (8B/1B-active MoE, 128K context, 38T pre-training tokens) with day-one llama.cpp / MLX / vLLM / SGLang support on 2026-05-29.",
       "created_at": "2026-05-29",
       "updated_at": "2026-05-30",
+      "timestamp": "2026-05-30T00:00:00Z",
       "file": "entities/liquid-ai.md",
       "aliases": [
         "Liquid AI",
@@ -817,8 +859,10 @@
         "social"
       ],
       "summary": "Social-platform hyperscaler and frontier-model builder (Llama); on 2026-06-16 launched \"AI Mode\" on Facebook, pulling from public info across its platforms as it races to catch up in the AI-assistant race.",
+      "description": "Social-platform hyperscaler and frontier-model builder (Llama); on 2026-06-16 launched \"AI Mode\" on Facebook, pulling from public info across its platforms as it races to catch up in the AI-assistant race.",
       "created_at": "2026-06-16",
       "updated_at": "2026-06-16",
+      "timestamp": "2026-06-16T00:00:00Z",
       "file": "entities/meta.md",
       "aliases": [
         "Meta",
@@ -850,8 +894,10 @@
         "custom-silicon"
       ],
       "summary": "Hyperscaler and frontier-model builder; at Build 2026 shipped a full first-party MAI model stack and made Project Polaris the default GitHub Copilot engine, the clearest move yet to cut its dependence on OpenAI.",
+      "description": "Hyperscaler and frontier-model builder; at Build 2026 shipped a full first-party MAI model stack and made Project Polaris the default GitHub Copilot engine, the clearest move yet to cut its dependence on OpenAI.",
       "created_at": "2026-06-03",
       "updated_at": "2026-06-04",
+      "timestamp": "2026-06-04T00:00:00Z",
       "file": "entities/microsoft.md",
       "aliases": [
         "Microsoft",
@@ -889,8 +935,10 @@
         "long-context"
       ],
       "summary": "MiniMax's open-weights model with 1M context and 59% SWE-Bench Pro — the strongest open-weights agentic-coding model of the cycle.",
+      "description": "MiniMax's open-weights model with 1M context and 59% SWE-Bench Pro — the strongest open-weights agentic-coding model of the cycle.",
       "created_at": "2026-06-03",
       "updated_at": "2026-06-04",
+      "timestamp": "2026-06-04T00:00:00Z",
       "file": "entities/minimax-m3.md",
       "aliases": [
         "MiniMax M3",
@@ -924,8 +972,10 @@
         "nvidia-partner"
       ],
       "summary": "Amsterdam-based AI cloud (\"neocloud\") provider spun out of Yandex, scaling GPU capacity for AI training and inference.",
+      "description": "Amsterdam-based AI cloud (\"neocloud\") provider spun out of Yandex, scaling GPU capacity for AI training and inference.",
       "created_at": "2026-05-24",
       "updated_at": "2026-05-24",
+      "timestamp": "2026-05-24T00:00:00Z",
       "file": "entities/nebius.md",
       "aliases": [
         "Nebius",
@@ -955,8 +1005,10 @@
         "take-or-pay"
       ],
       "summary": "Business model where a specialized provider buys GPUs on debt and rents the capacity back under multi-year take-or-pay contracts, distinct from general-purpose hyperscalers.",
+      "description": "Business model where a specialized provider buys GPUs on debt and rents the capacity back under multi-year take-or-pay contracts, distinct from general-purpose hyperscalers.",
       "created_at": "2026-05-24",
       "updated_at": "2026-05-24",
+      "timestamp": "2026-05-24T00:00:00Z",
       "file": "concepts/neocloud.md",
       "aliases": [
         "neocloud",
@@ -992,8 +1044,10 @@
         "semiconductors"
       ],
       "summary": "The dominant AI accelerator supplier; its GPUs underwrite the AI-capex buildout, and on 2026-06-05 it released the open-weights Nemotron-3-Ultra-550B that dominated developer mindshare alongside Gemma 4.",
+      "description": "The dominant AI accelerator supplier; its GPUs underwrite the AI-capex buildout, and on 2026-06-05 it released the open-weights Nemotron-3-Ultra-550B that dominated developer mindshare alongside Gemma 4.",
       "created_at": "2026-06-05",
       "updated_at": "2026-06-05",
+      "timestamp": "2026-06-05T00:00:00Z",
       "file": "entities/nvidia.md",
       "aliases": [
         "NVIDIA",
@@ -1034,8 +1088,10 @@
         "decentralization"
       ],
       "summary": "The 2026 storyline of open-weight models closing on frontier capability while a decentralization backlash — torrent networks, local hosting, \"APIs are rented, weights are forever\" — gains force, surging directly on the Fable 5 government shutdown.",
+      "description": "The 2026 storyline of open-weight models closing on frontier capability while a decentralization backlash — torrent networks, local hosting, \"APIs are rented, weights are forever\" — gains force, surging directly on the Fable 5 government shutdown.",
       "created_at": "2026-06-14",
       "updated_at": "2026-06-16",
+      "timestamp": "2026-06-16T00:00:00Z",
       "file": "themes/open-weights.md",
       "aliases": [
         "open weights",
@@ -1074,8 +1130,10 @@
         "ai-policy"
       ],
       "summary": "AI lab behind the GPT family; March 2026 private valuation of $852B (now exceeded by Anthropic's $965B); ChatGPT crossed 600M MAU as OpenAI pivots to an agent-first \"super app\" (\"chat is dead\").",
+      "description": "AI lab behind the GPT family; March 2026 private valuation of $852B (now exceeded by Anthropic's $965B); ChatGPT crossed 600M MAU as OpenAI pivots to an agent-first \"super app\" (\"chat is dead\").",
       "created_at": "2026-05-30",
       "updated_at": "2026-06-15",
+      "timestamp": "2026-06-15T00:00:00Z",
       "file": "entities/openai.md",
       "aliases": [
         "OpenAI",
@@ -1125,8 +1183,10 @@
         "capital-markets"
       ],
       "summary": "LLM-routing API serving 400+ models to 8M+ developers; closed a $113M Series B at $1.3B post-money on 2026-05-30 (CapitalG led, NVentures participated); weekly volume jumped 5× to 25T tokens, on track for >1 quadrillion tokens in 2026.",
+      "description": "LLM-routing API serving 400+ models to 8M+ developers; closed a $113M Series B at $1.3B post-money on 2026-05-30 (CapitalG led, NVentures participated); weekly volume jumped 5× to 25T tokens, on track for >1 quadrillion tokens in 2026.",
       "created_at": "2026-06-01",
       "updated_at": "2026-06-01",
+      "timestamp": "2026-06-01T00:00:00Z",
       "file": "entities/openrouter.md",
       "aliases": [
         "OpenRouter",
@@ -1158,8 +1218,10 @@
         "jeff-bezos"
       ],
       "summary": "Jeff Bezos's industrial-AI startup building an \"artificial general engineer\"; disclosed a $12B Series B at a ~$41B valuation on 2026-06-11 — industrial AI's first megaround.",
+      "description": "Jeff Bezos's industrial-AI startup building an \"artificial general engineer\"; disclosed a $12B Series B at a ~$41B valuation on 2026-06-11 — industrial AI's first megaround.",
       "created_at": "2026-06-12",
       "updated_at": "2026-06-12",
+      "timestamp": "2026-06-12T00:00:00Z",
       "file": "entities/prometheus.md",
       "aliases": [
         "Prometheus",
@@ -1191,8 +1253,10 @@
         "ab-mcts"
       ],
       "summary": "Tokyo-based AI lab shipping Marlin — an autonomous \"Ultra Deep Research\" agent (\"Virtual CSO\") built on its AB-MCTS multi-model reasoning — a non-US entrant into the deep-research category dominated by OpenAI/Google.",
+      "description": "Tokyo-based AI lab shipping Marlin — an autonomous \"Ultra Deep Research\" agent (\"Virtual CSO\") built on its AB-MCTS multi-model reasoning — a non-US entrant into the deep-research category dominated by OpenAI/Google.",
       "created_at": "2026-06-16",
       "updated_at": "2026-06-16",
+      "timestamp": "2026-06-16T00:00:00Z",
       "file": "entities/sakana-ai.md",
       "aliases": [
         "Sakana AI",
@@ -1219,8 +1283,10 @@
         "claude-code"
       ],
       "summary": "Enterprise CRM giant betting its AI future on agentic software (Agentforce); acquired AI customer-service platform Fin (formerly Intercom) for $3.6B on 2026-06-15 — the day's largest confirmed AI M&A.",
+      "description": "Enterprise CRM giant betting its AI future on agentic software (Agentforce); acquired AI customer-service platform Fin (formerly Intercom) for $3.6B on 2026-06-15 — the day's largest confirmed AI M&A.",
       "created_at": "2026-06-16",
       "updated_at": "2026-06-16",
+      "timestamp": "2026-06-16T00:00:00Z",
       "file": "entities/salesforce.md",
       "aliases": [
         "Salesforce",
@@ -1248,8 +1314,10 @@
         "public-listing"
       ],
       "summary": "Aerospace company whose record IPO (Nasdaq SPCX, pricing 2026-06-11 at $135/share, ~$1.75T valuation, ~$74.4B net raise) anchors the 2026 AI-financing issuance wave on the public-markets side.",
+      "description": "Aerospace company whose record IPO (Nasdaq SPCX, pricing 2026-06-11 at $135/share, ~$1.75T valuation, ~$74.4B net raise) anchors the 2026 AI-financing issuance wave on the public-markets side.",
       "created_at": "2026-06-05",
       "updated_at": "2026-06-15",
+      "timestamp": "2026-06-15T00:00:00Z",
       "file": "entities/spacex.md",
       "aliases": [
         "SpaceX",
@@ -1284,8 +1352,10 @@
         "ai-infrastructure"
       ],
       "summary": "Elon Musk's frontier lab behind Grok; increasingly defined by its compute-landlord business — renting Colossus capacity to rival labs at $2B+/month (Anthropic ~$1.25B, Google ~$920M).",
+      "description": "Elon Musk's frontier lab behind Grok; increasingly defined by its compute-landlord business — renting Colossus capacity to rival labs at $2B+/month (Anthropic ~$1.25B, Google ~$920M).",
       "created_at": "2026-06-08",
       "updated_at": "2026-06-08",
+      "timestamp": "2026-06-08T00:00:00Z",
       "file": "entities/xai.md",
       "aliases": [
         "xAI",

--- a/research/wiki/themes/agentic-ai-security.md
+++ b/research/wiki/themes/agentic-ai-security.md
@@ -4,9 +4,9 @@ title: Agentic AI Security Crisis
 type: theme
 aliases: ["agentic AI security", "agent security", "AI supply-chain security", "agentic supply-chain"]
 tags: [security, supply-chain, mcp, agents, governance]
-summary: The 2026 storyline of agentic AI systems — MCP servers, agent frameworks, and integrated runtimes — surfacing a new class of supply-chain and capability-misuse vulnerabilities at scale.
+description: The 2026 storyline of agentic AI systems — MCP servers, agent frameworks, and integrated runtimes — surfacing a new class of supply-chain and capability-misuse vulnerabilities at scale.
 created_at: 2026-05-29
-updated_at: 2026-06-15
+timestamp: 2026-06-15T00:00:00Z
 sources:
   - {title: "ARA daily digest 2026-06-15", path: research/digest/2026-06-15-digest.md}
   - {title: "ARA daily digest 2026-06-14", path: research/digest/2026-06-14-digest.md}

--- a/research/wiki/themes/ai-capex.md
+++ b/research/wiki/themes/ai-capex.md
@@ -4,9 +4,9 @@ title: The AI Capex Supercycle
 type: theme
 aliases: ["AI capex", "AI capex supercycle", "compute buildout", "AI infrastructure buildout"]
 tags: [macro, ai-infrastructure, compute, capital-markets]
-summary: The cross-cutting narrative of a historically large, debt- and equity-financed buildout of GPU/TPU compute capacity, and the question of whether demand justifies it.
+description: The cross-cutting narrative of a historically large, debt- and equity-financed buildout of GPU/TPU compute capacity, and the question of whether demand justifies it.
 created_at: 2026-05-24
-updated_at: 2026-06-12
+timestamp: 2026-06-12T00:00:00Z
 sources:
   - {title: "ARA daily digest 2026-06-12", path: research/digest/2026-06-12-digest.md}
   - {title: "ARA daily digest 2026-06-10", path: research/digest/2026-06-10-digest.md}

--- a/research/wiki/themes/california-ai-regulation.md
+++ b/research/wiki/themes/california-ai-regulation.md
@@ -4,9 +4,9 @@ title: California AI Regulation
 type: theme
 aliases: ["California AI regulation", "California AI bills", "Sacramento AI policy", "California Transparency in Frontier AI Act", "AB 1609", "AB 1159", "A 9317"]
 tags: [policy, regulation, california, ai-governance, frontier-ai]
-summary: The 2026 storyline of California acting as the operative US AI regulator while the federal AI executive order remains pulled — anchored by the Transparency in Frontier AI Act and a ~30-bill package that cleared the May 29 chamber-of-origin crossover.
+description: The 2026 storyline of California acting as the operative US AI regulator while the federal AI executive order remains pulled — anchored by the Transparency in Frontier AI Act and a ~30-bill package that cleared the May 29 chamber-of-origin crossover.
 created_at: 2026-05-30
-updated_at: 2026-06-03
+timestamp: 2026-06-03T00:00:00Z
 sources:
   - {title: "ARA daily digest 2026-06-03", path: research/digest/2026-06-03-digest.md}
   - {title: "ARA daily digest 2026-05-30", path: research/digest/2026-05-30-digest.md}

--- a/research/wiki/themes/federal-ai-policy.md
+++ b/research/wiki/themes/federal-ai-policy.md
@@ -4,9 +4,9 @@ title: Federal AI Policy
 type: theme
 aliases: ["federal AI policy", "Trump AI executive order", "federal AI executive order", "Promoting Advanced AI Innovation and Security", "30-day pre-release access", "CAISI MOU"]
 tags: [policy, regulation, federal, executive-order, ai-governance, frontier-ai]
-summary: The 2026 storyline of US federal AI governance — culminating in Trump's June 2 executive order mandating 30-day government pre-release access to frontier models for cybersecurity review.
+description: The 2026 storyline of US federal AI governance — culminating in Trump's June 2 executive order mandating 30-day government pre-release access to frontier models for cybersecurity review.
 created_at: 2026-06-03
-updated_at: 2026-06-16
+timestamp: 2026-06-16T00:00:00Z
 sources:
   - {title: "ARA daily digest 2026-06-16", path: research/digest/2026-06-16-digest.md}
   - {title: "ARA daily digest 2026-06-15", path: research/digest/2026-06-15-digest.md}

--- a/research/wiki/themes/open-weights.md
+++ b/research/wiki/themes/open-weights.md
@@ -4,9 +4,9 @@ title: The Open-Weights Wave
 type: theme
 aliases: ["open weights", "open-weights", "open source AI", "open-source AI", "open weights wave", "local weights"]
 tags: [open-weights, open-source, local-llm, china, decentralization]
-summary: The 2026 storyline of open-weight models closing on frontier capability while a decentralization backlash — torrent networks, local hosting, "APIs are rented, weights are forever" — gains force, surging directly on the Fable 5 government shutdown.
+description: The 2026 storyline of open-weight models closing on frontier capability while a decentralization backlash — torrent networks, local hosting, "APIs are rented, weights are forever" — gains force, surging directly on the Fable 5 government shutdown.
 created_at: 2026-06-14
-updated_at: 2026-06-16
+timestamp: 2026-06-16T00:00:00Z
 sources:
   - {title: "ARA daily digest 2026-06-16", path: research/digest/2026-06-16-digest.md}
   - {title: "ARA daily digest 2026-06-15", path: research/digest/2026-06-15-digest.md}

--- a/scripts/build_wiki_index.py
+++ b/scripts/build_wiki_index.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from datetime import date
+from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -46,6 +46,10 @@ RECENT_LOG_LIMIT = 20
 def _isoformat(value: Any) -> str | None:
     if value is None:
         return None
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.isoformat()
+        return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
     if isinstance(value, date):
         return value.isoformat()
     return str(value)
@@ -53,7 +57,7 @@ def _isoformat(value: Any) -> str | None:
 
 def _page_extra_fields(path: Path) -> dict[str, Any]:
     """Re-read a page's frontmatter for fields check_wiki's Page doesn't carry
-    (tags, summary, created_at). check_wiki already validated the page, so this
+    (tags, description, created_at). check_wiki already validated the page, so this
     is a thin metadata read, not a re-validation."""
     text = path.read_text(encoding="utf-8")
     throwaway = cw.Report()
@@ -64,8 +68,10 @@ def _page_extra_fields(path: Path) -> dict[str, Any]:
         tags = []
     return {
         "tags": [str(t) for t in tags],
-        "summary": str(data.get("summary") or ""),
+        "summary": str(data.get("description") or data.get("summary") or ""),
+        "description": str(data.get("description") or data.get("summary") or ""),
         "created_at": _isoformat(data.get("created_at")),
+        "timestamp": _isoformat(data.get("timestamp") or data.get("updated_at")),
     }
 
 
@@ -118,8 +124,10 @@ def build_index(wiki_dir: Path) -> dict[str, Any]:
                 "type": page.type,
                 "tags": extra["tags"],
                 "summary": extra["summary"],
+                "description": extra["description"],
                 "created_at": extra["created_at"],
-                "updated_at": _isoformat(page.updated_at),
+                "updated_at": _isoformat(page.timestamp),
+                "timestamp": extra["timestamp"],
                 "file": str(page.path.relative_to(wiki_dir)),
                 "aliases": list(page.aliases),
                 "outbound": sorted(outbound[page.slug]),

--- a/scripts/check_wiki.py
+++ b/scripts/check_wiki.py
@@ -22,7 +22,7 @@ import argparse
 import re
 import sys
 from dataclasses import dataclass, field
-from datetime import date
+from datetime import date, datetime
 from pathlib import Path
 from typing import Any
 
@@ -72,7 +72,7 @@ class Page:
     aliases: list[str]
     title: str
     body: str
-    updated_at: date | None
+    timestamp: date | None
     links: list[str]  # resolved-target slugs of outbound wikilinks
 
 
@@ -147,6 +147,29 @@ def _check_date(data: dict, key: str, path: Path, report: Report) -> date | None
             report.fail(path, key, f"not a valid ISO date (YYYY-MM-DD): {val!r}")
             return None
     report.fail(path, key, f"must be a date, got {type(val).__name__}")
+    return None
+
+
+def _check_timestamp(data: dict, key: str, path: Path, report: Report) -> date | None:
+    """Required OKF timestamp. Return its date component for freshness checks."""
+    val = data.get(key)
+    if val is None:
+        report.fail(path, key, "required timestamp missing or null")
+        return None
+    if isinstance(val, datetime):
+        return val.date()
+    if isinstance(val, date):
+        return val
+    if isinstance(val, str):
+        try:
+            if re.fullmatch(r"\d{4}-\d{2}-\d{2}", val):
+                return date.fromisoformat(val)
+            normalized = val[:-1] + "+00:00" if val.endswith("Z") else val
+            return datetime.fromisoformat(normalized).date()
+        except ValueError:
+            report.fail(path, key, f"not a valid ISO 8601 timestamp: {val!r}")
+            return None
+    report.fail(path, key, f"must be a timestamp, got {type(val).__name__}")
     return None
 
 
@@ -295,16 +318,16 @@ def load_page(path: Path, report: Report) -> Page | None:
 
     aliases = _check_str_list(data, "aliases", path, report)
     _check_str_list(data, "tags", path, report)
-    _check_str(data, "summary", path, report)
-    # summary must be a single line (one-liner contract).
-    summary_val = data.get("summary")
-    if isinstance(summary_val, str) and "\n" in summary_val.strip():
-        report.fail(path, "summary", "must be a single line (no embedded newlines)")
+    _check_str(data, "description", path, report)
+    # OKF description must stay a single-line preview in the ARA wiki.
+    description_val = data.get("description")
+    if isinstance(description_val, str) and "\n" in description_val.strip():
+        report.fail(path, "description", "must be a single line (no embedded newlines)")
 
     created_at = _check_date(data, "created_at", path, report)
-    updated_at = _check_date(data, "updated_at", path, report)
-    if created_at and updated_at and updated_at < created_at:
-        report.fail(path, "updated_at", f"updated_at {updated_at} < created_at {created_at}")
+    timestamp = _check_timestamp(data, "timestamp", path, report)
+    if created_at and timestamp and timestamp < created_at:
+        report.fail(path, "timestamp", f"timestamp {timestamp} < created_at {created_at}")
 
     if "sources" in data and data["sources"] is not None:
         _check_sources(data["sources"], path, report)
@@ -323,7 +346,7 @@ def load_page(path: Path, report: Report) -> Page | None:
         aliases=aliases,
         title=title or slug,
         body=body,
-        updated_at=updated_at,
+        timestamp=timestamp,
         links=links,
     )
 
@@ -497,10 +520,10 @@ def run_lint(pages: list[Page], resolver: dict[str, str], report: Report, *, tod
     for page in pages:
         if not inbound[page.slug]:
             report.warn(page.path, "orphan", f"{page.slug!r} has no inbound links from other pages")
-        if page.updated_at is not None:
-            age = (today - page.updated_at).days
+        if page.timestamp is not None:
+            age = (today - page.timestamp).days
             if age > STALE_AFTER_DAYS:
-                report.warn(page.path, "stale", f"{page.slug!r} updated_at {page.updated_at} is {age}d old (> {STALE_AFTER_DAYS}d)")
+                report.warn(page.path, "stale", f"{page.slug!r} timestamp {page.timestamp} is {age}d old (> {STALE_AFTER_DAYS}d)")
         # Missing reciprocal: A links B but B does not link back to A.
         for tgt in sorted(outbound[page.slug]):
             if tgt in by_slug and page.slug not in outbound.get(tgt, set()):

--- a/scripts/export_wiki_okf.py
+++ b/scripts/export_wiki_okf.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Export research/wiki as an Open Knowledge Format bundle.
+
+The maintained ARA wiki is stricter than baseline OKF and uses ARA-specific
+fields plus [[wikilinks]]. This exporter validates that source bundle, then
+writes a portable Markdown/YAML bundle whose concept files expose the OKF
+frontmatter fields and standard Markdown links.
+
+Usage:
+    uv run python scripts/export_wiki_okf.py --out /tmp/ara-okf
+    uv run python scripts/export_wiki_okf.py --root research/wiki --out /tmp/ara-okf
+"""
+
+from __future__ import annotations
+
+import argparse
+import posixpath
+import re
+import shutil
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+import check_wiki as cw
+
+SECTION_FOR_TYPE = {
+    "entity": "Entities",
+    "concept": "Concepts",
+    "theme": "Themes",
+}
+
+
+def _split_page(path: Path) -> tuple[dict[str, Any], str]:
+    report = cw.Report()
+    data, body = cw._split_frontmatter(path.read_text(encoding="utf-8"), path, report)
+    if data is None:
+        raise ValueError(f"{path} did not parse after validation")
+    return data, body
+
+
+def _date_to_timestamp(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.isoformat()
+        return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+    if isinstance(value, date):
+        return f"{value.isoformat()}T00:00:00Z"
+    if isinstance(value, str):
+        # The source contract uses YYYY-MM-DD. Preserve already-expanded
+        # timestamps if a caller feeds a custom bundle.
+        if re.fullmatch(r"\d{4}-\d{2}-\d{2}", value):
+            return f"{value}T00:00:00Z"
+        return value
+    return str(value)
+
+
+def rewrite_wikilinks(
+    body: str,
+    pages: list[cw.Page],
+    resolver: dict[str, str],
+    wiki_dir: Path,
+    current_path: Path,
+) -> str:
+    """Convert ARA [[wikilinks]] to OKF-friendly Markdown links.
+
+    Fenced code blocks are preserved verbatim, matching check_wiki's extraction
+    behavior so examples do not become links.
+    """
+    page_by_slug = {p.slug: p for p in pages}
+
+    def replacement(match: re.Match[str]) -> str:
+        raw = match.group(1)
+        target, _, label = raw.partition("|")
+        target = target.strip()
+        slug = resolver.get(target.lower())
+        if not slug or slug not in page_by_slug:
+            return match.group(0)
+        page = page_by_slug[slug]
+        display = label.strip() or page.title
+        target = page.path.relative_to(wiki_dir).as_posix()
+        start = current_path.relative_to(wiki_dir).parent.as_posix()
+        href = posixpath.relpath(target, start=start)
+        return f"[{display}]({href})"
+
+    out: list[str] = []
+    fence: str | None = None
+    fence_indent = ""
+    for line in body.splitlines(keepends=True):
+        line_without_newline = line.rstrip("\n")
+        m = cw.FENCE_RE.match(line_without_newline)
+        if fence is None:
+            if m:
+                fence = m.group(2)
+                fence_indent = m.group(1)
+                out.append(line)
+                continue
+            out.append(cw.WIKILINK_RE.sub(replacement, line))
+            continue
+
+        out.append(line)
+        if (
+            m
+            and m.group(2)[0] == fence[0]
+            and len(m.group(2)) >= len(fence)
+            and m.group(1) == fence_indent
+            and not line_without_newline[m.end() :].strip()
+        ):
+            fence = None
+
+    return "".join(out)
+
+
+def okf_frontmatter(data: dict[str, Any]) -> dict[str, Any]:
+    """Preserve OKF-native ARA wiki frontmatter with local extension fields."""
+    out: dict[str, Any] = {
+        "type": str(data["type"]),
+        "title": data["title"],
+        "description": data["description"],
+        "ara_slug": data["slug"],
+        "created_at": str(data["created_at"]),
+        "timestamp": _date_to_timestamp(data["timestamp"]),
+    }
+    for key in ("aliases", "tags", "sources"):
+        if key in data and data[key]:
+            out[key] = data[key]
+    return out
+
+
+def render_concept(data: dict[str, Any], body: str) -> str:
+    header = yaml.safe_dump(okf_frontmatter(data), sort_keys=False, allow_unicode=True).strip()
+    return f"---\n{header}\n---\n\n{body.strip()}\n"
+
+
+def render_index(pages: list[cw.Page], wiki_dir: Path) -> str:
+    lines = [
+        "# ARA Open Knowledge Format Bundle",
+        "",
+        "Generated from `research/wiki/`. Each listed file is an OKF concept document.",
+        "",
+    ]
+    for type_ in ("entity", "concept", "theme"):
+        lines.append(f"## {SECTION_FOR_TYPE[type_]}")
+        lines.append("")
+        for page in sorted((p for p in pages if p.type == type_), key=lambda p: p.title.lower()):
+            href = str(page.path.relative_to(wiki_dir))
+            data, _ = _split_page(page.path)
+            preview = str(data.get("description") or "").strip()
+            lines.append(f"* [{page.title}]({href}) - {preview}")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def load_valid_wiki(wiki_dir: Path) -> tuple[list[cw.Page], dict[str, str]]:
+    report = cw.Report()
+    targets = cw.gather_pages(wiki_dir)
+    cw.validate(targets, wiki_dir, report, lint=False)
+    if not report.ok():
+        for failure in report.failures:
+            print(f"FAIL {failure.path}: {failure.field}: {failure.msg}", file=sys.stderr)
+        raise SystemExit(1)
+
+    pages: list[cw.Page] = []
+    load_report = cw.Report()
+    for path in targets:
+        page = cw.load_page(path, load_report)
+        if page is not None:
+            pages.append(page)
+    resolver = cw.build_resolver(pages, load_report)
+    if not load_report.ok():
+        for failure in load_report.failures:
+            print(f"FAIL {failure.path}: {failure.field}: {failure.msg}", file=sys.stderr)
+        raise SystemExit(1)
+    return pages, resolver
+
+
+def export_okf(wiki_dir: Path, out_dir: Path, *, clean: bool) -> None:
+    pages, resolver = load_valid_wiki(wiki_dir)
+
+    if out_dir.exists():
+        if not clean:
+            raise SystemExit(f"{out_dir} already exists; pass --clean to replace it")
+        shutil.rmtree(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    (out_dir / "index.md").write_text(render_index(pages, wiki_dir), encoding="utf-8")
+
+    for page in pages:
+        data, body = _split_page(page.path)
+        converted = rewrite_wikilinks(body, pages, resolver, wiki_dir, page.path)
+        rel = page.path.relative_to(wiki_dir)
+        dest = out_dir / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(render_concept(data, converted), encoding="utf-8")
+
+    print(f"wrote OKF bundle to {out_dir} ({len(pages)} concept document(s))")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--root", default=None, help="wiki root dir (default research/wiki)")
+    parser.add_argument("--out", required=True, help="output directory for the OKF bundle")
+    parser.add_argument("--clean", action="store_true", help="replace the output directory if it already exists")
+    args = parser.parse_args(argv)
+
+    wiki_dir = Path(args.root) if args.root else cw.WIKI_DIR
+    out_dir = Path(args.out)
+    export_okf(wiki_dir, out_dir, clean=args.clean)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_build_wiki_index.py
+++ b/scripts/test_build_wiki_index.py
@@ -25,9 +25,9 @@ title: Alpha Corp
 type: entity
 aliases: [A1]
 tags: [infra]
-summary: Alpha summary.
+description: Alpha description.
 created_at: 2026-05-01
-updated_at: 2026-05-02
+timestamp: 2026-05-02T00:00:00Z
 ---
 Alpha links to [[beta]] and again via alias [[b-one|Beta]].
 """
@@ -37,9 +37,9 @@ slug: beta
 title: Beta Concept
 type: concept
 aliases: [b-one]
-summary: Beta summary.
+description: Beta description.
 created_at: 2026-05-01
-updated_at: 2026-05-03
+timestamp: 2026-05-03T00:00:00Z
 ---
 Beta links back to [[alpha]].
 
@@ -82,9 +82,11 @@ class BuildWikiIndexTest(unittest.TestCase):
             self.assertEqual(alpha["inbound"], ["beta"])
             self.assertEqual(alpha["file"], "entities/alpha.md")
             self.assertEqual(alpha["tags"], ["infra"])
-            self.assertEqual(alpha["summary"], "Alpha summary.")
-            self.assertEqual(alpha["created_at"], "2026-05-01")
+            self.assertEqual(alpha["summary"], "Alpha description.")
             self.assertEqual(alpha["updated_at"], "2026-05-02")
+            self.assertEqual(alpha["description"], "Alpha description.")
+            self.assertEqual(alpha["created_at"], "2026-05-01")
+            self.assertEqual(alpha["timestamp"], "2026-05-02T00:00:00Z")
             self.assertEqual(alpha["aliases"], ["A1"])
 
     def test_fenced_links_excluded_from_graph(self):
@@ -114,7 +116,7 @@ class BuildWikiIndexTest(unittest.TestCase):
             self.assertEqual(bwi.main(["--root", str(root)]), 0)
             self.assertEqual(bwi.main(["--root", str(root), "--check"]), 0)
             # Mutate a page → committed index.json is now stale → --check fails.
-            _write(root, "concepts/beta.md", BETA.replace("updated_at: 2026-05-03", "updated_at: 2026-05-09"))
+            _write(root, "concepts/beta.md", BETA.replace("timestamp: 2026-05-03", "timestamp: 2026-05-09"))
             self.assertEqual(bwi.main(["--root", str(root), "--check"]), 1)
 
     def test_check_missing_file_fails(self):

--- a/scripts/test_export_wiki_okf.py
+++ b/scripts/test_export_wiki_okf.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Tests for export_wiki_okf.py."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+import check_wiki
+import export_wiki_okf as okf
+
+
+def _write(root: Path, rel: str, text: str) -> None:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+ALPHA = """---
+slug: alpha
+title: Alpha Corp
+type: entity
+aliases: [A1]
+tags: [infra]
+description: Alpha description.
+created_at: 2026-05-01
+timestamp: 2026-05-02T00:00:00Z
+sources:
+  - {title: "ARA digest", path: research/digest/2026-05-02-digest.md}
+---
+
+Alpha links to [[beta]] and [[b-one|Beta by alias]].
+
+```
+[[beta]] inside a fence stays literal.
+```
+"""
+
+BETA = """---
+slug: beta
+title: Beta Concept
+type: concept
+aliases: [b-one]
+description: Beta description.
+created_at: 2026-05-01
+timestamp: 2026-05-03T00:00:00Z
+---
+
+Beta links back to [[alpha]].
+"""
+
+INDEX = """# Wiki Index
+
+## Entities
+- [[alpha]] — Alpha description.
+
+## Concepts
+- [[beta]] — Beta description.
+
+## Themes
+"""
+
+LOG = """# Wiki Log
+
+## [2026-05-01] seed | seeded alpha and beta
+"""
+
+
+def _fixture(root: Path) -> None:
+    for subdir in check_wiki.PAGE_SUBDIRS:
+        (root / subdir).mkdir(parents=True, exist_ok=True)
+    _write(root, "entities/alpha.md", ALPHA)
+    _write(root, "concepts/beta.md", BETA)
+    _write(root, "index.md", INDEX)
+    _write(root, "log.md", LOG)
+
+
+def _frontmatter(path: Path) -> dict:
+    text = path.read_text(encoding="utf-8")
+    header = text.split("\n---\n", 1)[0][4:]
+    data = yaml.safe_load(header)
+    assert isinstance(data, dict)
+    return data
+
+
+class ExportWikiOkfTest(unittest.TestCase):
+    def test_export_maps_frontmatter_to_okf(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "wiki"
+            out = Path(td) / "okf"
+            _fixture(root)
+
+            okf.export_okf(root, out, clean=False)
+
+            data = _frontmatter(out / "entities" / "alpha.md")
+            self.assertEqual(data["type"], "entity")
+            self.assertEqual(data["title"], "Alpha Corp")
+            self.assertEqual(data["description"], "Alpha description.")
+            self.assertEqual(data["timestamp"], "2026-05-02T00:00:00Z")
+            self.assertEqual(data["ara_slug"], "alpha")
+            self.assertEqual(data["aliases"], ["A1"])
+            self.assertEqual(data["tags"], ["infra"])
+            self.assertEqual(data["sources"][0]["title"], "ARA digest")
+
+    def test_export_rewrites_wikilinks_to_markdown_links(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "wiki"
+            out = Path(td) / "okf"
+            _fixture(root)
+
+            okf.export_okf(root, out, clean=False)
+
+            body = (out / "entities" / "alpha.md").read_text(encoding="utf-8")
+            self.assertIn("[Beta Concept](../concepts/beta.md)", body)
+            self.assertIn("[Beta by alias](../concepts/beta.md)", body)
+            self.assertIn("[[beta]] inside a fence stays literal.", body)
+
+            index = (out / "index.md").read_text(encoding="utf-8")
+            self.assertIn("* [Alpha Corp](entities/alpha.md) - Alpha description.", index)
+            self.assertNotIn("[[", index)
+
+    def test_clean_replaces_existing_output(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "wiki"
+            out = Path(td) / "okf"
+            _fixture(root)
+            out.mkdir()
+            (out / "stale.txt").write_text("old", encoding="utf-8")
+
+            okf.export_okf(root, out, clean=True)
+
+            self.assertFalse((out / "stale.txt").exists())
+            self.assertTrue((out / "index.md").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_wiki.py
+++ b/scripts/test_wiki.py
@@ -26,9 +26,9 @@ title: {title}
 type: {type}
 aliases: {aliases}
 tags: [alpha, beta]
-summary: {summary}
+description: {description}
 created_at: 2026-05-24
-updated_at: 2026-05-24
+timestamp: 2026-05-24T00:00:00Z
 sources:
   - {{title: "ARA daily digest", path: research/digest/2026-05-24-digest.md}}
 ---
@@ -54,7 +54,7 @@ def write_page(
     type_: str = "entity",
     title: str | None = None,
     aliases: str = "[]",
-    summary: str = "A one-line summary.",
+    description: str = "A one-line description.",
     body: str = "No links here.",
     subdir: str | None = None,
     filename: str | None = None,
@@ -68,7 +68,7 @@ def write_page(
             title=title or slug.title(),
             type=type_,
             aliases=aliases,
-            summary=summary,
+            description=description,
             body=body,
         ),
         encoding="utf-8",
@@ -81,7 +81,7 @@ def write_index(root: Path, entities=(), concepts=(), themes=()) -> Path:
     for header, slugs in (("Entities", entities), ("Concepts", concepts), ("Themes", themes)):
         lines.append(f"## {header}")
         for slug in slugs:
-            lines.append(f"- [[{slug}]] — summary for {slug}")
+            lines.append(f"- [[{slug}]] — description for {slug}")
         lines.append("")
     path = root / "index.md"
     path.write_text("\n".join(lines), encoding="utf-8")
@@ -133,9 +133,9 @@ title: NBX Group
 type: entity
 aliases: [NBX, "N.B.X. Group"]
 tags: [neocloud, gpu-cloud]
-summary: Flow-style frontmatter must parse.
+description: Flow-style frontmatter must parse.
 created_at: 2026-05-24
-updated_at: 2026-05-24
+timestamp: 2026-05-24T00:00:00Z
 sources:
   - {title: "Q1 results", url: "https://example.com/q1", date: 2026-05-20}
   - {title: "ARA digest", path: research/digest/2026-05-24-digest.md}
@@ -163,19 +163,19 @@ class FrontmatterFailureTest(unittest.TestCase):
             return run_validate(root)
 
     def test_missing_required_field_fails(self):
-        # Drop `summary` (required).
+        # Drop `description` (required).
         def build(root):
             p = root / "entities" / "alpha.md"
             p.write_text(
                 "---\nslug: alpha\ntitle: Alpha\ntype: entity\n"
-                "created_at: 2026-05-24\nupdated_at: 2026-05-24\n---\n\nBody.\n",
+                "created_at: 2026-05-24\ntimestamp: 2026-05-24\n---\n\nBody.\n",
                 encoding="utf-8",
             )
             write_index(root, entities=["alpha"])
 
         report = self._one_page_report(build)
         self.assertFalse(report.ok())
-        self.assertIn("summary", fail_fields(report))
+        self.assertIn("description", fail_fields(report))
 
     def test_bad_slug_fails(self):
         def build(root):
@@ -205,7 +205,7 @@ class FrontmatterFailureTest(unittest.TestCase):
             # Rewrite with an illegal type but keep it in entities/.
             (root / "entities" / "alpha.md").write_text(
                 "---\nslug: alpha\ntitle: Alpha\ntype: widget\n"
-                "summary: x\ncreated_at: 2026-05-24\nupdated_at: 2026-05-24\n---\n\nBody.\n",
+                "description: x\ncreated_at: 2026-05-24\ntimestamp: 2026-05-24\n---\n\nBody.\n",
                 encoding="utf-8",
             )
             write_index(root, entities=["alpha"])
@@ -228,22 +228,22 @@ class FrontmatterFailureTest(unittest.TestCase):
         def build(root):
             p = root / "entities" / "alpha.md"
             p.write_text(
-                "---\nslug: alpha\ntitle: Alpha\ntype: entity\nsummary: x\n"
-                "created_at: 2026-05-24\nupdated_at: 2026-05-01\n---\n\nBody.\n",
+                "---\nslug: alpha\ntitle: Alpha\ntype: entity\ndescription: x\n"
+                "created_at: 2026-05-24\ntimestamp: 2026-05-01\n---\n\nBody.\n",
                 encoding="utf-8",
             )
             write_index(root, entities=["alpha"])
 
         report = self._one_page_report(build)
         self.assertFalse(report.ok())
-        self.assertIn("updated_at", fail_fields(report))
+        self.assertIn("timestamp", fail_fields(report))
 
     def test_bad_date_format_fails(self):
         def build(root):
             p = root / "entities" / "alpha.md"
             p.write_text(
-                "---\nslug: alpha\ntitle: Alpha\ntype: entity\nsummary: x\n"
-                'created_at: "05/24/2026"\nupdated_at: 2026-05-24\n---\n\nBody.\n',
+                "---\nslug: alpha\ntitle: Alpha\ntype: entity\ndescription: x\n"
+                'created_at: "05/24/2026"\ntimestamp: 2026-05-24\n---\n\nBody.\n',
                 encoding="utf-8",
             )
             write_index(root, entities=["alpha"])
@@ -256,8 +256,8 @@ class FrontmatterFailureTest(unittest.TestCase):
         def build(root):
             p = root / "entities" / "alpha.md"
             p.write_text(
-                "---\nslug: alpha\ntitle: Alpha\ntype: entity\nsummary: x\n"
-                "created_at: 2026-05-24\nupdated_at: 2026-05-24\n---\n\n   \n",
+                "---\nslug: alpha\ntitle: Alpha\ntype: entity\ndescription: x\n"
+                "created_at: 2026-05-24\ntimestamp: 2026-05-24\n---\n\n   \n",
                 encoding="utf-8",
             )
             write_index(root, entities=["alpha"])
@@ -266,27 +266,27 @@ class FrontmatterFailureTest(unittest.TestCase):
         self.assertFalse(report.ok())
         self.assertIn("body", fail_fields(report))
 
-    def test_multiline_summary_fails(self):
+    def test_multiline_description_fails(self):
         def build(root):
             p = root / "entities" / "alpha.md"
             p.write_text(
                 "---\nslug: alpha\ntitle: Alpha\ntype: entity\n"
-                "summary: |\n  line one\n  line two\n"
-                "created_at: 2026-05-24\nupdated_at: 2026-05-24\n---\n\nBody.\n",
+                "description: |\n  line one\n  line two\n"
+                "created_at: 2026-05-24\ntimestamp: 2026-05-24\n---\n\nBody.\n",
                 encoding="utf-8",
             )
             write_index(root, entities=["alpha"])
 
         report = self._one_page_report(build)
         self.assertFalse(report.ok())
-        self.assertIn("summary", fail_fields(report))
+        self.assertIn("description", fail_fields(report))
 
     def test_bad_source_missing_title_fails(self):
         def build(root):
             p = root / "entities" / "alpha.md"
             p.write_text(
-                "---\nslug: alpha\ntitle: Alpha\ntype: entity\nsummary: x\n"
-                "created_at: 2026-05-24\nupdated_at: 2026-05-24\n"
+                "---\nslug: alpha\ntitle: Alpha\ntype: entity\ndescription: x\n"
+                "created_at: 2026-05-24\ntimestamp: 2026-05-24\n"
                 "sources:\n  - {url: \"https://example.com\"}\n---\n\nBody.\n",
                 encoding="utf-8",
             )
@@ -401,7 +401,7 @@ class IndexLogFailureTest(unittest.TestCase):
             root = make_wiki(Path(td))
             write_page(root, "alpha", type_="entity")
             write_index(root, entities=["alpha"])
-            # Missing the ' | summary' segment.
+            # Missing the ' | description' segment.
             write_log(root, lines=["## [2026-05-24] seed no-pipe-here"])
             report = run_validate(root)
             self.assertFalse(report.ok())
@@ -499,7 +499,7 @@ class WikiSearchTest(unittest.TestCase):
             type_="entity",
             title="Nebius Group",
             aliases="[Nebius, NBIS]",
-            summary="Amsterdam neocloud provider for GPU compute.",
+            description="Amsterdam neocloud provider for GPU compute.",
             body="Nebius rents GPU capacity. It competes with CoreWeave.",
         )
         write_page(
@@ -507,7 +507,7 @@ class WikiSearchTest(unittest.TestCase):
             "coreweave",
             type_="entity",
             title="CoreWeave",
-            summary="GPU-as-a-service neocloud with a large backlog.",
+            description="GPU-as-a-service neocloud with a large backlog.",
             body="CoreWeave is the reference neocloud. Mentions nebius once.",
         )
         write_page(
@@ -515,7 +515,7 @@ class WikiSearchTest(unittest.TestCase):
             "neocloud",
             type_="concept",
             title="Neocloud",
-            summary="Buy GPUs on debt, rent capacity back.",
+            description="Buy GPUs on debt, rent capacity back.",
             body="The neocloud model underwrites debt against contracts.",
         )
 
@@ -566,7 +566,7 @@ class WikiSearchTest(unittest.TestCase):
                 "alpha",
                 type_="entity",
                 title="Alpha",
-                summary="No special terms.",
+                description="No special terms.",
                 body="Normal text.\n\n```\nquxzzytoken here\n```\n",
             )
             results = wiki_search.search(root, "quxzzytoken")

--- a/scripts/wiki_search.py
+++ b/scripts/wiki_search.py
@@ -10,7 +10,7 @@ Usage:
 Prints ranked (slug, score, snippet). With --json, prints a JSON array.
 
 Scoring: Okapi BM25 over a per-page bag of tokens assembled from weighted
-fields — title + aliases (heaviest), tags, summary, body — so a name match in
+fields — title + aliases (heaviest), tags, description, body — so a name match in
 the title beats a passing mention in the body. The corpus is tiny (~6 pages),
 so two BM25 quirks are handled explicitly: the IDF term is clamped to >= 0
 (otherwise terms appearing in >half the corpus become anti-signal), and field
@@ -119,7 +119,7 @@ def _field_text(data: dict, body: str) -> dict[str, str]:
         "title": str(data.get("title", "") or ""),
         "aliases": join_list("aliases"),
         "tags": join_list("tags"),
-        "summary": str(data.get("summary", "") or ""),
+        "summary": str(data.get("description", data.get("summary", "")) or ""),
         "body": _strip_fences(body),
     }
 


### PR DESCRIPTION
## Summary
- convert maintained `research/wiki/{entities,concepts,themes}/*.md` pages from ARA-specific `summary` / `updated_at` frontmatter to OKF-native `description` / `timestamp` fields
- keep ARA extension fields where needed (`slug`, `aliases`, `created_at`, `sources`) and keep `type` values as `entity`, `concept`, or `theme`
- update `docs/wiki-schema.md`, `docs/okf.md`, `CLAUDE.md`, and `wiki-ingest.yml` so future wiki maintenance writes OKF-native source documents
- update `scripts/check_wiki.py`, `scripts/wiki_search.py`, and `scripts/build_wiki_index.py` to read OKF-native fields
- preserve dashboard compatibility by continuing to emit `summary` and `updated_at` aliases in `research/wiki/index.json`, while also emitting `description` and `timestamp`
- add `scripts/export_wiki_okf.py` to package the OKF-native wiki as a portable bundle with standard Markdown links instead of ARA `[[wikilinks]]`

## Claude review reconciliation
- GitHub Claude Code Review completed successfully and left no PR comments, reviews, or inline review threads.
- Local Claude Code direct review found one actionable portability issue: exported body links were root-absolute. Reconciled by changing OKF export body links to page-relative paths and updating docs/tests.
- Claude also requested a grep for stale `summary:` / `updated_at` prompt text. Verified remaining hits are intentional compatibility aliases or model-ticket/log-summary text, not wiki frontmatter instructions.

## Notes
- This corrects the prior OKR interpretation. The requested Google-developed item is Open Knowledge Format, based on the Google Cloud article and OKF v0.1 draft spec.
- `research/wiki/` is now the OKF-native source of truth; generated `index.json` remains the dashboard contract.

## Validation
- `uv run python -m unittest discover -s scripts -p 'test_*.py'`\n- `uv run python scripts/check_wiki.py`\n- `uv run python scripts/build_wiki_index.py --check`\n- `uv run python scripts/export_wiki_okf.py --out /tmp/ara-okf-test --clean`\n- `git diff --check`\n- `cd dashboard && bun run build`