### PR TITLE
Simplify Arm timeline cards

### DIFF
--- a/dashboard/src/render/agents.ts
+++ b/dashboard/src/render/agents.ts
@@ -201,8 +201,6 @@ export function hydrateAgentsTimeline(root: ParentNode, timeline: ArmTimeline | 
       card.style.width = width.toFixed(3) + '%';
       card.setAttribute('aria-label', item.title + ', ' + formatUtcDateTime(item.startMs) + ' to ' + formatUtcDateTime(item.endMs));
       card.appendChild(makeText('strong', '', item.title));
-      card.appendChild(makeText('span', '', formatUtcTime(item.startMs) + '-' + formatUtcTime(item.endMs) + ' UTC'));
-      card.appendChild(makeText('em', '', item.status + ' · ' + item.source));
       track.appendChild(card);
     }
     scroll.appendChild(track);

--- a/dashboard/src/style.css
+++ b/dashboard/src/style.css
@@ -834,16 +834,14 @@ body.tab-agents .section-nav {
 
 .agents-work-item {
   position: absolute;
-  top: 14px;
+  top: 21px;
   min-width: 132px;
-  height: 56px;
+  height: 42px;
   display: grid;
   align-content: center;
-  gap: 3px;
-  padding: 7px 10px;
+  padding: 8px 10px;
   border: 1px solid var(--border);
-  border-left: 4px solid var(--accent);
-  border-radius: 8px;
+  border-radius: 0;
   background: var(--bg);
   box-shadow: var(--shadow-sm);
   color: inherit;
@@ -851,13 +849,10 @@ body.tab-agents .section-nav {
 }
 
 .agents-work-item--scheduled {
-  border-left-color: var(--text-tertiary);
   background: var(--bg-secondary);
 }
 
-.agents-work-item strong,
-.agents-work-item span,
-.agents-work-item em {
+.agents-work-item strong {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -868,17 +863,6 @@ body.tab-agents .section-nav {
   color: var(--text);
   font-size: 0.8rem;
   line-height: 1.15;
-}
-
-.agents-work-item span,
-.agents-work-item em {
-  color: var(--text-tertiary);
-  font-size: 0.68rem;
-  font-style: normal;
-  font-weight: 650;
-  letter-spacing: 0;
-  line-height: 1.2;
-  text-transform: uppercase;
 }
 
 @media (max-width: 760px) {


### PR DESCRIPTION
## Summary
- remove visible time and status/source metadata from Arm timeline cards
- remove the heavy left accent line from cards
- make Arm work cards square-cornered and more compact

## Verification
- npm run build
- local browser check on /agents: card span/em count is 0, first card has no COMPLETED/SCHEDULED text, no UTC time text, border radius is 0px, timeline still renders 100 items with horizontal scroll
- screenshot: /tmp/ara-arm-simple-items.png