### PR TITLE
[codex] Fallback scheduled agents when Fireworks is unavailable

### DIFF
--- a/.github/actions/agent-run/action.yml
+++ b/.github/actions/agent-run/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: Fireworks API key for Fireworks-routed backends.
     required: false
     default: ""
+  fireworks-fallback:
+    description: Fallback when Fireworks preflight is unavailable. Use claude or none.
+    required: false
+    default: claude
   claude-args:
     description: Arguments passed to claude-code-action.
     required: true
@@ -42,6 +46,12 @@ outputs:
   backend:
     description: Normalized backend selector.
     value: ${{ steps.profile.outputs.backend }}
+  effective-backend:
+    description: Backend actually used after provider preflight and fallback.
+    value: ${{ steps.effective.outputs.backend }}
+  used-fallback:
+    description: "true when a Fireworks backend fell back to Claude"
+    value: ${{ steps.effective.outputs.used-fallback }}
   model-id:
     description: Provider model id for Fireworks backends.
     value: ${{ steps.profile.outputs.model-id }}
@@ -97,17 +107,57 @@ runs:
         echo "ARA agent backend: $display_name"
 
     - name: Preflight Fireworks backend
+      id: fireworks-preflight
       if: steps.profile.outputs.model-id != ''
+      continue-on-error: true
       shell: bash
       env:
         FIREWORKS_API_KEY: ${{ inputs.fireworks-api-key }}
         FIREWORKS_MODEL_ID: ${{ steps.profile.outputs.model-id }}
       run: |
         set -euo pipefail
-        python3 scripts/check_fireworks_backend.py --model "$FIREWORKS_MODEL_ID"
+        python3 scripts/check_fireworks_backend.py \
+          --model "$FIREWORKS_MODEL_ID" \
+          --github-output "$GITHUB_OUTPUT"
+
+    - name: Resolve effective backend
+      id: effective
+      shell: bash
+      env:
+        REQUESTED_BACKEND: ${{ steps.profile.outputs.backend }}
+        REQUESTED_MODEL_ID: ${{ steps.profile.outputs.model-id }}
+        PREFLIGHT_OUTCOME: ${{ steps.fireworks-preflight.outcome }}
+        PREFLIGHT_AVAILABLE: ${{ steps.fireworks-preflight.outputs.available }}
+        PREFLIGHT_STATUS: ${{ steps.fireworks-preflight.outputs.status }}
+        PREFLIGHT_MESSAGE: ${{ steps.fireworks-preflight.outputs.message }}
+        FIREWORKS_FALLBACK: ${{ inputs.fireworks-fallback }}
+      run: |
+        set -euo pipefail
+
+        backend="$REQUESTED_BACKEND"
+        used_fallback=false
+
+        if [ -n "$REQUESTED_MODEL_ID" ]; then
+          if [ "$PREFLIGHT_OUTCOME" = "success" ] && [ "$PREFLIGHT_AVAILABLE" = "true" ]; then
+            backend="$REQUESTED_BACKEND"
+          elif [ "$FIREWORKS_FALLBACK" = "claude" ]; then
+            backend="claude"
+            used_fallback=true
+            echo "::warning::Fireworks backend ${REQUESTED_BACKEND} is unavailable (status=${PREFLIGHT_STATUS:-unknown}); falling back to native Claude. ${PREFLIGHT_MESSAGE:-}"
+          else
+            echo "::error::Fireworks backend ${REQUESTED_BACKEND} is unavailable (status=${PREFLIGHT_STATUS:-unknown}) and fireworks-fallback=${FIREWORKS_FALLBACK}."
+            exit 1
+          fi
+        fi
+
+        {
+          echo "backend=$backend"
+          echo "used-fallback=$used_fallback"
+        } >> "$GITHUB_OUTPUT"
+        echo "ARA agent effective backend: $backend"
 
     - name: Run agent with Claude
-      if: steps.profile.outputs.backend == 'claude' && inputs.allowed-bots == ''
+      if: steps.effective.outputs.backend == 'claude' && inputs.allowed-bots == ''
       uses: anthropics/claude-code-action@v1
       with:
         claude_code_oauth_token: ${{ inputs.claude-code-oauth-token }}
@@ -115,7 +165,7 @@ runs:
         prompt: ${{ inputs.prompt }}
 
     - name: Run agent with Claude
