### PR TITLE
Reduce RSS workflow frequency

### DIFF
--- a/.github/workflows/auto-rerun-on-runner-loss.yml
+++ b/.github/workflows/auto-rerun-on-runner-loss.yml
@@ -20,7 +20,7 @@ on:
     # Unattended, main-branch pipelines worth auto-recovering. PR-scoped CI /
     # code-review are intentionally excluded (their author re-runs those).
     workflows:
-      - "Hourly RSS Official Announcements"
+      - "RSS Official Announcements (Every 2 Hours)"
       - "Twitter AI News (matrix — claude / deepseek-claude-code / deepseek-pi / fireworks-pi)"
       - "Daily AI Expert Blogs"
       - "Bluesky AI Researcher Feed (Twice Daily)"

--- a/.github/workflows/hourly-rss.yml
+++ b/.github/workflows/hourly-rss.yml
@@ -1,9 +1,9 @@
-name: Hourly RSS Official Announcements
+name: RSS Official Announcements (Every 2 Hours)
 
 on:
   schedule:
-    # Run every hour
-    - cron: '30 * * * *'
+    # Run every 2 hours at :30 UTC.
+    - cron: '30 */2 * * *'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/liveness-check.yml
+++ b/.github/workflows/liveness-check.yml
@@ -54,8 +54,8 @@ name: Pipeline Liveness Check
 
 on:
   schedule:
-    # Every 6h: catches an hourly lane (rss) within ~6h instead of the old
-    # 48h-and-no-alert. Self-hosted cost is a few seconds per run.
+    # Every 6h: catches the every-2h RSS lane within one watchdog interval
+    # instead of the old 48h-and-no-alert. Self-hosted cost is a few seconds.
     - cron: '0 */6 * * *'
   workflow_dispatch:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,7 @@ the Claude action directly; when they do, pass the model via
 
 | Workflow | Schedule | Output |
 |---|---|---|
