### PR TITLE
Sync docs with pipeline reality (improve cadence, S3/front-page media, secrets state, fallback coverage)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,8 @@ short pointer plus the few genuinely agent-specific notes.
   none` only when strict provider failure is desired. Set `expected-paths` in
   `agent-run`, or call `.github/actions/require-output` after deterministic
   commit steps, so green no-op runs do not leave the freshness watchdog stale.
-  RSS and HN/Reddit community lanes also have deterministic parser fallbacks;
+  RSS, HN/Reddit community, arXiv, daily-digest, and Bluesky lanes (plus the
+  twitter-deepseek comparison tier) have deterministic model-free fallbacks;
   a green run there means committed lane output exists, not necessarily that
   the model provider was healthy. Check the agent/fallback step logs before
   drawing provider conclusions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,8 +136,11 @@ through Fireworks profiles when Fireworks preflight passes. If Fireworks is
 unavailable (for example billing/spend-limit suspension), the wrapper falls
 back to native Claude by default so scheduled freshness does not hard-stop.
 It can also enforce that the expected output paths were actually committed. The
-RSS and HN/Reddit community workflows add deterministic parser fallbacks after
-the agent step, then run a final `.github/actions/require-output` guard. For
+RSS, HN/Reddit community, arXiv, daily-digest, and Bluesky workflows (plus the
+twitter-deepseek comparison tier) add deterministic model-free fallbacks after
+the agent step, then run a final `.github/actions/require-output` guard — the
+digest additionally gates its agent output on a hard content floor
+(`scripts/check_digest_content.py`) before the fallback decision. For
 those lanes, a green run means a committed daily artifact exists; inspect the
 agent/fallback step logs before treating it as evidence that Fireworks or
 native Claude was healthy. PR/review/on-demand Claude workflows may still call
@@ -178,7 +181,7 @@ the Claude action directly; when they do, pass the model via
 
 | Workflow | Trigger | Purpose |
 |---|---|---|
-| `daily-improve.yml` | daily `00:17` | Opens improve/YYYY-MM-DD PR with workflow fixes. See "Load-bearing rules" for where the IMPROVEMENTS file belongs. |
+| `daily-improve.yml` | weekly, Monday `00:17` UTC | Opens improve/YYYY-MM-DD PR with methodology fixes; each run auto-closes prior unmerged `improve/*` PRs. See "Load-bearing rules" for where the IMPROVEMENTS file belongs. |
 | `ci.yml` | push/PR on workflows/dashboard/scripts | actionlint + dashboard build + Python tests |
 | `claude.yml` | `@claude` mention in issue/PR/review | Interactive Claude-Code agent |
 | `claude-code-review.yml` | PR opened/synced | Automated Claude code review |
@@ -230,11 +233,11 @@ gh workflow run generative-research.yml \
 ```
 research/
 ├── arxiv/                     # daily-arxiv.yml
-├── audio/                     # ad-hoc audio artifacts
+├── audio/                     # digest audio; mp3s live on S3 (since May 2026) — committed files are 0-byte stubs
 ├── bluesky/                   # 2h-bluesky.yml
 ├── community/                 # 4h-community.yml (-hn.md, -reddit.md)
 ├── digest/                    # daily-digest.yml
-├── front-page/                # daily-front-page.yml (PNG)
+├── front-page/                # daily-front-page.yml (committed PNG + interactive .ara.md/.html edition)
 ├── generative/                # generative-research.yml + Oracle runner (HTML + .ara.md + index.json)
 ├── issues/                    # research-issue.yml
 ├── models/                    # 24h-model-timeline.yml
@@ -268,12 +271,13 @@ Secrets are configured in GitHub Actions. None are committed.
 | `DEEPSEEK_API_KEY` | _Retired_ — DeepSeek lanes now route through Fireworks | No longer referenced by any workflow. |
 | `FIREWORKS_API_KEY` | Scheduled content lanes through `.github/actions/agent-run`; `generative-research backend=deepseek-v4-flash` / `backend=glm-5p2`; all `hourly-twitter.yml` non-primary comparison lanes (`deepseek-claude-code`, `deepseek-pi`, `fireworks-pi`) | Required for the DeepSeek-V4-Flash/GLM-via-Fireworks and Kimi lanes. |
 | `BIRD_AUTH_TOKEN`, `BIRD_CT0` | All bird-CLI workflows (`hourly-twitter*`, `24h-model-timeline`) | X/Twitter cookies. |
-| `EXA_API_KEY`, `PERPLEXITY_API_KEY` | `daily-digest`, `ai-news-research`, `research-issue` | Optional; enhance MCP search. |
+| `EXA_API_KEY`, `PERPLEXITY_API_KEY` | `daily-digest`, `ai-news-research`, `research-issue` | Optional; enhance MCP search. **Currently unset in the repo** (verified absent 2026-07-02) — `daily-digest` detects the absence, emits a run warning, and uses its local-source synthesis path until they are restored. |
 | `GEMINI_API_KEY` | `daily-digest` (inline Gemini Flash TTS for digest audio); also the manual `generate_generative_article_audio.py` | Optional; without it, audio generation is skipped. |
+| `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY`, `S3_ENDPOINT_URL`, `S3_BUCKET` | `daily-digest` (audio upload) | Optional; generated digest mp3s upload to S3 while the working tree keeps 0-byte stubs. Missing = upload skipped. |
 | `HOOKER_TOKEN` | Telemetry composite action | Optional; without it, telemetry steps no-op. |
 | `HOOKER_URL` | Hooker telemetry composite + most workflows (the hooker endpoint, distinct from `HOOKER_TOKEN`) | The `https://hooker.guzus.xyz`-style base URL the telemetry/alert steps POST to. Referenced widely across workflows/actions. |
 | `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID` | `hourly-twitter*` | For headline alert delivery. |
-| `VERCEL_DEPLOY_HOOK` | `24h-model-timeline`, `wiki-ingest`, `hourly-twitter` (claude tier) | Optional legacy nudge to a Vercel project that does NOT serve ara.guzus.xyz (prod deploys are Railway, git-push driven — Load-bearing rule 3; Vercel's last recorded deploy failed 2026-05-25). Harmless: the step no-ops when unset. |
+| `VERCEL_DEPLOY_HOOK` | `24h-model-timeline`, `wiki-ingest`, `hourly-twitter` (claude tier) | **Secret removed from the repo** (verified absent 2026-07-02); the referencing steps are permanent no-ops kept as legacy scaffolding and safe to delete in a future cleanup. Vercel does NOT serve ara.guzus.xyz — prod deploys are Railway, git-push driven (Load-bearing rule 3). |
 | `GITHUB_TOKEN` | All workflows | Auto-provided. |
 
 ## Load-bearing Rules
@@ -310,10 +314,10 @@ output or break the pipeline. Read them before editing.
    the builder + healthcheck). ara.guzus.xyz is served by that
    container behind Cloudflare (responses carry `x-railway-edge`) —
    NOT by Vercel, whose last recorded deploy failed 2026-05-25. Its
-   `dashboard/vercel.json` was removed during open-sourcing; the only
-   remaining leftover is the `VERCEL_DEPLOY_HOOK` secret — a harmless
-   legacy no-op still referenced by a few workflows. There is still no
-   workflow file for deploys.
+   `dashboard/vercel.json` was removed during open-sourcing, and the
+   `VERCEL_DEPLOY_HOOK` secret has since been deleted from the repo —
+   the steps that still reference it in a few workflows are permanent
+   no-ops. There is still no workflow file for deploys.
    `dashboard/scripts/prebuild.mjs` copies `research/<source>/` into
    `public/research/` and emits `manifest.json` before Vite runs (the
    Docker build runs the same `bun run build` lifecycle). Touching it
@@ -338,8 +342,10 @@ output or break the pipeline. Read them before editing.
    state — bird CLI + warm birdy daemon (`hourly-twitter*`,
    `24h-model-timeline`), recent `research/` checkout for prior-output context
    (`daily-digest`, `ci.yml` dashboard job), pre-installed pnpm/Oracle
-   tooling. Generated media lives in S3; `daily-front-page` renders via
-   resvg and uploads the PNG rather than committing it. Use
+   tooling. Digest audio lives in S3 (uploaded by `daily-digest` via the
+   `S3_*` secrets; the committed `research/audio/*.mp3` files are 0-byte
+   stubs), while `daily-front-page` renders via resvg and COMMITS the
+   PNG alongside the interactive `.ara.md`/`.html` edition. Use
    `[self-hosted, Linux]` for anything touching that state,
    which is nearly everything. Reserve `ubuntu-latest` for the two
    watchdogs that must outlive a self-hosted outage (`liveness-check.yml`,
@@ -356,9 +362,9 @@ output or break the pipeline. Read them before editing.
 7. **Improvement logs belong in `docs/archive/`.** When
    `daily-improve.yml` (or any agent) generates a new improvements
    file, write it to `docs/archive/YYYY-MM-DD-improvements.md`, not
-   to repo root. The workflow prompt still says "Create an
-   IMPROVEMENTS.md" — that text predates this rule. Follow this rule,
-   not the older prompt.
+   to repo root. (The workflow prompt now says this too — the old
+   "Create an IMPROVEMENTS.md" wording is gone. The improve loop runs
+   weekly on Mondays and auto-closes its own stale `improve/*` PRs.)
 
 8. **Atomic file writes.** Long-running aggregation scripts that
    write into `research/` should write to a temp file in the same

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ flowchart TB
     Digest --> digest_out["research/digest/"]
 
     subgraph improve["🔄 Self-Improvement"]
-        Improve["daily-improve.yml<br/><i>00:17 UTC</i>"]
+        Improve["daily-improve.yml<br/><i>Mon 00:17 UTC</i>"]
     end
 
     digest_out --> Improve
@@ -156,13 +156,13 @@ gantt
 | `hourly-rss.yml` | Every 2 hours (:30) | Official blogs, TechCrunch, arXiv RSS | `research/rss/` |
 | `daily-ai-blogs.yml` | Every 6 hours (:13) | Curated KOL Substacks, expert blogs, research/operator blogs | `research/blogs/` |
 | `daily-youtube.yml` | Daily 23:20 UTC for the next 00:00 digest | tuber API trending/search/channel metadata, existing summaries, transcript probes | `research/youtube/` |
-| `2h-bluesky.yml` | Daily 00:11 UTC | Bluesky AI posts | `research/bluesky/` |
+| `2h-bluesky.yml` | Daily 10:11 UTC | Bluesky AI posts | `research/bluesky/` |
 | `4h-community.yml` | Every 4 hours | Reddit RSS + HN MCP | `research/community/` |
 | `daily-arxiv.yml` | Daily 06:13 UTC | arXiv papers | `research/arxiv/` |
 | `daily-digest.yml` | Daily 00:00 UTC | All sources + MCP search | `research/digest/` |
 | `hourly-twitter.yml` (matrix) | claude tier every 3h (`:07`), deepseek-claude-code tier every 6h (`:37`), deepseek-pi and fireworks-pi tiers manual | Twitter/X via bird CLI (reviewed account manifest, 7 search queries) | `research/twitter/` (claude) + `research/twitter-deepseek/` (Claude Code) + `research/twitter-deepseek-pi/` (pi) + `research/twitter-fireworks-pi/` (Fireworks pi) |
 | `ai-news-research.yml` | Twice daily (08:23, 20:23 UTC) | Perplexity/Exa MCP | `research/` |
-| `daily-improve.yml` | Daily 00:17 UTC | Self-improvement | PRs with improvements |
+| `daily-improve.yml` | Weekly (Mon 00:17 UTC) | Self-improvement | PRs with improvements |
 | `twitter-account-explorer.yml` | Weekly (Tue 01:47 UTC) + manual | Scouts high-signal AI accounts; trust-weighted curation of `data/sources/twitter_accounts.json` | Reviewed PRs (`app/claude`) |
 | `research-issue.yml` | On issue label | Deep research on any topic | `research/issues/` |
 | `generative-research.yml` | On `gen-research` issue label or `workflow_dispatch` (`topic` or `twitter_url`) | Claude, Codex, or Fireworks-backed models write an HTML article | `research/generative/` |


### PR DESCRIPTION
Docs-only truth-sync pass; every corrected claim was verified against the live repo (crons, `gh secret list`, actual lane commits) rather than assumed. Highlights:

- **daily-improve is weekly** (Mon 00:17 UTC), not daily — meta table, rule 7, README table + mermaid all said daily. Rule 7's "the workflow prompt still says IMPROVEMENTS.md" escape hatch was also stale (the prompt was fixed).
- **Rule 5 had the media story backwards**: the front-page PNG *is committed* (a 1.4MB blob lands in every daily front-page commit); it's the digest audio that lives on S3 with 0-byte stubs in the tree. Also added the missing `S3_*` secrets row (daily-digest audio upload).
- **Secrets table matches reality**: `EXA_API_KEY`/`PERPLEXITY_API_KEY` are currently unset (digest runs its local-source path with a warning until restored); `VERCEL_DEPLOY_HOOK` no longer exists in repo secrets, so the referencing steps are permanent no-ops.
- **Deterministic-fallback coverage** updated in CLAUDE.md + AGENTS.md after #186/#179/#188: RSS, community, arXiv, digest (+ content floor), Bluesky, and the twitter-deepseek tier.
- README: bluesky cron is 10:11 UTC, not 00:11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)