-      if: steps.profile.outputs.backend == 'claude' && inputs.allowed-bots != ''
+      if: steps.effective.outputs.backend == 'claude' && inputs.allowed-bots != ''
       uses: anthropics/claude-code-action@v1
       with:
         claude_code_oauth_token: ${{ inputs.claude-code-oauth-token }}
@@ -124,7 +174,7 @@ runs:
         prompt: ${{ inputs.prompt }}
 
     - name: Run agent with Fireworks
-      if: steps.profile.outputs.model-id != '' && inputs.allowed-bots == ''
+      if: steps.profile.outputs.model-id != '' && steps.effective.outputs.backend != 'claude' && inputs.allowed-bots == ''
       uses: anthropics/claude-code-action@v1
       env:
         ANTHROPIC_BASE_URL: https://api.fireworks.ai/inference
@@ -144,7 +194,7 @@ runs:
         prompt: ${{ inputs.prompt }}
 
     - name: Run agent with Fireworks
-      if: steps.profile.outputs.model-id != '' && inputs.allowed-bots != ''
+      if: steps.profile.outputs.model-id != '' && steps.effective.outputs.backend != 'claude' && inputs.allowed-bots != ''
       uses: anthropics/claude-code-action@v1
       env:
         ANTHROPIC_BASE_URL: https://api.fireworks.ai/inference

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,9 +30,11 @@ short pointer plus the few genuinely agent-specific notes.
 
 - **Fireworks scheduled lanes** should select `fireworks-deepseek-v4-flash`
   for high-frequency summarization and `fireworks-glm-5p2` for deeper CRUD or
-  synthesis work. Set `expected-paths` in `agent-run`, or call
-  `.github/actions/require-output` after deterministic commit steps, so green
-  no-op runs do not leave the freshness watchdog stale.
+  synthesis work. `agent-run` preflights Fireworks and falls back to native
+  Claude by default when Fireworks is unavailable; set `fireworks-fallback:
+  none` only when strict provider failure is desired. Set `expected-paths` in
+  `agent-run`, or call `.github/actions/require-output` after deterministic
+  commit steps, so green no-op runs do not leave the freshness watchdog stale.
 
 - **Codex generative-research workflows** use the Codex CLI with
   ChatGPT-managed file auth, not OpenAI API billing. Seed the workflow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,10 +125,13 @@ the autoscaler landed and the stateless lanes moved back to self-hosted).
 Scheduled content workflows should use `.github/actions/agent-run` instead
 of calling `anthropics/claude-code-action@v1` directly. The wrapper keeps the
 Claude-Code-compatible tool harness but routes the primary freshness lanes
-through Fireworks profiles and can enforce that the expected output paths were
-actually committed. PR/review/on-demand Claude workflows may still call the
-Claude action directly; when they do, pass the model via `claude_args:
-"--model opus"` (never as a separate `model:` input).
+through Fireworks profiles when Fireworks preflight passes. If Fireworks is
+unavailable (for example billing/spend-limit suspension), the wrapper falls
+back to native Claude by default so scheduled freshness does not hard-stop.
+It can also enforce that the expected output paths were actually committed.
+PR/review/on-demand Claude workflows may still call the Claude action directly;
+when they do, pass the model via `claude_args: "--model opus"` (never as a
+separate `model:` input).
 
 ### Aggregation (raw signal → `research/<source>/`)
 
@@ -181,8 +184,8 @@ workflow file rather than assuming one provider everywhere.
 |---|---|---|---|
 | **Claude (default)** | All Claude workflows; `generative-research backend=claude` | `CLAUDE_CODE_OAUTH_TOKEN` | Native Anthropic. `claude-opus-4-8` for generative-research. |
 | **Codex** | `generative-research backend=codex` | `CODEX_AUTH_JSON` | Runs Codex CLI with ChatGPT-managed file auth (`auth.json` from `codex login`), so usage follows the ChatGPT/Codex subscription entitlement rather than API billing. Publishes through the same writer/verifier contract and records `codex` metadata. |
