### PR TITLE
Fix Twitter explorer PR publishing (route through Claude App, not GITHUB_TOKEN)

### DIFF
--- a/.github/workflows/twitter-account-explorer.yml
+++ b/.github/workflows/twitter-account-explorer.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
-            --model opus --allowedTools "Read,Write,Edit,Bash(git checkout:*),Bash(git status:*),Bash(git diff:*),Bash(git add:*),Bash(git commit:*),Bash(uv:*),Bash(python:*),Bash(python3:*),Bash(bird:*),Bash(jq:*),Bash(cat:*)"
+            --model opus --allowedTools "Read,Write,Edit,Bash(git checkout:*),Bash(git status:*),Bash(git diff:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(gh:*),Bash(uv:*),Bash(python:*),Bash(python3:*),Bash(bird:*),Bash(jq:*),Bash(cat:*)"
           prompt: |
             You are the ARA Twitter account explorer agent.
 
@@ -117,45 +117,30 @@ jobs:
                - Run:
                  `uv run python scripts/curate_twitter_accounts.py validate`
                  `uv run python -m unittest scripts/test_curate_twitter_accounts.py scripts/test_explore_twitter_accounts.py`
-               - Commit only:
+               - Commit the manifest and the proposal doc:
                  data/sources/twitter_accounts.json
                  docs/archive/${{ steps.dates.outputs.today }}-twitter-account-explorer.md
+                 If — and only if — a test asserts a hard-coded manifest account
+                 count and your change makes the unittest above fail, fix that
+                 assertion to be baseline-relative (compare against the live
+                 manifest, not a literal) and include
+                 scripts/test_curate_twitter_accounts.py in the same commit so
+                 CI stays green. Do not commit any other files.
                - Write `/tmp/twitter-account-explorer-pr-body.md` with the PR
-                 body described below. Do not push or call `gh`; the workflow
-                 publishes the branch and PR after your step.
+                 body described below.
+               - Push the branch and open the PR YOURSELF. This step runs inside
+                 the Claude GitHub App, which IS permitted to create pull
+                 requests; a downstream plain-`GITHUB_TOKEN` `run:` step is NOT
+                 ("GitHub Actions is not permitted to create or approve pull
+                 requests"), which is why publishing must happen here:
+                 `git push -u origin ${{ steps.dates.outputs.branch }}`
+                 Then check for an existing open PR and create one only if none
+                 exists (keeps same-day re-runs idempotent):
+                 `gh pr list --head ${{ steps.dates.outputs.branch }} --state open --json number --jq 'length'`
+                 If that prints `0`, run:
+                 `gh pr create --base main --head ${{ steps.dates.outputs.branch }} --title "Twitter account explorer - ${{ steps.dates.outputs.today }}" --body-file /tmp/twitter-account-explorer-pr-body.md`
 
             PR body must include:
             - Added accounts with evidence URLs and why they improve coverage.
             - Removed accounts with evidence and why removal is safe.
             - Validation commands run.
-
-      - name: Publish PR if agent created branch
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          CURRENT_BRANCH=$(git branch --show-current)
-          if [ -n "$CURRENT_BRANCH" ] && [ "$CURRENT_BRANCH" != "main" ]; then
-            git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
-            git push -u origin "$CURRENT_BRANCH"
-            BODY_PATH="/tmp/twitter-account-explorer-pr-body.md"
-            if [ ! -s "$BODY_PATH" ]; then
-              BODY_PATH="docs/archive/${{ steps.dates.outputs.today }}-twitter-account-explorer.md"
-            fi
-            if [ ! -s "$BODY_PATH" ]; then
-              BODY_PATH="/tmp/twitter-account-explorer-pr-body.md"
-              cat > "$BODY_PATH" <<'EOF'
-          Automated Twitter account explorer update.
-
-          See the branch diff for the proposed account manifest changes.
-          EOF
-            fi
-            EXISTING_COUNT=$(gh pr list --head "$CURRENT_BRANCH" --state open --json number --jq 'length')
-            if [ "$EXISTING_COUNT" -eq 0 ]; then
-              gh pr create \
-                --base main \
-                --head "$CURRENT_BRANCH" \
-                --title "Twitter account explorer - ${{ steps.dates.outputs.today }}" \
-                --body-file "$BODY_PATH"
-            fi
-          fi


### PR DESCRIPTION
## Problem

The first-ever **Twitter Account Explorer** run ([27868754333](https://github.com/guzus/ai-research-arm/actions/runs/27868754333)) did its job — the agent curated 4 high-signal AI accounts (47 turns, $2.95, ~5.7 min) and pushed branch `twitter-account-explorer/2026-06-20` — but the workflow was marked **failed**. The branch pushed fine; only the final external publish step broke:

```
pull request create failed: GraphQL: GitHub Actions is not permitted to
create or approve pull requests (createPullRequest)
```

### Root cause
The explorer created the PR from a separate `run:` step using the default `GITHUB_TOKEN`, which **cannot open PRs** in this repo (the "Allow GitHub Actions to create and approve pull requests" setting is off — there are **zero** `github-actions[bot]`-authored PRs in the repo's history).

`daily-improve.yml` does **not** hit this: it runs `gh pr create` **inside** the `claude-code-action`, which authenticates as the **Claude GitHub App** (`app/claude`) and *is* permitted. All 14 `improve/*` PRs were opened that way. The explorer's own prompt explicitly opted out — *"Do not push or call `gh`; the workflow publishes the branch and PR after your step"* — routing into the one path that's blocked.

## Fix (mirrors the working `daily-improve.yml` pattern)
- Add `Bash(git push:*),Bash(gh:*)` to the agent `allowedTools`.
- Move push + `gh pr create` **into the agent prompt**, so it runs under the permitted `app/claude` identity. Idempotent: only creates a PR when none is open for the branch.
- Delete the blocked external `GITHUB_TOKEN` "Publish PR" step.
- Let the agent fix the brittle hard-coded `assertEqual(handles, 75)` test when its change trips it (baseline-relative), so CI stays green. (Already de-hardcoded in #148.)

**Bonus:** `app/claude`-authored PRs trigger `pull_request` workflows (CI); `GITHUB_TOKEN`-authored ones don't — so this also gets the explorer's manifest changes through CI.

## Validation
- `python3 -c "import yaml; yaml.safe_load(...)"` parses; step list confirmed (publish step removed). CI runs `actionlint`.
- No change to triggers (`schedule`/`workflow_dispatch`) or to any untrusted-input handling — only `steps.dates.outputs.*` (from `date`) is interpolated.

## Related
- #148 recovers the orphaned output of the failed run (the 4 curated accounts).

## Follow-ups (not in this PR — seed signal quality)
`scripts/explore_twitter_accounts.py` scoring surfaced mostly noise (crypto/NFT, military-PR `@adgpi`/`@PRODefDehradun`, Senator `@SenTuberville`, astrology "Gemini" accounts) scoring **above** the real AI accounts. Two concrete causes: the mention graph traverses from unvetted *search-surfaced* authors instead of the *trusted manifest* (`explore_twitter_accounts.py:161`), and the score (`:183`) has no AI-topicality term — only engagement + citations. Worth a separate PR.
