### PR TITLE
[codex] Modularize scheduled Fireworks agent lanes

### DIFF
--- a/.github/actions/agent-run/action.yml
+++ b/.github/actions/agent-run/action.yml
@@ -1,0 +1,179 @@
+name: ARA agent run
+description: Run a Claude-Code-compatible agent through native Claude or Fireworks and optionally require committed output.
+
+inputs:
+  backend:
+    description: claude, fireworks-deepseek-v4-flash, fireworks-glm-5p2, deepseek-v4-flash, or glm-5p2.
+    required: false
+    default: fireworks-deepseek-v4-flash
+  claude-code-oauth-token:
+    description: Claude Code OAuth token. Required by claude-code-action, even for Fireworks-routed runs.
+    required: true
+  fireworks-api-key:
+    description: Fireworks API key for Fireworks-routed backends.
+    required: false
+    default: ""
+  claude-args:
+    description: Arguments passed to claude-code-action.
+    required: true
+  prompt:
+    description: Prompt passed to claude-code-action.
+    required: true
+  expected-paths:
+    description: Optional newline-delimited git pathspecs that must change between pre-run HEAD and post-run HEAD.
+    required: false
+    default: ""
+  label:
+    description: Human-readable label for logs and output guard annotations.
+    required: false
+    default: agent run
+  allowed-bots:
+    description: Optional allowed_bots value for claude-code-action.
+    required: false
+    default: ""
+
+outputs:
+  pre-sha:
+    description: HEAD before the agent ran.
+    value: ${{ steps.pre.outputs.sha }}
+  post-sha:
+    description: HEAD after the agent ran.
+    value: ${{ steps.post.outputs.sha }}
+  backend:
+    description: Normalized backend selector.
+    value: ${{ steps.profile.outputs.backend }}
+  model-id:
+    description: Provider model id for Fireworks backends.
+    value: ${{ steps.profile.outputs.model-id }}
+  changed:
+    description: "true when expected-paths were provided and changed"
+    value: ${{ steps.guard.outputs.changed }}
+  changed-files:
+    description: Newline-delimited changed files under expected paths.
+    value: ${{ steps.guard.outputs.changed-files }}
+
+runs:
+  using: composite
+  steps:
+    - name: Capture pre-run HEAD
+      id: pre
+      shell: bash
+      run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+    - name: Resolve agent backend
+      id: profile
+      shell: bash
+      env:
+        BACKEND: ${{ inputs.backend }}
+      run: |
+        set -euo pipefail
+        case "$BACKEND" in
+          claude)
+            normalized="claude"
+            model_id=""
+            display_name="Claude"
+            ;;
+          fireworks-deepseek-v4-flash|deepseek-v4-flash|deepseek)
+            normalized="fireworks-deepseek-v4-flash"
+            model_id="accounts/fireworks/models/deepseek-v4-flash"
+            display_name="DeepSeek V4 Flash via Fireworks"
+            ;;
+          fireworks-glm-5p2|glm-5p2|glm)
+            normalized="fireworks-glm-5p2"
+            model_id="accounts/fireworks/models/glm-5p2"
+            display_name="GLM 5.2 via Fireworks"
+            ;;
+          *)
+            echo "::error::Unsupported ARA agent backend: $BACKEND"
+            exit 1
+            ;;
+        esac
+
+        {
+          echo "backend=$normalized"
+          echo "model-id=$model_id"
+          echo "display-name=$display_name"
+        } >> "$GITHUB_OUTPUT"
+        echo "ARA agent backend: $display_name"
+
+    - name: Preflight Fireworks backend
+      if: steps.profile.outputs.model-id != ''
+      shell: bash
+      env:
+        FIREWORKS_API_KEY: ${{ inputs.fireworks-api-key }}
+        FIREWORKS_MODEL_ID: ${{ steps.profile.outputs.model-id }}
+      run: |
+        set -euo pipefail
+        python3 scripts/check_fireworks_backend.py --model "$FIREWORKS_MODEL_ID"
+
+    - name: Run agent with Claude
+      if: steps.profile.outputs.backend == 'claude' && inputs.allowed-bots == ''
+      uses: anthropics/claude-code-action@v1
+      with:
+        claude_code_oauth_token: ${{ inputs.claude-code-oauth-token }}
+        claude_args: ${{ inputs.claude-args }}
+        prompt: ${{ inputs.prompt }}
+
+    - name: Run agent with Claude
+      if: steps.profile.outputs.backend == 'claude' && inputs.allowed-bots != ''
+      uses: anthropics/claude-code-action@v1
+      with:
+        claude_code_oauth_token: ${{ inputs.claude-code-oauth-token }}
+        allowed_bots: ${{ inputs.allowed-bots }}
+        claude_args: ${{ inputs.claude-args }}
+        prompt: ${{ inputs.prompt }}
+
+    - name: Run agent with Fireworks
+      if: steps.profile.outputs.model-id != '' && inputs.allowed-bots == ''
+      uses: anthropics/claude-code-action@v1
+      env:
+        ANTHROPIC_BASE_URL: https://api.fireworks.ai/inference
+        ANTHROPIC_API_KEY: ${{ inputs.fireworks-api-key }}
+        ANTHROPIC_AUTH_TOKEN: ${{ inputs.fireworks-api-key }}
+        ANTHROPIC_MODEL: ${{ steps.profile.outputs.model-id }}
+        ANTHROPIC_DEFAULT_OPUS_MODEL: ${{ steps.profile.outputs.model-id }}
+        ANTHROPIC_DEFAULT_SONNET_MODEL: ${{ steps.profile.outputs.model-id }}
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: ${{ steps.profile.outputs.model-id }}
+        CLAUDE_CODE_SUBAGENT_MODEL: ${{ steps.profile.outputs.model-id }}
+        CLAUDE_CODE_EFFORT_LEVEL: max
+        ARA_AGENT_BACKEND: ${{ steps.profile.outputs.backend }}
+        ARA_AGENT_MODEL_ID: ${{ steps.profile.outputs.model-id }}
+      with:
+        claude_code_oauth_token: ${{ inputs.claude-code-oauth-token }}
+        claude_args: ${{ inputs.claude-args }}
+        prompt: ${{ inputs.prompt }}
+
+    - name: Run agent with Fireworks
+      if: steps.profile.outputs.model-id != '' && inputs.allowed-bots != ''
+      uses: anthropics/claude-code-action@v1
+      env:
+        ANTHROPIC_BASE_URL: https://api.fireworks.ai/inference
+        ANTHROPIC_API_KEY: ${{ inputs.fireworks-api-key }}
+        ANTHROPIC_AUTH_TOKEN: ${{ inputs.fireworks-api-key }}
+        ANTHROPIC_MODEL: ${{ steps.profile.outputs.model-id }}
+        ANTHROPIC_DEFAULT_OPUS_MODEL: ${{ steps.profile.outputs.model-id }}
+        ANTHROPIC_DEFAULT_SONNET_MODEL: ${{ steps.profile.outputs.model-id }}
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: ${{ steps.profile.outputs.model-id }}
+        CLAUDE_CODE_SUBAGENT_MODEL: ${{ steps.profile.outputs.model-id }}
+        CLAUDE_CODE_EFFORT_LEVEL: max
+        ARA_AGENT_BACKEND: ${{ steps.profile.outputs.backend }}
+        ARA_AGENT_MODEL_ID: ${{ steps.profile.outputs.model-id }}
+      with:
+        claude_code_oauth_token: ${{ inputs.claude-code-oauth-token }}
+        allowed_bots: ${{ inputs.allowed-bots }}
+        claude_args: ${{ inputs.claude-args }}
+        prompt: ${{ inputs.prompt }}
+
+    - name: Capture post-run HEAD
+      id: post
+      shell: bash
+      run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+    - name: Require committed output
+      id: guard
+      if: inputs.expected-paths != ''
+      uses: ./.github/actions/require-output
+      with:
+        base-sha: ${{ steps.pre.outputs.sha }}
+        expected-paths: ${{ inputs.expected-paths }}
+        label: ${{ inputs.label }}