-| **DeepSeek V4 Flash (via Fireworks)** | High-frequency scheduled lanes through `.github/actions/agent-run`; `generative-research backend=deepseek-v4-flash`; `hourly-twitter.yml` comparison lanes | `FIREWORKS_API_KEY` | Uses Fireworks' Anthropic-compatible endpoint at `https://api.fireworks.ai/inference` with model `accounts/fireworks/models/deepseek-v4-flash` (base URL omits `/v1`; the client appends `/v1/messages`). Overrides `ANTHROPIC_BASE_URL`/`ANTHROPIC_AUTH_TOKEN`/`ANTHROPIC_MODEL` so the Claude Code action transparently calls Fireworks. The direct DeepSeek API (`api.deepseek.com`) is retired (billing/credits). Selector token: `fireworks-deepseek-v4-flash`, `deepseek-v4-flash`, or `deepseek`. Generative-research retries up to 2x on socket drops before commit. |
-| **GLM 5.2 (via Fireworks)** | Higher-reasoning scheduled lanes through `.github/actions/agent-run`; `generative-research backend=glm-5p2` | `FIREWORKS_API_KEY` | Uses the same Fireworks Anthropic-compatible env slots with model `accounts/fireworks/models/glm-5p2`. Selector token: `fireworks-glm-5p2`, `glm-5p2`, or `glm`. |
+| **DeepSeek V4 Flash (via Fireworks)** | High-frequency scheduled lanes through `.github/actions/agent-run`; `generative-research backend=deepseek-v4-flash`; `hourly-twitter.yml` comparison lanes | `FIREWORKS_API_KEY` | Uses Fireworks' Anthropic-compatible endpoint at `https://api.fireworks.ai/inference` with model `accounts/fireworks/models/deepseek-v4-flash` (base URL omits `/v1`; the client appends `/v1/messages`). Overrides `ANTHROPIC_BASE_URL`/`ANTHROPIC_AUTH_TOKEN`/`ANTHROPIC_MODEL` so the Claude Code action transparently calls Fireworks. The direct DeepSeek API (`api.deepseek.com`) is retired (billing/credits). Selector token: `fireworks-deepseek-v4-flash`, `deepseek-v4-flash`, or `deepseek`. In scheduled `agent-run` lanes, Fireworks preflight falls back to native Claude by default when unavailable. Generative-research retries up to 2x on socket drops before commit. |
+| **GLM 5.2 (via Fireworks)** | Higher-reasoning scheduled lanes through `.github/actions/agent-run`; `generative-research backend=glm-5p2` | `FIREWORKS_API_KEY` | Uses the same Fireworks Anthropic-compatible env slots with model `accounts/fireworks/models/glm-5p2`. Selector token: `fireworks-glm-5p2`, `glm-5p2`, or `glm`. In scheduled `agent-run` lanes, Fireworks preflight falls back to native Claude by default when unavailable. |
 | **Fireworks pi** | `hourly-twitter.yml backend=fireworks-pi` manual comparison lane | `FIREWORKS_API_KEY` | Uses pi's built-in Fireworks provider with `accounts/fireworks/models/kimi-k2p6`; writes `research/twitter-fireworks-pi/` plus a Telegram summary. |
 | **Local Oracle (GPT-5.5 Pro)** | `scripts/run_generative_research_oracle.py` | Local `../oracle` checkout (browser engine by default) | Runs entirely on the developer machine; outputs go through the same `check_generative_research.py` → `write_generative_research.py` contract. Source metadata: `local-oracle`. |
 


### PR DESCRIPTION
## What changed

- Makes `.github/actions/agent-run` treat Fireworks preflight as a routing decision instead of a hard stop.
- Scheduled Fireworks-profile lanes still prefer Fireworks, but fall back to native Claude by default when Fireworks is unavailable.
- Adds `fireworks-fallback` input; set `none` later if a strict provider failure is desired.
- Updates `AGENTS.md` and `CLAUDE.md` with the fallback contract.

## Why

The post-merge RSS smoke test on `main` failed before the model step because Fireworks returned HTTP 412: the account is suspended/spend-limited. Without fallback, every migrated scheduled freshness lane would fail immediately until billing is fixed.

## Validation

- `actionlint -shellcheck= -pyflakes=`
- YAML parse for all `.github/workflows/*.yml` and `.github/actions/*/action.yml`
- `git diff --check`
- `uv run python -m unittest discover -s scripts -p 'test_*.py'` — 351 tests, 6 skipped
