### PR TITLE
Document headline-alert dedup contract with Mermaid flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ and opens a PR with methodology fixes.
 | [`docs/model-tickets.md`](docs/model-tickets.md) | Schema + lifecycle + dedup protocol for `research/models/tickets/*.md`. Read by the CRUD agent in `24h-model-timeline.yml` and enforced by `scripts/check_model_tickets.py`. |
 | [`docs/wiki-schema.md`](docs/wiki-schema.md) | Canonical schema + page conventions for the LLM Wiki (`research/wiki/`). Read at runtime by the ingest agent in `wiki-ingest.yml` and enforced by `scripts/check_wiki.py`. |
 | [`docs/hooker-telemetry.md`](docs/hooker-telemetry.md) | Non-blocking telemetry route via `https://hooker.guzus.xyz` topic `ara-telemetry`. |
+| [`docs/headline-dedupe.md`](docs/headline-dedupe.md) | Dedup contract + Mermaid flow for the Twitter headline-alert ledger (`research/summaries/twitter-announced-history.json`). Documents the layered `duplicate_reason` check (exact / same-source / cross-source) in `scripts/dedupe_headline_alerts.py`, used by `hourly-twitter.yml`. |
 | [`docs/archive/`](docs/archive/) | Historical improvement logs and superseded docs. |
 | `dashboard/` | Vite + Bun + TypeScript SPA. `prebuild.mjs` copies `research/*` into `public/research/` and emits `manifest.json`; Railway auto-deploys on every push to `main` (next row). |
 | [`Dockerfile`](Dockerfile) + [`Caddyfile`](Caddyfile) + [`railway.json`](railway.json) | The Railway deploy stack serving **ara.guzus.xyz** (behind Cloudflare — responses carry `x-railway-edge`). The root `Dockerfile` builds the dashboard with bun (`oven/bun:1-alpine`, plus `nodejs` for the pre/postbuild node scripts) and serves `dashboard/dist` with Caddy; `railway.json` pins the DOCKERFILE builder + `/` healthcheck. `dashboard/vercel.json` is the legacy Vercel config — Vercel no longer serves the domain (Load-bearing rule 3). |
@@ -56,7 +57,7 @@ and opens a PR with methodology fixes.
 | `prior_context.py` | Find prior generative-research articles related to a new topic. |
 | `research_search.py` | Specialized search wrappers for primary-source research. |
 | `stock_prices.py` | Yahoo Finance time series → copy-paste lines for `:::line-chart`. |
-| `dedupe_headline_alerts.py` | Filter + record delivered Twitter headline alerts (used by `hourly-twitter.yml`). |
+| `dedupe_headline_alerts.py` | Filter + record delivered Twitter headline alerts (used by `hourly-twitter.yml`). Layered dedup contract + Mermaid diagrams in [`docs/headline-dedupe.md`](docs/headline-dedupe.md). |
 | `check_model_tickets.py` | Validator for `research/models/tickets/*.md` against the schema in `docs/model-tickets.md`. The CRUD agent in `24h-model-timeline.yml` runs it after every pass; CI runs it on every PR. |
 | `check_wiki.py` | Validator for `research/wiki/` pages against the schema in `docs/wiki-schema.md`. `uv run python scripts/check_wiki.py` (exit 0 = safe); `--lint` adds advisory checks. The ingest agent in `wiki-ingest.yml` runs it until exit 0; CI runs it on every PR. |
 | `wiki_search.py` | Search wrapper over `research/wiki/` (`uv run python scripts/wiki_search.py "<query>"`). The ingest agent runs it before writing any page so it UPDATEs an existing page instead of duplicating. |

