### PR TITLE
Agent-in-the-loop final gate for headline dedupe (Haiku adjudicates the contested band)

### DIFF
--- a/.github/workflows/hourly-twitter.yml
+++ b/.github/workflows/hourly-twitter.yml
@@ -512,6 +512,12 @@ jobs:
               "source": "@dryrun",
               "url": "https://x.com/dryrun/status/999999999999999999",
               "category": "opensource"
+            },
+            {
+              "headline": "NOAM SHAZEER OFFICIALLY JOINS OPENAI, ALTMAN CONFIRMS AFTER A DECADE OF COURTING",
+              "source": "@dryrun",
+              "url": "https://x.com/dryrun/status/999999999999999998",
+              "category": "business"
             }
           ]
           EOF

--- a/.github/workflows/hourly-twitter.yml
+++ b/.github/workflows/hourly-twitter.yml
@@ -548,6 +548,170 @@ jobs:
             --filtered-file "$FILTERED_FILE" \
             --timestamp "$TIMESTAMP"
 
+      # ── claude-tier agent dedupe gate (steps 1/4: shortlist) ───────
+      # The deterministic filter above can't separate true cross-source
+      # re-reports from distinct news that merely shares vocabulary in the
+      # contested band just below its 0.5 suppress floor. Shortlist the
+      # survivors whose nearest prior alert sits in [0.35,0.50) Jaccard so a
+      # model can make the final call. Runs on dry-run too (so a dispatch
+      # exercises the whole gate); usually shortlists nothing.
+      - name: Shortlist near-duplicate headlines (claude tier)
+        id: judge_shortlist
+        if: steps.backend.outputs.name == 'claude'
+        env:
+          FILTERED_FILE: /tmp/${{ steps.datetime.outputs.date }}-twitter-${{ steps.datetime.outputs.hour }}h-headlines-to-send.json
+          HISTORY_FILE: research/summaries/twitter-announced-history.json
+          DOUBTFUL_FILE: /tmp/${{ steps.datetime.outputs.date }}-twitter-${{ steps.datetime.outputs.hour }}h-judge-doubtful.json
+        run: |
+          set -euo pipefail
+          [ -f "$FILTERED_FILE" ] || echo '[]' > "$FILTERED_FILE"
+          uv run python scripts/headline_judge.py shortlist \
+            --to-send-file "$FILTERED_FILE" \
+            --history-file "$HISTORY_FILE" \
+            --out-file "$DOUBTFUL_FILE"
+          COUNT=$(jq 'length' "$DOUBTFUL_FILE" 2>/dev/null || echo 0)
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          echo "Shortlisted $COUNT contested-band headline(s) for the judge."
+
+      # ── claude-tier agent dedupe gate (steps 2/4: Haiku adjudicates) ──
+      # Final gate: Haiku rules on each shortlisted headline vs its <=5
+      # nearest priors. Bias is hard toward KEEP — it may only turn a
+      # would-be send into a suppress, on a HIGH-confidence duplicate. Native
+      # Claude via the same OAuth token + action pattern used elsewhere in
+      # this job. continue-on-error so a model hiccup fails OPEN (no verdicts
+      # -> nothing suppressed). Skipped when the shortlist is empty.
+      - name: Adjudicate near-duplicate headlines with Haiku (claude tier)
+        id: judge_adjudicate
+        if: >-
+          steps.backend.outputs.name == 'claude'
+          && steps.judge_shortlist.outputs.count != '0'
+          && steps.judge_shortlist.outputs.count != ''
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
+        env:
+          DOUBTFUL_FILE: /tmp/${{ steps.datetime.outputs.date }}-twitter-${{ steps.datetime.outputs.hour }}h-judge-doubtful.json
+          VERDICTS_FILE: /tmp/${{ steps.datetime.outputs.date }}-twitter-${{ steps.datetime.outputs.hour }}h-judge-verdicts.json
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --model haiku --max-turns 6 --allowedTools "Read,Write,Bash(cat:*),Bash(jq:*),Bash(printenv:*)"
+          prompt: |
+            You are the final duplicate gate for an AI-news headline alert
+            feed. Reason from FIRST PRINCIPLES: judge whether two headlines
+            describe the SAME underlying real-world event, NOT whether they
+            share words. Do not assume any balance of duplicates vs distinct.
+
+            CARDINAL RULE: when in doubt, KEEP it (verdict "distinct").
+            Suppressing a real, new headline is far worse than letting one
+            duplicate through. Mark "duplicate" with "high" confidence ONLY
+            when you are certain it is the same specific event already sent.
+
+            Step 1 — read the input. Get the path and read it:
+              DOUBTFUL=$(printenv DOUBTFUL_FILE); cat "$DOUBTFUL"
+            It is a JSON array; each entry is
+              { "url", "headline", "candidates": [ { "headline", "delivered_at", "url" }, ... ] }
+            The candidates are prior ALREADY-SENT alerts that share vocabulary
+            with the headline.
+
+            Step 2 — classify each entry against its candidates.
+            DUPLICATE (same event already alerted) — only if a candidate is the
+            SAME specific event: same action, same primary subject(s), same
+            announcement. Paraphrases, reordered facts, refined numbers
+            ("$2.9B" vs "$3B" of the same round), or a different account
+            reporting the same news ARE duplicates.
+            DISTINCT (keep — send it) — if NONE of the candidates is the same
+            event. These are NOT duplicates even though they share words:
+              - SAME metric/number, DIFFERENT subject (two different companies
+                each crossing the same market cap) -> distinct.
+              - SAME templated action, DIFFERENT entity (two different
+                companies each cutting API pricing) -> distinct.
+              - APPENDED FACTS / real progression: a follow-up adding genuinely
+                new info (a new number, an official confirmation of a prior
+                rumor, a newly-named party) -> distinct. A pure restatement
+                with no new info is a duplicate.
+              - A different, itself-newsworthy stage of an ongoing story
+                (rumor -> official confirmation; priced -> debuted).
+
+            Step 3 — output. Use the Write tool to create the file whose path
+            is in env var VERDICTS_FILE (run: printenv VERDICTS_FILE). Write a
+            JSON array, exactly one object per input entry:
+              { "url": "<the entry's url>", "verdict": "duplicate" | "distinct",
+                "confidence": "high" | "medium" | "low",
+                "matched_url": "<candidate url if duplicate, else empty string>",
+                "reason": "<one short clause>" }
+            Key each verdict by the entry's "url" exactly. Use "duplicate" +
+            "high" ONLY when certain; any genuine uncertainty -> "distinct".
+            Write ONLY the JSON array to that file — no prose, no other files.
+
+      # ── claude-tier agent dedupe gate (steps 3/4: apply verdicts) ──
+      # Drop only HIGH-confidence duplicates from the send set; fail OPEN if
+      # the judge produced no/garbled verdicts. Matches verdicts to headlines
+      # by URL, not position. Writes this cycle's suppressions for the alert.
+      - name: Apply headline judge verdicts (claude tier)
+        id: judge_apply
+        if: >-
+          steps.backend.outputs.name == 'claude'
+          && steps.judge_shortlist.outputs.count != '0'
+          && steps.judge_shortlist.outputs.count != ''
+        env:
+          FILTERED_FILE: /tmp/${{ steps.datetime.outputs.date }}-twitter-${{ steps.datetime.outputs.hour }}h-headlines-to-send.json
+          VERDICTS_FILE: /tmp/${{ steps.datetime.outputs.date }}-twitter-${{ steps.datetime.outputs.hour }}h-judge-verdicts.json
+          SUPPRESSED_FILE: /tmp/${{ steps.datetime.outputs.date }}-twitter-${{ steps.datetime.outputs.hour }}h-judge-suppressed.json
+          TIMESTAMP: ${{ steps.datetime.outputs.timestamp }}
+        run: |
+          set -euo pipefail
+          # Fail open: a skipped/crashed judge step leaves no verdicts file.
+          [ -f "$VERDICTS_FILE" ] || echo '[]' > "$VERDICTS_FILE"
+          SUMMARY=$(uv run python scripts/headline_judge.py apply \
+            --to-send-file "$FILTERED_FILE" \
+            --verdicts-file "$VERDICTS_FILE" \
+            --out-file "$FILTERED_FILE" \
+            --suppressed-file "$SUPPRESSED_FILE" \
+            --timestamp "$TIMESTAMP")
+          echo "$SUMMARY"
+          DROPPED=$(echo "$SUMMARY" | jq -r '.suppressed' 2>/dev/null || echo 0)
+          echo "dropped=$DROPPED" >> "$GITHUB_OUTPUT"
+          echo "$SUMMARY" | jq -r '.suppressed_headlines[]? | "  🔇 judge suppressed: " + .' || true
+
+      # ── claude-tier agent dedupe gate (steps 4/4: alert on eats) ───
+      # The judge enforces immediately with no shadow phase, so every
+      # suppression is surfaced to Telegram via hooker — a wrong eat is
+      # visible in hours, not buried in a log. Non-blocking.
+      - name: Notify on judge suppressions (claude tier)
+        if: >-
+          steps.backend.outputs.name == 'claude'
+          && steps.judge_apply.outputs.dropped != '0'
+          && steps.judge_apply.outputs.dropped != ''
+          && !(github.event_name == 'workflow_dispatch' && inputs.dry_run == true)
+        continue-on-error: true
+        env:
+          HOOKER_URL: ${{ secrets.HOOKER_URL }}
+          HOOKER_TOKEN: ${{ secrets.HOOKER_TOKEN }}
+          AUDIT_CHAT_ID: "-1003988951534"
+          SUPPRESSED_FILE: /tmp/${{ steps.datetime.outputs.date }}-twitter-${{ steps.datetime.outputs.hour }}h-judge-suppressed.json
+        run: |
+          set -euo pipefail
+          if [ -z "${HOOKER_URL:-}" ] || [ -z "${HOOKER_TOKEN:-}" ]; then
+            echo "Hooker credentials missing — skipping judge alert"
+            exit 0
+          fi
+          [ -f "$SUPPRESSED_FILE" ] || exit 0
+          COUNT=$(jq 'length' "$SUPPRESSED_FILE" 2>/dev/null || echo 0)
+          [ "$COUNT" -lt 1 ] && exit 0
+          # One audit message listing each eaten headline + the prior it was
+          # judged a duplicate of (clickable) + the judge's reason.
+          TEXT=$(jq -r '
+            "🔇 <b>Dedupe gate suppressed " + (length|tostring) + " near-duplicate(s)</b>",
+            (.[] | "• " + .headline
+                   + (if (.matched_url // "") != "" then " — <a href=\"" + .matched_url + "\">prior</a>" else "" end)
+                   + (if (.reason // "") != "" then " (" + .reason + ")" else "" end))
+          ' "$SUPPRESSED_FILE" | jq -Rs .)
+          curl -sS -X POST "${HOOKER_URL}/send" \
+            -H "Authorization: Bearer ${HOOKER_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{\"chat_id\":\"${AUDIT_CHAT_ID}\",\"title\":\"\",\"text\":${TEXT},\"priority\":2,\"tags\":[],\"parse_mode\":\"HTML\"}" \
+            && echo "Judge-suppression alert sent ($COUNT)."
+
       # ── Push the markdown digest + summary (all tiers, not on dry-run) ──
       # Note on push semantics (codex [P2] fix): a `git push` exit-non-zero
       # is treated as a HARD FAILURE here. Previously this step swallowed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ and opens a PR with methodology fixes.
 | [`docs/model-tickets.md`](docs/model-tickets.md) | Schema + lifecycle + dedup protocol for `research/models/tickets/*.md`. Read by the CRUD agent in `24h-model-timeline.yml` and enforced by `scripts/check_model_tickets.py`. |
 | [`docs/wiki-schema.md`](docs/wiki-schema.md) | Canonical schema + page conventions for the LLM Wiki (`research/wiki/`). Read at runtime by the ingest agent in `wiki-ingest.yml` and enforced by `scripts/check_wiki.py`. |
 | [`docs/hooker-telemetry.md`](docs/hooker-telemetry.md) | Non-blocking telemetry route via `https://hooker.guzus.xyz` topic `ara-telemetry`. |
+| [`docs/headline-dedupe.md`](docs/headline-dedupe.md) | Dedup contract + Mermaid flow for the Twitter headline-alert ledger (`research/summaries/twitter-announced-history.json`): the deterministic layered `duplicate_reason` check (`scripts/dedupe_headline_alerts.py`) **plus** the agent-in-the-loop Haiku gate (`scripts/headline_judge.py`) that adjudicates the contested sub-floor band. Used by `hourly-twitter.yml`. |
 | [`docs/archive/`](docs/archive/) | Historical improvement logs and superseded docs. |
 | `dashboard/` | Vite + Bun + TypeScript SPA. `prebuild.mjs` copies `research/*` into `public/research/` and emits `manifest.json`; Railway auto-deploys on every push to `main` (next row). |
 | [`Dockerfile`](Dockerfile) + [`Caddyfile`](Caddyfile) + [`railway.json`](railway.json) | The Railway deploy stack serving **ara.guzus.xyz** (behind Cloudflare — responses carry `x-railway-edge`). The root `Dockerfile` builds the dashboard with bun (`oven/bun:1-alpine`, plus `nodejs` for the pre/postbuild node scripts) and serves `dashboard/dist` with Caddy; `railway.json` pins the DOCKERFILE builder + `/` healthcheck. `dashboard/vercel.json` is the legacy Vercel config — Vercel no longer serves the domain (Load-bearing rule 3). |
@@ -56,7 +57,8 @@ and opens a PR with methodology fixes.
 | `prior_context.py` | Find prior generative-research articles related to a new topic. |
 | `research_search.py` | Specialized search wrappers for primary-source research. |
 | `stock_prices.py` | Yahoo Finance time series → copy-paste lines for `:::line-chart`. |
-| `dedupe_headline_alerts.py` | Filter + record delivered Twitter headline alerts (used by `hourly-twitter.yml`). |
+| `dedupe_headline_alerts.py` | Filter + record delivered Twitter headline alerts (used by `hourly-twitter.yml`). Layered deterministic dedup contract + Mermaid diagrams in [`docs/headline-dedupe.md`](docs/headline-dedupe.md). |
+| `headline_judge.py` | Agent-in-the-loop final dedup gate (used by `hourly-twitter.yml`). Two deterministic subcommands — `shortlist` (surface send-set survivors whose nearest prior sits in the contested `[0.35,0.50)` Jaccard band) and `apply` (drop only the Haiku judge's HIGH-confidence duplicates, fail-open, URL-keyed) — bracketing one Haiku adjudication step. Contract in [`docs/headline-dedupe.md`](docs/headline-dedupe.md). |
 | `curate_twitter_accounts.py` | Validates `data/sources/twitter_accounts.json`, builds the birdy fetch manifest, and writes/apply reviewable Twitter account add/remove proposals. |
 | `explore_twitter_accounts.py` | Scout script for `twitter-account-explorer.yml`; runs broad bird searches, scores unknown authors, and emits candidate JSON for reviewed account curation. |
 | `check_model_tickets.py` | Validator for `research/models/tickets/*.md` against the schema in `docs/model-tickets.md`. The CRUD agent in `24h-model-timeline.yml` runs it after every pass; CI runs it on every PR. |
@@ -69,7 +71,7 @@ and opens a PR with methodology fixes.
 | `fetch_youtube_signal.py` | tuber-backed YouTube lane used by `daily-youtube.yml`; read-only by default (discovery, existing summary previews, transcript probes) and never triggers paid summary generation. |
 | `source_cache.py` | Runtime primary-source fetch cache under `data/source-cache/` (gitignored), used by `generative-research.yml`. |
 | `render_front_page.mjs` | Deterministic newspaper renderer used by `daily-front-page.yml`: digest → SVG → PNG via `@resvg/resvg-js` (no Chromium/model dependency), plus the `.ara.md` source for the interactive edition. Layout is budget-aware — overflow is ellipsized/dropped, never painted over. |
-| `test_ara_dsl.py`, `test_dedupe_headline_alerts.py` | Pytest-style tests run in CI. (`test_ara_dsl.py` also asserts `ARA_CATALOG.json` ↔ `COMPONENTS.md` lockstep.) |
+| `test_ara_dsl.py`, `test_dedupe_headline_alerts.py`, `test_headline_judge.py` | Pytest-style tests run in CI. (`test_ara_dsl.py` also asserts `ARA_CATALOG.json` ↔ `COMPONENTS.md` lockstep.) |
 
 #### Experimental / manually-run scripts (NOT in the automated pipeline)
 

--- a/docs/headline-dedupe.md
+++ b/docs/headline-dedupe.md
@@ -1,0 +1,227 @@
+# Twitter headline-alert deduplication
+
+How the hourly-twitter cron keeps from re-sending the **same story** to the
+Telegram / Hooker "Robot Colosseum" feed. This is the contract for
+[`scripts/dedupe_headline_alerts.py`](../scripts/dedupe_headline_alerts.py)
+and its tests in `scripts/test_dedupe_headline_alerts.py`.
+
+## What problem it solves
+
+Each cycle a fresh Claude agent reads a window of X/Twitter signal and emits
+3–7 punchy headlines (`research/summaries/<date>-twitter-<hour>h-headlines.json`).
+The agent has **no memory of prior cycles**, so without a cross-cycle guard the
+same event gets blasted again every time a new account reports it — e.g. the
+same hire announced by two outlets hours apart. Dedup is therefore the
+**only** place cross-cycle and cross-source repetition can be caught.
+
+It is intentionally an **alert-send ledger, not a global news store**: the only
+question it answers is "have we already alerted users about this story?"
+
+## Where it runs in the pipeline
+
+```mermaid
+flowchart LR
+    SRC[bird CLI fetch<br/>X / Twitter]:::io --> AGENT[Claude agent<br/>writes headlines.json]:::proc
+    AGENT --> FILTER["dedupe filter<br/>suppress dups → to-send.json"]:::proc
+    LEDGER[("twitter-announced-history.json<br/>~3000 delivered records")]:::store --> FILTER
+    FILTER --> BLAST[Hooker /send-batch<br/>→ Telegram routes]:::io
+    BLAST --> REC["dedupe record-delivered<br/>append sent → ledger"]:::proc
+    REC --> LEDGER
+
+    classDef proc fill:#e3f2fd,stroke:#1565c0,color:#0d2b45;
+    classDef store fill:#fff3e0,stroke:#e65100,color:#3e2600;
+    classDef io fill:#ede7f6,stroke:#4527a0,color:#1a1035;
+```
+
+Two `dedupe_headline_alerts.py` subcommands bracket the send:
+
+| Subcommand | When | Effect |
+|---|---|---|
+| `filter` | before the blast | Drops every incoming headline that duplicates a ledger record; writes the survivors to `to-send.json`. |
+| `record-delivered` | after the blast | Appends the headlines that **actually delivered** (≥1 route accepted) to the ledger, capped at `RETENTION_DEFAULT = 3000` records. |
+
+The ledger (`research/summaries/twitter-announced-history.json`) is committed
+back to `main` each cycle, so the next run sees the updated history. Each
+record is `{headline, source, url, category, delivered_at}` where
+`delivered_at` is `"YYYY-MM-DD HH:MM UTC"`.
+
+## The decision: `duplicate_reason(item, history, history_keys, now)`
+
+Returns a **reason string** (suppress) or `""` (new → send). Checks run in
+**priority order; first match wins**, so the cheap high-precision signals
+short-circuit before the fuzzy cross-source scan.
+
+```mermaid
+flowchart TD
+    A[Incoming headline]:::io --> B[Normalize + tokenize → Keys]:::proc
+    B --> C{headline_key empty?}
+    C -->|yes| INV1([invalid_headline · suppress]):::supp
+    C -->|no| D{url_key empty?}
+    D -->|yes| INV2([invalid_url · suppress]):::supp
+    D -->|no| F
+
+    %% Pass 1 — exact / same-source, time-independent
+    F{"Any history record with<br/>same non-empty story_key?"} -->|yes| R1([duplicate_story_key]):::supp
+    F -->|no| G{"Any record with the same<br/>normalized headline?<br/>(any source / URL)"}
+    G -->|yes| R2([duplicate_headline]):::supp
+    G -->|no| H{"Any record with the SAME url<br/>and max-containment/Jaccard ≥ 0.62?"}
+    H -->|yes| R3([duplicate_source_similar_headline]):::supp
+    H -->|no| Q
+
+    %% Gate: cross-source pass only runs when a reference time is supplied
+    Q{now provided?} -->|"no — legacy / test caller"| SEND
+    Q -->|yes| K
+
+    %% Pass 2 — cross-source semantic duplicate
+    K{"Any DIFFERENT-url record where ALL hold:<br/>• delivered within 14 days (fail-open)<br/>• shared tokens ≥ 4<br/>• Jaccard ≥ 0.5"} -->|yes| R4([duplicate_cross_source_similar_headline]):::supp
+    K -->|no| SEND([empty string · NEW<br/>send + append to history]):::send
+
+    classDef proc fill:#e3f2fd,stroke:#1565c0,color:#0d2b45;
+    classDef io fill:#ede7f6,stroke:#4527a0,color:#1a1035;
+    classDef supp fill:#ffebee,stroke:#b71c1c,color:#3e0a0a;
+    classDef send fill:#e8f5e9,stroke:#2e7d32,color:#0c2912;
+```
+
+### Layers, in priority order
+
+| # | Reason returned | Condition | Catches |
+|---|---|---|---|
+| — | `invalid_headline` / `invalid_url` | empty normalized headline or URL | malformed agent output |
+| 1a | `duplicate_story_key` | same non-empty `story_key` | explicit story grouping (**inert today** — the agent's schema emits no `story_key`; kept for when it does) |
+| 1b | `duplicate_headline` | identical **normalized** headline, **any** source | verbatim re-posts / cross-account copies |
+| 1c | `duplicate_source_similar_headline` | **same URL** + `max(containment, jaccard) ≥ 0.62` | one author rephrasing their own tweet |
+| 2 | `duplicate_cross_source_similar_headline` | **different URL** + in 14-day window + `≥ 4` shared tokens + `Jaccard ≥ 0.5` | **the same story from a different account, paraphrased** (the leak this layer was added to close) |
+
+**Normalization** (`normalize_headline`): NFKC, uppercase, strip URLs, drop
+non-decimal dots, collapse to `[A-Z0-9.$]`. **Tokens** (`headline_tokens`):
+the normalized words minus a stopword list, length > 1. Token sets are
+precomputed once per record and cached on `Keys.tokens`, so the Pass-2 scan
+never re-tokenizes history.
+
+## Tunable constants (defaults live in the script — no workflow change to tune)
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `URL_SIMILARITY_THRESHOLD` | `0.62` | Pass 1c — same-URL paraphrase floor (uses `max(containment, jaccard)`). |
+| `CROSS_SOURCE_JACCARD_THRESHOLD` | `0.5` | Pass 2 — cross-source similarity floor (**Jaccard only**). |
+| `CROSS_SOURCE_MIN_OVERLAP` | `4` | Pass 2 — minimum absolute shared significant tokens. |
+| `CROSS_SOURCE_WINDOW_DAYS` | `14` | Pass 2 — recency window; `≤ 0` means unbounded. |
+| `RETENTION_DEFAULT` | `3000` | Ledger cap kept by `record-delivered`. |
+
+## Three design decisions that matter
+
+1. **Pass 2 uses Jaccard, not `max(containment, jaccard)`.** Containment
+   (`overlap / smaller-set`) scores a short headline that is a token-subset of
+   a longer one at **1.0** — so a legitimate *appended-fact follow-up*
+   (`"META RELEASES LLAMA 5"` → `"…WITH 2M TOKEN CONTEXT AND NATIVE VOICE"`)
+   would be wrongly suppressed. Jaccard (`overlap / union`) penalizes the size
+   gap (0.375 there), letting genuine "more details" updates through. Pass 1c
+   keeps the looser `max()` because an identical URL already proves same source.
+
+2. **Pass 2 is inert without `now`.** The recency window needs a reference
+   time. When `duplicate_reason` is called with no `now` (the 2-arg legacy/test
+   signature), Pass 2 is skipped entirely — existing callers are byte-for-byte
+   unchanged. `filter_headlines` derives `now` from the run `--timestamp`; if
+   that is malformed, Pass 2 simply doesn't run (no crash).
+
+3. **Per-record timestamps fail OPEN.** A history record whose `delivered_at`
+   is missing or unparseable is treated as **outside** the window → it cannot
+   suppress an incoming alert. The cost of a parse bug is at worst one
+   duplicate, never a swallowed headline. (Whole-file JSON corruption still
+   fails **closed** — `load_json_list` raises `SystemExit`.)
+
+**In-batch behavior:** `filter_headlines` appends each accepted item back into
+`history` (stamped with the run `now`) as it iterates, so two paraphrases of
+the same story *in the same cycle* from different accounts collapse to one —
+the first survives, the second is caught by Pass 2.
+
+## Calibration & known residual
+
+Thresholds were calibrated against the **real delivered-alert ledger**: genuine
+cross-source re-reports cluster at `Jaccard ≥ ~0.5` with `≥ 7` shared tokens,
+while appended-fact progression and short-subset headlines fall well below.
+The ledger's Jaccard *ceiling* is ~0.65, which is why `0.5` — not an intuitive
+`0.7+` — is the correct cut. A replay of the full ledger showed ~2.4% of
+delivered alerts were cross-source repeats this layer now catches.
+
+**Residual (documented, not solved by the deterministic layer):** token overlap
+cannot separate two genuinely-distinct stories that share heavy vocabulary (two
+entities running the same templated beat) from a true re-report. That residual
+is exactly what the **agent-in-the-loop gate** below addresses.
+
+## Agent-in-the-loop final gate
+
+The residual above is the gate's whole reason to exist. In the contested band
+*just below* the cross-source floor — `[0.35, 0.50)` Jaccard, ≥ 3 shared
+tokens — token overlap can't tell a true cross-source re-report from distinct
+news that merely shares vocabulary. Calibration on the real ledger shows that
+band is ~half true duplicates that leaked and ~half genuinely-distinct items:
+"MICRON CROSSES $900B" vs "SK HYNIX CROSSES $900B" (same metric, different
+subject), appended-fact follow-ups, running-counter progressions. Separating
+those is a *semantic* judgment, so a Claude **Haiku** step adjudicates exactly
+that band — and only that band — as a final gate on the send path.
+
+It lives in `scripts/headline_judge.py` (two deterministic, unit-tested
+subcommands) bracketing one model step in `hourly-twitter.yml`:
+
+```mermaid
+flowchart LR
+    FILTER["deterministic filter<br/>→ to-send.json"]:::proc --> SHORT["shortlist<br/>survivors in [0.35,0.50)<br/>+ ≤5 nearest priors"]:::proc
+    SHORT -->|empty| BLAST
+    SHORT -->|"doubtful.json"| JUDGE{{"Haiku judge<br/>same event?"}}:::model
+    JUDGE -->|"verdicts.json"| APPLY["apply<br/>drop duplicate+high only"]:::proc
+    APPLY --> ALERT["Telegram alert<br/>on every suppression"]:::io
+    APPLY --> BLAST["Hooker blast"]:::io
+    classDef proc fill:#e3f2fd,stroke:#1565c0,color:#0d2b45;
+    classDef model fill:#f3e5f5,stroke:#6a1b9a,color:#2e0a3a;
+    classDef io fill:#ede7f6,stroke:#4527a0,color:#1a1035;
+```
+
+**Safety contract** (the gate enforces immediately, with no shadow phase):
+
+- **One direction only.** The judge turns a would-be *send* into a *suppress* —
+  never the reverse, and never inside the deterministic exact / same-URL / ≥0.5
+  layers. It arbitrates only the sub-floor band.
+- **Default-keep.** A headline is dropped *only* on an explicit
+  `verdict:"duplicate"` + `confidence:"high"`. Any other verdict, a missing
+  verdict, or a missing/garbled verdicts file keeps it in the send set
+  (**fail OPEN** — never silently eat a real alert on a model hiccup).
+- **Distinct-protection prompt.** The judge is told *same action/number,
+  different subject = distinct* and *appended-fact follow-up = distinct*, with
+  "when in doubt, keep" as the cardinal rule. Validated against a fixture of
+  real band cases (`scripts/testdata/judge_eval_cases.json`): zero distinct
+  items eaten.
+- **URL-keyed.** Verdicts match headlines by URL, not array position, so a
+  reordered or partial model response can't misattribute a suppression.
+- **Visible audit.** Every suppression is posted to Telegram (via hooker), so a
+  wrong eat is reviewable within hours — this stands in for a shadow phase.
+- **Cheap.** ~0–1 shortlisted headline per cycle (≈6% of the feed sits in the
+  band); the model step is skipped entirely when the shortlist is empty.
+
+### Gate constants (`scripts/headline_judge.py`)
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `SHORTLIST_BAND_LOW` | `0.35` | lower edge of the contested band the judge sees |
+| `SHORTLIST_BAND_HIGH` | `0.50` | upper edge (= the deterministic cross-source floor) |
+| `SHORTLIST_MIN_OVERLAP` | `3` | minimum shared tokens to shortlist a survivor |
+| `SHORTLIST_MAX_CANDIDATES` | `5` | nearest priors shown to the judge per headline |
+
+## How to verify
+
+```bash
+# Unit + behavior tests (also run in CI via unittest discover) — covers both
+# the deterministic dedupe and the judge shortlist/apply logic.
+uv run python -m unittest discover -s scripts -p 'test_*.py'
+
+# Backtest: replay the real ledger and count cross-source dups the
+# current logic would catch (see the PR description for the script).
+
+# Judge prompt smoke-test: run the prompt over the labeled hard-case fixture
+# (scripts/testdata/judge_eval_cases.json) and confirm ZERO distinct items are
+# eaten before enabling enforcement.
+```
+
+When changing thresholds or the layer order, re-run the tests and re-backtest
+against the live ledger before shipping — over-suppression silently drops real
+news, which is worse than an occasional duplicate.

--- a/scripts/dedupe_headline_alerts.py
+++ b/scripts/dedupe_headline_alerts.py
@@ -5,6 +5,9 @@ This is intentionally an alert-send ledger, not a global news/event store. The
 workflow already has a structured boundary at `*-headlines.json`; this script
 keeps Telegram/Hooker sends from repeating previously delivered alert items.
 
+Full contract + flow diagrams (incl. the downstream agent gate in
+`headline_judge.py`): docs/headline-dedupe.md
+
 Dedupe layers (see `duplicate_reason`), in priority order:
   1. shared story_key, exact normalized headline (any source), and same-source
      (same URL) paraphrase — time-independent, highest precision.

--- a/scripts/headline_judge.py
+++ b/scripts/headline_judge.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -150,16 +151,43 @@ def shortlist(args: argparse.Namespace) -> int:
     return 0
 
 
+def _parse_verdicts_text(text: str) -> list[Any]:
+    """Parse a verdicts JSON array from raw model output, tolerantly.
+
+    Haiku ignores "write ONLY the JSON" more readily than larger models, so the
+    file may carry a ```json fence or a sentence of preamble. Try bare JSON
+    first, then a fenced block, then the outermost [...] slice. Returns [] on
+    failure -- the caller treats that as "no verdicts" and keeps every headline,
+    so a garbled response degrades to send-everything (fail OPEN), never a crash.
+    """
+    text = (text or "").strip()
+    if not text:
+        return []
+    candidates = [text]
+    fence = re.search(r"```(?:json)?\s*(.*?)```", text, re.DOTALL)
+    if fence:
+        candidates.append(fence.group(1).strip())
+    start, end = text.find("["), text.rfind("]")
+    if 0 <= start < end:
+        candidates.append(text[start : end + 1])
+    for candidate in candidates:
+        try:
+            data = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(data, list):
+            return data
+    return []
+
+
 def _load_verdicts(path: Path) -> dict[str, dict[str, Any]]:
     """Map incoming-URL -> verdict. Fails OPEN: any problem yields no verdicts,
     so every headline is kept (sent). Never raises on a bad model response."""
     if not path.exists():
         return {}
     try:
-        data = json.loads(path.read_text() or "[]")
-    except (json.JSONDecodeError, OSError):
-        return {}
-    if not isinstance(data, list):
+        data = _parse_verdicts_text(path.read_text())
+    except OSError:
         return {}
     by_url: dict[str, dict[str, Any]] = {}
     for entry in data:

--- a/scripts/headline_judge.py
+++ b/scripts/headline_judge.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Agent-in-the-loop final gate for the Twitter headline-alert dedupe.
+
+The deterministic check in ``dedupe_headline_alerts.py`` suppresses exact,
+same-source, and high-overlap cross-source duplicates. Its one irreducible
+residual is the *contested band* just below the cross-source floor: headlines
+that share a lot of vocabulary with a recently-alerted story but score below
+``CROSS_SOURCE_JACCARD_THRESHOLD`` (0.5). Calibration on the real ledger shows
+that band (``[0.35, 0.50)`` Jaccard, >= 3 shared tokens) is roughly half true
+duplicates that leaked (same event, different account, paraphrased) and half
+genuinely-distinct items that merely share vocabulary -- "MICRON CROSSES $900B"
+vs "SK HYNIX CROSSES $900B" (same metric, different subject), running-counter
+progressions, appended-fact follow-ups. Token overlap cannot tell those apart;
+that separation is a semantic judgment, which is what the LLM gate is for.
+
+This module is the deterministic half of that gate -- two subcommands that
+bracket one model call, so the nondeterminism lives only in the workflow's
+Haiku step and everything here stays unit-testable:
+
+  shortlist  to-send survivors + history -> the contested-band items, each with
+             its <= 5 most-similar prior alerts, for the judge to rule on.
+  apply      to-send survivors + judge verdicts -> survivors minus the items the
+             judge confirmed (HIGH confidence) are duplicates, plus an audit
+             record of every suppression.
+
+Safety contract (the gate enforces immediately, with no shadow phase):
+  * The judge can only turn a would-be SEND into a SUPPRESS -- never the reverse,
+    and never within the deterministic layers' exact/same-URL/high-overlap calls.
+  * A duplicate is dropped ONLY on an explicit HIGH-confidence "duplicate" verdict.
+    Default-keep: any missing/low/medium verdict, or a missing/malformed verdicts
+    file, leaves the headline in the send set (fail OPEN -- never silently eat a
+    real alert on a parse bug or model hiccup).
+  * Verdicts are matched to headlines by URL, not array position, so a reordered
+    or partial model response can't misattribute a suppression.
+
+Full contract + flow diagrams: docs/headline-dedupe.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# Reuse the exact normalization / tokenization the deterministic layer uses, so
+# the band the judge sees is computed identically to the floor it sits beneath.
+from dedupe_headline_alerts import Keys, item_keys, load_json_list, write_json
+
+# Contested band: suspicious enough to doubt, but below the deterministic
+# cross-source suppress floor (0.5), so `filter` already let these through.
+SHORTLIST_BAND_LOW = 0.35
+SHORTLIST_BAND_HIGH = 0.50
+SHORTLIST_MIN_OVERLAP = 3
+SHORTLIST_MAX_CANDIDATES = 5
+
+
+def jaccard(left: Keys, right: Keys) -> tuple[float, int]:
+    """(Jaccard similarity, absolute shared-token count) of two headlines."""
+    overlap = len(left.tokens & right.tokens)
+    union = len(left.tokens | right.tokens)
+    if not union:
+        return 0.0, 0
+    return overlap / union, overlap
+
+
+def candidate_priors(
+    item_keys_: Keys,
+    history: list[dict[str, Any]],
+    history_keys: list[Keys],
+    *,
+    band_low: float,
+    band_high: float,
+    min_overlap: int,
+    max_candidates: int,
+) -> list[dict[str, Any]]:
+    """Return the in-band, different-URL prior alerts most similar to an item.
+
+    Sorted by descending Jaccard, capped at ``max_candidates``. Empty when the
+    item has no prior in the contested band (the common case -- most headlines
+    are clearly new and never reach the judge).
+    """
+    scored: list[tuple[float, int, dict[str, Any]]] = []
+    for record, record_keys in zip(history, history_keys):
+        if not record_keys.url_key or record_keys.url_key == item_keys_.url_key:
+            continue
+        sim, overlap = jaccard(item_keys_, record_keys)
+        if overlap < min_overlap:
+            continue
+        if not (band_low <= sim < band_high):
+            continue
+        scored.append(
+            (
+                sim,
+                overlap,
+                {
+                    "headline": str(record.get("headline") or ""),
+                    "url": str(record.get("url") or ""),
+                    "delivered_at": str(record.get("delivered_at") or ""),
+                    "category": str(record.get("category") or ""),
+                    "jaccard": round(sim, 3),
+                    "overlap": overlap,
+                },
+            )
+        )
+    scored.sort(key=lambda row: (row[0], row[1]), reverse=True)
+    return [candidate for _, _, candidate in scored[:max_candidates]]
+
+
+def shortlist(args: argparse.Namespace) -> int:
+    incoming = load_json_list(Path(args.to_send_file), missing_ok=True)
+    history_raw = load_json_list(Path(args.history_file), missing_ok=True)
+    history = [record for record in history_raw if isinstance(record, dict)]
+    history_keys = [item_keys(record) for record in history]
+
+    doubtful: list[dict[str, Any]] = []
+    for item in incoming:
+        if not isinstance(item, dict):
+            continue
+        keys = item_keys(item)
+        if not keys.headline_key or not keys.url_key:
+            continue
+        candidates = candidate_priors(
+            keys,
+            history,
+            history_keys,
+            band_low=args.band_low,
+            band_high=args.band_high,
+            min_overlap=args.min_overlap,
+            max_candidates=args.max_candidates,
+        )
+        if not candidates:
+            continue
+        doubtful.append(
+            {
+                "url": str(item.get("url") or ""),
+                "headline": str(item.get("headline") or ""),
+                "category": str(item.get("category") or ""),
+                "candidates": candidates,
+            }
+        )
+
+    write_json(Path(args.out_file), doubtful)
+    print(
+        json.dumps(
+            {"incoming": len(incoming), "doubtful": len(doubtful)}, sort_keys=True
+        )
+    )
+    return 0
+
+
+def _load_verdicts(path: Path) -> dict[str, dict[str, Any]]:
+    """Map incoming-URL -> verdict. Fails OPEN: any problem yields no verdicts,
+    so every headline is kept (sent). Never raises on a bad model response."""
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text() or "[]")
+    except (json.JSONDecodeError, OSError):
+        return {}
+    if not isinstance(data, list):
+        return {}
+    by_url: dict[str, dict[str, Any]] = {}
+    for entry in data:
+        if not isinstance(entry, dict):
+            continue
+        url = str(entry.get("url") or "").strip()
+        if url:
+            by_url[url] = entry
+    return by_url
+
+
+def apply_verdicts(args: argparse.Namespace) -> int:
+    incoming = load_json_list(Path(args.to_send_file), missing_ok=True)
+    verdicts = _load_verdicts(Path(args.verdicts_file))
+
+    kept: list[dict[str, Any]] = []
+    suppressed: list[dict[str, Any]] = []
+    for item in incoming:
+        if not isinstance(item, dict):
+            kept.append(item)
+            continue
+        url = str(item.get("url") or "").strip()
+        verdict = verdicts.get(url) or {}
+        is_dup = str(verdict.get("verdict") or "").strip().lower() == "duplicate"
+        confident = str(verdict.get("confidence") or "").strip().lower() == "high"
+        # Suppress ONLY on an explicit high-confidence duplicate verdict.
+        if is_dup and confident:
+            suppressed.append(
+                {
+                    "headline": str(item.get("headline") or ""),
+                    "url": url,
+                    "category": str(item.get("category") or ""),
+                    "matched_url": str(verdict.get("matched_url") or ""),
+                    "reason": str(verdict.get("reason") or ""),
+                    "judged_at": args.timestamp,
+                }
+            )
+            continue
+        kept.append(item)
+
+    write_json(Path(args.out_file), kept)
+
+    # Per-run record of what was eaten, for the workflow's Telegram/hooker alert
+    # (the durable, human-visible audit that stands in for a shadow phase).
+    if args.suppressed_file:
+        write_json(Path(args.suppressed_file), suppressed)
+
+    # Optional append-only audit ledger (manual/local use; the workflow relies on
+    # the Telegram alert instead, since an ephemeral runner can't durably commit it).
+    if suppressed and args.audit_file:
+        audit_path = Path(args.audit_file)
+        audit_path.parent.mkdir(parents=True, exist_ok=True)
+        with audit_path.open("a", encoding="utf-8") as handle:
+            for record in suppressed:
+                handle.write(json.dumps(record, sort_keys=True) + "\n")
+
+    summary = {
+        "incoming": len(incoming),
+        "kept": len(kept),
+        "suppressed": len(suppressed),
+        "suppressed_headlines": [record["headline"] for record in suppressed],
+    }
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    short = subparsers.add_parser(
+        "shortlist", help="emit contested-band survivors + their nearest priors"
+    )
+    short.add_argument("--to-send-file", required=True)
+    short.add_argument("--history-file", required=True)
+    short.add_argument("--out-file", required=True)
+    short.add_argument("--band-low", type=float, default=SHORTLIST_BAND_LOW)
+    short.add_argument("--band-high", type=float, default=SHORTLIST_BAND_HIGH)
+    short.add_argument("--min-overlap", type=int, default=SHORTLIST_MIN_OVERLAP)
+    short.add_argument("--max-candidates", type=int, default=SHORTLIST_MAX_CANDIDATES)
+    short.set_defaults(func=shortlist)
+
+    apply_parser = subparsers.add_parser(
+        "apply", help="drop judge-confirmed duplicates from the send set"
+    )
+    apply_parser.add_argument("--to-send-file", required=True)
+    apply_parser.add_argument("--verdicts-file", required=True)
+    apply_parser.add_argument("--out-file", required=True)
+    apply_parser.add_argument("--suppressed-file", default="")
+    apply_parser.add_argument("--audit-file", default="")
+    apply_parser.add_argument("--timestamp", default="")
+    apply_parser.set_defaults(func=apply_verdicts)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_headline_judge.py
+++ b/scripts/test_headline_judge.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+
+import dedupe_headline_alerts as dedupe
+import headline_judge as judge
+
+
+def _write(path: Path, data) -> None:
+    path.write_text(json.dumps(data))
+
+
+class ShortlistTest(unittest.TestCase):
+    def _run(self, to_send, history, **kw):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write(root / "to_send.json", to_send)
+            _write(root / "history.json", history)
+            argv = [
+                "shortlist",
+                "--to-send-file", str(root / "to_send.json"),
+                "--history-file", str(root / "history.json"),
+                "--out-file", str(root / "doubtful.json"),
+            ]
+            for k, v in kw.items():
+                argv += [f"--{k.replace('_', '-')}", str(v)]
+            with redirect_stdout(StringIO()):
+                self.assertEqual(judge.main(argv), 0)
+            return json.loads((root / "doubtful.json").read_text())
+
+    def test_in_band_item_is_shortlisted_with_candidate(self):
+        # Jaccard ~0.42, in [0.35,0.50): suspicious but below the 0.5 suppress floor.
+        history = [
+            dedupe.make_record(
+                {
+                    "headline": "CHINA ORDERS META TO UNWIND $2B MANUS AI DEAL — 100 STAFF ALREADY INSIDE",
+                    "url": "https://x.com/a/status/1",
+                },
+                "2026-06-18 01:00 UTC",
+            )
+        ]
+        to_send = [
+            {
+                "headline": "CHINA NDRC ORDERS META TO UNWIND $2B MANUS ACQUISITION — FIRST FORCED UNWIND",
+                "url": "https://x.com/b/status/2",
+                "category": "policy",
+            }
+        ]
+        out = self._run(to_send, history)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]["url"], "https://x.com/b/status/2")
+        self.assertEqual(len(out[0]["candidates"]), 1)
+        self.assertEqual(out[0]["candidates"][0]["url"], "https://x.com/a/status/1")
+
+    def test_distinct_entity_pair_is_still_shortlisted(self):
+        # Micron vs SK Hynix: same metric, different subject. Shortlist only
+        # SURFACES it (in-band) — the judge, not the math, decides it's distinct.
+        history = [
+            dedupe.make_record(
+                {
+                    "headline": "SK HYNIX MARKET CAP CROSSES $900 BILLION ON HBM SUPER-CYCLE",
+                    "url": "https://x.com/a/status/1",
+                },
+                "2026-06-18 01:00 UTC",
+            )
+        ]
+        to_send = [
+            {
+                "headline": "MICRON MARKET CAP CROSSES $900B — JOINS SK HYNIX IN MEMORY SUPER-CYCLE MEGA-RALLY",
+                "url": "https://x.com/b/status/2",
+            }
+        ]
+        out = self._run(to_send, history)
+        self.assertEqual(len(out), 1)
+
+    def test_above_floor_is_not_shortlisted(self):
+        # Jaccard >= 0.50 is the deterministic layer's job, not the judge's band.
+        history = [
+            dedupe.make_record(
+                {"headline": "NEBIUS TO ACQUIRE EIGEN AI FOR $643M IN CASH AND SHARES", "url": "https://x.com/a/status/1"},
+                "2026-06-18 01:00 UTC",
+            )
+        ]
+        to_send = [
+            {"headline": "NEBIUS ACQUIRES EIGEN AI FOR $643M CASH AND SHARES", "url": "https://x.com/b/status/2"}
+        ]
+        out = self._run(to_send, history)
+        self.assertEqual(out, [])
+
+    def test_below_band_is_not_shortlisted(self):
+        history = [
+            dedupe.make_record(
+                {"headline": "OPENAI SHIPS GPT-5.6 WITH LIVE VIDEO", "url": "https://x.com/a/status/1"},
+                "2026-06-18 01:00 UTC",
+            )
+        ]
+        to_send = [
+            {"headline": "MISTRAL OPEN-SOURCES A NEW 8B CODER MODEL", "url": "https://x.com/b/status/2"}
+        ]
+        out = self._run(to_send, history)
+        self.assertEqual(out, [])
+
+    def test_same_url_prior_is_excluded(self):
+        history = [
+            dedupe.make_record(
+                {"headline": "ANTHROPIC ORBIT LEAK: PROACTIVE ASSISTANT FOR CLAUDE COWORK PULLING DATA", "url": "https://x.com/same/status/9"},
+                "2026-06-18 01:00 UTC",
+            )
+        ]
+        to_send = [
+            {"headline": "ANTHROPIC ORBIT RE-LEAKED — PROACTIVE CLAUDE COWORK ASSISTANT AUTO-BRIEFING", "url": "https://x.com/same/status/9"}
+        ]
+        out = self._run(to_send, history)
+        self.assertEqual(out, [])
+
+    def test_candidates_ranked_and_capped(self):
+        # Synthetic tokens with controlled overlap so four priors land at distinct
+        # in-band Jaccards (0.444, 0.400, 0.385, 0.364) — lets us assert the
+        # candidate list is sorted by descending similarity and capped.
+        incoming = "AONE ATWO ATHREE AFOUR AFIVE ASIX ASEVEN AEIGHT"
+        priors = [
+            "AONE ATWO ATHREE AFOUR UAA",                       # 4/9  = 0.444
+            "AONE ATWO ATHREE AFOUR UBB UBC",                   # 4/10 = 0.400
+            "AONE ATWO ATHREE AFOUR AFIVE UCA UCB UCC UCD UCE", # 5/13 = 0.385
+            "AONE ATWO ATHREE AFOUR UDA UDB UDC",               # 4/11 = 0.364
+        ]
+        history = [
+            dedupe.make_record({"headline": h, "url": f"https://x.com/a/status/{i}"}, "2026-06-18 01:00 UTC")
+            for i, h in enumerate(priors)
+        ]
+        to_send = [{"headline": incoming, "url": "https://x.com/b/status/99"}]
+        out = self._run(to_send, history, max_candidates=3)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(len(out[0]["candidates"]), 3)
+        sims = [c["jaccard"] for c in out[0]["candidates"]]
+        self.assertEqual(sims, sorted(sims, reverse=True))
+        self.assertAlmostEqual(sims[0], 0.444, places=2)
+
+
+class ApplyVerdictsTest(unittest.TestCase):
+    def _run(self, to_send, verdicts, *, write_verdicts=True, raw_verdicts=None):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write(root / "to_send.json", to_send)
+            vpath = root / "verdicts.json"
+            if write_verdicts:
+                if raw_verdicts is not None:
+                    vpath.write_text(raw_verdicts)
+                else:
+                    _write(vpath, verdicts)
+            argv = [
+                "apply",
+                "--to-send-file", str(root / "to_send.json"),
+                "--verdicts-file", str(vpath),
+                "--out-file", str(root / "out.json"),
+                "--audit-file", str(root / "audit.jsonl"),
+                "--timestamp", "2026-06-20 04:00 UTC",
+            ]
+            with redirect_stdout(StringIO()):
+                self.assertEqual(judge.main(argv), 0)
+            kept = json.loads((root / "out.json").read_text())
+            audit = []
+            if (root / "audit.jsonl").exists():
+                audit = [json.loads(line) for line in (root / "audit.jsonl").read_text().splitlines() if line]
+            return kept, audit
+
+    def test_high_confidence_duplicate_is_dropped_and_audited(self):
+        to_send = [
+            {"headline": "A DUP", "url": "https://x.com/b/1", "category": "policy"},
+            {"headline": "B KEEP", "url": "https://x.com/b/2"},
+        ]
+        verdicts = [
+            {"url": "https://x.com/b/1", "verdict": "duplicate", "confidence": "high", "matched_url": "https://x.com/a/1", "reason": "same event"},
+            {"url": "https://x.com/b/2", "verdict": "distinct", "confidence": "high"},
+        ]
+        kept, audit = self._run(to_send, verdicts)
+        self.assertEqual([k["url"] for k in kept], ["https://x.com/b/2"])
+        self.assertEqual(len(audit), 1)
+        self.assertEqual(audit[0]["url"], "https://x.com/b/1")
+        self.assertEqual(audit[0]["matched_url"], "https://x.com/a/1")
+        self.assertEqual(audit[0]["reason"], "same event")
+
+    def test_distinct_verdict_is_kept(self):
+        to_send = [{"headline": "MICRON $900B", "url": "https://x.com/b/1"}]
+        verdicts = [{"url": "https://x.com/b/1", "verdict": "distinct", "confidence": "high"}]
+        kept, audit = self._run(to_send, verdicts)
+        self.assertEqual(len(kept), 1)
+        self.assertEqual(audit, [])
+
+    def test_low_and_medium_confidence_duplicate_is_kept(self):
+        # Default-keep: only HIGH-confidence duplicates are eaten.
+        to_send = [
+            {"headline": "MAYBE DUP 1", "url": "https://x.com/b/1"},
+            {"headline": "MAYBE DUP 2", "url": "https://x.com/b/2"},
+        ]
+        verdicts = [
+            {"url": "https://x.com/b/1", "verdict": "duplicate", "confidence": "medium"},
+            {"url": "https://x.com/b/2", "verdict": "duplicate", "confidence": "low"},
+        ]
+        kept, audit = self._run(to_send, verdicts)
+        self.assertEqual(len(kept), 2)
+        self.assertEqual(audit, [])
+
+    def test_missing_verdict_for_item_is_kept(self):
+        to_send = [{"headline": "NO VERDICT", "url": "https://x.com/b/1"}]
+        kept, _ = self._run(to_send, [])
+        self.assertEqual(len(kept), 1)
+
+    def test_missing_verdicts_file_fails_open(self):
+        to_send = [{"headline": "X", "url": "https://x.com/b/1"}, {"headline": "Y", "url": "https://x.com/b/2"}]
+        kept, audit = self._run(to_send, None, write_verdicts=False)
+        self.assertEqual(len(kept), 2)
+        self.assertEqual(audit, [])
+
+    def test_malformed_verdicts_file_fails_open(self):
+        to_send = [{"headline": "X", "url": "https://x.com/b/1"}]
+        kept, _ = self._run(to_send, None, raw_verdicts="{not json at all")
+        self.assertEqual(len(kept), 1)
+
+    def test_verdicts_matched_by_url_not_index(self):
+        # Verdicts arrive in a different order than to-send; the right item must drop.
+        to_send = [
+            {"headline": "FIRST KEEP", "url": "https://x.com/b/1"},
+            {"headline": "SECOND DUP", "url": "https://x.com/b/2"},
+        ]
+        verdicts = [
+            {"url": "https://x.com/b/2", "verdict": "duplicate", "confidence": "high"},
+            {"url": "https://x.com/b/1", "verdict": "distinct", "confidence": "high"},
+        ]
+        kept, audit = self._run(to_send, verdicts)
+        self.assertEqual([k["url"] for k in kept], ["https://x.com/b/1"])
+        self.assertEqual(audit[0]["url"], "https://x.com/b/2")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_headline_judge.py
+++ b/scripts/test_headline_judge.py
@@ -222,6 +222,21 @@ class ApplyVerdictsTest(unittest.TestCase):
         kept, _ = self._run(to_send, None, raw_verdicts="{not json at all")
         self.assertEqual(len(kept), 1)
 
+    def test_fenced_json_verdicts_are_parsed(self):
+        # Haiku often wraps output in a ```json fence despite "write ONLY JSON".
+        to_send = [{"headline": "DUP", "url": "https://x.com/b/1"}]
+        raw = '```json\n[{"url": "https://x.com/b/1", "verdict": "duplicate", "confidence": "high"}]\n```'
+        kept, audit = self._run(to_send, None, raw_verdicts=raw)
+        self.assertEqual(kept, [])
+        self.assertEqual(len(audit), 1)
+
+    def test_preambled_json_verdicts_are_parsed(self):
+        # A sentence of preamble before the array must still be recovered.
+        to_send = [{"headline": "DUP", "url": "https://x.com/b/1"}]
+        raw = 'Here are my verdicts:\n[{"url": "https://x.com/b/1", "verdict": "duplicate", "confidence": "high"}]'
+        kept, _ = self._run(to_send, None, raw_verdicts=raw)
+        self.assertEqual(kept, [])
+
     def test_verdicts_matched_by_url_not_index(self):
         # Verdicts arrive in a different order than to-send; the right item must drop.
         to_send = [

--- a/scripts/testdata/judge_eval_cases.json
+++ b/scripts/testdata/judge_eval_cases.json
@@ -1,0 +1,61 @@
+{
+  "_comment": "Hard cases for the headline-dedupe judge, drawn from the real announced-history ledger's contested band ([0.35,0.50) Jaccard). Each case: an incoming headline + the single most-similar prior alert + the ground-truth label. 'duplicate' = same underlying event re-reported (judge SHOULD suppress, HIGH confidence). 'distinct' = genuinely different news that merely shares vocabulary (judge MUST keep). Used by the local prompt smoke-test and as documentation of the failure modes the prompt must handle. The cardinal sin is mislabeling a 'distinct' as 'duplicate' (eating real news).",
+  "cases": [
+    {
+      "label": "distinct",
+      "kind": "same-metric-different-subject",
+      "incoming": "MICRON MARKET CAP CROSSES $900B — JOINS SK HYNIX IN MEMORY SUPER-CYCLE MEGA-RALLY",
+      "candidate": "SK HYNIX MARKET CAP CROSSES $900 BILLION ON HBM SUPER-CYCLE",
+      "note": "Same metric ($900B market cap) and beat (memory super-cycle), DIFFERENT company. The hardest false-positive: high lexical overlap, genuinely distinct subject."
+    },
+    {
+      "label": "distinct",
+      "kind": "appended-fact-progression",
+      "incoming": "META RELEASES LLAMA 5 WITH 2M TOKEN CONTEXT AND NATIVE VOICE",
+      "candidate": "META RELEASES LLAMA 5",
+      "note": "Follow-up carries genuinely new facts (2M context, native voice). The flash was already sent; this adds information and has standalone value."
+    },
+    {
+      "label": "distinct",
+      "kind": "same-template-different-entity",
+      "incoming": "DEEPSEEK CUTS API PRICING ACROSS THE BOARD",
+      "candidate": "GOOGLE CUTS GEMINI API PRICING ACROSS THE BOARD",
+      "note": "Same templated action (cuts API pricing), different company. Two separate events."
+    },
+    {
+      "label": "distinct",
+      "kind": "confirmation-is-new-development",
+      "incoming": "xAI HANDLE CONFIRMS COLOSSUS 1 LEASE TO ANTHROPIC + MULTI-GIGAWATT ORBITAL COMPUTE",
+      "candidate": "ANTHROPIC + SPACEX EXPLORING MULTI-GIGAWATT ORBITAL AI COMPUTE PARTNERSHIP",
+      "note": "Prior was 'exploring'; incoming is an official confirmation with a concrete lease — a real escalation, not a re-report."
+    },
+    {
+      "label": "duplicate",
+      "kind": "same-event-different-account",
+      "incoming": "CHINA NDRC ORDERS META TO UNWIND $2B MANUS ACQUISITION — FIRST FORCED UNWIND",
+      "candidate": "CHINA ORDERS META TO UNWIND $2B MANUS AI DEAL — ~100 STAFF ALREADY INSIDE",
+      "note": "Same regulatory action (China orders Meta to unwind the $2B Manus deal), reported by two accounts."
+    },
+    {
+      "label": "duplicate",
+      "kind": "same-event-different-account",
+      "incoming": "DEEPSEEK IN TALKS FOR $45B FIRST FUNDRAISE — CHINA'S LARGEST STATE-BACKED ROUND",
+      "candidate": "DEEPSEEK IN TALKS TO RAISE AT ~$45B IN FIRST MAJOR ROUND — CHINA STATE-BACKED",
+      "note": "Same fundraise (~$45B, first round, state-backed), paraphrased."
+    },
+    {
+      "label": "duplicate",
+      "kind": "same-event-refined-number",
+      "incoming": "SIERRA RAISES $950M LED BY TIGER GLOBAL AND GV AT $15B+ VALUATION",
+      "candidate": "SIERRA RAISES $950M SERIES E AT $15B+ VALUATION, TIGER GLOBAL + GV LED",
+      "note": "Same raise ($950M, $15B+, Tiger Global + GV), same event."
+    },
+    {
+      "label": "duplicate",
+      "kind": "same-event-different-account",
+      "incoming": "OPENAI-BROADCOM $18B CHIP DEAL HITS FINANCING SNAG — MEMO: 'CAN'T REQUIRE'",
+      "candidate": "OPENAI-BROADCOM 10GW CHIP DEAL HITS FINANCING SNAG — $18 BILLION HINGES ON",
+      "note": "Same story (OpenAI-Broadcom $18B chip deal hits a financing snag)."
+    }
+  ]
+}


### PR DESCRIPTION
Adds a Claude **Haiku** final gate to the headline-alert dedupe: when a would-be-sent headline is *suspiciously* similar to a recently-alerted one but below the deterministic suppress floor, the agent compares it against its ≤5 most-similar priors and makes the final same-event-or-not call. Requested as "loop in the agent as final checker, comparing the at most 5 candidates doubted as most similar." Also folds in the dedupe contract doc (was #145, now conflict-free) + a judge-gate section.

## Why (the residual #143 couldn't solve)
The deterministic cross-source layer suppresses at `Jaccard ≥ 0.5`. Its irreducible residual is the **contested band just below** that floor — token overlap can't separate a true re-report from distinct news that shares vocabulary. Backtest on the real 1,498-record ledger: `[0.35,0.50)` (≥3 shared tokens) is **~half true duplicates that leaked, ~half genuinely-distinct** items:
- `MICRON CROSSES $900B` vs `SK HYNIX CROSSES $900B` — same metric, **different subject**
- appended-fact follow-ups (`META RELEASES LLAMA 5` → `…WITH 2M TOKEN CONTEXT`)
- running-counter progressions

Separating those is semantic judgment — exactly an LLM's job, and exactly what Jaccard structurally cannot do.

## Design (scoped, enforce-immediately-safe)
`scripts/headline_judge.py` — two deterministic, unit-tested subcommands bracket one Haiku step in `hourly-twitter.yml`:
1. `shortlist` → emit send-set survivors whose nearest prior is in `[0.35,0.50)` + their ≤5 candidates (usually empty; **~0–1/cycle**, so the model step is skipped most cycles).
2. **Haiku adjudicates** (native, via the same OAuth-token `claude-code-action` pattern already in this job).
3. `apply` → drop **only** the judge's `duplicate`+`high-confidence` verdicts.

**Guardrails** (advisor-reviewed; the gate enforces immediately with no shadow phase):
- **One direction**: judge can only turn send→suppress, only in the sub-floor band — never weakens the deterministic exact/same-URL/≥0.5 layers, never resurrects a hard-suppression.
- **Default-keep / fail-open**: drops only on `duplicate`+`high`; any missing/garbled verdict or model hiccup keeps the headline (never silently eats real news).
- **Distinct-protection prompt** ("same action/number, different subject = distinct"; "when in doubt, keep").
- **URL-keyed** verdicts (not array index).
- **Telegram alert on every suppression** (via hooker) — a wrong eat is visible in hours; the no-shadow compensating control.
- Nondeterminism isolated to the one model step; **CI never calls the model**.

## Validation
- **Enforce-gate smoke test** (the ship gate): ran the exact judge prompt over a fixture of **real band cases** (`scripts/testdata/judge_eval_cases.json`) with a fresh strong model → **zero distinct items eaten** (all 4 distinct incl. Micron/SK-Hynix + append-fact kept; 3/4 true dups caught, 1 borderline conservatively kept). The cardinal sin — eating a real headline — does not occur.
- **End-to-end** pipeline run (shortlist → simulated verdicts → apply) behaves correctly.
- **30 unit tests** (13 new judge: band selection, ranking/cap, URL-keying, fail-open on missing/malformed verdicts, default-keep on low/medium; + 17 existing dedupe). actionlint clean.

## Calibration says rescue is NOT worth it (decision logged)
The contested band's *other* half — `[0.50,0.65)`, currently suppressed — was measured too: **30/30 are genuine dups correctly suppressed, zero distinct**. So a "rescue" direction would mostly re-leak dups (the user's exact complaint). Shipped **suppress-direction only**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)