### PR TITLE
Fix headline judge gate: Haiku hit max-turns before writing verdicts

### DIFF
--- a/.github/workflows/hourly-twitter.yml
+++ b/.github/workflows/hourly-twitter.yml
@@ -594,13 +594,10 @@ jobs:
           && steps.judge_shortlist.outputs.count != ''
         continue-on-error: true
         uses: anthropics/claude-code-action@v1
-        env:
-          DOUBTFUL_FILE: /tmp/${{ steps.datetime.outputs.date }}-twitter-${{ steps.datetime.outputs.hour }}h-judge-doubtful.json
-          VERDICTS_FILE: /tmp/${{ steps.datetime.outputs.date }}-twitter-${{ steps.datetime.outputs.hour }}h-judge-verdicts.json
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
-            --model haiku --max-turns 6 --allowedTools "Read,Write,Bash(cat:*),Bash(jq:*),Bash(printenv:*)"
+            --model haiku --max-turns 12 --allowedTools "Read,Write"
           prompt: |
             You are the final duplicate gate for an AI-news headline alert
             feed. Reason from FIRST PRINCIPLES: judge whether two headlines
@@ -612,8 +609,11 @@ jobs:
             duplicate through. Mark "duplicate" with "high" confidence ONLY
             when you are certain it is the same specific event already sent.
 
-            Step 1 — read the input. Get the path and read it:
-              DOUBTFUL=$(printenv DOUBTFUL_FILE); cat "$DOUBTFUL"
+            Work in as few steps as possible: Read one file, then Write one
+            file. Use ONLY the Read and Write tools, nothing else.
+
+            Step 1 — Read this input file with the Read tool:
+              /tmp/${{ steps.datetime.outputs.date }}-twitter-${{ steps.datetime.outputs.hour }}h-judge-doubtful.json
             It is a JSON array; each entry is
               { "url", "headline", "candidates": [ { "headline", "delivered_at", "url" }, ... ] }
             The candidates are prior ALREADY-SENT alerts that share vocabulary
@@ -638,16 +638,16 @@ jobs:
               - A different, itself-newsworthy stage of an ongoing story
                 (rumor -> official confirmation; priced -> debuted).
 
-            Step 3 — output. Use the Write tool to create the file whose path
-            is in env var VERDICTS_FILE (run: printenv VERDICTS_FILE). Write a
-            JSON array, exactly one object per input entry:
+            Step 3 — with the Write tool, write your answer to this exact path:
+              /tmp/${{ steps.datetime.outputs.date }}-twitter-${{ steps.datetime.outputs.hour }}h-judge-verdicts.json
+            Content = a JSON array, exactly one object per input entry:
               { "url": "<the entry's url>", "verdict": "duplicate" | "distinct",
                 "confidence": "high" | "medium" | "low",
                 "matched_url": "<candidate url if duplicate, else empty string>",
                 "reason": "<one short clause>" }
             Key each verdict by the entry's "url" exactly. Use "duplicate" +
             "high" ONLY when certain; any genuine uncertainty -> "distinct".
-            Write ONLY the JSON array to that file — no prose, no other files.
+            Write ONLY the JSON array to that file, then stop.
 
       # ── claude-tier agent dedupe gate (steps 3/4: apply verdicts) ──
       # Drop only HIGH-confidence duplicates from the send set; fail OPEN if


### PR DESCRIPTION
**Follow-up to #146 — the post-merge dry-run validation caught a silent no-op.**

When the judge step finally ran Haiku for real (post-merge, since `claude-code-action` self-skips on branches), it failed with:
```
Execution failed: Reached maximum number of turns (6)
```
Haiku spent its 6-turn budget on the `printenv DOUBTFUL_FILE → cat → printenv VERDICTS_FILE → Write` dance and never wrote the verdicts file. `continue-on-error` masked the error as "success", so `apply` fail-opened and kept everything — the gate was inert (safe, but doing nothing).

## Fix
- **Interpolate the literal doubtful/verdicts paths into the prompt** (via `steps.datetime.outputs.*`, internal — not user input), so Haiku only needs **Read + Write (~2 turns)** instead of 4+.
- **Drop `Bash` from `allowedTools`** → `Read,Write` only (no temptation to wander).
- **Raise `--max-turns` 6 → 12** for ample slack.

No behavior/safety change — fail-open, suppress-only, default-keep, URL-keying, Telegram audit all unchanged. This just lets the model actually finish and write its verdicts.

Verified end-to-end on the prior run that everything *around* the model works (shortlist surfaced the seed, apply fail-opened cleanly). After merge I'll re-dispatch the dry-run on `main` to confirm Haiku now writes parseable verdicts and drops the seeded near-dup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)