### PR TITLE
Docs: bring Twitter explorer lane up to date and consolidate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ and opens a PR with methodology fixes.
 | `dedupe_headline_alerts.py` | Filter + record delivered Twitter headline alerts (used by `hourly-twitter.yml`). Layered deterministic dedup contract + Mermaid diagrams in [`docs/headline-dedupe.md`](docs/headline-dedupe.md). |
 | `headline_judge.py` | Agent-in-the-loop final dedup gate (used by `hourly-twitter.yml`). Two deterministic subcommands — `shortlist` (surface send-set survivors whose nearest prior sits in the contested `[0.35,0.50)` Jaccard band) and `apply` (drop only the Haiku judge's HIGH-confidence duplicates, fail-open, URL-keyed) — bracketing one Haiku adjudication step. Contract in [`docs/headline-dedupe.md`](docs/headline-dedupe.md). |
 | `curate_twitter_accounts.py` | Validates `data/sources/twitter_accounts.json`, builds the birdy fetch manifest, and writes/apply reviewable Twitter account add/remove proposals. |
-| `explore_twitter_accounts.py` | Scout script for `twitter-account-explorer.yml`; runs broad bird searches, scores unknown authors, and emits candidate JSON for reviewed account curation. |
+| `explore_twitter_accounts.py` | Scout script for `twitter-account-explorer.yml`; runs broad bird searches and emits candidate JSON for reviewed account curation. Scores from three bounded signals — trust-weighted mentions (a mention-graph candidate needs ≥1 *monitored* citer, not just any search-surfaced one), AI topicality (bonus for AI-vocabulary terms in the evidence), and bounded engagement — so viral off-topic/spam accounts don't outrank genuine AI sources. Contract: [`docs/twitter-account-curation.md`](docs/twitter-account-curation.md). |
 | `check_model_tickets.py` | Validator for `research/models/tickets/*.md` against the schema in `docs/model-tickets.md`. The CRUD agent in `24h-model-timeline.yml` runs it after every pass; CI runs it on every PR. |
 | `check_wiki.py` | Validator for `research/wiki/` pages against the schema in `docs/wiki-schema.md`. `uv run python scripts/check_wiki.py` (exit 0 = safe); `--lint` adds advisory checks. The ingest agent in `wiki-ingest.yml` runs it until exit 0; CI runs it on every PR. |
 | `wiki_search.py` | Search wrapper over `research/wiki/` (`uv run python scripts/wiki_search.py "<query>"`). The ingest agent runs it before writing any page so it UPDATEs an existing page instead of duplicating. |
@@ -389,6 +389,21 @@ output or break the pipeline. Read them before editing.
     self-trigger) and it runs GitHub-hosted (so a Cloud Run blip can't take
     out the recovery path too). Adding its name to the trigger list, or
     moving it to self-hosted, breaks both protections.