-| `hourly-rss.yml` | `:30` every hour | `research/rss/` |
+| `hourly-rss.yml` | `:30` every 2h | `research/rss/` |
 | `daily-ai-blogs.yml` | `:13` every 6h | `research/blogs/` |
 | `daily-youtube.yml` | daily `23:20` for the next `00:00` digest | `research/youtube/` (tuber discovery + read-only summary/transcript evidence) |
 | `hourly-twitter.yml` | every 3h `:07`; primary lane uses Fireworks through `.github/actions/agent-run`; comparison lanes via matrix/manual dispatch | `research/twitter/` + `research/summaries/` + Telegram headline alerts; comparison outputs under `research/twitter-deepseek/`, `research/twitter-deepseek-pi/`, and `research/twitter-fireworks-pi/` |

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ infrastructure — see [What you can run vs. what needs accounts](#what-you-can-
 ```mermaid
 flowchart TB
     subgraph sources["📡 Real-Time Sources"]
-        RSS["🔗 RSS Feeds<br/><i>Hourly</i>"]
+        RSS["🔗 RSS Feeds<br/><i>Every 2h</i>"]
         Bluesky["🦋 Bluesky<br/><i>Daily</i>"]
         Reddit["🔴 Reddit<br/><i>Every 4h</i>"]
         HN["🟠 Hacker News<br/><i>Every 4h</i>"]
@@ -111,7 +111,7 @@ flowchart TB
 | Source | Method | Frequency | Real-time? |
 |--------|--------|-----------|------------|
 | **Twitter/X** | bird CLI (reviewed account manifest + 7 searches) | Every 3 hours | ✅ Yes |
-| **RSS Feeds** | Direct XML fetch | Hourly | ✅ Yes |
+| **RSS Feeds** | Direct XML fetch | Every 2 hours | ✅ Yes |
 | **Bluesky** | Public API | Daily | ✅ Yes |
 | **Reddit** | RSS feeds | Every 4 hours | ✅ Yes |
 | **Hacker News** | MCP Server | Every 4 hours | ✅ Yes |
@@ -128,8 +128,8 @@ gantt
     dateFormat HH:mm
     axisFormat %H:%M
 
-    section Hourly
-    RSS Feeds           :crit, 00:00, 1h
+    section Every 2h
+    RSS Feeds           :crit, 00:30, 2h
 
     section Every 3h
     Twitter/X           :active, 00:07, 3h
@@ -153,7 +153,7 @@ gantt
 
 | Workflow | Schedule | Source | Output |
 |----------|----------|--------|--------|
-| `hourly-rss.yml` | Every hour (:30) | Official blogs, TechCrunch, arXiv RSS | `research/rss/` |
+| `hourly-rss.yml` | Every 2 hours (:30) | Official blogs, TechCrunch, arXiv RSS | `research/rss/` |
 | `daily-ai-blogs.yml` | Every 6 hours (:13) | Curated KOL Substacks, expert blogs, research/operator blogs | `research/blogs/` |
 | `daily-youtube.yml` | Daily 23:20 UTC for the next 00:00 digest | tuber API trending/search/channel metadata, existing summaries, transcript probes | `research/youtube/` |
 | `2h-bluesky.yml` | Daily 00:11 UTC | Bluesky AI posts | `research/bluesky/` |
@@ -383,7 +383,7 @@ insiders; researchers, analysts, builders, and media.
 infrastructure & hardware, policy & safety, business & funding, open source &
 dev tools
 
-### RSS Feeds (Hourly)
+### RSS Feeds (Every 2 Hours)
 Official announcements from:
 - OpenAI Blog
 - Anthropic News

--- a/research/arm/timeline.json
+++ b/research/arm/timeline.json
@@ -1,7 +1,7 @@
 {
-  "generatedAt": "2026-06-25T14:47:35.224Z",
-  "windowStart": "2026-06-24T02:00:00.000Z",
-  "windowEnd": "2026-06-27T03:00:00.000Z",
+  "generatedAt": "2026-06-25T17:20:33.953Z",
+  "windowStart": "2026-06-24T05:00:00.000Z",
+  "windowEnd": "2026-06-27T06:00:00.000Z",
   "timezone": "UTC",
   "items": [
     {
@@ -304,54 +304,134 @@
       "url": "https://github.com/guzus/ai-research-arm/commit/7f600ed38d4fbeefd1e25e25b934d56ac66e73be"
     },
     {
-      "id": "scheduled-hourly-twitter-yml-7---3-------2026-06-25T15-07-00-000Z",
-      "kind": "scheduled",
+      "id": "commit-171128e9f94c",
+      "kind": "completed",
+      "lane": "Dashboard",
+      "title": "Preserve Arm timeline fallback in production",
+      "status": "completed",
+      "start": "2026-06-25T14:31:00.000Z",
+      "end": "2026-06-25T14:52:00.000Z",
+      "source": "guzus",
+      "model": "codex",
+      "commit": "171128e9f94c",
+      "url": "https://github.com/guzus/ai-research-arm/commit/171128e9f94c5761a8a5378d6ef905321395ff18"
+    },
+    {
+      "id": "commit-e0042c941b1d",
+      "kind": "completed",
+      "lane": "Dashboard",
+      "title": "Include Arm timeline in deploy context",
+      "status": "completed",
+      "start": "2026-06-25T14:36:00.000Z",
+      "end": "2026-06-25T14:57:00.000Z",
+      "source": "guzus",
+      "model": "codex",
+      "commit": "e0042c941b1d",
+      "url": "https://github.com/guzus/ai-research-arm/commit/e0042c941b1dd8bbcdad5392de68184beebba4a9"
+    },
+    {
+      "id": "commit-f88eaf496a55",
+      "kind": "completed",
+      "lane": "Dashboard",
+      "title": "Remove Arm header model badge",
+      "status": "completed",
+      "start": "2026-06-25T14:47:00.000Z",
+      "end": "2026-06-25T15:08:00.000Z",
+      "source": "guzus",
+      "model": "codex",
+      "commit": "f88eaf496a55",
+      "url": "https://github.com/guzus/ai-research-arm/commit/f88eaf496a5581fd3ec17231a639d201373eb986"
+    },
+    {
+      "id": "commit-da824851087d",
+      "kind": "completed",
+      "lane": "RSS",
+      "title": "RSS official announcements",
+      "status": "completed",
+      "start": "2026-06-25T15:26:00.000Z",
+      "end": "2026-06-25T15:35:00.000Z",
+      "source": "claude[bot]",
+      "model": "scheduled agent",
+      "commit": "da824851087d",
+      "url": "https://github.com/guzus/ai-research-arm/commit/da824851087d5f0152fa1198ae6c30d11414fbdd"
+    },
+    {
+      "id": "commit-c972f4606d54",
+      "kind": "completed",
       "lane": "Twitter/X",
-      "title": "Twitter AI News (matrix — claude / deepseek-claude-code / deepseek-pi / fireworks-pi)",
-      "status": "scheduled",
-      "start": "2026-06-25T15:07:00.000Z",
-      "end": "2026-06-25T16:07:00.000Z",
-      "source": "cron 7 */3 * * *"
+      "title": "Twitter/X brief",
+      "status": "completed",
+      "start": "2026-06-25T16:05:00.000Z",
+      "end": "2026-06-25T16:14:00.000Z",
+      "source": "claude[bot]",
+      "model": "deepseek-v4-flash",
+      "commit": "c972f4606d54",
+      "url": "https://github.com/guzus/ai-research-arm/commit/c972f4606d54df6dbd463a367133e4a459a963ef"
     },
     {
-      "id": "scheduled-hourly-rss-yml-30---------2026-06-25T15-30-00-000Z",
-      "kind": "scheduled",
+      "id": "commit-78f1ec3316cc",
+      "kind": "completed",
+      "lane": "Delivery",
+      "title": "Twitter alert delivery",
+      "status": "completed",
+      "start": "2026-06-25T16:06:00.000Z",
+      "end": "2026-06-25T16:15:00.000Z",
+      "source": "claude[bot]",
+      "model": "hooker",
+      "commit": "78f1ec3316cc",
+      "url": "https://github.com/guzus/ai-research-arm/commit/78f1ec3316cc894d9a816ae04337e1d328ccd05b"
+    },
+    {
+      "id": "commit-291d6983d227",
+      "kind": "completed",
+      "lane": "Generative",
+      "title": "Native Computer Use in Gemini 3.5 Flash: Google's cheap-tier agentic control bet",
+      "status": "completed",
+      "start": "2026-06-25T16:13:00.000Z",
+      "end": "2026-06-25T17:04:00.000Z",
+      "source": "claude[bot]",
+      "model": "research agent",
+      "commit": "291d6983d227",
+      "url": "https://github.com/guzus/ai-research-arm/commit/291d6983d2277fcfe0ead752a885d0141b8cbcd3"
+    },
+    {
+      "id": "commit-125405704ab9",
+      "kind": "completed",
       "lane": "RSS",
-      "title": "Hourly RSS Official Announcements",
-      "status": "scheduled",
-      "start": "2026-06-25T15:30:00.000Z",
-      "end": "2026-06-25T15:45:00.000Z",
-      "source": "cron 30 * * * *"
+      "title": "RSS official announcements",
+      "status": "completed",
+      "start": "2026-06-25T17:01:00.000Z",
+      "end": "2026-06-25T17:10:00.000Z",
+      "source": "claude[bot]",
+      "model": "scheduled agent",
+      "commit": "125405704ab9",
+      "url": "https://github.com/guzus/ai-research-arm/commit/125405704ab9dd96d98a44181358c9305d7c15e3"
     },
     {
-      "id": "scheduled-4h-community-yml-19---4-------2026-06-25T16-19-00-000Z",
-      "kind": "scheduled",
+      "id": "commit-fb5888505ea9",
+      "kind": "completed",
       "lane": "Community",
-      "title": "Community AI Digest (HN + Reddit)",
-      "status": "scheduled",
-      "start": "2026-06-25T16:19:00.000Z",
-      "end": "2026-06-25T17:19:00.000Z",
-      "source": "cron 19 */4 * * *"
+      "title": "HN + Reddit digest",
+      "status": "completed",
+      "start": "2026-06-25T17:04:00.000Z",
+      "end": "2026-06-25T17:13:00.000Z",
+      "source": "claude[bot]",
+      "model": "scheduled agent",
+      "commit": "fb5888505ea9",
+      "url": "https://github.com/guzus/ai-research-arm/commit/fb5888505ea9c462bb16c8e5ef3891e12a3e418a"
     },
     {
-      "id": "scheduled-hourly-rss-yml-30---------2026-06-25T16-30-00-000Z",
-      "kind": "scheduled",
+      "id": "commit-6788023919d4",
+      "kind": "completed",
       "lane": "RSS",
-      "title": "Hourly RSS Official Announcements",
-      "status": "scheduled",
-      "start": "2026-06-25T16:30:00.000Z",
-      "end": "2026-06-25T16:45:00.000Z",
-      "source": "cron 30 * * * *"
-    },
-    {
-      "id": "scheduled-hourly-rss-yml-30---------2026-06-25T17-30-00-000Z",
-      "kind": "scheduled",
-      "lane": "RSS",
-      "title": "Hourly RSS Official Announcements",
-      "status": "scheduled",
-      "start": "2026-06-25T17:30:00.000Z",
-      "end": "2026-06-25T17:45:00.000Z",
-      "source": "cron 30 * * * *"
+      "title": "RSS official announcements",
+      "status": "completed",
+      "start": "2026-06-25T17:08:00.000Z",
+      "end": "2026-06-25T17:17:00.000Z",
+      "source": "claude[bot]",
+      "model": "scheduled agent",
+      "commit": "6788023919d4",
+      "url": "https://github.com/guzus/ai-research-arm/commit/6788023919d421ddc6841145f354c8086e60381b"
     },
     {
       "id": "scheduled-liveness-check-yml-0---6-------2026-06-25T18-00-00-000Z",
@@ -384,14 +464,14 @@
       "source": "cron 13 */6 * * *"
     },
     {
-      "id": "scheduled-hourly-rss-yml-30---------2026-06-25T18-30-00-000Z",
+      "id": "scheduled-hourly-rss-yml-30---2-------2026-06-25T18-30-00-000Z",
       "kind": "scheduled",
       "lane": "RSS",
-      "title": "Hourly RSS Official Announcements",
+      "title": "RSS Official Announcements (Every 2 Hours)",
       "status": "scheduled",
       "start": "2026-06-25T18:30:00.000Z",
       "end": "2026-06-25T18:45:00.000Z",
-      "source": "cron 30 * * * *"
+      "source": "cron 30 */2 * * *"
     },
     {
       "id": "scheduled-hourly-twitter-yml-37---6-------2026-06-25T18-37-00-000Z",
@@ -402,16 +482,6 @@
       "start": "2026-06-25T18:37:00.000Z",
       "end": "2026-06-25T19:37:00.000Z",
       "source": "cron 37 */6 * * *"
-    },
-    {
-      "id": "scheduled-hourly-rss-yml-30---------2026-06-25T19-30-00-000Z",
-      "kind": "scheduled",
-      "lane": "RSS",
-      "title": "Hourly RSS Official Announcements",
-      "status": "scheduled",
-      "start": "2026-06-25T19:30:00.000Z",
-      "end": "2026-06-25T19:45:00.000Z",
-      "source": "cron 30 * * * *"
     },
     {
       "id": "scheduled-4h-community-yml-19---4-------2026-06-25T20-19-00-000Z",
@@ -434,14 +504,14 @@
       "source": "cron 23 8,20 * * *"
     },
     {
-      "id": "scheduled-hourly-rss-yml-30---------2026-06-25T20-30-00-000Z",
+      "id": "scheduled-hourly-rss-yml-30---2-------2026-06-25T20-30-00-000Z",
       "kind": "scheduled",
       "lane": "RSS",
-      "title": "Hourly RSS Official Announcements",
+      "title": "RSS Official Announcements (Every 2 Hours)",
       "status": "scheduled",
       "start": "2026-06-25T20:30:00.000Z",
       "end": "2026-06-25T20:45:00.000Z",
-      "source": "cron 30 * * * *"
+      "source": "cron 30 */2 * * *"
     },
     {
       "id": "scheduled-hourly-twitter-yml-7---3-------2026-06-25T21-07-00-000Z",
@@ -454,24 +524,14 @@
       "source": "cron 7 */3 * * *"
     },
     {
-      "id": "scheduled-hourly-rss-yml-30---------2026-06-25T21-30-00-000Z",
+      "id": "scheduled-hourly-rss-yml-30---2-------2026-06-25T22-30-00-000Z",
       "kind": "scheduled",
       "lane": "RSS",
-      "title": "Hourly RSS Official Announcements",
-      "status": "scheduled",
-      "start": "2026-06-25T21:30:00.000Z",
-      "end": "2026-06-25T21:45:00.000Z",
-      "source": "cron 30 * * * *"
-    },
-    {
-      "id": "scheduled-hourly-rss-yml-30---------2026-06-25T22-30-00-000Z",
-      "kind": "scheduled",
-      "lane": "RSS",
-      "title": "Hourly RSS Official Announcements",
+      "title": "RSS Official Announcements (Every 2 Hours)",
       "status": "scheduled",
       "start": "2026-06-25T22:30:00.000Z",
       "end": "2026-06-25T22:45:00.000Z",
-      "source": "cron 30 * * * *"
+      "source": "cron 30 */2 * * *"
     },
     {
       "id": "scheduled-daily-youtube-yml-20-23-------2026-06-25T23-20-00-000Z",
@@ -482,16 +542,6 @@
       "start": "2026-06-25T23:20:00.000Z",
       "end": "2026-06-25T23:45:00.000Z",
       "source": "cron 20 23 * * *"
-    },
-    {
-      "id": "scheduled-hourly-rss-yml-30---------2026-06-25T23-30-00-000Z",
-      "kind": "scheduled",
-      "lane": "RSS",
-      "title": "Hourly RSS Official Announcements",
-      "status": "scheduled",
-      "start": "2026-06-25T23:30:00.000Z",
-      "end": "2026-06-25T23:45:00.000Z",
-      "source": "cron 30 * * * *"
     },
     {
       "id": "scheduled-daily-digest-yml-0-0-------2026-06-26T00-00-00-000Z",
@@ -544,14 +594,14 @@
       "source": "cron 19 */4 * * *"
     },
     {
-      "id": "scheduled-hourly-rss-yml-30---------2026-06-26T00-30-00-000Z",
+      "id": "scheduled-hourly-rss-yml-30---2-------2026-06-26T00-30-00-000Z",
       "kind": "scheduled",
       "lane": "RSS",
-      "title": "Hourly RSS Official Announcements",
+      "title": "RSS Official Announcements (Every 2 Hours)",
       "status": "scheduled",
       "start": "2026-06-26T00:30:00.000Z",
       "end": "2026-06-26T00:45:00.000Z",
-      "source": "cron 30 * * * *"
+      "source": "cron 30 */2 * * *"
     },
     {
       "id": "scheduled-hourly-twitter-yml-37---6-------2026-06-26T00-37-00-000Z",
@@ -564,24 +614,14 @@
       "source": "cron 37 */6 * * *"
     },
     {
-      "id": "scheduled-hourly-rss-yml-30---------2026-06-26T01-30-00-000Z",
+      "id": "scheduled-hourly-rss-yml-30---2-------2026-06-26T02-30-00-000Z",
       "kind": "scheduled",
       "lane": "RSS",
-      "title": "Hourly RSS Official Announcements",
-      "status": "scheduled",
-      "start": "2026-06-26T01:30:00.000Z",
-      "end": "2026-06-26T01:45:00.000Z",
-      "source": "cron 30 * * * *"
-    },
-    {
-      "id": "scheduled-hourly-rss-yml-30---------2026-06-26T02-30-00-000Z",
-      "kind": "scheduled",
-      "lane": "RSS",
-      "title": "Hourly RSS Official Announcements",
+      "title": "RSS Official Announcements (Every 2 Hours)",
       "status": "scheduled",
       "start": "2026-06-26T02:30:00.000Z",
       "end": "2026-06-26T02:45:00.000Z",
-      "source": "cron 30 * * * *"
+      "source": "cron 30 */2 * * *"
     },
     {
       "id": "scheduled-hourly-twitter-yml-7---3-------2026-06-26T03-07-00-000Z",
@@ -594,16 +634,6 @@
       "source": "cron 7 */3 * * *"
     },
     {
-      "id": "scheduled-hourly-rss-yml-30---------2026-06-26T03-30-00-000Z",
-      "kind": "scheduled",
-      "lane": "RSS",
-      "title": "Hourly RSS Official Announcements",
-      "status": "scheduled",
-      "start": "2026-06-26T03:30:00.000Z",
-      "end": "2026-06-26T03:45:00.000Z",
-      "source": "cron 30 * * * *"
-    },
-    {
       "id": "scheduled-4h-community-yml-19---4-------2026-06-26T04-19-00-000Z",
       "kind": "scheduled",
       "lane": "Community",
@@ -614,24 +644,14 @@
       "source": "cron 19 */4 * * *"
     },
     {
-      "id": "scheduled-hourly-rss-yml-30---------2026-06-26T04-30-00-000Z",
+      "id": "scheduled-hourly-rss-yml-30---2-------2026-06-26T04-30-00-000Z",
       "kind": "scheduled",
       "lane": "RSS",
-      "title": "Hourly RSS Official Announcements",
+      "title": "RSS Official Announcements (Every 2 Hours)",
       "status": "scheduled",
       "start": "2026-06-26T04:30:00.000Z",
       "end": "2026-06-26T04:45:00.000Z",
-      "source": "cron 30 * * * *"
-    },
-    {
-      "id": "scheduled-hourly-rss-yml-30---------2026-06-26T05-30-00-000Z",
-      "kind": "scheduled",
-      "lane": "RSS",
-      "title": "Hourly RSS Official Announcements",
-      "status": "scheduled",
-      "start": "2026-06-26T05:30:00.000Z",
-      "end": "2026-06-26T05:45:00.000Z",
-      "source": "cron 30 * * * *"
+      "source": "cron 30 */2 * * *"
     },
     {
       "id": "scheduled-liveness-check-yml-0---6-------2026-06-26T06-00-00-000Z",
@@ -684,14 +704,14 @@
       "source": "cron 29 6 * * *"
     },
     {
-      "id": "scheduled-hourly-rss-yml-30---------2026-06-26T06-30-00-000Z",
+      "id": "scheduled-hourly-rss-yml-30---2-------2026-06-26T06-30-00-000Z",
       "kind": "scheduled",
       "lane": "RSS",
-      "title": "Hourly RSS Official Announcements",
+      "title": "RSS Official Announcements (Every 2 Hours)",
       "status": "scheduled",
       "start": "2026-06-26T06:30:00.000Z",
       "end": "2026-06-26T06:45:00.000Z",
-      "source": "cron 30 * * * *"
+      "source": "cron 30 */2 * * *"
     },
     {
       "id": "scheduled-hourly-twitter-yml-37---6-------2026-06-26T06-37-00-000Z",
@@ -702,16 +722,6 @@
       "start": "2026-06-26T06:37:00.000Z",
       "end": "2026-06-26T07:37:00.000Z",
       "source": "cron 37 */6 * * *"
-    },
-    {
-      "id": "scheduled-hourly-rss-yml-30---------2026-06-26T07-30-00-000Z",
-      "kind": "scheduled",
-      "lane": "RSS",
-      "title": "Hourly RSS Official Announcements",
-      "status": "scheduled",
-      "start": "2026-06-26T07:30:00.000Z",
-      "end": "2026-06-26T07:45:00.000Z",
-      "source": "cron 30 * * * *"
     },
     {
       "id": "scheduled-4h-community-yml-19---4-------2026-06-26T08-19-00-000Z",
@@ -734,14 +744,14 @@
       "source": "cron 23 8,20 * * *"
     },
     {
-      "id": "scheduled-hourly-rss-yml-30---------2026-06-26T08-30-00-000Z",
+      "id": "scheduled-hourly-rss-yml-30---2-------2026-06-26T08-30-00-000Z",
       "kind": "scheduled",
       "lane": "RSS",
-      "title": "Hourly RSS Official Announcements",
+      "title": "RSS Official Announcements (Every 2 Hours)",
       "status": "scheduled",
       "start": "2026-06-26T08:30:00.000Z",
       "end": "2026-06-26T08:45:00.000Z",
-      "source": "cron 30 * * * *"
+      "source": "cron 30 */2 * * *"
     },
     {
       "id": "scheduled-hourly-twitter-yml-7---3-------2026-06-26T09-07-00-000Z",
@@ -754,16 +764,6 @@
       "source": "cron 7 */3 * * *"
     },
     {
-      "id": "scheduled-hourly-rss-yml-30---------2026-06-26T09-30-00-000Z",
-      "kind": "scheduled",
-      "lane": "RSS",
-      "title": "Hourly RSS Official Announcements",
-      "status": "scheduled",
-      "start": "2026-06-26T09:30:00.000Z",
-      "end": "2026-06-26T09:45:00.000Z",
-      "source": "cron 30 * * * *"
-    },
-    {
       "id": "scheduled-2h-bluesky-yml-11-10-------2026-06-26T10-11-00-000Z",
       "kind": "scheduled",
       "lane": "Bluesky",
@@ -774,24 +774,14 @@
       "source": "cron 11 10 * * *"
     },
     {
-      "id": "scheduled-hourly-rss-yml-30---------2026-06-26T10-30-00-000Z",
+      "id": "scheduled-hourly-rss-yml-30---2-------2026-06-26T10-30-00-000Z",
       "kind": "scheduled",
       "lane": "RSS",
-      "title": "Hourly RSS Official Announcements",
+      "title": "RSS Official Announcements (Every 2 Hours)",
       "status": "scheduled",
       "start": "2026-06-26T10:30:00.000Z",
       "end": "2026-06-26T10:45:00.000Z",
-      "source": "cron 30 * * * *"
-    },
-    {
-      "id": "scheduled-hourly-rss-yml-30---------2026-06-26T11-30-00-000Z",
-      "kind": "scheduled",
-      "lane": "RSS",
-      "title": "Hourly RSS Official Announcements",
-      "status": "scheduled",
-      "start": "2026-06-26T11:30:00.000Z",
-      "end": "2026-06-26T11:45:00.000Z",
-      "source": "cron 30 * * * *"
+      "source": "cron 30 */2 * * *"
     },
     {
       "id": "scheduled-liveness-check-yml-0---6-------2026-06-26T12-00-00-000Z",
@@ -834,14 +824,14 @@
       "source": "cron 19 */4 * * *"
     },
     {
-      "id": "scheduled-hourly-rss-yml-30---------2026-06-26T12-30-00-000Z",
+      "id": "scheduled-hourly-rss-yml-30---2-------2026-06-26T12-30-00-000Z",
       "kind": "scheduled",
       "lane": "RSS",
-      "title": "Hourly RSS Official Announcements",
+      "title": "RSS Official Announcements (Every 2 Hours)",
       "status": "scheduled",
       "start": "2026-06-26T12:30:00.000Z",
       "end": "2026-06-26T12:45:00.000Z",
-      "source": "cron 30 * * * *"
+      "source": "cron 30 */2 * * *"
     },
     {
       "id": "scheduled-hourly-twitter-yml-37---6-------2026-06-26T12-37-00-000Z",
@@ -854,24 +844,14 @@
       "source": "cron 37 */6 * * *"
     },
     {
-      "id": "scheduled-hourly-rss-yml-30---------2026-06-26T13-30-00-000Z",
+      "id": "scheduled-hourly-rss-yml-30---2-------2026-06-26T14-30-00-000Z",
       "kind": "scheduled",
       "lane": "RSS",
-      "title": "Hourly RSS Official Announcements",
-      "status": "scheduled",
-      "start": "2026-06-26T13:30:00.000Z",
-      "end": "2026-06-26T13:45:00.000Z",
-      "source": "cron 30 * * * *"
-    },
-    {
-      "id": "scheduled-hourly-rss-yml-30---------2026-06-26T14-30-00-000Z",
-      "kind": "scheduled",
-      "lane": "RSS",
-      "title": "Hourly RSS Official Announcements",
+      "title": "RSS Official Announcements (Every 2 Hours)",
       "status": "scheduled",
       "start": "2026-06-26T14:30:00.000Z",
       "end": "2026-06-26T14:45:00.000Z",
-      "source": "cron 30 * * * *"
+      "source": "cron 30 */2 * * *"
     },
     {
       "id": "scheduled-hourly-twitter-yml-7---3-------2026-06-26T15-07-00-000Z",
@@ -884,16 +864,6 @@
       "source": "cron 7 */3 * * *"
     },
     {
-      "id": "scheduled-hourly-rss-yml-30---------2026-06-26T15-30-00-000Z",
-      "kind": "scheduled",
-      "lane": "RSS",
-      "title": "Hourly RSS Official Announcements",
-      "status": "scheduled",
-      "start": "2026-06-26T15:30:00.000Z",
-      "end": "2026-06-26T15:45:00.000Z",
-      "source": "cron 30 * * * *"
-    },
-    {
       "id": "scheduled-4h-community-yml-19---4-------2026-06-26T16-19-00-000Z",
       "kind": "scheduled",
       "lane": "Community",
@@ -904,24 +874,14 @@
       "source": "cron 19 */4 * * *"
     },
     {
-      "id": "scheduled-hourly-rss-yml-30---------2026-06-26T16-30-00-000Z",
+      "id": "scheduled-hourly-rss-yml-30---2-------2026-06-26T16-30-00-000Z",
       "kind": "scheduled",
       "lane": "RSS",
-      "title": "Hourly RSS Official Announcements",
+      "title": "RSS Official Announcements (Every 2 Hours)",
       "status": "scheduled",
       "start": "2026-06-26T16:30:00.000Z",
       "end": "2026-06-26T16:45:00.000Z",
-      "source": "cron 30 * * * *"
-    },
-    {
-      "id": "scheduled-hourly-rss-yml-30---------2026-06-26T17-30-00-000Z",
-      "kind": "scheduled",
-      "lane": "RSS",
-      "title": "Hourly RSS Official Announcements",
-      "status": "scheduled",
-      "start": "2026-06-26T17:30:00.000Z",
-      "end": "2026-06-26T17:45:00.000Z",
-      "source": "cron 30 * * * *"
+      "source": "cron 30 */2 * * *"
     },
     {
       "id": "scheduled-liveness-check-yml-0---6-------2026-06-26T18-00-00-000Z",
@@ -954,14 +914,14 @@
       "source": "cron 13 */6 * * *"
     },
     {
-      "id": "scheduled-hourly-rss-yml-30---------2026-06-26T18-30-00-000Z",
+      "id": "scheduled-hourly-rss-yml-30---2-------2026-06-26T18-30-00-000Z",
       "kind": "scheduled",
       "lane": "RSS",
-      "title": "Hourly RSS Official Announcements",
+      "title": "RSS Official Announcements (Every 2 Hours)",
       "status": "scheduled",
       "start": "2026-06-26T18:30:00.000Z",
       "end": "2026-06-26T18:45:00.000Z",
-      "source": "cron 30 * * * *"
+      "source": "cron 30 */2 * * *"
     },
     {
       "id": "scheduled-hourly-twitter-yml-37---6-------2026-06-26T18-37-00-000Z",
@@ -972,16 +932,6 @@
       "start": "2026-06-26T18:37:00.000Z",
       "end": "2026-06-26T19:37:00.000Z",
       "source": "cron 37 */6 * * *"
-    },
-    {
-      "id": "scheduled-hourly-rss-yml-30---------2026-06-26T19-30-00-000Z",
-      "kind": "scheduled",
-      "lane": "RSS",
-      "title": "Hourly RSS Official Announcements",
-      "status": "scheduled",
-      "start": "2026-06-26T19:30:00.000Z",
-      "end": "2026-06-26T19:45:00.000Z",
-      "source": "cron 30 * * * *"
     },
     {
       "id": "scheduled-4h-community-yml-19---4-------2026-06-26T20-19-00-000Z",
@@ -1004,14 +954,14 @@
       "source": "cron 23 8,20 * * *"
     },
     {
-      "id": "scheduled-hourly-rss-yml-30---------2026-06-26T20-30-00-000Z",
+      "id": "scheduled-hourly-rss-yml-30---2-------2026-06-26T20-30-00-000Z",
       "kind": "scheduled",
       "lane": "RSS",
-      "title": "Hourly RSS Official Announcements",
+      "title": "RSS Official Announcements (Every 2 Hours)",
       "status": "scheduled",
       "start": "2026-06-26T20:30:00.000Z",
       "end": "2026-06-26T20:45:00.000Z",
-      "source": "cron 30 * * * *"
+      "source": "cron 30 */2 * * *"
     },
     {
       "id": "scheduled-hourly-twitter-yml-7---3-------2026-06-26T21-07-00-000Z",
@@ -1024,24 +974,14 @@
       "source": "cron 7 */3 * * *"
     },
     {
-      "id": "scheduled-hourly-rss-yml-30---------2026-06-26T21-30-00-000Z",
+      "id": "scheduled-hourly-rss-yml-30---2-------2026-06-26T22-30-00-000Z",
       "kind": "scheduled",
       "lane": "RSS",
-      "title": "Hourly RSS Official Announcements",
-      "status": "scheduled",
-      "start": "2026-06-26T21:30:00.000Z",
-      "end": "2026-06-26T21:45:00.000Z",
-      "source": "cron 30 * * * *"
-    },
-    {
-      "id": "scheduled-hourly-rss-yml-30---------2026-06-26T22-30-00-000Z",
-      "kind": "scheduled",
-      "lane": "RSS",
-      "title": "Hourly RSS Official Announcements",
+      "title": "RSS Official Announcements (Every 2 Hours)",
       "status": "scheduled",
       "start": "2026-06-26T22:30:00.000Z",
       "end": "2026-06-26T22:45:00.000Z",
-      "source": "cron 30 * * * *"
+      "source": "cron 30 */2 * * *"
     },
     {
       "id": "scheduled-daily-youtube-yml-20-23-------2026-06-26T23-20-00-000Z",
@@ -1052,16 +992,6 @@
       "start": "2026-06-26T23:20:00.000Z",
       "end": "2026-06-26T23:45:00.000Z",
       "source": "cron 20 23 * * *"
-    },
-    {
-      "id": "scheduled-hourly-rss-yml-30---------2026-06-26T23-30-00-000Z",
-      "kind": "scheduled",
-      "lane": "RSS",
-      "title": "Hourly RSS Official Announcements",
-      "status": "scheduled",
-      "start": "2026-06-26T23:30:00.000Z",
-      "end": "2026-06-26T23:45:00.000Z",
-      "source": "cron 30 * * * *"
     },
     {
       "id": "scheduled-daily-digest-yml-0-0-------2026-06-27T00-00-00-000Z",
@@ -1114,14 +1044,14 @@
       "source": "cron 19 */4 * * *"
     },
     {
-      "id": "scheduled-hourly-rss-yml-30---------2026-06-27T00-30-00-000Z",
+      "id": "scheduled-hourly-rss-yml-30---2-------2026-06-27T00-30-00-000Z",
       "kind": "scheduled",
       "lane": "RSS",
-      "title": "Hourly RSS Official Announcements",
+      "title": "RSS Official Announcements (Every 2 Hours)",
       "status": "scheduled",
       "start": "2026-06-27T00:30:00.000Z",
       "end": "2026-06-27T00:45:00.000Z",
-      "source": "cron 30 * * * *"
+      "source": "cron 30 */2 * * *"
     },
     {
       "id": "scheduled-hourly-twitter-yml-37---6-------2026-06-27T00-37-00-000Z",
@@ -1134,24 +1064,44 @@
       "source": "cron 37 */6 * * *"
     },
     {
-      "id": "scheduled-hourly-rss-yml-30---------2026-06-27T01-30-00-000Z",
+      "id": "scheduled-hourly-rss-yml-30---2-------2026-06-27T02-30-00-000Z",
       "kind": "scheduled",
       "lane": "RSS",
-      "title": "Hourly RSS Official Announcements",
-      "status": "scheduled",
-      "start": "2026-06-27T01:30:00.000Z",
-      "end": "2026-06-27T01:45:00.000Z",
-      "source": "cron 30 * * * *"
-    },
-    {
-      "id": "scheduled-hourly-rss-yml-30---------2026-06-27T02-30-00-000Z",
-      "kind": "scheduled",
-      "lane": "RSS",
-      "title": "Hourly RSS Official Announcements",
+      "title": "RSS Official Announcements (Every 2 Hours)",
       "status": "scheduled",
       "start": "2026-06-27T02:30:00.000Z",
       "end": "2026-06-27T02:45:00.000Z",
-      "source": "cron 30 * * * *"
+      "source": "cron 30 */2 * * *"
+    },
+    {
+      "id": "scheduled-hourly-twitter-yml-7---3-------2026-06-27T03-07-00-000Z",
+      "kind": "scheduled",
+      "lane": "Twitter/X",
+      "title": "Twitter AI News (matrix — claude / deepseek-claude-code / deepseek-pi / fireworks-pi)",
+      "status": "scheduled",
+      "start": "2026-06-27T03:07:00.000Z",
+      "end": "2026-06-27T04:07:00.000Z",
+      "source": "cron 7 */3 * * *"
+    },
+    {
+      "id": "scheduled-4h-community-yml-19---4-------2026-06-27T04-19-00-000Z",
+      "kind": "scheduled",
+      "lane": "Community",
+      "title": "Community AI Digest (HN + Reddit)",
+      "status": "scheduled",
+      "start": "2026-06-27T04:19:00.000Z",
+      "end": "2026-06-27T05:19:00.000Z",
+      "source": "cron 19 */4 * * *"
+    },
+    {
+      "id": "scheduled-hourly-rss-yml-30---2-------2026-06-27T04-30-00-000Z",
+      "kind": "scheduled",
+      "lane": "RSS",
+      "title": "RSS Official Announcements (Every 2 Hours)",
+      "status": "scheduled",
+      "start": "2026-06-27T04:30:00.000Z",
+      "end": "2026-06-27T04:45:00.000Z",
+      "source": "cron 30 */2 * * *"
     }
   ]
 }

--- a/scripts/check_lane_freshness.py
+++ b/scripts/check_lane_freshness.py
@@ -47,7 +47,7 @@ from typing import Callable, Optional
 # (twitter-deepseek*, twitter-viral) are intentionally excluded: they
 # have no fixed cadence, so staleness is not a meaningful signal there.
 LANE_THRESHOLDS_HOURS: dict[str, float] = {
-    "rss": 4,           # hourly at :30
+    "rss": 8,           # every 2h at :30 — four missed cycles + runner slack
     "blogs": 15,        # every 6h at :13 (~2 missed cycles + runner slack)
     "twitter": 9,       # every 3h at :07
     "community": 11,    # every 4h at :19


### PR DESCRIPTION
## Summary
- change RSS official-announcements workflow from hourly to every 2 hours at :30 UTC
- update auto-rerun workflow name matching and RSS freshness threshold to 8 hours
- refresh README/CLAUDE schedule docs and Arm timeline fallback data

## Verification
- python3 scripts/test_check_lane_freshness.py
- actionlint -shellcheck= -pyflakes= .github/workflows/hourly-rss.yml .github/workflows/auto-rerun-on-runner-loss.yml .github/workflows/liveness-check.yml
- npm run build
- confirmed research/arm/timeline.json RSS scheduled starts advance every 2 hours with source cron pattern 30 slash-2 * * *