### PR TITLE
Add deterministic fallbacks for scheduled aggregators

### DIFF
--- a/.github/workflows/4h-community.yml
+++ b/.github/workflows/4h-community.yml
@@ -111,6 +111,10 @@ jobs:
           cp /tmp/hn/*.json data/hn/ || echo "No files to copy"
           ls -la data/hn/
 
+      - name: Capture community output base
+        id: community-output-base
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Create MCP Config
         run: |
           cat > /tmp/mcp-config.json << 'EOF'
@@ -125,6 +129,8 @@ jobs:
           EOF
 
       - name: Process Community Data with Fireworks
+        id: community-agent
+        continue-on-error: true
         uses: ./.github/actions/agent-run
         with:
           backend: fireworks-glm-5p2
@@ -132,7 +138,7 @@ jobs:
           fireworks-api-key: ${{ secrets.FIREWORKS_API_KEY }}
           claude-args: |
             --model opus --mcp-config /tmp/mcp-config.json
-            --allowedTools "Read,Write,Edit,Bash(git:*),mcp__hackernews__*"
+            --allowedTools "Read,Write,Edit,Bash(git:*),Bash(ls:*),Bash(cat:*),mcp__hackernews__*"
           expected-paths: |
             research/community/
           label: Community Fireworks processor
@@ -229,6 +235,28 @@ jobs:
             After writing both files:
             git add research/community/
             git commit -m "Community digest ${{ steps.datetime.outputs.timestamp }}"
+
+      - name: Deterministic community fallback
+        if: steps.community-agent.outcome == 'failure'
+        run: |
+          set -euo pipefail
+          echo "::warning::Community agent path failed; writing deterministic fallback from fetched HN/Reddit data."
+          python3 scripts/deterministic_community_digest.py \
+            --hn-json data/hn/frontpage.json \
+            --reddit-dir data/reddit \
+            --out-dir research/community \
+            --date "${{ steps.datetime.outputs.date }}" \
+            --timestamp "${{ steps.datetime.outputs.timestamp }}"
+          git add research/community/
+          git commit -m "Community deterministic fallback ${{ steps.datetime.outputs.timestamp }}" || echo "No deterministic community changes"
+
+      - name: Require community output
+        uses: ./.github/actions/require-output
+        with:
+          base-sha: ${{ steps.community-output-base.outputs.sha }}
+          expected-paths: |
+            research/community/
+          label: Community workflow output
 
       # Use the shared safe-push composite action (post-PR-#58 algorithm):
       # stash any leftover working-tree state before rebasing, so the

--- a/.github/workflows/hourly-rss.yml
+++ b/.github/workflows/hourly-rss.yml
@@ -145,7 +145,13 @@ jobs:
           echo "RSS feeds fetched successfully"
           ls -la /tmp/rss/
 
+      - name: Capture RSS output base
+        id: rss-output-base
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Process RSS Feeds with Fireworks
+        id: rss-agent
+        continue-on-error: true
         uses: ./.github/actions/agent-run
         with:
           backend: fireworks-deepseek-v4-flash
@@ -290,6 +296,27 @@ jobs:
             After writing:
             git add research/rss/
             git commit -m "RSS update ${{ steps.datetime.outputs.timestamp }}" || echo "No changes"
+
+      - name: Deterministic RSS fallback
+        if: steps.rss-agent.outcome == 'failure'
+        run: |
+          set -euo pipefail
+          echo "::warning::RSS agent path failed; writing deterministic RSS fallback from fetched XML."
+          python3 scripts/deterministic_rss_digest.py \
+            --input-dir /tmp/rss \
+            --out-dir research/rss \
+            --date "${{ steps.datetime.outputs.date }}" \
+            --timestamp "${{ steps.datetime.outputs.timestamp }}"
+          git add research/rss/
+          git commit -m "RSS deterministic fallback ${{ steps.datetime.outputs.timestamp }}" || echo "No deterministic RSS changes"
+
+      - name: Require RSS output
+        uses: ./.github/actions/require-output
+        with:
+          base-sha: ${{ steps.rss-output-base.outputs.sha }}
+          expected-paths: |
+            research/rss/
+          label: RSS workflow output
 
       # Use the shared safe-push composite action (post-PR-#58 algorithm):
       # stash any leftover working-tree state before rebasing, so the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,10 @@ short pointer plus the few genuinely agent-specific notes.
   none` only when strict provider failure is desired. Set `expected-paths` in
   `agent-run`, or call `.github/actions/require-output` after deterministic
   commit steps, so green no-op runs do not leave the freshness watchdog stale.
+  RSS and HN/Reddit community lanes also have deterministic parser fallbacks;
+  a green run there means committed lane output exists, not necessarily that
+  the model provider was healthy. Check the agent/fallback step logs before
+  drawing provider conclusions.
 
 - **Codex generative-research workflows** use the Codex CLI with
   ChatGPT-managed file auth, not OpenAI API billing. Seed the workflow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,8 @@ and opens a PR with methodology fixes.
 | `check_lane_freshness.py` | Freshness watchdog. Measures git-commit recency per research lane against per-lane cadence thresholds; exits 2 (and emits a hooker/Telegram alert from `liveness-check.yml`) when a lane is stale. Stdlib-only so it runs on both runner tiers. |
 | `build_wiki_index.py` | Rebuilds `research/wiki/index.json` from the wiki pages. **CI-load-bearing**: `ci.yml` runs `--check` (exit 1 if the committed index is stale or any page fails validation); `wiki-ingest.yml` regenerates it every run. |
 | `fetch_ai_blogs.py` | Per-feed AI-blog fetcher used by `daily-ai-blogs.yml`; boundary-handles bad feeds so one failure doesn't crash the run. |
+| `deterministic_rss_digest.py` | Model-free fallback for `hourly-rss.yml`; parses fetched RSS/Atom files and appends a timestamped `research/rss/YYYY-MM-DD.md` section when the agent path fails. |
+| `deterministic_community_digest.py` | Model-free fallback for `4h-community.yml`; parses pre-fetched HN JSON and Reddit RSS into `research/community/*-hn.md` and `*-reddit.md` when the agent path fails. |
 | `fetch_youtube_signal.py` | tuber-backed YouTube lane used by `daily-youtube.yml`; read-only by default (discovery, existing summary previews, transcript probes) and never triggers paid summary generation. |
 | `source_cache.py` | Runtime primary-source fetch cache under `data/source-cache/` (gitignored), used by `generative-research.yml`. |
 | `render_front_page.mjs` | Deterministic newspaper renderer used by `daily-front-page.yml`: digest → SVG → PNG via `@resvg/resvg-js` (no Chromium/model dependency), plus the `.ara.md` source for the interactive edition. Layout is budget-aware — overflow is ellipsized/dropped, never painted over. |
@@ -128,10 +130,14 @@ Claude-Code-compatible tool harness but routes the primary freshness lanes
 through Fireworks profiles when Fireworks preflight passes. If Fireworks is
 unavailable (for example billing/spend-limit suspension), the wrapper falls
 back to native Claude by default so scheduled freshness does not hard-stop.
-It can also enforce that the expected output paths were actually committed.
-PR/review/on-demand Claude workflows may still call the Claude action directly;
-when they do, pass the model via `claude_args: "--model opus"` (never as a
-separate `model:` input).
+It can also enforce that the expected output paths were actually committed. The
+RSS and HN/Reddit community workflows add deterministic parser fallbacks after
+the agent step, then run a final `.github/actions/require-output` guard. For
+those lanes, a green run means a committed daily artifact exists; inspect the
+agent/fallback step logs before treating it as evidence that Fireworks or
+native Claude was healthy. PR/review/on-demand Claude workflows may still call
+the Claude action directly; when they do, pass the model via
+`claude_args: "--model opus"` (never as a separate `model:` input).
 
 ### Aggregation (raw signal → `research/<source>/`)
 

--- a/scripts/deterministic_community_digest.py
+++ b/scripts/deterministic_community_digest.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Deterministic fallback writer for the HN/Reddit community lane."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as dt
+import email.utils
+import html
+import json
+import os
+import re
+import sys
+import tempfile
+import urllib.parse
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Any
+
+
+AI_TERMS = re.compile(
+    r"\b(ai|agent|agents|agentic|alignment|anthropic|benchmark|claude|codex|"
+    r"deepseek|diffusion|eval|evaluation|frontier|gpt|gpu|inference|llama|llm|"
+    r"machine learning|model|neural|openai|post-training|prompt|rag|reasoning|"
+    r"robot|safety|synthetic data|transformer|vibe coding)\b",
+    re.I,
+)
+LOW_SIGNAL_TERMS = re.compile(r"\b(beginner|homework|meme|shitpost|wallpaper)\b", re.I)
+
+
+@dataclasses.dataclass(frozen=True)
+class HNItem:
+    title: str
+    url: str
+    points: int
+    comments: int
+    object_id: str
+
+    @property
+    def discuss_url(self) -> str:
+        return f"https://news.ycombinator.com/item?id={self.object_id}"
+
+
+@dataclasses.dataclass(frozen=True)
+class RedditItem:
+    subreddit: str
+    title: str
+    url: str
+    updated_at: dt.datetime | None
+
+
+def clean_text(value: str | None) -> str:
+    value = re.sub(r"<[^>]+>", " ", value or "")
+    value = html.unescape(value)
+    return re.sub(r"\s+", " ", value).strip()
+
+
+def markdown_escape(value: str) -> str:
+    return value.replace("|", r"\|").replace("\n", " ")
+
+
+def local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def child_text(element: ET.Element, *names: str) -> str:
+    wanted = set(names)
+    for child in list(element):
+        if local_name(child.tag) in wanted:
+            return clean_text("".join(child.itertext()))
+    return ""
+
+
+def parse_datetime(value: str | None) -> dt.datetime | None:
+    value = clean_text(value)
+    if not value:
+        return None
+    parsed: dt.datetime | None
+    try:
+        parsed = email.utils.parsedate_to_datetime(value)
+    except (TypeError, ValueError):
+        parsed = None
+    if parsed is None:
+        try:
+            parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed.astimezone(dt.timezone.utc)
+
+
+def canonical_url(url: str) -> str:
+    parts = urllib.parse.urlsplit(url.strip())
+    query = [
+        (key, value)
+        for key, value in urllib.parse.parse_qsl(parts.query, keep_blank_values=True)
+        if not key.lower().startswith("utm_") and key.lower() not in {"fbclid", "gclid"}
+    ]
+    path = parts.path
+    if path != "/" and path.endswith("/"):
+        path = path[:-1]
+    return urllib.parse.urlunsplit(
+        (parts.scheme.lower(), parts.netloc.lower(), path, urllib.parse.urlencode(query, doseq=True), "")
+    )
+
+
+def is_relevant(text: str) -> bool:
+    return bool(AI_TERMS.search(text)) and not LOW_SIGNAL_TERMS.search(text)
+
+
+def load_hn_items(path: Path, limit: int) -> list[HNItem]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        payload = {"hits": []}
+    items: list[HNItem] = []
+    for row in payload.get("hits", []):
+        if not isinstance(row, dict):
+            continue
+        title = clean_text(row.get("title") or row.get("story_title"))
+        object_id = clean_text(str(row.get("objectID") or ""))
+        if not title or not object_id:
+            continue
+        text = " ".join(
+            clean_text(str(row.get(key) or ""))
+            for key in ("title", "story_title", "url", "story_text", "comment_text")
+        )
+        if not is_relevant(text):
+            continue
+        url = clean_text(row.get("url") or row.get("story_url")) or f"https://news.ycombinator.com/item?id={object_id}"
+        try:
+            points = int(row.get("points") or 0)
+        except (TypeError, ValueError):
+            points = 0
+        try:
+            comments = int(row.get("num_comments") or 0)
+        except (TypeError, ValueError):
+            comments = 0
+        items.append(HNItem(title=title, url=canonical_url(url), points=points, comments=comments, object_id=object_id))
+    items.sort(key=lambda item: (-item.points, -item.comments, item.title))
+    return items[:limit]
+
+
+def reddit_link(entry: ET.Element) -> str:
+    for child in list(entry):
+        if local_name(child.tag) != "link":
+            continue
+        href = child.get("href")
+        if href:
+            return href
+    return child_text(entry, "link")
+
+
+def parse_reddit_feed(path: Path, subreddit: str, limit: int) -> tuple[list[RedditItem], str | None]:
+    try:
+        root = ET.fromstring(path.read_bytes())
+    except FileNotFoundError:
+        return [], f"{path}: missing"
+    except ET.ParseError as exc:
+        return [], f"{path}: parse error: {exc}"
+    except OSError as exc:
+        return [], f"{path}: read error: {exc}"
+
+    entries = [child for child in list(root) if local_name(child.tag) == "entry"]
+    parsed: list[RedditItem] = []
+    fallback: list[RedditItem] = []
+    for entry in entries:
+        title = child_text(entry, "title")
+        url = reddit_link(entry)
+        content = child_text(entry, "content", "summary")
+        if not title or not url:
+            continue
+        item = RedditItem(
+            subreddit=subreddit,
+            title=title,
+            url=canonical_url(url),
+            updated_at=parse_datetime(child_text(entry, "updated", "published")),
+        )
+        if LOW_SIGNAL_TERMS.search(f"{title} {content}"):
+            continue
+        fallback.append(item)
+        if is_relevant(f"{title} {content}"):
+            parsed.append(item)
+    selected = parsed or fallback
+    selected.sort(key=lambda item: (-(item.updated_at.timestamp() if item.updated_at else 0), item.title))
+    return selected[:limit], None
+
+
+def existing_section(markdown: str, timestamp: str) -> bool:
+    return f"## {timestamp}" in markdown
+
+
+def section_body(timestamp: str, lines: list[str]) -> str:
+    return "\n".join([f"## {timestamp}", "", *lines]).rstrip() + "\n"
+
+
+def render_hn_section(timestamp: str, items: list[HNItem]) -> str:
+    lines = ["### Top Stories", "", "| Title | Points | Comments | Link |", "|-------|--------|----------|------|"]
+    if not items:
+        lines.append("| _No AI-related HN front-page stories matched deterministic filters._ | - | - | - |")
+    else:
+        for item in items:
+            lines.append(
+                f"| [{markdown_escape(item.title)}]({item.url}) | {item.points} | {item.comments} | "
+                f"[discuss]({item.discuss_url}) |"
+            )
+    lines.extend(["", "### Notable Discussions", ""])
+    if not items:
+        lines.append("- No deterministic HN discussion candidates this run.")
+    else:
+        for item in items[:8]:
+            lines.append(
+                f"- **{markdown_escape(item.title)}**: {item.points} points, "
+                f"{item.comments} comments - [discuss]({item.discuss_url})"
+            )
+    return section_body(timestamp, lines)
+
+
+def render_reddit_section(timestamp: str, by_subreddit: dict[str, list[RedditItem]], notes: list[str]) -> str:
+    lines: list[str] = []
+    for subreddit in ("MachineLearning", "LocalLLaMA", "artificial"):
+        lines.extend(
+            [
+                f"### r/{subreddit} (Hot)",
+                "",
+                "| Title | Score | Comments | Link |",
+                "|-------|-------|----------|------|",
+            ]
+        )
+        items = by_subreddit.get(subreddit, [])
+        if not items:
+            lines.append("| _No matching RSS entries._ | N/A | - | - |")
+        else:
+            for item in items:
+                lines.append(
+                    f"| [{markdown_escape(item.title)}]({item.url}) | N/A | - | [link]({item.url}) |"
+                )
+        lines.append("")
+    lines.extend(
+        [
+            "> Note: Reddit RSS does not expose score/comment counts; N/A reflects the source limitation.",
+            "",
+        ]
+    )
+    if notes:
+        lines.extend(["### Feed Notes", ""])
+        for note in notes:
+            lines.append(f"- {markdown_escape(note)}")
+    return section_body(timestamp, lines)
+
+
+def write_atomic(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        "w", encoding="utf-8", dir=path.parent, delete=False, prefix=f".{path.name}.", suffix=".tmp"
+    ) as handle:
+        handle.write(text)
+        tmp_path = Path(handle.name)
+    os.replace(tmp_path, path)
+
+
+def append_daily_section(path: Path, title: str, timestamp: str, body: str) -> None:
+    existing = path.read_text(encoding="utf-8") if path.exists() else ""
+    if existing_section(existing, timestamp):
+        print(f"{path} already has section {timestamp}; no write needed")
+        return
+    full = existing.rstrip() + "\n\n" + body if existing else f"# {title}\n\n{body}"
+    write_atomic(path, full)
+    print(f"Wrote {path}")
+
+
+def update_digest(hn_path: Path, reddit_dir: Path, out_dir: Path, target_date: str, timestamp: str) -> tuple[Path, Path]:
+    hn_items = load_hn_items(hn_path, limit=15)
+    hn_out = out_dir / f"{target_date}-hn.md"
+    append_daily_section(
+        hn_out,
+        f"Hacker News AI Digest - {target_date}",
+        timestamp,
+        render_hn_section(timestamp, hn_items),
+    )
+
+    reddit_specs = {
+        "MachineLearning": "ml.rss",
+        "LocalLLaMA": "localllama.rss",
+        "artificial": "artificial.rss",
+    }
+    reddit_items: dict[str, list[RedditItem]] = {}
+    notes: list[str] = []
+    for subreddit, filename in reddit_specs.items():
+        items, note = parse_reddit_feed(reddit_dir / filename, subreddit, limit=12)
+        reddit_items[subreddit] = items
+        if note:
+            notes.append(note)
+    reddit_out = out_dir / f"{target_date}-reddit.md"
+    append_daily_section(
+        reddit_out,
+        f"Reddit AI Digest - {target_date}",
+        timestamp,
+        render_reddit_section(timestamp, reddit_items, notes),
+    )
+    return hn_out, reddit_out
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--hn-json", type=Path, default=Path("data/hn/frontpage.json"))
+    parser.add_argument("--reddit-dir", type=Path, default=Path("data/reddit"))
+    parser.add_argument("--out-dir", type=Path, default=Path("research/community"))
+    parser.add_argument("--date", required=True)
+    parser.add_argument("--timestamp", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    update_digest(args.hn_json, args.reddit_dir, args.out_dir, args.date, args.timestamp)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/deterministic_rss_digest.py
+++ b/scripts/deterministic_rss_digest.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""Deterministic fallback writer for the hourly RSS lane.
+
+The model lane is still the preferred curator, but RSS extraction itself is a
+structured-data problem. This script keeps the workflow useful when the model
+provider is unavailable by parsing the already-fetched XML files and appending
+a timestamped daily section.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as dt
+import email.utils
+import html
+import os
+import re
+import sys
+import tempfile
+import urllib.parse
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Iterable
+
+
+SOURCE_GROUPS = {
+    "company": ("Company Announcements", ("openai", "anthropic", "google_deepmind", "huggingface")),
+    "tech": (
+        "Tech News",
+        (
+            "techcrunch",
+            "the_verge",
+            "venturebeat",
+            "ars_technica",
+            "mit_technology_review",
+            "the_decoder",
+            "marktechpost",
+        ),
+    ),
+    "expert": (
+        "Expert Commentary",
+        ("simon_willison", "interconnects", "import_ai", "one_useful_thing"),
+    ),
+    "papers": ("New arXiv Papers", ("arxiv_cs_ai", "arxiv_cs_lg")),
+}
+
+
+@dataclasses.dataclass(frozen=True)
+class Source:
+    key: str
+    filename: str
+    label: str
+    group: str
+    ai_filter: bool = False
+
+
+SOURCES = (
+    Source("openai", "openai.xml", "OpenAI", "company"),
+    Source("anthropic", "anthropic.xml", "Anthropic", "company"),
+    Source("google_deepmind", "google_ai.xml", "Google/DeepMind", "company"),
+    Source("google_deepmind", "deepmind.xml", "Google/DeepMind", "company"),
+    Source("huggingface", "huggingface.xml", "Hugging Face", "company"),
+    Source("arxiv_cs_ai", "arxiv_ai.xml", "CS.AI", "papers"),
+    Source("arxiv_cs_lg", "arxiv_lg.xml", "CS.LG", "papers"),
+    Source("techcrunch", "techcrunch_ai.xml", "TechCrunch", "tech"),
+    Source("the_verge", "verge_ai.xml", "The Verge", "tech"),
+    Source("venturebeat", "venturebeat_ai.xml", "VentureBeat", "tech"),
+    Source("ars_technica", "arstechnica_ai.xml", "Ars Technica", "tech"),
+    Source("mit_technology_review", "mit_tech_review_ai.xml", "MIT Technology Review", "tech"),
+    Source("the_decoder", "the_decoder.xml", "The Decoder", "tech"),
+    Source("marktechpost", "marktechpost.xml", "MarkTechPost", "tech"),
+    Source("simon_willison", "simonwillison.xml", "Simon Willison", "expert", True),
+    Source("interconnects", "interconnects.xml", "Interconnects (Nathan Lambert)", "expert"),
+    Source("import_ai", "import_ai.xml", "Import AI (Jack Clark)", "expert"),
+    Source("one_useful_thing", "one_useful_thing.xml", "One Useful Thing", "expert"),
+)
+
+
+AI_TERMS = re.compile(
+    r"\b(ai|agent|agents|agentic|alignment|anthropic|benchmark|claude|codex|"
+    r"deepseek|diffusion|eval|evaluation|frontier|gpt|gpu|inference|llama|llm|"
+    r"machine learning|model|openai|post-training|prompt|reasoning|robot|"
+    r"safety|synthetic data|transformer)\b",
+    re.I,
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class FeedItem:
+    source: Source
+    title: str
+    url: str
+    published_at: dt.datetime | None
+    summary: str
+
+
+def clean_text(value: str | None) -> str:
+    value = re.sub(r"<[^>]+>", " ", value or "")
+    value = html.unescape(value)
+    return re.sub(r"\s+", " ", value).strip()
+
+
+def local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def child_text(element: ET.Element, *names: str) -> str:
+    wanted = set(names)
+    for child in list(element):
+        if local_name(child.tag) in wanted:
+            return clean_text("".join(child.itertext()))
+    return ""
+
+
+def parse_datetime(value: str | None) -> dt.datetime | None:
+    value = clean_text(value)
+    if not value:
+        return None
+    parsed: dt.datetime | None
+    try:
+        parsed = email.utils.parsedate_to_datetime(value)
+    except (TypeError, ValueError):
+        parsed = None
+    if parsed is None:
+        try:
+            parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed.astimezone(dt.timezone.utc)
+
+
+def parse_timestamp(value: str) -> dt.datetime:
+    parsed = parse_datetime(value)
+    if parsed is not None:
+        return parsed
+    try:
+        parsed = dt.datetime.strptime(value, "%Y-%m-%d %H:%M UTC")
+    except ValueError as exc:
+        raise ValueError(f"invalid timestamp {value!r}") from exc
+    return parsed.replace(tzinfo=dt.timezone.utc)
+
+
+def canonical_url(url: str) -> str:
+    parts = urllib.parse.urlsplit(url.strip())
+    query = [
+        (key, value)
+        for key, value in urllib.parse.parse_qsl(parts.query, keep_blank_values=True)
+        if not key.lower().startswith("utm_") and key.lower() not in {"fbclid", "gclid"}
+    ]
+    path = parts.path
+    if path != "/" and path.endswith("/"):
+        path = path[:-1]
+    return urllib.parse.urlunsplit(
+        (parts.scheme.lower(), parts.netloc.lower(), path, urllib.parse.urlencode(query, doseq=True), "")
+    )
+
+
+def find_link(entry: ET.Element, *, atom: bool, base_url: str) -> str:
+    if atom:
+        for child in list(entry):
+            if local_name(child.tag) != "link":
+                continue
+            rel = child.get("rel")
+            href = child.get("href")
+            if href and rel in (None, "alternate"):
+                return urllib.parse.urljoin(base_url, href)
+        return ""
+    return urllib.parse.urljoin(base_url, child_text(entry, "link"))
+
+
+def iter_entries(root: ET.Element) -> tuple[bool, Iterable[ET.Element]]:
+    atom = local_name(root.tag) == "feed"
+    if atom:
+        return True, [child for child in list(root) if local_name(child.tag) == "entry"]
+    channel = next((child for child in list(root) if local_name(child.tag) == "channel"), None)
+    parent = channel if channel is not None else root
+    return False, [child for child in list(parent) if local_name(child.tag) == "item"]
+
+
+def parse_feed(source: Source, body: bytes) -> list[FeedItem]:
+    root = ET.fromstring(body)
+    atom, entries = iter_entries(root)
+    items: list[FeedItem] = []
+    for entry in entries:
+        title = child_text(entry, "title")
+        url = find_link(entry, atom=atom, base_url=source.filename)
+        if atom:
+            date_value = child_text(entry, "published") or child_text(entry, "updated")
+            summary = child_text(entry, "summary") or child_text(entry, "content")
+        else:
+            date_value = child_text(entry, "pubDate", "published", "updated", "date")
+            summary = child_text(entry, "description", "summary", "encoded", "content")
+        if not title or not url:
+            continue
+        summary = summary[:320]
+        text_for_filter = f"{title} {summary}"
+        if source.ai_filter and not AI_TERMS.search(text_for_filter):
+            continue
+        items.append(
+            FeedItem(
+                source=source,
+                title=title,
+                url=canonical_url(url),
+                published_at=parse_datetime(date_value),
+                summary=summary,
+            )
+        )
+    return items
+
+
+def collect_items(input_dir: Path, now: dt.datetime, lookback_hours: int) -> tuple[list[FeedItem], list[str]]:
+    threshold = now - dt.timedelta(hours=lookback_hours)
+    items: list[FeedItem] = []
+    errors: list[str] = []
+    for source in SOURCES:
+        path = input_dir / source.filename
+        if not path.exists():
+            errors.append(f"{source.filename}: missing")
+            continue
+        try:
+            parsed = parse_feed(source, path.read_bytes())
+        except ET.ParseError as exc:
+            errors.append(f"{source.filename}: parse error: {exc}")
+            continue
+        except OSError as exc:
+            errors.append(f"{source.filename}: read error: {exc}")
+            continue
+        for item in parsed:
+            if item.published_at is None:
+                continue
+            if threshold <= item.published_at <= now + dt.timedelta(minutes=10):
+                items.append(item)
+    return dedupe_items(items), errors
+
+
+def dedupe_items(items: Iterable[FeedItem]) -> list[FeedItem]:
+    by_url: dict[str, FeedItem] = {}
+    for item in items:
+        previous = by_url.get(item.url)
+        if previous is None or (
+            item.published_at is not None
+            and (previous.published_at is None or item.published_at > previous.published_at)
+        ):
+            by_url[item.url] = item
+    return sorted(
+        by_url.values(),
+        key=lambda item: (
+            item.source.group,
+            item.source.label,
+            -(item.published_at.timestamp() if item.published_at else 0),
+            item.title,
+        ),
+    )
+
+
+def markdown_escape(value: str) -> str:
+    return value.replace("|", r"\|").replace("\n", " ")
+
+
+def published_label(item: FeedItem) -> str:
+    if item.published_at is None:
+        return "unknown date"
+    return item.published_at.strftime("%b %-d")
+
+
+def existing_urls(markdown: str) -> set[str]:
+    return {canonical_url(match) for match in re.findall(r"\]\((https?://[^)\s]+)\)", markdown)}
+
+
+def render_section(timestamp: str, items: list[FeedItem], errors: list[str], existing: str) -> str:
+    seen_urls = existing_urls(existing)
+    fresh = [item for item in items if item.url not in seen_urls]
+    grouped: dict[str, dict[str, list[FeedItem]]] = {}
+    for item in fresh:
+        grouped.setdefault(item.source.group, {}).setdefault(item.source.label, []).append(item)
+
+    lines = [f"## {timestamp} Update", ""]
+    if not fresh:
+        lines.extend(["_No new updates this hour._", ""])
+    else:
+        for group_key, (group_label, source_order) in SOURCE_GROUPS.items():
+            group = grouped.get(group_key, {})
+            if not group:
+                continue
+            lines.extend([f"### {group_label}", ""])
+            ordered_labels = [
+                source.label
+                for source_key in source_order
+                for source in SOURCES
+                if source.key == source_key
+            ]
+            for label in dict.fromkeys(ordered_labels):
+                label_items = group.get(label, [])
+                if not label_items:
+                    continue
+                lines.extend([f"#### {label}", ""])
+                for item in label_items[:8]:
+                    lines.append(
+                        f"- [{markdown_escape(item.title)}]({item.url}) - {published_label(item)}"
+                    )
+                    if item.summary:
+                        lines.append(f"  > {markdown_escape(item.summary)}")
+                    lines.append("")
+
+    if errors:
+        lines.extend(["### Feed Notes", ""])
+        for error in errors:
+            lines.append(f"- {markdown_escape(error)}")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def write_atomic(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        "w", encoding="utf-8", dir=path.parent, delete=False, prefix=f".{path.name}.", suffix=".tmp"
+    ) as handle:
+        handle.write(text)
+        tmp_path = Path(handle.name)
+    os.replace(tmp_path, path)
+
+
+def update_digest(input_dir: Path, out_dir: Path, target_date: str, timestamp: str, lookback_hours: int) -> Path:
+    now = parse_timestamp(timestamp)
+    out_path = out_dir / f"{target_date}.md"
+    existing = out_path.read_text(encoding="utf-8") if out_path.exists() else ""
+    heading = f"# Official AI News - {target_date}\n\n"
+    if f"## {timestamp} Update" in existing:
+        print(f"{out_path} already has section {timestamp}; no write needed")
+        return out_path
+    items, errors = collect_items(input_dir, now, lookback_hours)
+    section = render_section(timestamp, items, errors, existing)
+    body = existing.rstrip() + "\n\n" + section if existing else heading + section
+    write_atomic(out_path, body)
+    print(f"Wrote {out_path} with {len(items)} candidate item(s) and {len(errors)} feed note(s)")
+    return out_path
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input-dir", type=Path, default=Path("/tmp/rss"))
+    parser.add_argument("--out-dir", type=Path, default=Path("research/rss"))
+    parser.add_argument("--date", required=True)
+    parser.add_argument("--timestamp", required=True)
+    parser.add_argument("--lookback-hours", type=int, default=24)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    update_digest(args.input_dir, args.out_dir, args.date, args.timestamp, args.lookback_hours)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_deterministic_community_digest.py
+++ b/scripts/test_deterministic_community_digest.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Tests for the deterministic community fallback writer."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import deterministic_community_digest as community  # noqa: E402
+
+
+class DeterministicCommunityDigestTest(unittest.TestCase):
+    def test_load_hn_items_filters_and_sorts_ai_posts(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "frontpage.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "hits": [
+                            {
+                                "title": "LLM inference benchmark",
+                                "url": "https://example.com/llm?utm_campaign=x",
+                                "points": 42,
+                                "num_comments": 7,
+                                "objectID": "1",
+                            },
+                            {
+                                "title": "Woodworking notes",
+                                "url": "https://example.com/wood",
+                                "points": 99,
+                                "num_comments": 1,
+                                "objectID": "2",
+                            },
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            items = community.load_hn_items(path, limit=10)
+
+            self.assertEqual(len(items), 1)
+            self.assertEqual(items[0].title, "LLM inference benchmark")
+            self.assertEqual(items[0].url, "https://example.com/llm")
+            self.assertEqual(items[0].discuss_url, "https://news.ycombinator.com/item?id=1")
+
+    def test_update_digest_writes_hn_and_reddit_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            hn_path = root / "frontpage.json"
+            reddit_dir = root / "reddit"
+            out_dir = root / "out"
+            reddit_dir.mkdir()
+            hn_path.write_text(
+                json.dumps(
+                    {
+                        "hits": [
+                            {
+                                "title": "Claude agents in production",
+                                "url": "https://example.com/claude",
+                                "points": 12,
+                                "num_comments": 3,
+                                "objectID": "99",
+                            }
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+            atom = """<feed xmlns="http://www.w3.org/2005/Atom"><entry>
+            <title>Open model inference thread</title>
+            <link href="https://reddit.com/r/MachineLearning/comments/abc" />
+            <updated>2026-06-25T08:30:00Z</updated>
+            <content>LLM inference notes</content>
+            </entry></feed>"""
+            (reddit_dir / "ml.rss").write_text(atom, encoding="utf-8")
+
+            hn_out, reddit_out = community.update_digest(
+                hn_path,
+                reddit_dir,
+                out_dir,
+                "2026-06-25",
+                "2026-06-25 09:00 UTC",
+            )
+
+            self.assertIn("Claude agents in production", hn_out.read_text(encoding="utf-8"))
+            reddit_text = reddit_out.read_text(encoding="utf-8")
+            self.assertIn("Open model inference thread", reddit_text)
+            self.assertIn("localllama.rss", reddit_text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_deterministic_rss_digest.py
+++ b/scripts/test_deterministic_rss_digest.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Tests for the deterministic RSS fallback writer."""
+
+from __future__ import annotations
+
+import datetime as dt
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import deterministic_rss_digest as rss  # noqa: E402
+
+
+class DeterministicRssDigestTest(unittest.TestCase):
+    def test_parse_rss_and_atom_items(self):
+        source = rss.Source("openai", "openai.xml", "OpenAI", "company")
+        rss_body = b"""<rss><channel><item>
+        <title>OpenAI ships agent evals</title>
+        <link>https://openai.com/post?utm_source=x</link>
+        <pubDate>Thu, 25 Jun 2026 08:00:00 GMT</pubDate>
+        <description><![CDATA[<p>New evaluation detail.</p>]]></description>
+        </item></channel></rss>"""
+        atom_source = rss.Source("simon_willison", "simon.xml", "Simon", "expert", True)
+        atom_body = b"""<feed xmlns="http://www.w3.org/2005/Atom"><entry>
+        <title>Notes on LLM agents</title>
+        <link rel="alternate" href="https://example.com/agents" />
+        <published>2026-06-25T08:30:00Z</published>
+        <summary>Hands-on AI notes.</summary>
+        </entry></feed>"""
+
+        parsed = rss.parse_feed(source, rss_body) + rss.parse_feed(atom_source, atom_body)
+
+        self.assertEqual([item.title for item in parsed], ["OpenAI ships agent evals", "Notes on LLM agents"])
+        self.assertEqual(parsed[0].url, "https://openai.com/post")
+        self.assertEqual(parsed[1].published_at, dt.datetime(2026, 6, 25, 8, 30, tzinfo=dt.timezone.utc))
+
+    def test_update_digest_appends_no_new_section(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            input_dir = root / "rss"
+            out_dir = root / "out"
+            input_dir.mkdir()
+            (input_dir / "openai.xml").write_text("<rss></rss>", encoding="utf-8")
+
+            out_path = rss.update_digest(
+                input_dir,
+                out_dir,
+                "2026-06-25",
+                "2026-06-25 09:00 UTC",
+                24,
+            )
+
+            text = out_path.read_text(encoding="utf-8")
+            self.assertIn("# Official AI News - 2026-06-25", text)
+            self.assertIn("## 2026-06-25 09:00 UTC Update", text)
+            self.assertIn("_No new updates this hour._", text)
+            self.assertIn("anthropic.xml: missing", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add deterministic RSS and HN/Reddit fallback writers for scheduled aggregator lanes
- Run the model-backed Fireworks agent path as primary, then fall back to parser output when the agent step fails
- Add final require-output guards and document that green RSS/community runs may come from fallback output

## Verification
- uv run python -m unittest scripts.test_deterministic_rss_digest scripts.test_deterministic_community_digest
- uv run python -m unittest discover -s scripts -p 'test_*.py'
- actionlint -shellcheck= -pyflakes=
- uv run python YAML parse for .github/**/*.yml
- git diff --check