+
+12. **Workflow-opened PRs must be created inside `claude-code-action`.**
+    The default `GITHUB_TOKEN` cannot open pull requests in this repo: a
+    standalone `run: gh pr create` step fails with `GitHub Actions is not
+    permitted to create or approve pull requests (createPullRequest)`. The
+    working pattern (used by `daily-improve.yml` and
+    `twitter-account-explorer.yml`) is to have the agent push the branch and
+    run `gh pr create` **from inside the `anthropics/claude-code-action@v1`
+    step** — those PRs are authored as `app/claude` and succeed (and, unlike
+    `GITHUB_TOKEN`-authored PRs, they trigger `pull_request` workflows such as
+    CI). So: set `env: GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` on the claude
+    step, include `Bash(git push:*),Bash(gh:*)` in `--allowedTools`, and do the
+    `gh pr create` in the prompt — never in a downstream plain-`GITHUB_TOKEN`
+    `run:` step. (Learned when the explorer's first run curated accounts
+    correctly but failed at an external publish step — PR #149.)
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ flowchart TB
 
 | Source | Method | Frequency | Real-time? |
 |--------|--------|-----------|------------|
-| **Twitter/X** | bird CLI (75 accounts + 7 searches) | Every 3 hours | ✅ Yes |
+| **Twitter/X** | bird CLI (reviewed account manifest + 7 searches) | Every 3 hours | ✅ Yes |
 | **RSS Feeds** | Direct XML fetch | Hourly | ✅ Yes |
 | **Bluesky** | Public API | Daily | ✅ Yes |
 | **Reddit** | RSS feeds | Every 4 hours | ✅ Yes |
@@ -131,9 +131,10 @@ gantt
 | `4h-community.yml` | Every 4 hours | Reddit RSS + HN MCP | `research/community/` |
 | `daily-arxiv.yml` | Daily 06:13 UTC | arXiv papers | `research/arxiv/` |
 | `daily-digest.yml` | Daily 00:00 UTC | All sources + MCP search | `research/digest/` |
-| `hourly-twitter.yml` (matrix) | claude tier every 3h (`:07`), deepseek-claude-code tier every 6h (`:37`), deepseek-pi and fireworks-pi tiers manual | Twitter/X via bird CLI (75 accounts, 7 search queries) | `research/twitter/` (claude) + `research/twitter-deepseek/` (Claude Code) + `research/twitter-deepseek-pi/` (pi) + `research/twitter-fireworks-pi/` (Fireworks pi) |
+| `hourly-twitter.yml` (matrix) | claude tier every 3h (`:07`), deepseek-claude-code tier every 6h (`:37`), deepseek-pi and fireworks-pi tiers manual | Twitter/X via bird CLI (reviewed account manifest, 7 search queries) | `research/twitter/` (claude) + `research/twitter-deepseek/` (Claude Code) + `research/twitter-deepseek-pi/` (pi) + `research/twitter-fireworks-pi/` (Fireworks pi) |
 | `ai-news-research.yml` | Twice daily (08:23, 20:23 UTC) | Perplexity/Exa MCP | `research/` |
 | `daily-improve.yml` | Daily 00:17 UTC | Self-improvement | PRs with improvements |
+| `twitter-account-explorer.yml` | Weekly (Tue 01:47 UTC) + manual | Scouts high-signal AI accounts; trust-weighted curation of `data/sources/twitter_accounts.json` | Reviewed PRs (`app/claude`) |
 | `research-issue.yml` | On issue label | Deep research on any topic | `research/issues/` |
 | `generative-research.yml` | On `gen-research` issue label or `workflow_dispatch` (`topic` or `twitter_url`) | Claude or DeepSeek writes an HTML article | `research/generative/` |
 
@@ -294,12 +295,15 @@ dashboard/                          # Vite + Bun + TypeScript SPA
 
 ### Twitter/X (Every 3 hours)
 Via [bird CLI](https://github.com/steipete/bird) and birdy multi-fetch. The
-reviewed source manifest is `data/sources/twitter_accounts.json`: 75 monitored
-accounts, 20 tweets each, 7 search queries, and the AI-only news tab. Account
-add/remove proposals are generated with `scripts/curate_twitter_accounts.py`;
-see `docs/twitter-account-curation.md`. A weekly `twitter-account-explorer.yml`
-agent scouts for high-signal additions and opens reviewed PRs when evidence is
-strong enough.
+reviewed source manifest is `data/sources/twitter_accounts.json` (currently 80
+monitored accounts, periodically expanded by the explorer lane below), 20
+tweets each, 7 search queries, and the AI-only news tab. Account add/remove
+proposals are generated with `scripts/curate_twitter_accounts.py`; see
+[`docs/twitter-account-curation.md`](docs/twitter-account-curation.md) for the
+full contract. A weekly `twitter-account-explorer.yml` agent scouts for
+high-signal additions — favoring accounts vouched for by ones already monitored
+and on-topic for AI over merely viral handles — and opens reviewed PRs (as
+`app/claude`) when the evidence is strong enough.
 
 **Account groups:** AI labs/company accounts; hyperscalers, executives, and key
 insiders; researchers, analysts, builders, and media.

--- a/docs/twitter-account-curation.md
+++ b/docs/twitter-account-curation.md
@@ -62,16 +62,32 @@ handles case-insensitively, and re-validates before writing.
 dispatch. It is an agent loop, but it is intentionally review-gated:
 
 1. `scripts/explore_twitter_accounts.py` runs broad bird searches and writes
-   `/tmp/twitter-account-candidates.json` plus a Markdown evidence report.
-   It uses the `goodtweet` lesson that mention-graph traversal is often higher
-   signal than keyword search: unknown handles mentioned by multiple
-   search-surfaced accounts are scored as candidates too.
+   `/tmp/twitter-account-candidates.json` plus a Markdown evidence report. It
+   scores candidates from three deliberately bounded signals so no single one
+   can carry a watchlist change:
+   - **Trust-weighted mentions** — the `goodtweet` lesson applied to a *trusted*
+     seed set. A mention-graph candidate must be vouched for by at least one
+     account already in the manifest (a monitored citer); being cited only by
+     other broad-search-surfaced accounts is **not** enough, which keeps
+     crypto/spam rings out of the candidate pool.
+   - **AI topicality** — a bonus for distinct AI-vocabulary terms actually
+     present in the candidate's evidence text, so a viral but off-topic post
+     (politics, astrology, crypto) cannot outrank a genuine AI source.
+   - **Engagement** — logarithmic and bounded, so it nudges ranking rather than
+     dominating it.
+   Exact weights and the `--min-score` default live in the script (the source of
+   truth); this contract describes the mechanism, not the constants.
 2. A Claude explorer reads those candidates, the current manifest, recent
    Twitter outputs, and this curation contract.
 3. If no strong evidence exists, it prints `no account changes`.
 4. If evidence supports changes, it uses `curate_twitter_accounts.py propose`
-   and `apply`, validates the manifest, runs focused tests, then opens a PR
-   against `main`.
+   and `apply`, validates the manifest, runs focused tests, then pushes the
+   branch and opens the PR against `main` **from inside the
+   `claude-code-action` step** (the PR is authored as `app/claude`). PR
+   creation must happen there, not in a downstream `run:` step: the default
+   `GITHUB_TOKEN` cannot open PRs in this repo (it fails with "GitHub Actions
+   is not permitted to create or approve pull requests"). See CLAUDE.md's
+   load-bearing rules.
 
 The loop caps each run at five additions and two removals. Removals require
 clear observed evidence because losing a quiet but important source is costlier


### PR DESCRIPTION
## What & why

This session changed the Twitter Account Explorer's behavior (PRs #149/#150/#151), but the docs hadn't caught up — and the curation contract **directly contradicted the shipped code**. This brings the three docs that describe the lane into agreement, with the curation doc as the authoritative contract.

### `docs/twitter-account-curation.md` (the contract — most important)
- The "Explorer Loop" scoring description said candidates are scored when *"mentioned by multiple search-surfaced accounts"* — the **opposite** of what #150 ships. Rewritten to the real mechanism: **trust-weighted mentions** (a mention-graph candidate now needs ≥1 *monitored* citer), **AI topicality**, and **bounded engagement**. Describes the *mechanism*, not the constants (those live in the script, the single source of truth — so the doc won't drift when the scorer is tuned).
- Publishing step updated: the agent opens the PR **from inside `claude-code-action`** (authored `app/claude`), because a downstream `GITHUB_TOKEN` `run:` step can't.

### `CLAUDE.md`
- Refined the `explore_twitter_accounts.py` description (trust-weighted + topicality + bounded engagement).
- Added **load-bearing rule #12**: the default `GITHUB_TOKEN` can't open PRs in this repo; PR-opening workflows must run `gh pr create` inside `claude-code-action` (→ `app/claude`, which also triggers CI). This constraint silently broke the explorer's first run and previously lived only in a `daily-improve.yml` inline comment.

### `README.md`
- De-hardcoded the brittle **"75 accounts"** (a number the explorer *grows*) — removed from two terse table cells, kept one current, self-explaining figure (80, "periodically expanded by the explorer lane").
- Added the missing **`twitter-account-explorer.yml`** row to the workflow table (verified cron `47 1 * * 2`).
- Pointed the prose at the contract instead of duplicating scoring details.

## Scope / safety
- **Docs only** — no workflow, script, or dashboard change; no CI-validated artifact touched.
- Account count (80) confirmed from `data/sources/twitter_accounts.json` on disk at write time.
- Deliberately did **not** expand the README workflow table beyond the explorer (the other gaps are pre-existing and unrelated to this session; copying their schedules risks the drift CLAUDE.md itself warns about).
