### PR TITLE
Include Arm timeline in deploy context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -44,6 +44,8 @@ research/*
 !research/wiki/**
 !research/youtube
 !research/youtube/**
+!research/arm
+!research/arm/**
 
 node_modules
 __pycache__


### PR DESCRIPTION
## Summary
- whitelist research/arm in .dockerignore so Railway receives the committed Arm timeline fallback
- keeps the no-git/no-.github production prebuild from publishing an empty /research/arm/timeline.json

## Verification
- production-shaped temp tree with dashboard + whitelisted research dirs, no .git, no .github: prebuild emitted 108 Arm items (23 completed, 85 scheduled)
- npm run build

Note: docker build could not run locally because the Docker daemon is not running.