### PR TITLE
Preserve Arm timeline fallback in production

### DIFF
--- a/dashboard/scripts/prebuild.mjs
+++ b/dashboard/scripts/prebuild.mjs
@@ -440,23 +440,31 @@ function collectScheduledArmItems(now) {
   return items;
 }
 
-function readFallbackCompletedArmItems() {
-  if (!existsSync(armSourcePath)) return [];
-  try {
-    const data = JSON.parse(readFileSync(armSourcePath, 'utf8'));
-    return Array.isArray(data.items) ? data.items.filter((item) => item.kind === 'completed') : [];
-  } catch (e) {
-    console.warn(`prebuild: WARNING — failed to read arm timeline fallback: ${e.message}`);
-    return [];
+function readFallbackArmTimeline() {
+  for (const path of [armPublicPath, armSourcePath]) {
+    if (!existsSync(path)) continue;
+    try {
+      const data = JSON.parse(readFileSync(path, 'utf8'));
+      if (Array.isArray(data.items)) return data;
+    } catch (e) {
+      console.warn(`prebuild: WARNING — failed to read arm timeline fallback ${path}: ${e.message}`);
+    }
   }
+  return null;
 }
 
 function buildArmTimeline() {
   const now = new Date();
   const windowStart = new Date(Math.floor((now.getTime() - ARM_WINDOW_PAST_HOURS * ARM_HOUR_MS) / ARM_HOUR_MS) * ARM_HOUR_MS);
   const windowEnd = new Date(Math.ceil((now.getTime() + ARM_WINDOW_FUTURE_HOURS * ARM_HOUR_MS) / ARM_HOUR_MS) * ARM_HOUR_MS);
-  const completed = collectCompletedArmItems(now) || readFallbackCompletedArmItems();
-  const scheduled = collectScheduledArmItems(now);
+  const fallback = readFallbackArmTimeline();
+  const fallbackItems = Array.isArray(fallback?.items) ? fallback.items : [];
+  const completedFromGit = collectCompletedArmItems(now);
+  const scheduledFromWorkflows = collectScheduledArmItems(now);
+  const completed = completedFromGit || fallbackItems.filter((item) => item.kind === 'completed');
+  const scheduled = scheduledFromWorkflows.length > 0
+    ? scheduledFromWorkflows
+    : fallbackItems.filter((item) => item.kind === 'scheduled');
   const items = [...completed, ...scheduled]
     .filter((item) => Date.parse(item.end) >= windowStart.getTime() && Date.parse(item.start) <= windowEnd.getTime())
     .sort((a, b) => String(a.start).localeCompare(String(b.start)) || String(a.title).localeCompare(String(b.title)));

--- a/research/arm/timeline.json
+++ b/research/arm/timeline.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-25T14:33:53.715Z",
+  "generatedAt": "2026-06-25T14:47:35.224Z",
   "windowStart": "2026-06-24T02:00:00.000Z",
   "windowEnd": "2026-06-27T03:00:00.000Z",
   "timezone": "UTC",
@@ -289,6 +289,19 @@
       "model": "scheduled agent",
       "commit": "c3d7de7abb72",
       "url": "https://github.com/guzus/ai-research-arm/commit/c3d7de7abb72abb64ecc6c63e897cc8382645fec"
+    },
+    {
+      "id": "commit-7f600ed38d4f",
+      "kind": "completed",
+      "lane": "Dashboard",
+      "title": "Render Arm tab from real work timeline",
+      "status": "completed",
+      "start": "2026-06-25T14:23:00.000Z",
+      "end": "2026-06-25T14:44:00.000Z",
+      "source": "guzus",
+      "model": "codex",
+      "commit": "7f600ed38d4f",
+      "url": "https://github.com/guzus/ai-research-arm/commit/7f600ed38d4fbeefd1e25e25b934d56ac66e73be"
     },
     {
       "id": "scheduled-hourly-twitter-yml-7---3-------2026-06-25T15-07-00-000Z",


### PR DESCRIPTION
## Summary
- read the copied Arm timeline fallback before production prebuild overwrites it
- reuse fallback completed/scheduled items when git history or workflow metadata is unavailable
- refresh the committed Arm timeline so the latest dashboard work appears as completed

## Verification
- GIT_DIR=/tmp/ara-no-git npm run prebuild
- ARM_TIMELINE_WRITE_SOURCE=1 npm run prebuild
- npm run build