--- a/docs/headline-dedupe.md
+++ b/docs/headline-dedupe.md
@@ -1,0 +1,165 @@
+# Twitter headline-alert deduplication
+
+How the hourly-twitter cron keeps from re-sending the **same story** to the
+Telegram / Hooker "Robot Colosseum" feed. This is the contract for
+[`scripts/dedupe_headline_alerts.py`](../scripts/dedupe_headline_alerts.py)
+and its tests in `scripts/test_dedupe_headline_alerts.py`.
+
+## What problem it solves
+
+Each cycle a fresh Claude agent reads a window of X/Twitter signal and emits
+3–7 punchy headlines (`research/summaries/<date>-twitter-<hour>h-headlines.json`).
+The agent has **no memory of prior cycles**, so without a cross-cycle guard the
+same event gets blasted again every time a new account reports it — e.g. the
+same hire announced by two outlets hours apart. Dedup is therefore the
+**only** place cross-cycle and cross-source repetition can be caught.
+
+It is intentionally an **alert-send ledger, not a global news store**: the only
+question it answers is "have we already alerted users about this story?"
+
+## Where it runs in the pipeline
+
+```mermaid
+flowchart LR
+    SRC[bird CLI fetch<br/>X / Twitter]:::io --> AGENT[Claude agent<br/>writes headlines.json]:::proc
+    AGENT --> FILTER["dedupe filter<br/>suppress dups → to-send.json"]:::proc
+    LEDGER[("twitter-announced-history.json<br/>~3000 delivered records")]:::store --> FILTER
+    FILTER --> BLAST[Hooker /send-batch<br/>→ Telegram routes]:::io
+    BLAST --> REC["dedupe record-delivered<br/>append sent → ledger"]:::proc
+    REC --> LEDGER
+
+    classDef proc fill:#e3f2fd,stroke:#1565c0,color:#0d2b45;
+    classDef store fill:#fff3e0,stroke:#e65100,color:#3e2600;
+    classDef io fill:#ede7f6,stroke:#4527a0,color:#1a1035;
+```
+
+Two `dedupe_headline_alerts.py` subcommands bracket the send:
+
+| Subcommand | When | Effect |
+|---|---|---|
+| `filter` | before the blast | Drops every incoming headline that duplicates a ledger record; writes the survivors to `to-send.json`. |
+| `record-delivered` | after the blast | Appends the headlines that **actually delivered** (≥1 route accepted) to the ledger, capped at `RETENTION_DEFAULT = 3000` records. |
+
+The ledger (`research/summaries/twitter-announced-history.json`) is committed
+back to `main` each cycle, so the next run sees the updated history. Each
+record is `{headline, source, url, category, delivered_at}` where
+`delivered_at` is `"YYYY-MM-DD HH:MM UTC"`.
+
+## The decision: `duplicate_reason(item, history, history_keys, now)`
+
+Returns a **reason string** (suppress) or `""` (new → send). Checks run in
+**priority order; first match wins**, so the cheap high-precision signals
+short-circuit before the fuzzy cross-source scan.
+
+```mermaid
+flowchart TD
+    A[Incoming headline]:::io --> B[Normalize + tokenize → Keys]:::proc
+    B --> C{headline_key empty?}
+    C -->|yes| INV1([invalid_headline · suppress]):::supp
+    C -->|no| D{url_key empty?}
+    D -->|yes| INV2([invalid_url · suppress]):::supp
+    D -->|no| F
+
+    %% Pass 1 — exact / same-source, time-independent
+    F{"Any history record with<br/>same non-empty story_key?"} -->|yes| R1([duplicate_story_key]):::supp
+    F -->|no| G{"Any record with the same<br/>normalized headline?<br/>(any source / URL)"}
+    G -->|yes| R2([duplicate_headline]):::supp
+    G -->|no| H{"Any record with the SAME url<br/>and max-containment/Jaccard ≥ 0.62?"}
+    H -->|yes| R3([duplicate_source_similar_headline]):::supp
+    H -->|no| Q
+
+    %% Gate: cross-source pass only runs when a reference time is supplied
+    Q{now provided?} -->|"no — legacy / test caller"| SEND
+    Q -->|yes| K
+
+    %% Pass 2 — cross-source semantic duplicate
+    K{"Any DIFFERENT-url record where ALL hold:<br/>• delivered within 14 days (fail-open)<br/>• shared tokens ≥ 4<br/>• Jaccard ≥ 0.5"} -->|yes| R4([duplicate_cross_source_similar_headline]):::supp
+    K -->|no| SEND([empty string · NEW<br/>send + append to history]):::send
+
+    classDef proc fill:#e3f2fd,stroke:#1565c0,color:#0d2b45;
+    classDef io fill:#ede7f6,stroke:#4527a0,color:#1a1035;
+    classDef supp fill:#ffebee,stroke:#b71c1c,color:#3e0a0a;
+    classDef send fill:#e8f5e9,stroke:#2e7d32,color:#0c2912;
+```
+
+### Layers, in priority order
+
+| # | Reason returned | Condition | Catches |
+|---|---|---|---|
+| — | `invalid_headline` / `invalid_url` | empty normalized headline or URL | malformed agent output |
+| 1a | `duplicate_story_key` | same non-empty `story_key` | explicit story grouping (**inert today** — the agent's schema emits no `story_key`; kept for when it does) |
+| 1b | `duplicate_headline` | identical **normalized** headline, **any** source | verbatim re-posts / cross-account copies |
+| 1c | `duplicate_source_similar_headline` | **same URL** + `max(containment, jaccard) ≥ 0.62` | one author rephrasing their own tweet |
+| 2 | `duplicate_cross_source_similar_headline` | **different URL** + in 14-day window + `≥ 4` shared tokens + `Jaccard ≥ 0.5` | **the same story from a different account, paraphrased** (the leak this layer was added to close) |
+
+**Normalization** (`normalize_headline`): NFKC, uppercase, strip URLs, drop
+non-decimal dots, collapse to `[A-Z0-9.$]`. **Tokens** (`headline_tokens`):
+the normalized words minus a stopword list, length > 1. Token sets are
+precomputed once per record and cached on `Keys.tokens`, so the Pass-2 scan
+never re-tokenizes history.
+
+## Tunable constants (defaults live in the script — no workflow change to tune)
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `URL_SIMILARITY_THRESHOLD` | `0.62` | Pass 1c — same-URL paraphrase floor (uses `max(containment, jaccard)`). |
+| `CROSS_SOURCE_JACCARD_THRESHOLD` | `0.5` | Pass 2 — cross-source similarity floor (**Jaccard only**). |
+| `CROSS_SOURCE_MIN_OVERLAP` | `4` | Pass 2 — minimum absolute shared significant tokens. |
+| `CROSS_SOURCE_WINDOW_DAYS` | `14` | Pass 2 — recency window; `≤ 0` means unbounded. |
+| `RETENTION_DEFAULT` | `3000` | Ledger cap kept by `record-delivered`. |
+
+## Three design decisions that matter
+
+1. **Pass 2 uses Jaccard, not `max(containment, jaccard)`.** Containment
+   (`overlap / smaller-set`) scores a short headline that is a token-subset of
+   a longer one at **1.0** — so a legitimate *appended-fact follow-up*
+   (`"META RELEASES LLAMA 5"` → `"…WITH 2M TOKEN CONTEXT AND NATIVE VOICE"`)
+   would be wrongly suppressed. Jaccard (`overlap / union`) penalizes the size
+   gap (0.375 there), letting genuine "more details" updates through. Pass 1c
+   keeps the looser `max()` because an identical URL already proves same source.
+
+2. **Pass 2 is inert without `now`.** The recency window needs a reference
+   time. When `duplicate_reason` is called with no `now` (the 2-arg legacy/test
+   signature), Pass 2 is skipped entirely — existing callers are byte-for-byte
+   unchanged. `filter_headlines` derives `now` from the run `--timestamp`; if
+   that is malformed, Pass 2 simply doesn't run (no crash).
+
+3. **Per-record timestamps fail OPEN.** A history record whose `delivered_at`
+   is missing or unparseable is treated as **outside** the window → it cannot
+   suppress an incoming alert. The cost of a parse bug is at worst one
+   duplicate, never a swallowed headline. (Whole-file JSON corruption still
+   fails **closed** — `load_json_list` raises `SystemExit`.)
+
+**In-batch behavior:** `filter_headlines` appends each accepted item back into
+`history` (stamped with the run `now`) as it iterates, so two paraphrases of
+the same story *in the same cycle* from different accounts collapse to one —
+the first survives, the second is caught by Pass 2.
+
+## Calibration & known residual
+
+Thresholds were calibrated against the **real delivered-alert ledger**: genuine
+cross-source re-reports cluster at `Jaccard ≥ ~0.5` with `≥ 7` shared tokens,
+while appended-fact progression and short-subset headlines fall well below.
+The ledger's Jaccard *ceiling* is ~0.65, which is why `0.5` — not an intuitive
+`0.7+` — is the correct cut. A replay of the full ledger showed ~2.4% of
+delivered alerts were cross-source repeats this layer now catches.
+
+**Residual (documented, not solved):** token overlap cannot separate two
+genuinely-distinct stories that share heavy boilerplate vocabulary (two
+entities running the same templated beat with ≥ 4 shared tokens) from a true
+re-report. The conservative threshold keeps these a small minority. Tune the
+constants rather than adding a brittle hand-maintained salient-token list.
+
+## How to verify
+
+```bash
+# Unit + behavior tests (also run in CI via unittest discover)
+uv run python -m unittest discover -s scripts -p 'test_*.py'
+
+# Backtest: replay the real ledger and count cross-source dups the
+# current logic would catch (see the PR description for the script).
+```
+
+When changing thresholds or the layer order, re-run the tests and re-backtest
+against the live ledger before shipping — over-suppression silently drops real
+news, which is worse than an occasional duplicate.

--- a/scripts/dedupe_headline_alerts.py
+++ b/scripts/dedupe_headline_alerts.py
@@ -14,6 +14,8 @@ Dedupe layers (see `duplicate_reason`), in priority order:
      Jaccard floor (size-symmetric, so an appended-fact follow-up is not eaten),
      an absolute shared-token floor, and a recency window; it stays inert unless
      a reference time is supplied.
+
+Full contract + flow diagrams: docs/headline-dedupe.md
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Follow-up to #143 (cross-source headline dedup). Documents **how the dup check works** so the layered logic is discoverable without reading the script.

## Adds `docs/headline-dedupe.md`
- **Where it runs** — a Mermaid pipeline diagram: `bird fetch → agent → dedupe filter → Hooker send → record-delivered → ledger`.
- **The decision** — a Mermaid flowchart of `duplicate_reason`, showing the priority order (first match wins): `invalid_*` → Pass 1 (`duplicate_story_key` / `duplicate_headline` / same-URL `duplicate_source_similar_headline`) → the `now`-gated Pass 2 (`duplicate_cross_source_similar_headline`).
- **Reason-string table**, **tunable-constant table** (`URL_SIMILARITY_THRESHOLD=0.62`, `CROSS_SOURCE_JACCARD_THRESHOLD=0.5`, `CROSS_SOURCE_MIN_OVERLAP=4`, `CROSS_SOURCE_WINDOW_DAYS=14`, `RETENTION_DEFAULT=3000`).
- **The three load-bearing design choices** — Jaccard-not-containment (so appended-fact follow-ups survive), Pass 2 inert without `now`, per-record timestamps fail open.
- **Calibration evidence** (~2.4% of the real ledger were cross-source repeats) + the documented residual, and a verify/backtest section.

## Wires pointers
- `CLAUDE.md` — new row in Key Components + a note on the `dedupe_headline_alerts.py` Scripts row.
- Script module docstring → `docs/headline-dedupe.md`.

Docs only — no behavior change. The dedup tests (17) still pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)