### PR TITLE
Add Twitter account curation manifest

### DIFF
--- a/.github/actions/twitter-fetch/action.yml
+++ b/.github/actions/twitter-fetch/action.yml
@@ -118,52 +118,13 @@ runs:
       run: |
         mkdir -p /tmp/bird
 
-        # ── Unified handle list (superset across all three tiers) ───────
-        # AI Labs & Company accounts. Includes AIatMeta (real Meta AI
-        # account; @MetaAI is largely inactive) and ClaudeDevs (official
-        # Anthropic developer announcements) — added 2026-05-01 in the
-        # claude tier. We keep them on all tiers now that the workflows
-        # are unified.
-        labs="OpenAI AnthropicAI GoogleAI GoogleDeepMind MistralAI MetaAI AIatMeta CohereAI AI21Labs StabilityAI HuggingFace NVIDIAAIDev ClaudeDevs"
-
-        # Hyperscalers — top execs and key insiders. Includes
-        # ilyasut, alexandr_wang, OriolVinyalsML, woj_zaremba (claude-tier
-        # 2026-05-01 additions).
-        hyperscalers="elonmusk sama demishassabis OfficialLoganK alexalbert__ DrJimFan tszzl ilyasut alexandr_wang OriolVinyalsML woj_zaremba"
-
-        # Others — researchers, analysts, specialists, media. Includes
-        # jeremyphoward, soumithchintala, giffmana, arankomatsuzaki,
-        # percyliang, JonathanRoss321, hendrycks (claude-tier 2026-05-01
-        # additions from anchor-following discovery).
-        others="karpathy iruletheworldmo AndrewCurran_ fi56622380 jukan05 vitrupo dejavucoder jiratickets SemiAnalysis_ benthompson theinformation GavinSBaker mark_k ns123abc kimmonismus _akhaliq simonw emollick testingcatalog rasbt skirano jackclarkSF ylecun hardmaru JeffDean AravSrinivas deedydas swyx TheAITimeline levelsio steipete mckaywrigley nutlope rauchg amasad geoffreylitt jxnlco danshipper andreasklinger nikitabier tibo_maker marclou shl dharmesh jeremyphoward soumithchintala giffmana arankomatsuzaki percyliang JonathanRoss321 hendrycks"
-
-        # Build the manifest via Python (avoids jq's multi-line quoting
-        # issues inside YAML literal blocks): 50+ user-tweets ops + 7
-        # keyword searches + news. All ops run in parallel inside one Go
-        # process via birdy multi-fetch.
-        export HANDLES="$labs $hyperscalers $others"
-        export FETCH_CONCURRENCY
-        python3 -c '
-        import json, os
-        handles = os.environ["HANDLES"].split()
-        concurrency = int(os.environ.get("FETCH_CONCURRENCY", "8"))
-        ops = [
-            {"id": h, "args": ["user-tweets", "@" + h, "-n", "20", "--json", "--plain"]}
-            for h in handles if h
-        ] + [
-            {"id": "search-ai",         "args": ["search", "AI announcement OR new model release OR GPT OR Claude OR Gemini OR Llama", "-n", "50", "--json", "--plain"]},
-            {"id": "search-extra",      "args": ["search", "AI breakthrough OR AI launch OR AI update OR foundation model", "-n", "30", "--json", "--plain"]},
-            {"id": "search-research",   "args": ["search", "AI paper OR machine learning research OR new benchmark OR state of the art SOTA", "-n", "30", "--json", "--plain"]},
-            {"id": "search-infra",      "args": ["search", "AI chip OR GPU cluster OR AI infrastructure OR NVIDIA H100 OR TPU", "-n", "20", "--json", "--plain"]},
-            {"id": "search-policy",     "args": ["search", "AI regulation OR AI safety OR AI policy OR AI governance OR AI alignment", "-n", "20", "--json", "--plain"]},
-            {"id": "search-business",   "args": ["search", "AI startup funding OR AI acquisition OR AI valuation OR AI partnership", "-n", "20", "--json", "--plain"]},
-            {"id": "search-opensource", "args": ["search", "open source AI OR open weights OR AI API OR AI developer tools", "-n", "20", "--json", "--plain"]},
-            {"id": "news",              "args": ["news", "--ai-only", "-n", "40", "--json", "--plain"]},
-        ]
-        with open("/tmp/manifest.json", "w") as f:
-            json.dump({"operations": ops, "concurrency": concurrency}, f)
-        print(f"Built manifest: {len(ops)} ops, concurrency={concurrency}")
-        '
+        # Account and search curation lives in data/sources/twitter_accounts.json.
+        # Keep the scheduled fetch deterministic: validate the reviewed source
+        # manifest and compile it to birdy's multi-fetch contract for this run.
+        python3 scripts/curate_twitter_accounts.py build-fetch-manifest \
+          --manifest data/sources/twitter_accounts.json \
+          --output /tmp/manifest.json \
+          --concurrency "$FETCH_CONCURRENCY"
 
         echo "Manifest: $(jq '.operations | length' /tmp/manifest.json) ops, concurrency=$(jq '.concurrency' /tmp/manifest.json)"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,14 @@ on:
       - '.github/workflows/**'
       - '.github/actions/**'
       - 'dashboard/**'
+      - 'data/sources/twitter_accounts.json'
       - 'scripts/**'
   pull_request:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
       - 'dashboard/**'
+      - 'data/sources/twitter_accounts.json'
       - 'scripts/**'
   workflow_dispatch:
 

--- a/.github/workflows/twitter-account-explorer.yml
+++ b/.github/workflows/twitter-account-explorer.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
-            --model opus --allowedTools "Read,Write,Edit,Bash(git:*),Bash(gh:*),Bash(uv:*),Bash(python:*),Bash(python3:*),Bash(bird:*),Bash(jq:*),Bash(cat:*)"
+            --model opus --allowedTools "Read,Write,Edit,Bash(git checkout:*),Bash(git status:*),Bash(git diff:*),Bash(git add:*),Bash(git commit:*),Bash(uv:*),Bash(python:*),Bash(python3:*),Bash(bird:*),Bash(jq:*),Bash(cat:*)"
           prompt: |
             You are the ARA Twitter account explorer agent.
 
@@ -120,20 +120,42 @@ jobs:
                - Commit only:
                  data/sources/twitter_accounts.json
                  docs/archive/${{ steps.dates.outputs.today }}-twitter-account-explorer.md
-               - Push the branch and open a PR against main titled:
-                 `Twitter account explorer - ${{ steps.dates.outputs.today }}`
+               - Write `/tmp/twitter-account-explorer-pr-body.md` with the PR
+                 body described below. Do not push or call `gh`; the workflow
+                 publishes the branch and PR after your step.
 
             PR body must include:
             - Added accounts with evidence URLs and why they improve coverage.
             - Removed accounts with evidence and why removal is safe.
             - Validation commands run.
 
-      - name: Push changes if agent created branch
+      - name: Publish PR if agent created branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
           CURRENT_BRANCH=$(git branch --show-current)
           if [ -n "$CURRENT_BRANCH" ] && [ "$CURRENT_BRANCH" != "main" ]; then
             git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
             git push -u origin "$CURRENT_BRANCH"
+            BODY_PATH="/tmp/twitter-account-explorer-pr-body.md"
+            if [ ! -s "$BODY_PATH" ]; then
+              BODY_PATH="docs/archive/${{ steps.dates.outputs.today }}-twitter-account-explorer.md"
+            fi
+            if [ ! -s "$BODY_PATH" ]; then
+              BODY_PATH="/tmp/twitter-account-explorer-pr-body.md"
+              cat > "$BODY_PATH" <<'EOF'
+          Automated Twitter account explorer update.
+
+          See the branch diff for the proposed account manifest changes.
+          EOF
+            fi
+            EXISTING_COUNT=$(gh pr list --head "$CURRENT_BRANCH" --state open --json number --jq 'length')
+            if [ "$EXISTING_COUNT" -eq 0 ]; then
+              gh pr create \
+                --base main \
+                --head "$CURRENT_BRANCH" \
+                --title "Twitter account explorer - ${{ steps.dates.outputs.today }}" \
+                --body-file "$BODY_PATH"
+            fi
           fi

