### PR TITLE
Remove Arm header model badge

### DIFF
--- a/dashboard/src/render/agents.ts
+++ b/dashboard/src/render/agents.ts
@@ -1,5 +1,3 @@
-import { escapeHtml } from './shared';
-
 export type ArmTimelineItemKind = 'completed' | 'scheduled';
 
 export type ArmTimelineItem = {
@@ -24,7 +22,6 @@ export type ArmTimeline = {
   items: ArmTimelineItem[];
 };
 
-const MODEL_NAME = 'kimi-k2p7';
 const HOUR_MS = 60 * 60 * 1000;
 const MINUTE_MS = 60 * 1000;
 
@@ -80,10 +77,6 @@ export function renderAgentsStudioHtml(): string {
     '      <div>',
     '        <div class="content-card-title">Agent workers</div>',
     '        <p>Real completed and scheduled pipeline work, shown by UTC start and end time.</p>',
-    '        <dl class="agents-lite-model">',
-    '          <dt>model</dt>',
-    '          <dd>' + escapeHtml(MODEL_NAME) + '</dd>',
-    '        </dl>',
     '      </div>',
     '      <div class="agents-lite-metrics" id="armMetrics">',
     '        <div class="agents-lite-metric"><span>completed</span><strong>--</strong></div>',

--- a/dashboard/src/style.css
+++ b/dashboard/src/style.css
@@ -678,40 +678,6 @@ body.tab-agents .section-nav {
   letter-spacing: 0;
 }
 
-.agents-lite-model {
-  width: fit-content;
-  min-height: 32px;
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  margin: 12px 0 0;
-  padding: 6px 10px;
-  border: 1px solid var(--border-light);
-  border-radius: 8px;
-  background: var(--bg-secondary);
-}
-
-.agents-lite-model dt,
-.agents-lite-model dd {
-  margin: 0;
-}
-
-.agents-lite-model dt {
-  color: var(--text-tertiary);
-  font-size: 0.72rem;
-  font-weight: 650;
-  letter-spacing: 0;
-  line-height: 1.2;
-  text-transform: uppercase;
-}
-
-.agents-lite-model dd {
-  color: var(--text);
-  font-size: 0.86rem;
-  font-weight: 700;
-  line-height: 1.2;
-}
-
 .agents-lite-metrics {
   display: grid;
   grid-template-columns: repeat(3, minmax(88px, 1fr));


### PR DESCRIPTION
## Summary
- remove the top-level MODEL/kimi-k2p7 badge from the Arm tab header
- delete the now-unused badge CSS and renderer import

## Verification
- npm run build
- local browser check on /agents: .agents-lite-model count is 0, timeline still renders 110 items with horizontal scroll