### PR TITLE
[codex] Allow RSS agent to read fetched feeds

### DIFF
--- a/.github/workflows/hourly-rss.yml
+++ b/.github/workflows/hourly-rss.yml
@@ -152,7 +152,7 @@ jobs:
           claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           fireworks-api-key: ${{ secrets.FIREWORKS_API_KEY }}
           claude-args: |
-            --model opus --allowedTools "Read,Write,Edit,Bash(git:*)"
+            --model opus --allowedTools "Read,Write,Edit,Bash(git:*),Bash(ls:*),Bash(cat:*)"
           expected-paths: |
             research/rss/
           label: RSS Fireworks processor


### PR DESCRIPTION
## What changed

- Allows the RSS agent to run `ls` and `cat` so it can inspect `/tmp/rss/*.xml` fetched by the previous workflow step.

## Why

The live RSS smoke test proved Fireworks fallback routing works, but native Claude then errored before writing because the prompt asks it to read `/tmp/rss` while the old tool allowlist only exposed `Read`, `Write`, `Edit`, and `Bash(git:*)`.

## Validation

- `actionlint -shellcheck= -pyflakes=`
- YAML parse for `hourly-rss.yml` and `agent-run/action.yml`
- `git diff --check`