--- a/.github/workflows/twitter-account-explorer.yml
+++ b/.github/workflows/twitter-account-explorer.yml
@@ -1,0 +1,136 @@
+name: Twitter Account Explorer
+
+on:
+  schedule:
+    # Weekly scout for new high-signal AI Twitter/X accounts.
+    - cron: '47 1 * * 2'
+  workflow_dispatch:
+
+concurrency:
+  group: twitter-account-explorer
+  cancel-in-progress: false
+
+jobs:
+  explore:
+    runs-on: [self-hosted, Linux]
+    timeout-minutes: 45
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Get dates
+        id: dates
+        run: |
+          {
+            echo "today=$(date +'%Y-%m-%d')"
+            echo "branch=twitter-account-explorer/$(date +'%Y-%m-%d')"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install Python dependencies
+        run: uv sync --frozen
+
+      - name: Install bird CLI
+        run: npm install -g @steipete/bird@0.8.0
+
+      - name: Generate seed account candidates
+        env:
+          AUTH_TOKEN: ${{ secrets.BIRD_AUTH_TOKEN }}
+          CT0: ${{ secrets.BIRD_CT0 }}
+        run: |
+          set -euo pipefail
+          uv run python scripts/explore_twitter_accounts.py \
+            --output /tmp/twitter-account-candidates.json \
+            --report /tmp/twitter-account-explorer-report.md \
+            --max-candidates 30
+          cat /tmp/twitter-account-explorer-report.md
+
+      - name: Configure authenticated git remote
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+
+      - name: Explore and curate account list
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AUTH_TOKEN: ${{ secrets.BIRD_AUTH_TOKEN }}
+          CT0: ${{ secrets.BIRD_CT0 }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --model opus --allowedTools "Read,Write,Edit,Bash(git:*),Bash(gh:*),Bash(uv:*),Bash(python:*),Bash(python3:*),Bash(bird:*),Bash(jq:*),Bash(cat:*)"
+          prompt: |
+            You are the ARA Twitter account explorer agent.
+
+            Reason from first principles. Stress-test these premises before
+            acting:
+            1. A scheduled explorer should improve source coverage only when
+               there is concrete evidence, not because novelty is attractive.
+            2. The production account manifest should change through a PR, not
+               by direct pushes to main.
+            3. Removal is riskier than addition; remove an account only with
+               clear observed evidence that it is stale, off-topic, or low-value.
+
+            Inputs:
+            - Current manifest: data/sources/twitter_accounts.json
+            - Seed candidates: /tmp/twitter-account-candidates.json
+            - Seed report: /tmp/twitter-account-explorer-report.md
+            - Curation contract: docs/twitter-account-curation.md
+            - Recent Twitter output: research/twitter/*.md and research/summaries/*twitter*summary.txt
+
+            Task:
+            1. Read the manifest, curation docs, seed candidates, and seed report.
+            2. Inspect recent Twitter outputs for coverage gaps or noisy monitored accounts.
+            3. Optionally issue up to 10 follow-up `bird` calls with `--json --plain`
+               to verify candidate accounts or suspected stale accounts.
+            4. If there are no strong changes, print exactly `no account changes`
+               and stop without creating a branch.
+            5. If changes are justified:
+               - Create branch `${{ steps.dates.outputs.branch }}`.
+               - Write a candidate JSON file under /tmp with proposed additions
+                 and/or removals. Cap at 5 additions and 2 removals per run.
+               - Run:
+                 `uv run python scripts/curate_twitter_accounts.py propose --candidates <file> --output docs/archive/${{ steps.dates.outputs.today }}-twitter-account-explorer.md --changes-output /tmp/twitter-account-changes.json --min-score 3`
+               - Review the generated proposal. Apply only justified changes:
+                 `uv run python scripts/curate_twitter_accounts.py apply --changes /tmp/twitter-account-changes.json`
+               - Run:
+                 `uv run python scripts/curate_twitter_accounts.py validate`
+                 `uv run python -m unittest scripts/test_curate_twitter_accounts.py scripts/test_explore_twitter_accounts.py`
+               - Commit only:
+                 data/sources/twitter_accounts.json
+                 docs/archive/${{ steps.dates.outputs.today }}-twitter-account-explorer.md
+               - Push the branch and open a PR against main titled:
+                 `Twitter account explorer - ${{ steps.dates.outputs.today }}`
+
+            PR body must include:
+            - Added accounts with evidence URLs and why they improve coverage.
+            - Removed accounts with evidence and why removal is safe.
+            - Validation commands run.
+
+      - name: Push changes if agent created branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CURRENT_BRANCH=$(git branch --show-current)
+          if [ -n "$CURRENT_BRANCH" ] && [ "$CURRENT_BRANCH" != "main" ]; then
+            git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+            git push -u origin "$CURRENT_BRANCH"
+          fi

--- a/.github/workflows/twitter-account-explorer.yml
+++ b/.github/workflows/twitter-account-explorer.yml
@@ -99,6 +99,9 @@ jobs:
             Task:
             1. Read the manifest, curation docs, seed candidates, and seed report.
             2. Inspect recent Twitter outputs for coverage gaps or noisy monitored accounts.
+               Prefer mention-graph evidence when available: goodtweet's account
+               discovery work found repeated cross-account mentions more reliable
+               than keyword search alone.
             3. Optionally issue up to 10 follow-up `bird` calls with `--json --plain`
                to verify candidate accounts or suspected stale accounts.
             4. If there are no strong changes, print exactly `no account changes`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ and opens a PR with methodology fixes.
 | `research_search.py` | Specialized search wrappers for primary-source research. |
 | `stock_prices.py` | Yahoo Finance time series → copy-paste lines for `:::line-chart`. |
 | `dedupe_headline_alerts.py` | Filter + record delivered Twitter headline alerts (used by `hourly-twitter.yml`). |
+| `curate_twitter_accounts.py` | Validates `data/sources/twitter_accounts.json`, builds the birdy fetch manifest, and writes/apply reviewable Twitter account add/remove proposals. |
 | `check_model_tickets.py` | Validator for `research/models/tickets/*.md` against the schema in `docs/model-tickets.md`. The CRUD agent in `24h-model-timeline.yml` runs it after every pass; CI runs it on every PR. |
 | `check_wiki.py` | Validator for `research/wiki/` pages against the schema in `docs/wiki-schema.md`. `uv run python scripts/check_wiki.py` (exit 0 = safe); `--lint` adds advisory checks. The ingest agent in `wiki-ingest.yml` runs it until exit 0; CI runs it on every PR. |
 | `wiki_search.py` | Search wrapper over `research/wiki/` (`uv run python scripts/wiki_search.py "<query>"`). The ingest agent runs it before writing any page so it UPDATEs an existing page instead of duplicating. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ and opens a PR with methodology fixes.
 | `stock_prices.py` | Yahoo Finance time series → copy-paste lines for `:::line-chart`. |
 | `dedupe_headline_alerts.py` | Filter + record delivered Twitter headline alerts (used by `hourly-twitter.yml`). |
 | `curate_twitter_accounts.py` | Validates `data/sources/twitter_accounts.json`, builds the birdy fetch manifest, and writes/apply reviewable Twitter account add/remove proposals. |
+| `explore_twitter_accounts.py` | Scout script for `twitter-account-explorer.yml`; runs broad bird searches, scores unknown authors, and emits candidate JSON for reviewed account curation. |
 | `check_model_tickets.py` | Validator for `research/models/tickets/*.md` against the schema in `docs/model-tickets.md`. The CRUD agent in `24h-model-timeline.yml` runs it after every pass; CI runs it on every PR. |
 | `check_wiki.py` | Validator for `research/wiki/` pages against the schema in `docs/wiki-schema.md`. `uv run python scripts/check_wiki.py` (exit 0 = safe); `--lint` adds advisory checks. The ingest agent in `wiki-ingest.yml` runs it until exit 0; CI runs it on every PR. |
 | `wiki_search.py` | Search wrapper over `research/wiki/` (`uv run python scripts/wiki_search.py "<query>"`). The ingest agent runs it before writing any page so it UPDATEs an existing page instead of duplicating. |
@@ -123,6 +124,7 @@ input).
 | `daily-ai-blogs.yml` | `:13` every 6h | `research/blogs/` |
 | `daily-youtube.yml` | daily `23:20` for the next `00:00` digest | `research/youtube/` (tuber discovery + read-only summary/transcript evidence) |
 | `hourly-twitter.yml` | every 3h `:07`; DeepSeek/Fireworks comparison lanes via matrix/manual dispatch | `research/twitter/` + `research/summaries/` + Telegram headline alerts; comparison outputs under `research/twitter-deepseek/`, `research/twitter-deepseek-pi/`, and `research/twitter-fireworks-pi/` |
+| `twitter-account-explorer.yml` | weekly Tuesday `01:47` UTC + manual dispatch | Opens reviewed PRs for `data/sources/twitter_accounts.json` changes when high-signal account evidence exists |
 | `2h-bluesky.yml` | daily `10:11` | `research/bluesky/` (supplemental expert commentary, capped output) |
 | `4h-community.yml` | every 4h `:19` | `research/community/*-hn.md`, `*-reddit.md` |
 | `daily-arxiv.yml` | daily `06:13` | `research/arxiv/` |

--- a/README.md
+++ b/README.md
@@ -297,7 +297,9 @@ Via [bird CLI](https://github.com/steipete/bird) and birdy multi-fetch. The
 reviewed source manifest is `data/sources/twitter_accounts.json`: 75 monitored
 accounts, 20 tweets each, 7 search queries, and the AI-only news tab. Account
 add/remove proposals are generated with `scripts/curate_twitter_accounts.py`;
-see `docs/twitter-account-curation.md`.
+see `docs/twitter-account-curation.md`. A weekly `twitter-account-explorer.yml`
+agent scouts for high-signal additions and opens reviewed PRs when evidence is
+strong enough.
 
 **Account groups:** AI labs/company accounts; hyperscalers, executives, and key
 insiders; researchers, analysts, builders, and media.

--- a/README.md
+++ b/README.md
@@ -293,18 +293,18 @@ dashboard/                          # Vite + Bun + TypeScript SPA
 ## Data Source Details
 
 ### Twitter/X (Every 3 hours)
-Via [bird CLI](https://github.com/steipete/bird) — 75 monitored accounts, 20 tweets each, 7 search queries.
+Via [bird CLI](https://github.com/steipete/bird) and birdy multi-fetch. The
+reviewed source manifest is `data/sources/twitter_accounts.json`: 75 monitored
+accounts, 20 tweets each, 7 search queries, and the AI-only news tab. Account
+add/remove proposals are generated with `scripts/curate_twitter_accounts.py`;
+see `docs/twitter-account-curation.md`.
 
-**AI Labs & Companies (11):**
-OpenAI, Anthropic, Google AI, DeepMind, Mistral, Meta AI, Cohere, AI21Labs, Stability AI, Hugging Face, NVIDIA AI Dev
+**Account groups:** AI labs/company accounts; hyperscalers, executives, and key
+insiders; researchers, analysts, builders, and media.
 
-**Hyperscalers (7):**
-Elon Musk, Sam Altman, Demis Hassabis, Logan (Google AI), Alex Albert (Anthropic), Jim Fan (NVIDIA), Roon (OpenAI)
-
-**Researchers, Analysts & Media (15):**
-Karpathy, strawberry, Curran, fin (China AI), Jukan (semiconductors), Vitrupo, sankalp, JT, Semi Analysis, Ben Thompson, The Information, Gavin Baker, Mark, NIK, Chubby
-
-**Search queries:** AI models & products, breakthroughs, research papers, infrastructure & hardware, policy & safety, business & funding, open source & dev tools
+**Search queries:** AI models & products, breakthroughs, research papers,
+infrastructure & hardware, policy & safety, business & funding, open source &
+dev tools
 
 ### RSS Feeds (Hourly)
 Official announcements from:

--- a/data/sources/twitter_accounts.json
+++ b/data/sources/twitter_accounts.json
@@ -1,0 +1,141 @@
+{
+  "version": 1,
+  "tweets_per_account": 20,
+  "categories": [
+    {
+      "id": "labs",
+      "label": "AI labs and company accounts",
+      "handles": [
+        {"handle": "OpenAI", "name": "OpenAI"},
+        {"handle": "AnthropicAI", "name": "Anthropic"},
+        {"handle": "GoogleAI", "name": "Google AI"},
+        {"handle": "GoogleDeepMind", "name": "Google DeepMind"},
+        {"handle": "MistralAI", "name": "Mistral AI"},
+        {"handle": "MetaAI", "name": "Meta AI"},
+        {"handle": "AIatMeta", "name": "AI at Meta", "notes": "Real Meta AI account; @MetaAI is largely inactive."},
+        {"handle": "CohereAI", "name": "Cohere"},
+        {"handle": "AI21Labs", "name": "AI21 Labs"},
+        {"handle": "StabilityAI", "name": "Stability AI"},
+        {"handle": "HuggingFace", "name": "Hugging Face"},
+        {"handle": "NVIDIAAIDev", "name": "NVIDIA AI Developer"},
+        {"handle": "ClaudeDevs", "name": "Claude Developers", "notes": "Official Anthropic developer announcements."}
+      ]
+    },
+    {
+      "id": "hyperscalers",
+      "label": "Hyperscalers, executives, and key insiders",
+      "handles": [
+        {"handle": "elonmusk", "name": "Elon Musk"},
+        {"handle": "sama", "name": "Sam Altman"},
+        {"handle": "demishassabis", "name": "Demis Hassabis"},
+        {"handle": "OfficialLoganK", "name": "Logan Kilpatrick"},
+        {"handle": "alexalbert__", "name": "Alex Albert"},
+        {"handle": "DrJimFan", "name": "Jim Fan"},
+        {"handle": "tszzl", "name": "Roon"},
+        {"handle": "ilyasut", "name": "Ilya Sutskever"},
+        {"handle": "alexandr_wang", "name": "Alexandr Wang"},
+        {"handle": "OriolVinyalsML", "name": "Oriol Vinyals"},
+        {"handle": "woj_zaremba", "name": "Wojciech Zaremba"}
+      ]
+    },
+    {
+      "id": "others",
+      "label": "Researchers, analysts, builders, and media",
+      "handles": [
+        {"handle": "karpathy", "name": "Andrej Karpathy"},
+        {"handle": "iruletheworldmo", "name": "Strawberry"},
+        {"handle": "AndrewCurran_", "name": "Andrew Curran"},
+        {"handle": "fi56622380", "name": "Fin"},
+        {"handle": "jukan05", "name": "Jukan"},
+        {"handle": "vitrupo", "name": "Vitrupo"},
+        {"handle": "dejavucoder", "name": "Deja Vu Coder"},
+        {"handle": "jiratickets", "name": "Jira Tickets"},
+        {"handle": "SemiAnalysis_", "name": "SemiAnalysis"},
+        {"handle": "benthompson", "name": "Ben Thompson"},
+        {"handle": "theinformation", "name": "The Information"},
+        {"handle": "GavinSBaker", "name": "Gavin Baker"},
+        {"handle": "mark_k", "name": "Mark"},
+        {"handle": "ns123abc", "name": "NIK"},
+        {"handle": "kimmonismus", "name": "Chubby"},
+        {"handle": "_akhaliq", "name": "AK"},
+        {"handle": "simonw", "name": "Simon Willison"},
+        {"handle": "emollick", "name": "Ethan Mollick"},
+        {"handle": "testingcatalog", "name": "TestingCatalog"},
+        {"handle": "rasbt", "name": "Sebastian Raschka"},
+        {"handle": "skirano", "name": "Sriram Krishnan"},
+        {"handle": "jackclarkSF", "name": "Jack Clark"},
+        {"handle": "ylecun", "name": "Yann LeCun"},
+        {"handle": "hardmaru", "name": "David Ha"},
+        {"handle": "JeffDean", "name": "Jeff Dean"},
+        {"handle": "AravSrinivas", "name": "Aravind Srinivas"},
+        {"handle": "deedydas", "name": "Deedy Das"},
+        {"handle": "swyx", "name": "Swyx"},
+        {"handle": "TheAITimeline", "name": "The AI Timeline"},
+        {"handle": "levelsio", "name": "Pieter Levels"},
+        {"handle": "steipete", "name": "Peter Steinberger"},
+        {"handle": "mckaywrigley", "name": "McKay Wrigley"},
+        {"handle": "nutlope", "name": "Nutlope"},
+        {"handle": "rauchg", "name": "Guillermo Rauch"},
+        {"handle": "amasad", "name": "Amjad Masad"},
+        {"handle": "geoffreylitt", "name": "Geoffrey Litt"},
+        {"handle": "jxnlco", "name": "Jason Liu"},
+        {"handle": "danshipper", "name": "Dan Shipper"},
+        {"handle": "andreasklinger", "name": "Andreas Klinger"},
+        {"handle": "nikitabier", "name": "Nikita Bier"},
+        {"handle": "tibo_maker", "name": "Tibo"},
+        {"handle": "marclou", "name": "Marc Lou"},
+        {"handle": "shl", "name": "Suhail"},
+        {"handle": "dharmesh", "name": "Dharmesh Shah"},
+        {"handle": "jeremyphoward", "name": "Jeremy Howard"},
+        {"handle": "soumithchintala", "name": "Soumith Chintala"},
+        {"handle": "giffmana", "name": "David Giffman"},
+        {"handle": "arankomatsuzaki", "name": "Aran Komatsuzaki"},
+        {"handle": "percyliang", "name": "Percy Liang"},
+        {"handle": "JonathanRoss321", "name": "Jonathan Ross"},
+        {"handle": "hendrycks", "name": "Dan Hendrycks"}
+      ]
+    }
+  ],
+  "searches": [
+    {
+      "id": "search-ai",
+      "query": "AI announcement OR new model release OR GPT OR Claude OR Gemini OR Llama",
+      "limit": 50
+    },
+    {
+      "id": "search-extra",
+      "query": "AI breakthrough OR AI launch OR AI update OR foundation model",
+      "limit": 30
+    },
+    {
+      "id": "search-research",
+      "query": "AI paper OR machine learning research OR new benchmark OR state of the art SOTA",
+      "limit": 30
+    },
+    {
+      "id": "search-infra",
+      "query": "AI chip OR GPU cluster OR AI infrastructure OR NVIDIA H100 OR TPU",
+      "limit": 20
+    },
+    {
+      "id": "search-policy",
+      "query": "AI regulation OR AI safety OR AI policy OR AI governance OR AI alignment",
+      "limit": 20
+    },
+    {
+      "id": "search-business",
+      "query": "AI startup funding OR AI acquisition OR AI valuation OR AI partnership",
+      "limit": 20
+    },
+    {
+      "id": "search-opensource",
+      "query": "open source AI OR open weights OR AI API OR AI developer tools",
+      "limit": 20
+    }
+  ],
+  "news": {
+    "id": "news",
+    "limit": 40,
+    "ai_only": true
+  }
+}

--- a/docs/twitter-account-curation.md
+++ b/docs/twitter-account-curation.md
@@ -55,3 +55,21 @@ uv run python scripts/curate_twitter_accounts.py apply \
 The proposal step never mutates production state. The apply step preserves
 category order, appends additions to their target category, removes matching
 handles case-insensitively, and re-validates before writing.
+
+## Explorer Loop
+
+`.github/workflows/twitter-account-explorer.yml` runs weekly and by manual
+dispatch. It is an agent loop, but it is intentionally review-gated:
+
+1. `scripts/explore_twitter_accounts.py` runs broad bird searches and writes
+   `/tmp/twitter-account-candidates.json` plus a Markdown evidence report.
+2. A Claude explorer reads those candidates, the current manifest, recent
+   Twitter outputs, and this curation contract.
+3. If no strong evidence exists, it prints `no account changes`.
+4. If evidence supports changes, it uses `curate_twitter_accounts.py propose`
+   and `apply`, validates the manifest, runs focused tests, then opens a PR
+   against `main`.
+
+The loop caps each run at five additions and two removals. Removals require
+clear observed evidence because losing a quiet but important source is costlier
+than adding a marginal candidate.

--- a/docs/twitter-account-curation.md
+++ b/docs/twitter-account-curation.md
@@ -63,6 +63,9 @@ dispatch. It is an agent loop, but it is intentionally review-gated:
 
 1. `scripts/explore_twitter_accounts.py` runs broad bird searches and writes
    `/tmp/twitter-account-candidates.json` plus a Markdown evidence report.
+   It uses the `goodtweet` lesson that mention-graph traversal is often higher
+   signal than keyword search: unknown handles mentioned by multiple
+   search-surfaced accounts are scored as candidates too.
 2. A Claude explorer reads those candidates, the current manifest, recent
    Twitter outputs, and this curation contract.
 3. If no strong evidence exists, it prints `no account changes`.

--- a/docs/twitter-account-curation.md
+++ b/docs/twitter-account-curation.md
@@ -1,0 +1,57 @@
+# Twitter Account Curation
+
+The production Twitter/X monitor reads accounts and search queries from
+`data/sources/twitter_accounts.json`. The scheduled workflow should stay
+deterministic: every run validates the manifest, builds a birdy multi-fetch
+manifest, and fetches the exact reviewed account set.
+
+Use `scripts/curate_twitter_accounts.py` for account changes:
+
+```bash
+uv run python scripts/curate_twitter_accounts.py validate
+uv run python scripts/curate_twitter_accounts.py build-fetch-manifest \
+  --output /tmp/manifest.json \
+  --concurrency 8
+```
+
+To review candidates discovered by an agent or by manual research, put them in a
+JSON file:
+
+```json
+[
+  {
+    "action": "add",
+    "handle": "example_ai",
+    "category": "others",
+    "score": 4,
+    "reason": "Repeatedly surfaced primary AI launch details before search lanes.",
+    "evidence": ["https://x.com/example_ai/status/123"]
+  },
+  {
+    "action": "remove",
+    "handle": "old_handle",
+    "reason": "No AI-relevant posts in recent monitored snapshots.",
+    "evidence": ["research/twitter/2026-06-17.md"]
+  }
+]
+```
+
+Generate a reviewable proposal:
+
+```bash
+uv run python scripts/curate_twitter_accounts.py propose \
+  --candidates /tmp/twitter-account-candidates.json \
+  --output /tmp/twitter-account-proposal.md \
+  --changes-output /tmp/twitter-account-changes.json
+```
+
+After review, apply the approved changes file:
+
+```bash
+uv run python scripts/curate_twitter_accounts.py apply \
+  --changes /tmp/twitter-account-changes.json
+```
+
+The proposal step never mutates production state. The apply step preserves
+category order, appends additions to their target category, removes matching
+handles case-insensitively, and re-validates before writing.

--- a/scripts/curate_twitter_accounts.py
+++ b/scripts/curate_twitter_accounts.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+"""Validate and curate the Twitter/X account manifest used by hourly fetches."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_MANIFEST = REPO_ROOT / "data" / "sources" / "twitter_accounts.json"
+HANDLE_RE = re.compile(r"^[A-Za-z0-9_]{1,15}$")
+SEARCH_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+
+
+class ManifestError(ValueError):
+    pass
+
+
+def _load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ManifestError(f"missing file: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ManifestError(f"{path}: invalid JSON: {exc}") from exc
+
+
+def _write_json_atomic(path: Path, obj: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(obj, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def normalize_handle(handle: str) -> str:
+    value = str(handle or "").strip().lstrip("@")
+    if not HANDLE_RE.fullmatch(value):
+        raise ManifestError(f"invalid X/Twitter handle: {handle!r}")
+    return value
+
+
+def validate_manifest(manifest: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(manifest, dict):
+        raise ManifestError("manifest must be a JSON object")
+    if manifest.get("version") != 1:
+        raise ManifestError("manifest version must be 1")
+
+    tweets_per_account = manifest.get("tweets_per_account")
+    if not isinstance(tweets_per_account, int) or tweets_per_account <= 0:
+        raise ManifestError("tweets_per_account must be a positive integer")
+
+    categories = manifest.get("categories")
+    if not isinstance(categories, list) or not categories:
+        raise ManifestError("categories must be a non-empty list")
+
+    category_ids: set[str] = set()
+    seen_handles: dict[str, str] = {}
+    total_handles = 0
+    for category in categories:
+        if not isinstance(category, dict):
+            raise ManifestError("each category must be an object")
+        category_id = category.get("id")
+        if not isinstance(category_id, str) or not SEARCH_ID_RE.fullmatch(category_id):
+            raise ManifestError(f"invalid category id: {category_id!r}")
+        if category_id in category_ids:
+            raise ManifestError(f"duplicate category id: {category_id}")
+        category_ids.add(category_id)
+        if not isinstance(category.get("label"), str) or not category["label"].strip():
+            raise ManifestError(f"category {category_id} must have a label")
+        handles = category.get("handles")
+        if not isinstance(handles, list):
+            raise ManifestError(f"category {category_id} handles must be a list")
+        for entry in handles:
+            if isinstance(entry, str):
+                handle = normalize_handle(entry)
+            elif isinstance(entry, dict):
+                handle = normalize_handle(entry.get("handle", ""))
+                if "name" in entry and not isinstance(entry["name"], str):
+                    raise ManifestError(f"@{handle} name must be a string")
+                if "notes" in entry and not isinstance(entry["notes"], str):
+                    raise ManifestError(f"@{handle} notes must be a string")
+            else:
+                raise ManifestError(f"invalid handle entry in {category_id}: {entry!r}")
+            key = handle.lower()
+            if key in seen_handles:
+                raise ManifestError(f"duplicate handle @{handle} in {category_id}; first seen in {seen_handles[key]}")
+            seen_handles[key] = category_id
+            total_handles += 1
+
+    searches = manifest.get("searches")
+    if not isinstance(searches, list):
+        raise ManifestError("searches must be a list")
+    seen_searches: set[str] = set()
+    for search in searches:
+        if not isinstance(search, dict):
+            raise ManifestError("each search must be an object")
+        search_id = search.get("id")
+        if not isinstance(search_id, str) or not SEARCH_ID_RE.fullmatch(search_id):
+            raise ManifestError(f"invalid search id: {search_id!r}")
+        if search_id in seen_searches:
+            raise ManifestError(f"duplicate search id: {search_id}")
+        seen_searches.add(search_id)
+        if not isinstance(search.get("query"), str) or not search["query"].strip():
+            raise ManifestError(f"search {search_id} must have a query")
+        if not isinstance(search.get("limit"), int) or search["limit"] <= 0:
+            raise ManifestError(f"search {search_id} limit must be a positive integer")
+
+    news = manifest.get("news")
+    if not isinstance(news, dict):
+        raise ManifestError("news must be an object")
+    news_id = news.get("id")
+    if not isinstance(news_id, str) or not SEARCH_ID_RE.fullmatch(news_id):
+        raise ManifestError(f"invalid news id: {news_id!r}")
+    if not isinstance(news.get("limit"), int) or news["limit"] <= 0:
+        raise ManifestError("news limit must be a positive integer")
+
+    return {
+        "categories": len(categories),
+        "handles": total_handles,
+        "searches": len(searches),
+        "news_id": news_id,
+        "tweets_per_account": tweets_per_account,
+    }
+
+
+def iter_handle_entries(manifest: dict[str, Any]):
+    for category in manifest["categories"]:
+        for entry in category["handles"]:
+            if isinstance(entry, str):
+                yield category["id"], {"handle": entry}
+            else:
+                yield category["id"], entry
+
+
+def build_fetch_manifest(manifest: dict[str, Any], concurrency: int) -> dict[str, Any]:
+    stats = validate_manifest(manifest)
+    ops = []
+    for _category_id, entry in iter_handle_entries(manifest):
+        handle = normalize_handle(entry["handle"])
+        ops.append(
+            {
+                "id": handle,
+                "args": [
+                    "user-tweets",
+                    f"@{handle}",
+                    "-n",
+                    str(stats["tweets_per_account"]),
+                    "--json",
+                    "--plain",
+                ],
+            }
+        )
+    for search in manifest["searches"]:
+        ops.append(
+            {
+                "id": search["id"],
+                "args": ["search", search["query"], "-n", str(search["limit"]), "--json", "--plain"],
+            }
+        )
+    news = manifest["news"]
+    news_args = ["news"]
+    if news.get("ai_only", True):
+        news_args.append("--ai-only")
+    news_args.extend(["-n", str(news["limit"]), "--json", "--plain"])
+    ops.append({"id": news["id"], "args": news_args})
+    return {"operations": ops, "concurrency": concurrency}
+
+
+def _read_candidates(path: Path) -> list[dict[str, Any]]:
+    raw = _load_json(path)
+    if isinstance(raw, dict) and isinstance(raw.get("candidates"), list):
+        raw = raw["candidates"]
+    if not isinstance(raw, list):
+        raise ManifestError("candidate file must be a list or an object with a candidates list")
+    candidates = []
+    for index, item in enumerate(raw, 1):
+        if not isinstance(item, dict):
+            raise ManifestError(f"candidate {index} must be an object")
+        handle = normalize_handle(item.get("handle", ""))
+        action = str(item.get("action", "add")).strip().lower()
+        if action not in {"add", "remove"}:
+            raise ManifestError(f"candidate @{handle} has invalid action {action!r}")
+        evidence = item.get("evidence", [])
+        if isinstance(evidence, str):
+            evidence = [evidence]
+        if not isinstance(evidence, list) or not all(isinstance(v, str) and v.strip() for v in evidence):
+            raise ManifestError(f"candidate @{handle} evidence must be a string or list of strings")
+        category = item.get("category")
+        if category is not None and (not isinstance(category, str) or not SEARCH_ID_RE.fullmatch(category)):
+            raise ManifestError(f"candidate @{handle} has invalid category {category!r}")
+        score = item.get("score", 1)
+        if not isinstance(score, (int, float)):
+            raise ManifestError(f"candidate @{handle} score must be numeric")
+        candidates.append(
+            {
+                "action": action,
+                "handle": handle,
+                "category": category,
+                "score": score,
+                "reason": str(item.get("reason", "")).strip(),
+                "evidence": [v.strip() for v in evidence],
+            }
+        )
+    return candidates
+
+
+def _handle_index(manifest: dict[str, Any]) -> dict[str, str]:
+    return {entry["handle"].lower(): category_id for category_id, entry in iter_handle_entries(manifest)}
+
+
+def propose_changes(
+    manifest: dict[str, Any],
+    candidates: list[dict[str, Any]],
+    min_score: float,
+    default_category: str,
+) -> dict[str, Any]:
+    validate_manifest(manifest)
+    categories = {category["id"] for category in manifest["categories"]}
+    if default_category not in categories:
+        raise ManifestError(f"default category {default_category!r} does not exist")
+    current = _handle_index(manifest)
+    additions = []
+    removals = []
+    ignored = []
+    emitted: set[tuple[str, str]] = set()
+
+    for candidate in candidates:
+        handle = normalize_handle(candidate["handle"])
+        candidate = {**candidate, "handle": handle}
+        key = handle.lower()
+        action = candidate["action"]
+        dedupe_key = (action, key)
+        if dedupe_key in emitted:
+            ignored.append({**candidate, "why": "duplicate candidate"})
+            continue
+        emitted.add(dedupe_key)
+
+        if action == "add":
+            if key in current:
+                ignored.append({**candidate, "why": f"already monitored in {current[key]}"})
+                continue
+            if candidate["score"] < min_score:
+                ignored.append({**candidate, "why": f"score below threshold {min_score:g}"})
+                continue
+            category = candidate["category"] or default_category
+            if category not in categories:
+                ignored.append({**candidate, "why": f"unknown category {category!r}"})
+                continue
+            additions.append({**candidate, "category": category})
+        else:
+            if key not in current:
+                ignored.append({**candidate, "why": "not currently monitored"})
+                continue
+            removals.append({**candidate, "category": current[key]})
+
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "manifest": str(DEFAULT_MANIFEST.relative_to(REPO_ROOT)),
+        "additions": additions,
+        "removals": removals,
+        "ignored": ignored,
+    }
+
+
+def write_proposal_markdown(path: Path, changes: dict[str, Any]) -> None:
+    lines = [
+        "# Twitter Account Curation Proposal",
+        "",
+        f"Generated: {changes['generated_at']}",
+        "",
+        "## Proposed Additions",
+        "",
+    ]
+    if changes["additions"]:
+        for item in changes["additions"]:
+            lines.append(f"- `@{item['handle']}` -> `{item['category']}` (score {item['score']})")
+            lines.append(f"  Reason: {item['reason'] or 'No reason supplied.'}")
+            if item["evidence"]:
+                lines.append("  Evidence: " + ", ".join(item["evidence"]))
+    else:
+        lines.append("- None")
+
+    lines.extend(["", "## Proposed Removals", ""])
+    if changes["removals"]:
+        for item in changes["removals"]:
+            lines.append(f"- `@{item['handle']}` from `{item['category']}` (score {item['score']})")
+            lines.append(f"  Reason: {item['reason'] or 'No reason supplied.'}")
+            if item["evidence"]:
+                lines.append("  Evidence: " + ", ".join(item["evidence"]))
+    else:
+        lines.append("- None")
+
+    lines.extend(["", "## Ignored Candidates", ""])
+    if changes["ignored"]:
+        for item in changes["ignored"]:
+            lines.append(f"- `@{item['handle']}` `{item['action']}`: {item['why']}")
+    else:
+        lines.append("- None")
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def apply_changes(manifest: dict[str, Any], changes: dict[str, Any]) -> dict[str, Any]:
+    validate_manifest(manifest)
+    out = deepcopy(manifest)
+    category_by_id = {category["id"]: category for category in out["categories"]}
+
+    remove_keys = {normalize_handle(item["handle"]).lower() for item in changes.get("removals", [])}
+    for category in out["categories"]:
+        category["handles"] = [
+            entry for entry in category["handles"]
+            if normalize_handle(entry if isinstance(entry, str) else entry["handle"]).lower() not in remove_keys
+        ]
+
+    existing = _handle_index(out)
+    for item in changes.get("additions", []):
+        handle = normalize_handle(item["handle"])
+        key = handle.lower()
+        if key in existing:
+            continue
+        category_id = item.get("category")
+        if category_id not in category_by_id:
+            raise ManifestError(f"cannot add @{handle}: category {category_id!r} does not exist")
+        entry = {"handle": handle}
+        if item.get("reason"):
+            entry["notes"] = item["reason"]
+        if item.get("evidence"):
+            entry["evidence"] = item["evidence"]
+        category_by_id[category_id]["handles"].append(entry)
+        existing[key] = category_id
+
+    validate_manifest(out)
+    return out
+
+
+def cmd_validate(args: argparse.Namespace) -> int:
+    manifest = _load_json(args.manifest)
+    stats = validate_manifest(manifest)
+    print(
+        f"OK: {stats['handles']} handles, {stats['searches']} searches, "
+        f"news={stats['news_id']}, tweets_per_account={stats['tweets_per_account']}"
+    )
+    return 0
+
+
+def cmd_build_fetch_manifest(args: argparse.Namespace) -> int:
+    if args.concurrency <= 0:
+        raise ManifestError("--concurrency must be positive")
+    manifest = _load_json(args.manifest)
+    fetch_manifest = build_fetch_manifest(manifest, args.concurrency)
+    _write_json_atomic(args.output, fetch_manifest)
+    print(f"wrote {len(fetch_manifest['operations'])} operations to {args.output}")
+    return 0
+
+
+def cmd_propose(args: argparse.Namespace) -> int:
+    manifest = _load_json(args.manifest)
+    candidates = _read_candidates(args.candidates)
+    changes = propose_changes(manifest, candidates, args.min_score, args.default_category)
+    write_proposal_markdown(args.output, changes)
+    if args.changes_output:
+        _write_json_atomic(args.changes_output, changes)
+    print(
+        f"proposal: {len(changes['additions'])} additions, "
+        f"{len(changes['removals'])} removals, {len(changes['ignored'])} ignored"
+    )
+    return 0
+
+
+def cmd_apply(args: argparse.Namespace) -> int:
+    manifest = _load_json(args.manifest)
+    changes = _load_json(args.changes)
+    updated = apply_changes(manifest, changes)
+    _write_json_atomic(args.manifest, updated)
+    stats = validate_manifest(updated)
+    print(f"updated {args.manifest}: {stats['handles']} handles")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    validate = sub.add_parser("validate", help="validate the Twitter account manifest")
+    validate.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    validate.set_defaults(func=cmd_validate)
+
+    build = sub.add_parser("build-fetch-manifest", help="build a birdy multi-fetch manifest")
+    build.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    build.add_argument("--output", type=Path, required=True)
+    build.add_argument("--concurrency", type=int, default=8)
+    build.set_defaults(func=cmd_build_fetch_manifest)
+
+    propose = sub.add_parser("propose", help="write a reviewable add/remove proposal")
+    propose.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    propose.add_argument("--candidates", type=Path, required=True)
+    propose.add_argument("--output", type=Path, required=True)
+    propose.add_argument("--changes-output", type=Path)
+    propose.add_argument("--min-score", type=float, default=1)
+    propose.add_argument("--default-category", default="others")
+    propose.set_defaults(func=cmd_propose)
+
+    apply = sub.add_parser("apply", help="apply reviewed proposal changes to the manifest")
+    apply.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    apply.add_argument("--changes", type=Path, required=True)
+    apply.set_defaults(func=cmd_apply)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return args.func(args)
+    except ManifestError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/explore_twitter_accounts.py
+++ b/scripts/explore_twitter_accounts.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Discover candidate Twitter/X accounts for the ARA monitor.
+
+This script is intentionally a scout, not a mutator. It gathers candidate
+authors from broad X searches, scores them from observable tweet evidence, and
+writes JSON that `curate_twitter_accounts.py propose` can review.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import shutil
+import subprocess
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from curate_twitter_accounts import DEFAULT_MANIFEST, ManifestError, iter_handle_entries, normalize_handle
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_OUTPUT = Path("/tmp/twitter-account-candidates.json")
+DEFAULT_REPORT = Path("/tmp/twitter-account-explorer-report.md")
+BIRD_CMD = os.environ.get("ARA_BIRD_CMD") or ("birdy" if shutil.which("birdy") else "bird")
+
+DISCOVERY_QUERIES = [
+    '("new model" OR "model release" OR "open weights" OR "AI launch") min_faves:40 -filter:replies lang:en',
+    '(OpenAI OR Anthropic OR Claude OR GPT OR Gemini OR Llama OR Mistral OR DeepSeek) min_faves:40 -filter:replies lang:en',
+    '("AI agent" OR "coding agent" OR "AI infrastructure" OR "inference") min_faves:40 -filter:replies lang:en',
+    '("AI benchmark" OR "machine learning research" OR "state of the art" OR SOTA) min_faves:30 -filter:replies lang:en',
+]
+
+
+def _load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_json_atomic(path: Path, obj: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(obj, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def _extract_json(stdout: str) -> Any:
+    out = stdout.strip()
+    if not out:
+        return []
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError:
+        pass
+    start = out.find("[")
+    end = out.rfind("]")
+    if start != -1 and end > start:
+        try:
+            return json.loads(out[start : end + 1])
+        except json.JSONDecodeError:
+            return []
+    return []
+
+
+def run_bird_search(query: str, limit: int, timeout: int = 120) -> list[dict[str, Any]]:
+    cmd = [BIRD_CMD, "search", query, "-n", str(limit), "--json", "--plain"]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        print(f"warning: {BIRD_CMD} search failed: {exc}", file=sys.stderr)
+        return []
+    if proc.returncode != 0:
+        print(f"warning: {BIRD_CMD} rc={proc.returncode}: {proc.stderr.strip()[:240]}", file=sys.stderr)
+        return []
+    data = _extract_json(proc.stdout)
+    return [item for item in data if isinstance(item, dict)] if isinstance(data, list) else []
+
+
+def current_handles(manifest: dict[str, Any]) -> set[str]:
+    return {normalize_handle(entry["handle"]).lower() for _category_id, entry in iter_handle_entries(manifest)}
+
+
+def _author_username(tweet: dict[str, Any]) -> str | None:
+    author = tweet.get("author")
+    if isinstance(author, dict):
+        username = author.get("username") or author.get("screen_name")
+        if username:
+            return normalize_handle(str(username))
+    for key in ("username", "screen_name", "handle"):
+        if tweet.get(key):
+            return normalize_handle(str(tweet[key]))
+    return None
+
+
+def _tweet_url(tweet: dict[str, Any], handle: str) -> str | None:
+    if isinstance(tweet.get("url"), str) and tweet["url"].startswith(("https://x.com/", "https://twitter.com/")):
+        return tweet["url"]
+    tid = tweet.get("id") or tweet.get("id_str")
+    if tid:
+        return f"https://x.com/{handle}/status/{tid}"
+    return None
+
+
+def _count(tweet: dict[str, Any], key: str) -> int:
+    try:
+        return int(tweet.get(key) or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def candidates_from_tweets(
+    tweets: list[dict[str, Any]],
+    monitored_handles: set[str],
+    *,
+    min_score: float,
+    max_candidates: int,
+) -> list[dict[str, Any]]:
+    by_handle: dict[str, dict[str, Any]] = defaultdict(
+        lambda: {"handle": "", "tweet_count": 0, "likes": 0, "retweets": 0, "replies": 0, "examples": []}
+    )
+
+    for tweet in tweets:
+        try:
+            handle = _author_username(tweet)
+        except ManifestError:
+            continue
+        if not handle or handle.lower() in monitored_handles:
+            continue
+        bucket = by_handle[handle.lower()]
+        bucket["handle"] = handle
+        bucket["tweet_count"] += 1
+        bucket["likes"] += _count(tweet, "likeCount")
+        bucket["retweets"] += _count(tweet, "retweetCount")
+        bucket["replies"] += _count(tweet, "replyCount")
+        url = _tweet_url(tweet, handle)
+        if url and len(bucket["examples"]) < 3:
+            bucket["examples"].append(url)
+
+    candidates = []
+    for bucket in by_handle.values():
+        # First-principles scoring: repeated surfacing matters, but engagement
+        # is logarithmic because one viral post should not dominate the watchlist.
+        engagement = bucket["likes"] + (2 * bucket["retweets"]) + bucket["replies"]
+        score = bucket["tweet_count"] + min(4.0, math.log10(max(engagement, 1)))
+        if score < min_score:
+            continue
+        examples = bucket["examples"]
+        reason = (
+            f"Surfaced {bucket['tweet_count']} time(s) in AI discovery searches "
+            f"with aggregate engagement {engagement}."
+        )
+        candidates.append(
+            {
+                "action": "add",
+                "handle": bucket["handle"],
+                "category": "others",
+                "score": round(score, 2),
+                "reason": reason,
+                "evidence": examples,
+            }
+        )
+
+    candidates.sort(key=lambda item: (-item["score"], item["handle"].lower()))
+    return candidates[:max_candidates]
+
+
+def write_report(path: Path, candidates: list[dict[str, Any]], query_counts: list[tuple[str, int]]) -> None:
+    lines = [
+        "# Twitter Account Explorer Report",
+        "",
+        f"Generated: {datetime.now(timezone.utc).isoformat()}",
+        f"Discovery command: `{BIRD_CMD}`",
+        "",
+        "## Query Coverage",
+        "",
+    ]
+    for query, count in query_counts:
+        lines.append(f"- `{query}` -> {count} tweet(s)")
+    lines.extend(["", "## Candidate Additions", ""])
+    if candidates:
+        for item in candidates:
+            evidence = ", ".join(item["evidence"]) if item["evidence"] else "no URL evidence"
+            lines.append(f"- `@{item['handle']}` score {item['score']}: {item['reason']} Evidence: {evidence}")
+    else:
+        lines.append("- None")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def discover(args: argparse.Namespace) -> int:
+    try:
+        manifest = _load_json(args.manifest)
+        monitored = current_handles(manifest)
+    except (FileNotFoundError, json.JSONDecodeError, ManifestError) as exc:
+        print(f"error: cannot load manifest: {exc}", file=sys.stderr)
+        return 2
+
+    tweets: list[dict[str, Any]] = []
+    query_counts: list[tuple[str, int]] = []
+    for query in args.query:
+        rows = run_bird_search(query, args.per_query)
+        query_counts.append((query, len(rows)))
+        tweets.extend(rows)
+
+    candidates = candidates_from_tweets(
+        tweets,
+        monitored,
+        min_score=args.min_score,
+        max_candidates=args.max_candidates,
+    )
+    _write_json_atomic(args.output, candidates)
+    write_report(args.report, candidates, query_counts)
+    print(f"wrote {len(candidates)} candidate(s) to {args.output}")
+    print(f"wrote report to {args.report}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--report", type=Path, default=DEFAULT_REPORT)
+    parser.add_argument("--query", action="append", default=list(DISCOVERY_QUERIES))
+    parser.add_argument("--per-query", type=int, default=50)
+    parser.add_argument("--min-score", type=float, default=3)
+    parser.add_argument("--max-candidates", type=int, default=25)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    return discover(build_parser().parse_args(argv))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/explore_twitter_accounts.py
+++ b/scripts/explore_twitter_accounts.py
@@ -129,25 +129,28 @@ def candidates_from_tweets(
             "source": "author",
             "cited_by": set(),
             "mention_count": 0,
+            "citation_examples": [],
         }
     )
 
     for tweet in tweets:
+        url = None
         try:
             handle = _author_username(tweet)
         except ManifestError:
             continue
-        if not handle or handle.lower() in monitored_handles:
+        if not handle:
             continue
-        bucket = by_handle[handle.lower()]
-        bucket["handle"] = handle
-        bucket["tweet_count"] += 1
-        bucket["likes"] += _count(tweet, "likeCount")
-        bucket["retweets"] += _count(tweet, "retweetCount")
-        bucket["replies"] += _count(tweet, "replyCount")
-        url = _tweet_url(tweet, handle)
-        if url and len(bucket["examples"]) < 3:
-            bucket["examples"].append(url)
+        if handle.lower() not in monitored_handles:
+            bucket = by_handle[handle.lower()]
+            bucket["handle"] = handle
+            bucket["tweet_count"] += 1
+            bucket["likes"] += _count(tweet, "likeCount")
+            bucket["retweets"] += _count(tweet, "retweetCount")
+            bucket["replies"] += _count(tweet, "replyCount")
+            url = _tweet_url(tweet, handle)
+            if url and len(bucket["examples"]) < 3:
+                bucket["examples"].append(url)
         text = tweet.get("text") or tweet.get("fullText") or ""
         for mentioned in MENTION_RE.findall(text):
             try:
@@ -162,11 +165,9 @@ def candidates_from_tweets(
             mentioned_bucket["source"] = "mention_graph"
             mentioned_bucket["mention_count"] += 1
             mentioned_bucket["cited_by"].add(handle)
-            mentioned_bucket["likes"] += _count(tweet, "likeCount")
-            mentioned_bucket["retweets"] += _count(tweet, "retweetCount")
-            mentioned_bucket["replies"] += _count(tweet, "replyCount")
-            if url and len(mentioned_bucket["examples"]) < 3:
-                mentioned_bucket["examples"].append(url)
+            url = url or _tweet_url(tweet, handle)
+            if url and len(mentioned_bucket["citation_examples"]) < 3:
+                mentioned_bucket["citation_examples"].append(f"cited in: {url}")
 
     candidates = []
     for bucket in by_handle.values():
@@ -176,6 +177,8 @@ def candidates_from_tweets(
         # lesson: mention-graph traversal beats keyword search for real clusters.
         engagement = bucket["likes"] + (2 * bucket["retweets"]) + bucket["replies"]
         cited_by = sorted(bucket["cited_by"])
+        if bucket["source"] == "mention_graph" and len(cited_by) < 2:
+            continue
         mention_score = (2 * len(cited_by)) + min(3, bucket["mention_count"])
         score = bucket["tweet_count"] + mention_score + min(4.0, math.log10(max(engagement, 1)))
         if score < min_score:
@@ -187,6 +190,7 @@ def candidates_from_tweets(
                 f"by {len(cited_by)} search-surfaced account(s): "
                 f"{', '.join('@' + h for h in cited_by[:5])}."
             )
+            examples = bucket["citation_examples"]
         else:
             reason = (
                 f"Surfaced {bucket['tweet_count']} time(s) as an author in AI discovery searches "

--- a/scripts/explore_twitter_accounts.py
+++ b/scripts/explore_twitter_accounts.py
@@ -11,6 +11,7 @@ import argparse
 import json
 import math
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -25,6 +26,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_OUTPUT = Path("/tmp/twitter-account-candidates.json")
 DEFAULT_REPORT = Path("/tmp/twitter-account-explorer-report.md")
 BIRD_CMD = os.environ.get("ARA_BIRD_CMD") or ("birdy" if shutil.which("birdy") else "bird")
+MENTION_RE = re.compile(r"(?<![A-Za-z0-9_])@([A-Za-z0-9_]{1,15})")
 
 DISCOVERY_QUERIES = [
     '("new model" OR "model release" OR "open weights" OR "AI launch") min_faves:40 -filter:replies lang:en',
@@ -117,7 +119,17 @@ def candidates_from_tweets(
     max_candidates: int,
 ) -> list[dict[str, Any]]:
     by_handle: dict[str, dict[str, Any]] = defaultdict(
-        lambda: {"handle": "", "tweet_count": 0, "likes": 0, "retweets": 0, "replies": 0, "examples": []}
+        lambda: {
+            "handle": "",
+            "tweet_count": 0,
+            "likes": 0,
+            "retweets": 0,
+            "replies": 0,
+            "examples": [],
+            "source": "author",
+            "cited_by": set(),
+            "mention_count": 0,
+        }
     )
 
     for tweet in tweets:
@@ -136,20 +148,50 @@ def candidates_from_tweets(
         url = _tweet_url(tweet, handle)
         if url and len(bucket["examples"]) < 3:
             bucket["examples"].append(url)
+        text = tweet.get("text") or tweet.get("fullText") or ""
+        for mentioned in MENTION_RE.findall(text):
+            try:
+                mentioned_handle = normalize_handle(mentioned)
+            except ManifestError:
+                continue
+            mentioned_key = mentioned_handle.lower()
+            if mentioned_key == handle.lower() or mentioned_key in monitored_handles:
+                continue
+            mentioned_bucket = by_handle[mentioned_key]
+            mentioned_bucket["handle"] = mentioned_handle
+            mentioned_bucket["source"] = "mention_graph"
+            mentioned_bucket["mention_count"] += 1
+            mentioned_bucket["cited_by"].add(handle)
+            mentioned_bucket["likes"] += _count(tweet, "likeCount")
+            mentioned_bucket["retweets"] += _count(tweet, "retweetCount")
+            mentioned_bucket["replies"] += _count(tweet, "replyCount")
+            if url and len(mentioned_bucket["examples"]) < 3:
+                mentioned_bucket["examples"].append(url)
 
     candidates = []
     for bucket in by_handle.values():
-        # First-principles scoring: repeated surfacing matters, but engagement
-        # is logarithmic because one viral post should not dominate the watchlist.
+        # First-principles scoring: repeated surfacing and cross-account mentions
+        # matter, but engagement is logarithmic because one viral post should not
+        # dominate the watchlist. This borrows goodtweet's strongest discovery
+        # lesson: mention-graph traversal beats keyword search for real clusters.
         engagement = bucket["likes"] + (2 * bucket["retweets"]) + bucket["replies"]
-        score = bucket["tweet_count"] + min(4.0, math.log10(max(engagement, 1)))
+        cited_by = sorted(bucket["cited_by"])
+        mention_score = (2 * len(cited_by)) + min(3, bucket["mention_count"])
+        score = bucket["tweet_count"] + mention_score + min(4.0, math.log10(max(engagement, 1)))
         if score < min_score:
             continue
         examples = bucket["examples"]
-        reason = (
-            f"Surfaced {bucket['tweet_count']} time(s) in AI discovery searches "
-            f"with aggregate engagement {engagement}."
-        )
+        if bucket["source"] == "mention_graph":
+            reason = (
+                f"Mention-graph candidate cited {bucket['mention_count']} time(s) "
+                f"by {len(cited_by)} search-surfaced account(s): "
+                f"{', '.join('@' + h for h in cited_by[:5])}."
+            )
+        else:
+            reason = (
+                f"Surfaced {bucket['tweet_count']} time(s) as an author in AI discovery searches "
+                f"with aggregate engagement {engagement}."
+            )
         candidates.append(
             {
                 "action": "add",
@@ -158,6 +200,7 @@ def candidates_from_tweets(
                 "score": round(score, 2),
                 "reason": reason,
                 "evidence": examples,
+                "source": bucket["source"],
             }
         )
 

--- a/scripts/test_curate_twitter_accounts.py
+++ b/scripts/test_curate_twitter_accounts.py
@@ -24,15 +24,16 @@ class TwitterAccountCurationTests(unittest.TestCase):
     def test_manifest_validates_with_expected_counts(self):
         stats = validate_manifest(load_manifest())
 
-        self.assertEqual(stats["handles"], 75)
-        self.assertEqual(stats["searches"], 7)
-        self.assertEqual(stats["tweets_per_account"], 20)
+        self.assertGreater(stats["handles"], 0)
+        self.assertGreater(stats["searches"], 0)
+        self.assertGreater(stats["tweets_per_account"], 0)
 
     def test_build_fetch_manifest_preserves_bird_contract(self):
         fetch = build_fetch_manifest(load_manifest(), concurrency=6)
+        stats = validate_manifest(load_manifest())
 
         self.assertEqual(fetch["concurrency"], 6)
-        self.assertEqual(len(fetch["operations"]), 83)
+        self.assertEqual(len(fetch["operations"]), stats["handles"] + stats["searches"] + 1)
         self.assertEqual(
             fetch["operations"][0],
             {

--- a/scripts/test_curate_twitter_accounts.py
+++ b/scripts/test_curate_twitter_accounts.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from curate_twitter_accounts import (
+    DEFAULT_MANIFEST,
+    apply_changes,
+    build_fetch_manifest,
+    propose_changes,
+    validate_manifest,
+)
+
+
+def load_manifest():
+    return json.loads(DEFAULT_MANIFEST.read_text(encoding="utf-8"))
+
+
+class TwitterAccountCurationTests(unittest.TestCase):
+    def test_manifest_validates_with_expected_counts(self):
+        stats = validate_manifest(load_manifest())
+
+        self.assertEqual(stats["handles"], 75)
+        self.assertEqual(stats["searches"], 7)
+        self.assertEqual(stats["tweets_per_account"], 20)
+
+    def test_build_fetch_manifest_preserves_bird_contract(self):
+        fetch = build_fetch_manifest(load_manifest(), concurrency=6)
+
+        self.assertEqual(fetch["concurrency"], 6)
+        self.assertEqual(len(fetch["operations"]), 83)
+        self.assertEqual(
+            fetch["operations"][0],
+            {
+                "id": "OpenAI",
+                "args": ["user-tweets", "@OpenAI", "-n", "20", "--json", "--plain"],
+            },
+        )
+        self.assertEqual(
+            fetch["operations"][-1],
+            {
+                "id": "news",
+                "args": ["news", "--ai-only", "-n", "40", "--json", "--plain"],
+            },
+        )
+
+    def test_propose_and_apply_add_remove_round_trip(self):
+        manifest = load_manifest()
+        candidates = [
+            {
+                "action": "add",
+                "handle": "@new_ai_signal",
+                "category": "others",
+                "score": 3,
+                "reason": "Repeated primary launch evidence.",
+                "evidence": ["https://x.com/new_ai_signal/status/1"],
+            },
+            {
+                "action": "remove",
+                "handle": "MetaAI",
+                "reason": "Inactive compared with AIatMeta.",
+                "evidence": ["research/twitter/example.md"],
+            },
+            {
+                "action": "add",
+                "handle": "OpenAI",
+                "score": 5,
+                "reason": "Already monitored.",
+            },
+        ]
+
+        changes = propose_changes(manifest, candidates, min_score=2, default_category="others")
+        self.assertEqual([item["handle"] for item in changes["additions"]], ["new_ai_signal"])
+        self.assertEqual([item["handle"] for item in changes["removals"]], ["MetaAI"])
+        self.assertEqual(changes["ignored"][0]["why"], "already monitored in labs")
+
+        updated = apply_changes(manifest, changes)
+        handles = {
+            (entry if isinstance(entry, str) else entry["handle"]).lower()
+            for category in updated["categories"]
+            for entry in category["handles"]
+        }
+        self.assertIn("new_ai_signal", handles)
+        self.assertNotIn("metaai", handles)
+        self.assertEqual(validate_manifest(updated)["handles"], 75)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_explore_twitter_accounts.py
+++ b/scripts/test_explore_twitter_accounts.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from explore_twitter_accounts import candidates_from_tweets
+
+
+class TwitterAccountExplorerTests(unittest.TestCase):
+    def test_candidates_from_tweets_scores_unknown_authors(self):
+        tweets = [
+            {
+                "id": "1",
+                "author": {"username": "newsignal"},
+                "likeCount": 120,
+                "retweetCount": 20,
+                "replyCount": 4,
+            },
+            {
+                "id": "2",
+                "author": {"username": "newsignal"},
+                "likeCount": 60,
+                "retweetCount": 5,
+                "replyCount": 1,
+            },
+            {
+                "id": "3",
+                "author": {"username": "OpenAI"},
+                "likeCount": 10000,
+                "retweetCount": 100,
+                "replyCount": 50,
+            },
+        ]
+
+        candidates = candidates_from_tweets(tweets, {"openai"}, min_score=3, max_candidates=10)
+
+        self.assertEqual(len(candidates), 1)
+        self.assertEqual(candidates[0]["handle"], "newsignal")
+        self.assertEqual(candidates[0]["category"], "others")
+        self.assertEqual(candidates[0]["evidence"][0], "https://x.com/newsignal/status/1")
+
+    def test_candidates_from_tweets_respects_threshold_and_cap(self):
+        tweets = [
+            {"id": str(index), "author": {"username": f"user{index}"}, "likeCount": 1000}
+            for index in range(5)
+        ]
+
+        candidates = candidates_from_tweets(tweets, set(), min_score=2, max_candidates=2)
+
+        self.assertEqual(len(candidates), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_explore_twitter_accounts.py
+++ b/scripts/test_explore_twitter_accounts.py
@@ -74,6 +74,39 @@ class TwitterAccountExplorerTests(unittest.TestCase):
         self.assertIn("networknode", by_handle)
         self.assertEqual(by_handle["networknode"]["source"], "mention_graph")
         self.assertIn("@seed1", by_handle["networknode"]["reason"])
+        self.assertTrue(by_handle["networknode"]["evidence"][0].startswith("cited in: "))
+
+    def test_monitored_authors_still_contribute_mention_graph_signal(self):
+        tweets = [
+            {
+                "id": "1",
+                "author": {"username": "OpenAI"},
+                "text": "interesting work from @networknode",
+            },
+            {
+                "id": "2",
+                "author": {"username": "AnthropicAI"},
+                "text": "also watching @networknode",
+            },
+        ]
+
+        candidates = candidates_from_tweets(tweets, {"openai", "anthropicai"}, min_score=4, max_candidates=10)
+
+        self.assertEqual([item["handle"] for item in candidates], ["networknode"])
+
+    def test_single_mention_does_not_clear_mention_graph_threshold(self):
+        tweets = [
+            {
+                "id": "1",
+                "author": {"username": "seed1"},
+                "text": "one-off mention of @networknode",
+                "likeCount": 10000,
+            }
+        ]
+
+        candidates = candidates_from_tweets(tweets, set(), min_score=3, max_candidates=10)
+
+        self.assertNotIn("networknode", {item["handle"] for item in candidates})
 
 
 if __name__ == "__main__":

--- a/scripts/test_explore_twitter_accounts.py
+++ b/scripts/test_explore_twitter_accounts.py
@@ -52,6 +52,29 @@ class TwitterAccountExplorerTests(unittest.TestCase):
 
         self.assertEqual(len(candidates), 2)
 
+    def test_candidates_from_tweets_uses_mention_graph_signal(self):
+        tweets = [
+            {
+                "id": "1",
+                "author": {"username": "seed1"},
+                "text": "good thread by @networknode on AI infra",
+                "likeCount": 20,
+            },
+            {
+                "id": "2",
+                "author": {"username": "seed2"},
+                "text": "@networknode has the better sourcing here",
+                "likeCount": 30,
+            },
+        ]
+
+        candidates = candidates_from_tweets(tweets, set(), min_score=4, max_candidates=10)
+
+        by_handle = {item["handle"]: item for item in candidates}
+        self.assertIn("networknode", by_handle)
+        self.assertEqual(by_handle["networknode"]["source"], "mention_graph")
+        self.assertIn("@seed1", by_handle["networknode"]["reason"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- move the production Twitter/X monitored account list and search queries into data/sources/twitter_accounts.json
- compile the reviewed manifest into the birdy multi-fetch contract from the twitter-fetch action
- add scripts/curate_twitter_accounts.py for validation, proposal generation, and reviewed apply of add/remove changes
- add scripts/explore_twitter_accounts.py and a weekly/manual twitter-account-explorer workflow that scouts candidates, asks a Claude explorer to review evidence, and opens PRs for manifest changes
- incorporate the useful goodtweet discovery lesson: repeated cross-account mentions are scored as candidate evidence alongside search-result authors
- document the curation/explorer flow and add unittest coverage; include the manifest path in CI triggers

## Testing
- uv run python scripts/curate_twitter_accounts.py validate
- UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/curate_twitter_accounts.py build-fetch-manifest --output /tmp/ara-twitter-manifest.json --concurrency 8
- uv run python scripts/explore_twitter_accounts.py --output /tmp/ara-twitter-account-candidates.json --report /tmp/ara-twitter-account-report.md --max-candidates 3 --per-query 1
- uv run python -m unittest scripts/test_curate_twitter_accounts.py scripts/test_explore_twitter_accounts.py
- uv run python -m unittest discover -s scripts -p 'test_*.py'
- actionlint .github/workflows/ci.yml .github/workflows/twitter-account-explorer.yml
- git diff --check

Note: this repo has no staging branch available, so this PR targets main.