--- a/.github/actions/require-output/action.yml
+++ b/.github/actions/require-output/action.yml
@@ -1,0 +1,85 @@
+name: Require output changes
+description: Fail when a workflow run did not change the expected committed output paths.
+
+inputs:
+  base-sha:
+    description: Commit SHA captured before the producer ran.
+    required: true
+  expected-paths:
+    description: Newline-delimited git pathspecs that must change between base-sha and HEAD.
+    required: true
+  label:
+    description: Human-readable producer label for annotations.
+    required: false
+    default: agent run
+
+outputs:
+  changed:
+    description: "true when expected paths changed"
+    value: ${{ steps.guard.outputs.changed }}
+  changed-files:
+    description: Newline-delimited changed files under expected paths.
+    value: ${{ steps.guard.outputs.changed-files }}
+
+runs:
+  using: composite
+  steps:
+    - name: Check expected output diff
+      id: guard
+      shell: bash
+      env:
+        BASE_SHA: ${{ inputs.base-sha }}
+        EXPECTED_PATHS: ${{ inputs.expected-paths }}
+        LABEL: ${{ inputs.label }}
+      run: |
+        set -euo pipefail
+
+        if [ -z "${BASE_SHA:-}" ]; then
+          echo "::error::require-output needs a base-sha."
+          exit 1
+        fi
+        if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+          echo "::error::require-output base-sha is not a commit: ${BASE_SHA}"
+          exit 1
+        fi
+
+        pathspecs=()
+        while IFS= read -r pathspec; do
+          pathspec="${pathspec#"${pathspec%%[![:space:]]*}"}"
+          pathspec="${pathspec%"${pathspec##*[![:space:]]}"}"
+          [ -z "$pathspec" ] && continue
+          pathspecs+=("$pathspec")
+        done <<< "$EXPECTED_PATHS"
+
+        if [ "${#pathspecs[@]}" -eq 0 ]; then
+          echo "::error::require-output expected-paths is empty."
+          exit 1
+        fi
+
+        changed_files="$(git diff --name-only "${BASE_SHA}..HEAD" -- "${pathspecs[@]}" || true)"
+        if [ -z "$changed_files" ]; then
+          {
+            echo "::error::${LABEL} did not commit changes under expected path(s):"
+            printf '  - %s\n' "${pathspecs[@]}"
+            echo "HEAD: $(git rev-parse HEAD)"
+            echo "Status:"
+            git status --short
+          }
+          echo "changed=false" >> "$GITHUB_OUTPUT"
+          {
+            echo "changed-files<<__CHANGED_FILES__"
+            echo
+            echo "__CHANGED_FILES__"
+          } >> "$GITHUB_OUTPUT"
+          exit 1
+        fi
+
+        echo "changed=true" >> "$GITHUB_OUTPUT"
+        {
+          echo "changed-files<<__CHANGED_FILES__"
+          echo "$changed_files"
+          echo "__CHANGED_FILES__"
+        } >> "$GITHUB_OUTPUT"
+
+        echo "${LABEL} changed expected output files:"
+        echo "$changed_files"

--- a/.github/workflows/24h-model-timeline.yml
+++ b/.github/workflows/24h-model-timeline.yml
@@ -102,7 +102,7 @@ jobs:
       # and dedup protocol.
       # timeout-minutes mirrors the bump made on generative-research.yml
       # after the 2026-05-19 cluster of 45-min wall-clock failures. The
-      # CRUD agent does ~20 ticket reads + WebSearch corroborations +
+      # CRUD agent does ~20 ticket reads + source-file corroboration +
       # validate-loop, which can stretch on heavy news days. 90 min is
       # well clear of observed runs (~10-25 min) without leaving a
       # quietly-hung job to chew runner time forever.
@@ -112,19 +112,24 @@ jobs:
       # surface to job.status (and so hooker-telemetry's `if: always()`
       # step still fires). Without the inspect step, this flag would
       # silently mask timeouts as success — see the inspect step.
-      - name: CRUD model tickets via Claude
+      - name: CRUD model tickets via Fireworks
         id: crud
         timeout-minutes: 90
         continue-on-error: true
-        uses: anthropics/claude-code-action@v1
+        uses: ./.github/actions/agent-run
         env:
           DATE_TODAY: ${{ steps.datetime.outputs.date }}
           DATE_YESTERDAY: ${{ steps.datetime.outputs.yesterday }}
           TIMESTAMP: ${{ steps.datetime.outputs.timestamp }}
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: |
-            --model opus --max-turns 60 --allowedTools "Read,Write,Edit,Bash(uv:*),Bash(git:*),Bash(ls:*),Bash(cat:*),Bash(grep:*),Bash(jq:*),WebSearch,Task,TodoWrite"
+          backend: fireworks-glm-5p2
+          claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          fireworks-api-key: ${{ secrets.FIREWORKS_API_KEY }}
+          claude-args: |
+            --model opus --max-turns 60 --allowedTools "Read,Write,Edit,Bash(uv:*),Bash(git:*),Bash(ls:*),Bash(cat:*),Bash(grep:*),Bash(jq:*),Bash(curl:*),Task,TodoWrite"
+          expected-paths: |
+            research/models/
+          label: Model-ticket Fireworks CRUD
           prompt: |
             You maintain a persistent set of model-release tickets. Each
             ticket tracks one shipping artifact (a model release, a
@@ -164,9 +169,10 @@ jobs:
             STEP 2 — INGEST RAW SIGNAL.
               The bird CLI dropped JSON files at /tmp/bird/*.json. Read
               them. The data is messy and partly redundant; that's
-              expected. Use WebSearch sparingly to corroborate or
-              clarify a specific claim — not as a general research
-              pass. Watch for:
+              expected. Use the source URLs and quoted evidence already
+              present in the JSON; if a specific source URL is available, you
+              may use `curl` to corroborate that URL. Do not use WebSearch.
+              Watch for:
                 - Model leaks (GCP / AWS / iOS app / docs URL artifacts)
                 - Official announcements (company handles, blogs)
                 - Pricing / context / tier reveals
@@ -253,22 +259,22 @@ jobs:
               - Do not write outside research/models/tickets/ and the
                 single daily-diff file in research/models/.
 
-      # Propagate the Claude step's outcome to job.status. With
-      # continue-on-error: true on the Claude step, a timeout/error
+      # Propagate the agent step's outcome to job.status. With
+      # continue-on-error: true on the agent step, a timeout/error
       # would otherwise resolve to step.conclusion=success and
       # hooker-telemetry would report a green run. exit 1 here lets
       # later `if: always()` steps (telemetry) still fire while flipping
       # job.status to failure when it should be.
-      - name: Inspect Claude outcome
+      - name: Inspect Fireworks outcome
         if: always()
         env:
           OUTCOME: ${{ steps.crud.outcome }}
         run: |
           if [ "$OUTCOME" = "failure" ]; then
-            echo "::error::Claude CRUD step failed (timeout or error); failing the job so telemetry reports honestly."
+            echo "::error::Model-ticket Fireworks CRUD step failed (timeout, model error, or missing output); failing the job so telemetry reports honestly."
             exit 1
           fi
-          echo "Claude CRUD step succeeded."
+          echo "Model-ticket Fireworks CRUD step succeeded."
 
       # Use the shared safe-push composite action (post-PR-#58 algorithm):
       # stash any leftover working-tree state before rebasing, so the

--- a/.github/workflows/2h-bluesky.yml
+++ b/.github/workflows/2h-bluesky.yml
@@ -112,12 +112,16 @@ jobs:
             printf '# Bluesky AI Feed - %s\n' "$DATE" > "$FILE"
           fi
 
-      - name: Process Bluesky Feed with Claude
-        uses: anthropics/claude-code-action@v1
+      - name: Process Bluesky Feed with Fireworks
+        id: bluesky_agent
+        uses: ./.github/actions/agent-run
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: |
-            --model sonnet --allowedTools "Read,Write,Bash(ls:*)"
+          backend: fireworks-deepseek-v4-flash
+          claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          fireworks-api-key: ${{ secrets.FIREWORKS_API_KEY }}
+          claude-args: |
+            --model opus --allowedTools "Read,Write,Bash(ls:*)"
+          label: Bluesky Fireworks curator
           prompt: |
             You are a Bluesky AI expert-commentary curator. Process recent
             posts from a small set of tracked AI researchers and practitioners.
@@ -336,6 +340,14 @@ jobs:
           else
             git commit -m "Bluesky feed ${TIMESTAMP}"
           fi
+
+      - name: Require Bluesky output
+        uses: ./.github/actions/require-output
+        with:
+          base-sha: ${{ steps.bluesky_agent.outputs.pre-sha }}
+          expected-paths: |
+            research/bluesky/
+          label: Bluesky Fireworks curator
 
       # Use the shared safe-push composite action (post-PR-#58 algorithm).
       #

--- a/.github/workflows/4h-community.yml
+++ b/.github/workflows/4h-community.yml
@@ -124,13 +124,18 @@ jobs:
           }
           EOF
 
-      - name: Process Community Data with Claude
-        uses: anthropics/claude-code-action@v1
+      - name: Process Community Data with Fireworks
+        uses: ./.github/actions/agent-run
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: |
-            --model sonnet --mcp-config /tmp/mcp-config.json
+          backend: fireworks-glm-5p2
+          claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          fireworks-api-key: ${{ secrets.FIREWORKS_API_KEY }}
+          claude-args: |
+            --model opus --mcp-config /tmp/mcp-config.json
             --allowedTools "Read,Write,Edit,Bash(git:*),mcp__hackernews__*"
+          expected-paths: |
+            research/community/
+          label: Community Fireworks processor
           prompt: |
             You are a community AI news curator. Process REAL-TIME data from HN and Reddit.
 

--- a/.github/workflows/daily-arxiv.yml
+++ b/.github/workflows/daily-arxiv.yml
@@ -49,12 +49,17 @@ jobs:
           EOF
 
       - name: Fetch arXiv AI Papers
-        uses: anthropics/claude-code-action@v1
+        uses: ./.github/actions/agent-run
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: |
+          backend: fireworks-glm-5p2
+          claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          fireworks-api-key: ${{ secrets.FIREWORKS_API_KEY }}
+          claude-args: |
             --model opus --mcp-config /tmp/mcp-config.json
-            --allowedTools "Read,Write,Edit,Bash(git:*),WebSearch,mcp__arxiv__*"
+            --allowedTools "Read,Write,Edit,Bash(git:*),mcp__arxiv__*"
+          expected-paths: |
+            research/arxiv/
+          label: arXiv Fireworks curator
           prompt: |
             You are an AI research paper curator. Find the most important NEW papers from arXiv.
 
@@ -68,7 +73,7 @@ jobs:
             - cs.CV (Computer Vision)
             - cs.NE (Neural and Evolutionary Computing)
 
-            Use arXiv MCP tools AND WebSearch:
+            Use arXiv MCP tools:
             - Search for papers submitted in last 24 hours
             - "site:arxiv.org cs.AI" submitted today
             - "site:arxiv.org LLM language model" new

--- a/.github/workflows/daily-digest.yml
+++ b/.github/workflows/daily-digest.yml
@@ -125,12 +125,18 @@ jobs:
 
       - name: Synthesize Daily Digest (with MCP tools)
         if: steps.check-keys.outputs.has_exa == 'true' || steps.check-keys.outputs.has_perplexity == 'true'
-        uses: anthropics/claude-code-action@v1
+        uses: ./.github/actions/agent-run
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: |
+          backend: fireworks-glm-5p2
+          claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          fireworks-api-key: ${{ secrets.FIREWORKS_API_KEY }}
+          claude-args: |
             --model opus --mcp-config /tmp/mcp-config.json
             --allowedTools "Glob,Read,Write,Edit,Bash(git:*),mcp__exa__*,mcp__perplexity__*"
+          expected-paths: |
+            research/digest/
+            research/summaries/
+          label: Daily digest Fireworks synthesizer
           prompt: |
             You are the AI News Editor. Create a comprehensive DAILY DIGEST.
 
@@ -222,13 +228,19 @@ jobs:
             git add research/digest/${{ steps.date.outputs.date }}-digest.md research/summaries/${{ steps.date.outputs.date }}-digest-summary.txt
             git commit -m "Daily digest ${{ steps.date.outputs.date }}"
 
-      - name: Synthesize Daily Digest (WebSearch fallback)
+      - name: Synthesize Daily Digest (local-source fallback)
         if: steps.check-keys.outputs.has_exa != 'true' && steps.check-keys.outputs.has_perplexity != 'true'
-        uses: anthropics/claude-code-action@v1
+        uses: ./.github/actions/agent-run
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: |
-            --model opus --allowedTools "Glob,Read,Write,Edit,Bash(git:*),WebSearch"
+          backend: fireworks-glm-5p2
+          claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          fireworks-api-key: ${{ secrets.FIREWORKS_API_KEY }}
+          claude-args: |
+            --model opus --allowedTools "Glob,Read,Write,Edit,Bash(git:*)"
+          expected-paths: |
+            research/digest/
+            research/summaries/
+          label: Daily digest Fireworks local-source synthesizer
           prompt: |
             You are the AI News Editor. Create a comprehensive DAILY DIGEST.
 
@@ -239,8 +251,10 @@ jobs:
             Check subdirectories: twitter/, community/, arxiv/, rss/, bluesky/, blogs/, youtube/, perplexity/, and any others.
             Read all relevant files you find.
 
-            STEP 2: Use WebSearch to fill gaps
-            Search for any major AI news from today we might have missed.
+            STEP 2: Identify gaps from local sources
+            In this fallback path, no external MCP search provider is
+            configured. Do not use WebSearch. Synthesize from the local source
+            files only, and call out uncertainty when coverage is thin.
 
             STEP 3: Write the digest
             OUTPUT: research/digest/${{ steps.date.outputs.date }}-digest.md
@@ -318,14 +332,19 @@ jobs:
             git add research/digest/${{ steps.date.outputs.date }}-digest.md research/summaries/${{ steps.date.outputs.date }}-digest-summary.txt
             git commit -m "Daily digest ${{ steps.date.outputs.date }}"
 
-      - name: Rewrite summary as ARA spoken script (Claude Sonnet)
+      - name: Rewrite summary as ARA spoken script (Fireworks)
         if: success()
         continue-on-error: true
-        uses: anthropics/claude-code-action@v1
+        uses: ./.github/actions/agent-run
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: |
-            --model sonnet --allowedTools "Read,Write,Edit,Bash(git:*)"
+          backend: fireworks-deepseek-v4-flash
+          claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          fireworks-api-key: ${{ secrets.FIREWORKS_API_KEY }}
+          claude-args: |
+            --model opus --allowedTools "Read,Write,Edit,Bash(git:*)"
+          expected-paths: |
+            research/summaries/
+          label: Digest spoken-script Fireworks rewrite
           prompt: |
             You are writing the daily ARA broadcast — a TWO-HOST AI-news podcast
             with banter between Speaker 1 (anchor, deep voice) and Speaker 2
@@ -394,7 +413,7 @@ jobs:
 
             STEP 4 — Commit:
             git add research/summaries/${{ steps.date.outputs.date }}-digest-spoken.txt
-            git commit -m "Spoken script ${{ steps.date.outputs.date }} (ARA two-host, Claude Sonnet rewrite)" || echo "No changes"
+            git commit -m "Spoken script ${{ steps.date.outputs.date }} (ARA two-host Fireworks rewrite)" || echo "No changes"
 
       - name: Generate audio digest with Gemini 3.1 Flash TTS
         if: success()

--- a/.github/workflows/daily-front-page.yml
+++ b/.github/workflows/daily-front-page.yml
@@ -106,6 +106,11 @@ jobs:
         with:
           enable-cache: true
 
+      - name: Capture pre-render HEAD
+        if: steps.check.outputs.exists == 'true'
+        id: pre_render
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       # resvg is the renderer's only native dependency (prebuilt napi binary,
       # no Chromium/X11 libs). Text uses system fonts: the Cloud Run worker
       # image carries fonts-dejavu-core via ffmpeg's fontconfig dependency.
@@ -178,6 +183,15 @@ jobs:
           else
             git commit -m "Front page ${TODAY}"
           fi
+
+      - name: Require front page output
+        if: steps.check.outputs.exists == 'true'
+        uses: ./.github/actions/require-output
+        with:
+          base-sha: ${{ steps.pre_render.outputs.sha }}
+          expected-paths: |
+            research/front-page/
+          label: Front page renderer
 
       # Use the shared safe-push composite action (post-PR-#58 algorithm):
       # stash any leftover working-tree state before rebasing, so the

--- a/.github/workflows/hourly-rss.yml
+++ b/.github/workflows/hourly-rss.yml
@@ -145,12 +145,17 @@ jobs:
           echo "RSS feeds fetched successfully"
           ls -la /tmp/rss/
 
-      - name: Process RSS Feeds with Claude
-        uses: anthropics/claude-code-action@v1
+      - name: Process RSS Feeds with Fireworks
+        uses: ./.github/actions/agent-run
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: |
-            --model haiku --allowedTools "Read,Write,Edit,Bash(git:*)"
+          backend: fireworks-deepseek-v4-flash
+          claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          fireworks-api-key: ${{ secrets.FIREWORKS_API_KEY }}
+          claude-args: |
+            --model opus --allowedTools "Read,Write,Edit,Bash(git:*)"
+          expected-paths: |
+            research/rss/
+          label: RSS Fireworks processor
           prompt: |
             You are an RSS feed processor for AI news. Extract NEW articles from official sources.
 

--- a/.github/workflows/hourly-twitter.yml
+++ b/.github/workflows/hourly-twitter.yml
@@ -1,7 +1,8 @@
 name: Twitter AI News (matrix — claude / deepseek-claude-code / deepseek-pi / fireworks-pi)
 
 # Unified Twitter/X pipeline that fans out across four backend tiers:
-#   - claude            (cron '7 */3 * * *', model: opus,             output → research/twitter/)
+#   - claude            (cron '7 */3 * * *', model: DeepSeek V4 Flash via Fireworks,
+#                        output → research/twitter/)
 #   - deepseek-claude-code (cron '37 */6 * * *', model: deepseek-v4-flash via Fireworks, output → research/twitter-deepseek/)
 #   - deepseek-pi       (manual only,        model: deepseek-v4-flash via Fireworks + pi harness,
 #                        output → research/twitter-deepseek-pi/)
@@ -26,11 +27,11 @@ name: Twitter AI News (matrix — claude / deepseek-claude-code / deepseek-pi / 
 #   - legacy DeepSeek pi tier              (DeepSeek via pi harness)
 #
 # Required secrets:
-#   CLAUDE_CODE_OAUTH_TOKEN              — claude tier (also passed to deepseek-claude-code but unused there)
-#   FIREWORKS_API_KEY                    — deepseek-claude-code, deepseek-pi, fireworks-pi tiers (all served via Fireworks)
+#   CLAUDE_CODE_OAUTH_TOKEN              — required by claude-code-action wrapper
+#   FIREWORKS_API_KEY                    — primary claude-labeled tier and comparison tiers
 #   BIRD_AUTH_TOKEN, BIRD_CT0            — all tiers
-#   HOOKER_URL, HOOKER_TOKEN             — claude tier (headline-alert blast + telemetry) and comparison tiers (per-cycle notification, relayed to Telegram)
-#   VERCEL_DEPLOY_HOOK                   — optional, claude tier only
+#   HOOKER_URL, HOOKER_TOKEN             — primary tier (headline-alert blast + telemetry) and comparison tiers (per-cycle notification, relayed to Telegram)
+#   VERCEL_DEPLOY_HOOK                   — optional, primary tier only
 
 on:
   schedule:
@@ -366,43 +367,40 @@ jobs:
 
       # ── LLM step (one per backend) ─────────────────────────────────
 
-      - name: Process tweets with Claude (claude tier)
+      - name: Process tweets with Fireworks (primary tier)
         if: >-
           steps.backend.outputs.name == 'claude'
           && !(github.event_name == 'workflow_dispatch' && inputs.dry_run == true)
-        uses: anthropics/claude-code-action@v1
+        uses: ./.github/actions/agent-run
         env:
           AUTH_TOKEN: ${{ secrets.BIRD_AUTH_TOKEN }}
           CT0: ${{ secrets.BIRD_CT0 }}
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: |
+          backend: fireworks-deepseek-v4-flash
+          claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          fireworks-api-key: ${{ secrets.FIREWORKS_API_KEY }}
+          claude-args: |
             --model opus --allowedTools "Read,Write,Edit,Bash(git:*),Bash(bird:*),Bash(bird-fast:*),Bash(curl:*),Bash(jq:*)"
+          expected-paths: |
+            research/twitter/
+          label: Twitter primary Fireworks processor
           prompt: ${{ steps.render.outputs.prompt }}
 
       - name: Process tweets with DeepSeek v4 Flash via Fireworks (deepseek-claude-code tier)
         if: steps.backend.outputs.name == 'deepseek-claude-code'
-        uses: anthropics/claude-code-action@v1
+        uses: ./.github/actions/agent-run
         env:
-          # Redirect Claude Code CLI to Fireworks' Anthropic-compatible endpoint,
-          # which serves DeepSeek V4 Flash. Base URL omits /v1 — the client
-          # appends /v1/messages. The direct DeepSeek API is no longer used.
-          # See https://docs.fireworks.ai/tools-sdks/anthropic-compatibility
-          ANTHROPIC_BASE_URL: https://api.fireworks.ai/inference
-          ANTHROPIC_AUTH_TOKEN: ${{ secrets.FIREWORKS_API_KEY }}
-          ANTHROPIC_MODEL: accounts/fireworks/models/deepseek-v4-flash
-          ANTHROPIC_DEFAULT_OPUS_MODEL: accounts/fireworks/models/deepseek-v4-flash
-          ANTHROPIC_DEFAULT_SONNET_MODEL: accounts/fireworks/models/deepseek-v4-flash
-          ANTHROPIC_DEFAULT_HAIKU_MODEL: accounts/fireworks/models/deepseek-v4-flash
-          CLAUDE_CODE_SUBAGENT_MODEL: accounts/fireworks/models/deepseek-v4-flash
-          CLAUDE_CODE_EFFORT_LEVEL: max
           AUTH_TOKEN: ${{ secrets.BIRD_AUTH_TOKEN }}
           CT0: ${{ secrets.BIRD_CT0 }}
         with:
-          # Required by the action but ignored when ANTHROPIC_AUTH_TOKEN is set.
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: |
+          backend: fireworks-deepseek-v4-flash
+          claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          fireworks-api-key: ${{ secrets.FIREWORKS_API_KEY }}
+          claude-args: |
             --model opus --allowedTools "Read,Write,Edit,Bash(git:*),Bash(bird:*),Bash(bird-fast:*),Bash(curl:*),Bash(jq:*)"
+          expected-paths: |
+            research/twitter-deepseek/
+          label: Twitter DeepSeek comparison processor
           prompt: ${{ steps.render.outputs.prompt }}
 
       - name: Process tweets with pi + DeepSeek v4 Flash via Fireworks (deepseek-pi tier)
@@ -579,25 +577,27 @@ jobs:
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
           echo "Shortlisted $COUNT contested-band headline(s) for the judge."
 
-      # ── claude-tier agent dedupe gate (steps 2/4: Haiku adjudicates) ──
-      # Final gate: Haiku rules on each shortlisted headline vs its <=5
+      # ── primary-tier agent dedupe gate (steps 2/4: Fireworks adjudicates) ──
+      # Final gate: the Fireworks-backed agent rules on each shortlisted headline vs its <=5
       # nearest priors. Bias is hard toward KEEP — it may only turn a
-      # would-be send into a suppress, on a HIGH-confidence duplicate. Native
-      # Claude via the same OAuth token + action pattern used elsewhere in
-      # this job. continue-on-error so a model hiccup fails OPEN (no verdicts
-      # -> nothing suppressed). Skipped when the shortlist is empty.
-      - name: Adjudicate near-duplicate headlines with Haiku (claude tier)
+      # would-be send into a suppress, on a HIGH-confidence duplicate.
+      # continue-on-error so a model hiccup fails OPEN (no verdicts -> nothing
+      # suppressed). Skipped when the shortlist is empty.
+      - name: Adjudicate near-duplicate headlines with Fireworks (primary tier)
         id: judge_adjudicate
         if: >-
           steps.backend.outputs.name == 'claude'
           && steps.judge_shortlist.outputs.count != '0'
           && steps.judge_shortlist.outputs.count != ''
         continue-on-error: true
-        uses: anthropics/claude-code-action@v1
+        uses: ./.github/actions/agent-run
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: |
-            --model haiku --max-turns 12 --allowedTools "Read,Write"
+          backend: fireworks-deepseek-v4-flash
+          claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          fireworks-api-key: ${{ secrets.FIREWORKS_API_KEY }}
+          claude-args: |
+            --model opus --max-turns 12 --allowedTools "Read,Write"
+          label: Twitter headline Fireworks judge
           prompt: |
             You are the final duplicate gate for an AI-news headline alert
             feed. Reason from FIRST PRINCIPLES: judge whether two headlines
@@ -1142,19 +1142,22 @@ jobs:
             echo "Auto-research budget available — proceeding to topic selection."
           fi
 
-      - name: Auto-research topic selection (claude tier)
+      - name: Auto-research topic selection (primary Fireworks tier)
         id: autoresearch_select
         if: >-
           steps.backend.outputs.name == 'claude'
           && steps.autoresearch_throttle.outputs.skip == 'false'
         continue-on-error: true
-        uses: anthropics/claude-code-action@v1
+        uses: ./.github/actions/agent-run
         env:
           GEN_TOPIC_DATE: ${{ steps.datetime.outputs.date }}
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: |
+          backend: fireworks-glm-5p2
+          claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          fireworks-api-key: ${{ secrets.FIREWORKS_API_KEY }}
+          claude-args: |
             --model opus --max-turns 10 --allowedTools "Read,Bash(ls:*),Bash(cat:*),Bash(jq:*),Bash(date:*),Bash(printenv:*),Write"
+          label: Twitter auto-research Fireworks selector
           prompt: |
             You select AT MOST ONE topic from today's Twitter AI Pulse to
             dispatch to the generative-research deep pipeline (4500–7000

--- a/.github/workflows/wiki-ingest.yml
+++ b/.github/workflows/wiki-ingest.yml
@@ -78,7 +78,7 @@ jobs:
       #
       # timeout-minutes mirrors the bump on 24h-model-timeline.yml /
       # generative-research.yml: a page-by-page CRUD loop with wiki_search
-      # dedup lookups, a validate loop, and occasional WebSearch
+      # dedup lookups, a validate loop, and source-file corroboration
       # corroboration can stretch on heavy news days. 90 min is well clear
       # of expected runs without leaving a quietly-hung job to chew runner
       # time forever.
@@ -105,19 +105,24 @@ jobs:
       # to job.status (and so hooker-telemetry's `if: always()` step still
       # fires). Without the inspect step, this flag would silently mask
       # timeouts as success.
-      - name: Ingest digest into wiki via Claude
+      - name: Ingest digest into wiki via Fireworks
         id: ingest
         timeout-minutes: 90
         continue-on-error: true
-        uses: anthropics/claude-code-action@v1
+        uses: ./.github/actions/agent-run
         env:
           DATE_TODAY: ${{ steps.datetime.outputs.date }}
           DATE_YESTERDAY: ${{ steps.datetime.outputs.yesterday }}
           TIMESTAMP: ${{ steps.datetime.outputs.timestamp }}
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: |
-            --model opus --max-turns 80 --allowedTools "Read,Write,Edit,Bash(uv:*),Bash(git:*),Bash(ls:*),Bash(cat:*),Bash(grep:*),Bash(jq:*),WebSearch,Task,TodoWrite"
+          backend: fireworks-glm-5p2
+          claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          fireworks-api-key: ${{ secrets.FIREWORKS_API_KEY }}
+          claude-args: |
+            --model opus --max-turns 80 --allowedTools "Read,Write,Edit,Bash(uv:*),Bash(git:*),Bash(ls:*),Bash(cat:*),Bash(grep:*),Bash(jq:*),Task,TodoWrite"
+          expected-paths: |
+            research/wiki/
+          label: Wiki Fireworks ingest
           prompt: |
             You maintain the LLM Wiki: a compounding, interlinked knowledge
             base of markdown pages at research/wiki/. One page per
@@ -170,9 +175,10 @@ jobs:
               research/community/, research/arxiv/, or any other raw-source
               directory; the digest is the curated distillation of those and
               reading them again would re-introduce the noise the digest
-              exists to remove. Use WebSearch only sparingly, to disambiguate
-              or corroborate a single specific claim — never as a general
-              research pass.
+              exists to remove. Do not use WebSearch in this Fireworks-routed
+              lane; if a claim is not supported by the digest or model tickets,
+              leave it out or mark it as unresolved rather than expanding the
+              research scope.
 
             STEP 2 — EXTRACT SIGNIFICANT SUBJECTS (AND BOUND THE SET).
               From the curated input, pull the entities (companies, models,
@@ -284,22 +290,22 @@ jobs:
               - Write ONLY under research/wiki/. Do not touch the digest,
                 the tickets, the dashboard, or any other research subdir.
 
-      # Propagate the Claude step's outcome to job.status. With
-      # continue-on-error: true on the Claude step, a timeout/error would
+      # Propagate the agent step's outcome to job.status. With
+      # continue-on-error: true on the agent step, a timeout/error would
       # otherwise resolve to step.conclusion=success and hooker-telemetry
       # would report a green run. exit 1 here lets later `if: always()`
       # steps (telemetry) still fire while flipping job.status to failure
       # when it should be.
-      - name: Inspect Claude outcome
+      - name: Inspect Fireworks outcome
         if: always()
         env:
           OUTCOME: ${{ steps.ingest.outcome }}
         run: |
           if [ "$OUTCOME" = "failure" ]; then
-            echo "::error::Claude wiki-ingest step failed (timeout or error); failing the job so telemetry reports honestly."
+            echo "::error::Wiki Fireworks ingest step failed (timeout, model error, or missing output); failing the job so telemetry reports honestly."
             exit 1
           fi
-          echo "Claude wiki-ingest step succeeded."
+          echo "Wiki Fireworks ingest step succeeded."
 
       # Mechanically enforce the "never delete a page" invariant. The prompt
       # says it, but a prompt is not a guarantee. Diff exactly the agent's

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,8 +11,11 @@ short pointer plus the few genuinely agent-specific notes.
 
 ## Agent-specific notes
 
-- **Claude workflows** use `anthropics/claude-code-action@v1`. Pass the
-  model via `claude_args`, never as a separate `model:` input:
+- **Scheduled content workflows** use `.github/actions/agent-run` so the
+  provider route is modular and Fireworks-backed lanes can enforce committed
+  output. Direct Claude workflows may still use
+  `anthropics/claude-code-action@v1`; when they do, pass the model via
+  `claude_args`, never as a separate `model:` input:
 
   ```yaml
   # Correct (v1)
@@ -24,6 +27,12 @@ short pointer plus the few genuinely agent-specific notes.
 
   Reference: https://code.claude.com/docs/en/github-actions
   (action repo: https://github.com/anthropics/claude-code-action)
+
+- **Fireworks scheduled lanes** should select `fireworks-deepseek-v4-flash`
+  for high-frequency summarization and `fireworks-glm-5p2` for deeper CRUD or
+  synthesis work. Set `expected-paths` in `agent-run`, or call
+  `.github/actions/require-output` after deterministic commit steps, so green
+  no-op runs do not leave the freshness watchdog stale.
 
 - **Codex generative-research workflows** use the Codex CLI with
   ChatGPT-managed file auth, not OpenAI API billing. Seed the workflow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,9 +122,13 @@ those two watchdogs." **Always read the workflow's actual `runs-on:` —
 never trust a cached list** (the old list here drifted to 100% wrong once
 the autoscaler landed and the stateless lanes moved back to self-hosted).
 
-Claude workflows use `anthropics/claude-code-action@v1` with the model
-passed via `claude_args: "--model opus"` (never as a separate `model:`
-input).
+Scheduled content workflows should use `.github/actions/agent-run` instead
+of calling `anthropics/claude-code-action@v1` directly. The wrapper keeps the
+Claude-Code-compatible tool harness but routes the primary freshness lanes
+through Fireworks profiles and can enforce that the expected output paths were
+actually committed. PR/review/on-demand Claude workflows may still call the
+Claude action directly; when they do, pass the model via `claude_args:
+"--model opus"` (never as a separate `model:` input).
 
 ### Aggregation (raw signal → `research/<source>/`)
 
@@ -133,7 +137,7 @@ input).
 | `hourly-rss.yml` | `:30` every hour | `research/rss/` |
 | `daily-ai-blogs.yml` | `:13` every 6h | `research/blogs/` |
 | `daily-youtube.yml` | daily `23:20` for the next `00:00` digest | `research/youtube/` (tuber discovery + read-only summary/transcript evidence) |
-| `hourly-twitter.yml` | every 3h `:07`; DeepSeek/Fireworks comparison lanes via matrix/manual dispatch | `research/twitter/` + `research/summaries/` + Telegram headline alerts; comparison outputs under `research/twitter-deepseek/`, `research/twitter-deepseek-pi/`, and `research/twitter-fireworks-pi/` |
+| `hourly-twitter.yml` | every 3h `:07`; primary lane uses Fireworks through `.github/actions/agent-run`; comparison lanes via matrix/manual dispatch | `research/twitter/` + `research/summaries/` + Telegram headline alerts; comparison outputs under `research/twitter-deepseek/`, `research/twitter-deepseek-pi/`, and `research/twitter-fireworks-pi/` |
 | `twitter-account-explorer.yml` | weekly Tuesday `01:47` UTC + manual dispatch | Opens reviewed PRs for `data/sources/twitter_accounts.json` changes when high-signal account evidence exists |
 | `2h-bluesky.yml` | daily `10:11` | `research/bluesky/` (supplemental expert commentary, capped output) |
 | `4h-community.yml` | every 4h `:19` | `research/community/*-hn.md`, `*-reddit.md` |
@@ -165,10 +169,11 @@ input).
 | `claude.yml` | `@claude` mention in issue/PR/review | Interactive Claude-Code agent |
 | `claude-code-review.yml` | PR opened/synced | Automated Claude code review |
 
-Model convention: most Claude workflows pin `--model opus`. Cost-driven
-moves to Sonnet/Haiku for specific steps are made on a per-PR basis;
-defer to whatever the workflow file actually says rather than assuming
-opus everywhere.
+Model convention: scheduled content workflows pass `--model opus` to the
+Claude-Code-compatible CLI but the provider model is selected by the
+`agent-run` backend (`fireworks-deepseek-v4-flash` or `fireworks-glm-5p2`).
+Native Claude workflows still pin through `claude_args`; defer to the
+workflow file rather than assuming one provider everywhere.
 
 ## Backends
 
@@ -176,7 +181,8 @@ opus everywhere.
 |---|---|---|---|
 | **Claude (default)** | All Claude workflows; `generative-research backend=claude` | `CLAUDE_CODE_OAUTH_TOKEN` | Native Anthropic. `claude-opus-4-8` for generative-research. |
 | **Codex** | `generative-research backend=codex` | `CODEX_AUTH_JSON` | Runs Codex CLI with ChatGPT-managed file auth (`auth.json` from `codex login`), so usage follows the ChatGPT/Codex subscription entitlement rather than API billing. Publishes through the same writer/verifier contract and records `codex` metadata. |
-| **DeepSeek V4 Flash (via Fireworks)** | `generative-research backend=deepseek-v4-flash`; `hourly-twitter.yml` DeepSeek lanes | `FIREWORKS_API_KEY` | Uses Fireworks' Anthropic-compatible endpoint at `https://api.fireworks.ai/inference` with model `accounts/fireworks/models/deepseek-v4-flash` (base URL omits `/v1`; the client appends `/v1/messages`). Overrides `ANTHROPIC_BASE_URL`/`ANTHROPIC_AUTH_TOKEN`/`ANTHROPIC_MODEL` so the Claude Code action transparently calls Fireworks. The direct DeepSeek API (`api.deepseek.com`) is retired (billing/credits). Selector token: `deepseek-v4-flash` (or `deepseek`). Generative-research retries up to 2x on socket drops before commit. |
+| **DeepSeek V4 Flash (via Fireworks)** | High-frequency scheduled lanes through `.github/actions/agent-run`; `generative-research backend=deepseek-v4-flash`; `hourly-twitter.yml` comparison lanes | `FIREWORKS_API_KEY` | Uses Fireworks' Anthropic-compatible endpoint at `https://api.fireworks.ai/inference` with model `accounts/fireworks/models/deepseek-v4-flash` (base URL omits `/v1`; the client appends `/v1/messages`). Overrides `ANTHROPIC_BASE_URL`/`ANTHROPIC_AUTH_TOKEN`/`ANTHROPIC_MODEL` so the Claude Code action transparently calls Fireworks. The direct DeepSeek API (`api.deepseek.com`) is retired (billing/credits). Selector token: `fireworks-deepseek-v4-flash`, `deepseek-v4-flash`, or `deepseek`. Generative-research retries up to 2x on socket drops before commit. |
+| **GLM 5.2 (via Fireworks)** | Higher-reasoning scheduled lanes through `.github/actions/agent-run`; `generative-research backend=glm-5p2` | `FIREWORKS_API_KEY` | Uses the same Fireworks Anthropic-compatible env slots with model `accounts/fireworks/models/glm-5p2`. Selector token: `fireworks-glm-5p2`, `glm-5p2`, or `glm`. |
 | **Fireworks pi** | `hourly-twitter.yml backend=fireworks-pi` manual comparison lane | `FIREWORKS_API_KEY` | Uses pi's built-in Fireworks provider with `accounts/fireworks/models/kimi-k2p6`; writes `research/twitter-fireworks-pi/` plus a Telegram summary. |
 | **Local Oracle (GPT-5.5 Pro)** | `scripts/run_generative_research_oracle.py` | Local `../oracle` checkout (browser engine by default) | Runs entirely on the developer machine; outputs go through the same `check_generative_research.py` → `write_generative_research.py` contract. Source metadata: `local-oracle`. |
 
@@ -243,10 +249,10 @@ Secrets are configured in GitHub Actions. None are committed.
 
 | Secret | Used by | Notes |
 |---|---|---|
-| `CLAUDE_CODE_OAUTH_TOKEN` | All Claude workflows | Required. |
+| `CLAUDE_CODE_OAUTH_TOKEN` | Native Claude workflows and `.github/actions/agent-run` | Required by `anthropics/claude-code-action@v1`; Fireworks-routed wrapper runs still pass it for action schema compatibility. |
 | `CODEX_AUTH_JSON` | `generative-research backend=codex` | Required for the Codex CLI ChatGPT-auth path. Store the file-backed `~/.codex/auth.json` produced by `codex login`; treat it like a password and use one auth file per serialized runner stream. |
 | `DEEPSEEK_API_KEY` | _Retired_ — DeepSeek lanes now route through Fireworks | No longer referenced by any workflow. |
-| `FIREWORKS_API_KEY` | `generative-research backend=deepseek-v4-flash` / `backend=glm-5p2`; all `hourly-twitter.yml` non-claude lanes (`deepseek-claude-code`, `deepseek-pi`, `fireworks-pi`) | Required for the DeepSeek-V4-Flash/GLM-via-Fireworks and Kimi lanes. |
+| `FIREWORKS_API_KEY` | Scheduled content lanes through `.github/actions/agent-run`; `generative-research backend=deepseek-v4-flash` / `backend=glm-5p2`; all `hourly-twitter.yml` non-primary comparison lanes (`deepseek-claude-code`, `deepseek-pi`, `fireworks-pi`) | Required for the DeepSeek-V4-Flash/GLM-via-Fireworks and Kimi lanes. |
 | `BIRD_AUTH_TOKEN`, `BIRD_CT0` | All bird-CLI workflows (`hourly-twitter*`, `24h-model-timeline`) | X/Twitter cookies. |
 | `EXA_API_KEY`, `PERPLEXITY_API_KEY` | `daily-digest`, `ai-news-research`, `research-issue` | Optional; enhance MCP search. |
 | `GEMINI_API_KEY` | `daily-digest` (inline Gemini Flash TTS for digest audio); also the manual `generate_generative_article_audio.py` | Optional; without it, audio generation is skipped. |


### PR DESCRIPTION
## What changed

- Added `.github/actions/agent-run`, a shared Claude-Code-compatible runner that can route native Claude or Fireworks profiles and preflight Fireworks auth/model availability.
- Added `.github/actions/require-output`, a reusable guard that fails green no-op runs when expected committed output paths do not change.
- Migrated scheduled freshness lanes from direct Claude action calls to Fireworks-backed `agent-run` profiles while preserving existing output directories:
  - RSS, Twitter primary/comparison, Bluesky, Community, arXiv, Daily Digest, Model Tickets, Wiki ingest.
- Added output guards for deterministic Bluesky/front-page commit steps.
- Removed Claude-only `WebSearch` assumptions from Fireworks-routed scheduled lanes.
- Updated `AGENTS.md` and `CLAUDE.md` with the new scheduled-lane backend contract.

## Why

The liveness check was failing because scheduled jobs could exit green without committing lane outputs. Moving providers alone would not fix that. This change makes the provider route modular and turns no-output runs into explicit failures before `safe-push`.

## Validation

- `actionlint -shellcheck= -pyflakes=`
- `uv run python - <<'PY' ... yaml.safe_load(...) ... PY` parsed all workflow/action YAML files
- `git diff --check`
- `uv run python -m unittest discover -s scripts -p 'test_*.py'` — 351 tests, 6 skipped

## Notes

The Twitter workflow display name is intentionally unchanged so exact-name automations such as runner-loss auto-rerun keep matching it.
