### PR TITLE
Dedupe cross-source headline alerts (same story, different account)

### DIFF
--- a/scripts/dedupe_headline_alerts.py
+++ b/scripts/dedupe_headline_alerts.py
@@ -4,6 +4,16 @@
 This is intentionally an alert-send ledger, not a global news/event store. The
 workflow already has a structured boundary at `*-headlines.json`; this script
 keeps Telegram/Hooker sends from repeating previously delivered alert items.
+
+Dedupe layers (see `duplicate_reason`), in priority order:
+  1. shared story_key, exact normalized headline (any source), and same-source
+     (same URL) paraphrase — time-independent, highest precision.
+  2. cross-source semantic duplicate — the SAME story reported by a DIFFERENT
+     account (different tweet URL) with paraphrased wording. This catches the
+     re-reports the same-URL check structurally cannot see. It is gated on a
+     Jaccard floor (size-symmetric, so an appended-fact follow-up is not eaten),
+     an absolute shared-token floor, and a recency window; it stays inert unless
+     a reference time is supplied.
 """
 
 from __future__ import annotations
@@ -17,13 +27,35 @@ import sys
 import unicodedata
 from collections import Counter
 from dataclasses import dataclass
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, urlencode, urlsplit, urlunsplit
 
 
 RETENTION_DEFAULT = 3000
+# Same-source paraphrase gate: identical tweet URL + a high token overlap
+# (max of containment/Jaccard). Lenient because same URL already proves same source.
 URL_SIMILARITY_THRESHOLD = 0.62
+# Cross-source semantic-duplicate gate: the SAME story from a DIFFERENT account
+# (different tweet URL), paraphrased. Deliberately uses Jaccard (size-symmetric) — NOT
+# max-containment — so a short earlier headline being a subset of a longer appended-fact
+# follow-up ("META RELEASES LLAMA 5" -> "...WITH 2M TOKEN CONTEXT AND NATIVE VOICE")
+# does NOT score 1.0 and is not mistaken for a duplicate. Calibrated against the real
+# delivered-alert ledger: genuine cross-source re-reports cluster at Jaccard >= ~0.5 with
+# >= 7 shared tokens; append-a-fact progression and short subset headlines fall well below.
+# Known residual: two genuinely-distinct stories that share enough significant vocabulary
+# to clear BOTH floors can still be suppressed — e.g. two different entities running the
+# same templated beat ("GOOGLE CUTS GEMINI API PRICING ACROSS THE BOARD" / "DEEPSEEK CUTS
+# API PRICING ACROSS THE BOARD": 5 shared tokens, Jaccard ~0.62), or a same-entity
+# follow-up that re-states most of the original. (A short appended-fact follow-up like
+# "META RELEASES LLAMA 5" -> "...WITH 2M TOKEN CONTEXT" is NOT a residual — it shares only
+# 3 tokens and is correctly delivered.) Token overlap alone cannot separate the residual
+# cases from a true re-report; the conservative threshold keeps them a small minority.
+# Tune the constants rather than adding a brittle hand-maintained salient-token list.
+CROSS_SOURCE_JACCARD_THRESHOLD = 0.5
+CROSS_SOURCE_MIN_OVERLAP = 4
+CROSS_SOURCE_WINDOW_DAYS = 14
 STOPWORDS = {
     "A",
     "AN",
@@ -67,6 +99,9 @@ class Keys:
     url_key: str
     external_key: str
     story_key: str
+    # Significant-token set of the headline, precomputed once so the cross-source
+    # pass doesn't re-tokenize every history record for every incoming item.
+    tokens: frozenset[str]
 
 
 def load_json_list(path: Path, *, missing_ok: bool = False) -> list[Any]:
@@ -168,6 +203,31 @@ def external_key(url: str) -> str:
     return f"url:{digest}"
 
 
+def parse_delivered_at(value: Any) -> datetime | None:
+    """Parse a ledger ``delivered_at`` ("YYYY-MM-DD HH:MM UTC"); None if unparseable."""
+    try:
+        return datetime.strptime(str(value or "").strip(), "%Y-%m-%d %H:%M UTC")
+    except (TypeError, ValueError):
+        return None
+
+
+def within_cross_source_window(delivered_at: Any, now: datetime, window_days: int) -> bool:
+    """Is a history record an eligible cross-source suppression source at ``now``?
+
+    Fails OPEN: a record whose ``delivered_at`` is missing or unparseable returns
+    False (treated as outside the window), so a real — possibly new — alert is
+    delivered rather than silently eaten by a single bad timestamp. The cost of a
+    parse bug is at worst one duplicate, never a swallowed headline.
+    ``window_days <= 0`` means unbounded (any parseable record qualifies).
+    """
+    parsed = parse_delivered_at(delivered_at)
+    if parsed is None:
+        return False
+    if window_days <= 0:
+        return True
+    return (now - parsed) <= timedelta(days=window_days)
+
+
 def item_keys(item: dict[str, Any]) -> Keys:
     headline = str(item.get("headline") or "")
     url = str(item.get("url") or "")
@@ -177,6 +237,7 @@ def item_keys(item: dict[str, Any]) -> Keys:
         url_key=normalize_url(url),
         external_key=external_key(url),
         story_key=story,
+        tokens=frozenset(headline_tokens(headline)),
     )
 
 
@@ -200,6 +261,7 @@ def duplicate_reason(
     item: dict[str, Any],
     history: list[dict[str, Any]],
     history_keys: list[Keys] | None = None,
+    now: datetime | None = None,
 ) -> str:
     keys = item_keys(item)
     if not keys.headline_key:
@@ -211,6 +273,9 @@ def duplicate_reason(
         history_keys = [item_keys(record) for record in history]
 
     headline = str(item.get("headline") or "")
+    # Pass 1 — exact identity and same-source paraphrase. Time-independent and the
+    # highest-precision signals, so they always run and take priority over the
+    # fuzzy cross-source pass below.
     for record, record_keys in zip(history, history_keys):
         record_headline = str(record.get("headline") or "")
         if keys.story_key and keys.story_key == record_keys.story_key:
@@ -221,6 +286,27 @@ def duplicate_reason(
             similarity = headline_similarity(headline, record_headline)
             if similarity >= URL_SIMILARITY_THRESHOLD:
                 return "duplicate_source_similar_headline"
+
+    # Pass 2 — cross-source semantic duplicate: same story, DIFFERENT account
+    # (different tweet URL), paraphrased. Inert unless a reference time `now` is
+    # supplied, so 2-arg legacy callers keep their exact behavior. Jaccard (not
+    # max-containment) + an absolute shared-token floor keep an appended-fact
+    # follow-up from being mistaken for a duplicate; the recency window keeps a
+    # legitimately recurring beat much later from being suppressed.
+    if now is not None:
+        for record, record_keys in zip(history, history_keys):
+            if not record_keys.url_key or record_keys.url_key == keys.url_key:
+                continue
+            if not within_cross_source_window(
+                record.get("delivered_at"), now, CROSS_SOURCE_WINDOW_DAYS
+            ):
+                continue
+            overlap = len(keys.tokens & record_keys.tokens)
+            if overlap < CROSS_SOURCE_MIN_OVERLAP:
+                continue
+            union = len(keys.tokens | record_keys.tokens)
+            if union and overlap / union >= CROSS_SOURCE_JACCARD_THRESHOLD:
+                return "duplicate_cross_source_similar_headline"
     return ""
 
 
@@ -229,6 +315,10 @@ def filter_headlines(args: argparse.Namespace) -> int:
     history_raw = load_json_list(Path(args.history_file), missing_ok=True)
     history = [item for item in history_raw if isinstance(item, dict)]
     history_keys = [item_keys(record) for record in history]
+    # Reference "now" for the cross-source recency window. If the run timestamp is
+    # malformed the cross-source pass is skipped (now=None), falling back to the
+    # exact/same-source checks — never a crash.
+    now = parse_delivered_at(args.timestamp)
     accepted: list[dict[str, Any]] = []
     counts: Counter[str] = Counter()
 
@@ -236,7 +326,7 @@ def filter_headlines(args: argparse.Namespace) -> int:
         if not isinstance(item, dict):
             counts["invalid_item"] += 1
             continue
-        reason = duplicate_reason(item, history, history_keys)
+        reason = duplicate_reason(item, history, history_keys, now)
         if reason:
             counts[reason] += 1
             continue

--- a/scripts/test_dedupe_headline_alerts.py
+++ b/scripts/test_dedupe_headline_alerts.py
@@ -195,6 +195,186 @@ class DedupeHeadlineAlertsTest(unittest.TestCase):
         # record and detects the duplicate via headline_key.
         self.assertEqual(dedupe.duplicate_reason(item, [legacy]), "duplicate_headline")
 
+    # ── cross-source semantic duplicate (different account/URL, paraphrased) ──
+
+    def test_cross_source_similar_headline_is_duplicate(self):
+        # The same hire reported by two different accounts with paraphrased wording —
+        # different URLs, so the same-URL check can't see it. With a reference `now`
+        # inside the window it is caught as a cross-source duplicate (Jaccard ~0.71).
+        history = [
+            dedupe.make_record(
+                {
+                    "headline": "OPENAI HIRES EX-WHITE HOUSE AI ADVISER DEAN BALL AS HEAD OF STRATEGIC FUTURES",
+                    "url": "https://x.com/Polymarket/status/2066900000000000001",
+                },
+                "2026-06-18 01:00 UTC",
+            )
+        ]
+        item = {
+            "headline": "OPENAI HIRES EX-TRUMP AI POLICY ADVISER DEAN BALL AS HEAD OF STRATEGIC FUTURES",
+            "url": "https://x.com/another_source/status/2066900000000000002",
+        }
+        now = dedupe.parse_delivered_at("2026-06-18 03:00 UTC")
+        self.assertEqual(
+            dedupe.duplicate_reason(item, history, now=now),
+            "duplicate_cross_source_similar_headline",
+        )
+
+    def test_cross_source_append_fact_progression_is_not_duplicate(self):
+        # Flash -> updated-with-details. The follow-up carries genuinely new facts and
+        # must survive. Containment would score this 1.0 (the short headline is a subset);
+        # Jaccard drops it to ~0.375 and the shared-token floor (3 < 4) also rejects it.
+        history = [
+            dedupe.make_record(
+                {"headline": "META RELEASES LLAMA 5", "url": "https://x.com/a/status/1"},
+                "2026-06-18 01:00 UTC",
+            )
+        ]
+        item = {
+            "headline": "META RELEASES LLAMA 5 WITH 2M TOKEN CONTEXT AND NATIVE VOICE",
+            "url": "https://x.com/b/status/2",
+        }
+        now = dedupe.parse_delivered_at("2026-06-18 02:00 UTC")
+        self.assertEqual(dedupe.duplicate_reason(item, history, now=now), "")
+
+    def test_cross_source_short_headline_containment_is_not_duplicate(self):
+        # The short-subset false positive: "ANTHROPIC RAISES $5B" is a token-subset of
+        # the longer, distinct headline (containment 1.0). Jaccard (~0.43) + the overlap
+        # floor (3 < 4) keep it from being suppressed.
+        history = [
+            dedupe.make_record(
+                {"headline": "ANTHROPIC RAISES $5B", "url": "https://x.com/a/status/1"},
+                "2026-06-18 01:00 UTC",
+            )
+        ]
+        item = {
+            "headline": "ANTHROPIC RAISES CONCERNS ABOUT $5B SAFETY FUND",
+            "url": "https://x.com/b/status/2",
+        }
+        now = dedupe.parse_delivered_at("2026-06-18 02:00 UTC")
+        self.assertEqual(dedupe.duplicate_reason(item, history, now=now), "")
+
+    def test_cross_source_distinct_milestone_is_not_duplicate(self):
+        # Same beat (SpaceX IPO) but genuinely different milestones (marketing-start vs
+        # pricing). Jaccard ~0.31 keeps them apart.
+        history = [
+            dedupe.make_record(
+                {
+                    "headline": "SPACEX PRICES IPO: 555.6M SHARES AT $135, ~$75B RAISE, ~$1.75T VALUATION",
+                    "url": "https://x.com/a/status/1",
+                },
+                "2026-06-18 01:00 UTC",
+            )
+        ]
+        item = {
+            "headline": "SPACEX IPO MARKETING STARTS JUNE 4 — $75B RAISE AT ~$1.75T, ON TRACK TO BE LARGEST",
+            "url": "https://x.com/b/status/2",
+        }
+        now = dedupe.parse_delivered_at("2026-06-18 02:00 UTC")
+        self.assertEqual(dedupe.duplicate_reason(item, history, now=now), "")
+
+    def test_cross_source_inert_without_now(self):
+        # No reference time -> cross-source pass is skipped entirely, preserving exact
+        # 2-arg legacy behavior even for near-identical different-URL headlines.
+        history = [
+            dedupe.make_record(
+                {"headline": "OPENAI HIRES NOAM SHAZEER FROM GOOGLE DEEPMIND", "url": "https://x.com/a/status/1"},
+                "2026-06-18 01:00 UTC",
+            )
+        ]
+        item = {
+            "headline": "OPENAI HIRES NOAM SHAZEER AWAY FROM GOOGLE DEEPMIND",
+            "url": "https://x.com/b/status/2",
+        }
+        self.assertEqual(dedupe.duplicate_reason(item, history), "")
+
+    def test_cross_source_outside_window_is_not_duplicate(self):
+        # A near-identical headline delivered well outside the recency window is treated
+        # as a (rare) recurring beat, not a duplicate, and is delivered.
+        history = [
+            dedupe.make_record(
+                {"headline": "OPENAI HIRES NOAM SHAZEER FROM GOOGLE DEEPMIND", "url": "https://x.com/a/status/1"},
+                "2026-05-01 01:00 UTC",
+            )
+        ]
+        item = {
+            "headline": "OPENAI HIRES NOAM SHAZEER AWAY FROM GOOGLE DEEPMIND",
+            "url": "https://x.com/b/status/2",
+        }
+        now = dedupe.parse_delivered_at("2026-06-18 01:00 UTC")  # ~48 days later
+        self.assertEqual(dedupe.duplicate_reason(item, history, now=now), "")
+
+    def test_cross_source_unparseable_delivered_at_fails_open(self):
+        # A single record with a corrupt delivered_at must not eat a real alert: the
+        # window check fails open (treats it as out-of-window) and the item is delivered.
+        history = [
+            dedupe.make_record(
+                {"headline": "OPENAI HIRES NOAM SHAZEER FROM GOOGLE DEEPMIND", "url": "https://x.com/a/status/1"},
+                "not-a-timestamp",
+            )
+        ]
+        item = {
+            "headline": "OPENAI HIRES NOAM SHAZEER AWAY FROM GOOGLE DEEPMIND",
+            "url": "https://x.com/b/status/2",
+        }
+        now = dedupe.parse_delivered_at("2026-06-18 01:00 UTC")
+        self.assertEqual(dedupe.duplicate_reason(item, history, now=now), "")
+
+    def test_exact_headline_still_takes_priority_with_now(self):
+        # Enabling the cross-source pass must not change which reason wins: the exact
+        # (priority) pass still returns first.
+        history = [
+            dedupe.make_record(
+                {"headline": "MUSK V ALTMAN TRIAL OPENS IN OAKLAND", "url": "https://x.com/a/status/1"},
+                "2026-06-18 01:00 UTC",
+            )
+        ]
+        item = {"headline": "Musk v. Altman trial opens in Oakland!", "url": "https://x.com/b/status/2"}
+        now = dedupe.parse_delivered_at("2026-06-18 02:00 UTC")
+        self.assertEqual(dedupe.duplicate_reason(item, history, now=now), "duplicate_headline")
+
+    def test_filter_suppresses_in_batch_cross_source_paraphrase(self):
+        # Two different-account paraphrases of the same story in ONE cycle: the first is
+        # accepted (and appended to history at the run timestamp), so the second is caught
+        # as a cross-source duplicate. Exactly one survives.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            history_file = root / "history.json"
+            headlines_file = root / "headlines.json"
+            filtered_file = root / "filtered.json"
+            history_file.write_text("[]")
+            headlines_file.write_text(
+                json.dumps(
+                    [
+                        {
+                            "headline": "OPENAI HIRES EX-WHITE HOUSE AI ADVISER DEAN BALL AS HEAD OF STRATEGIC FUTURES",
+                            "url": "https://x.com/src1/status/1",
+                        },
+                        {
+                            "headline": "OPENAI HIRES EX-TRUMP AI POLICY ADVISER DEAN BALL AS HEAD OF STRATEGIC FUTURES",
+                            "url": "https://x.com/src2/status/2",
+                        },
+                    ]
+                )
+            )
+            with redirect_stdout(StringIO()):
+                rc = dedupe.main(
+                    [
+                        "filter",
+                        "--headlines-file",
+                        str(headlines_file),
+                        "--history-file",
+                        str(history_file),
+                        "--filtered-file",
+                        str(filtered_file),
+                        "--timestamp",
+                        "2026-06-18 04:00 UTC",
+                    ]
+                )
+            self.assertEqual(rc, 0)
+            filtered = json.loads(filtered_file.read_text())
+            self.assertEqual(len(filtered), 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

The hourly-twitter headline cron (Telegram/Hooker "Robot Colosseum" alerts) re-sends the **same story** when a *different account* reports it with paraphrased wording — e.g. the same OpenAI hire or Anthropic announcement showing up again a day later from another source.

## Root cause

`scripts/dedupe_headline_alerts.py` already dedupes, but its only fuzzy check was **gated behind an identical tweet URL**:

```python
if keys.url_key and keys.url_key == record_keys.url_key:   # same tweet only
    if headline_similarity(...) >= 0.62: ...
```

So two *different* tweets about the same event were never compared semantically. The intended `story_key` dimension is **dead** — the agent's headline schema (`render-twitter-prompt`) only emits `{headline, url, category}`, so `story_key` is `null` in 100% of the 1,488 ledger records, and a fresh per-cycle agent can't emit a stable cross-run key anyway.

## Fix

Add a **cross-source pass** to `duplicate_reason`: for a history record from a **different URL** within a recency window, suppress when the two headlines' **Jaccard** token similarity clears a floor *and* they share enough tokens.

- **Jaccard, not `max(containment, jaccard)`** — deliberate. An adversarial review found that containment scores an appended-fact follow-up (`"META RELEASES LLAMA 5"` → `"...WITH 2M TOKEN CONTEXT AND NATIVE VOICE"`) at **1.0** and would kill legitimate progression. Jaccard drops it to 0.375, so genuine "flash → updated-with-details" alerts survive.
- **Runs last** (after exact-headline + same-URL), so it never shadows a higher-precision reason.
- **Inert without a reference time** (`now=None`) — 2-arg legacy callers are byte-for-byte unchanged.
- **Fails open** on an unparseable per-record `delivered_at` (deliver, don't suppress); whole-file JSON corruption still fails closed.
- New reason code: `duplicate_cross_source_similar_headline`.

Thresholds (`CROSS_SOURCE_JACCARD_THRESHOLD=0.5`, `CROSS_SOURCE_MIN_OVERLAP=4`, `CROSS_SOURCE_WINDOW_DAYS=14`) are **calibrated against the real ledger** and live in-script → **no workflow change** (the `filter` invocation is untouched).

## Calibration & validation (evidence)

- Labeled every cross-URL pair in the recent ledger by hand: genuine re-reports cluster at Jaccard ≥ 0.5 with ≥ 7 shared tokens; append-a-fact and short-subset headlines fall well below. All real append-fact traps had overlap = 3 → `min-overlap 4` rejects them without touching any real dup.
- **Backtest replaying all 1,488 delivered alerts** through the new logic: **36 (2.4%) were cross-source repeats it would now catch** — including the **Dean Ball hire re-sent 2026-06-20 01:11 UTC** (the duplicate in the report screenshot), the Glasswing/Mythos re-report, Huawei TAU, WWDC Siri, Sarvam raise, Fable-5 pricing. Rate confirms it catches repeats without nuking the feed.
- The one clearly-distinct high-overlap pair (SpaceX *marketing-start* vs *pricing*, Jaccard 0.31) is correctly kept.

## Tests

17/17 pass (9 regression + 8 new): cross-source dup caught; append-fact / short-headline-containment / distinct-milestone progression **kept**; inert-without-`now`; outside-window kept; unparseable-timestamp fail-open; exact-headline still takes priority with `now`; in-batch same-cycle paraphrase suppressed.

## Known residual (documented, not solved)

Token overlap can't separate two genuinely-distinct stories that share heavy boilerplate vocabulary (e.g. two entities running the same templated beat with ≥4 shared tokens) from a true re-report. The conservative threshold keeps these a small minority (none of the clear-cut variety occurred in the calibration ledger). A salient-token guard was considered and rejected for v1 as a brittle maintenance treadmill that doesn't even fix the real same-entity-progression cases; tune the constants instead.

## Out of scope (noted)

`hourly-twitter.yml:175` builds the run timestamp with `date +'... UTC'` (not `date -u`), so the literal "UTC" suffix tracks runner-local time. It's internally consistent (both `now` and history `delivered_at` come from the same step), pre-existing, and doesn't affect this change — flagged for a possible separate one-char fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)