### PR TITLE
Suppress same-tweet headline rebroadcasts + collapse repeated Twitter-tab stories

### DIFF
--- a/dashboard/src/render/twitter.ts
+++ b/dashboard/src/render/twitter.ts
@@ -120,6 +120,76 @@ export function parseTwitterStories(body: string): TwitterStory[] {
   });
 }
 
+// ── Cross-cycle repeat collapse ──────────────────────────────────────
+// The report renders every cycle of the day (newest first), and an ongoing
+// storyline gets a full card in cycle after cycle. Stories in an OLDER cycle
+// that re-cover a story already rendered in a NEWER cycle collapse to a
+// compact expandable row, so the day reads as "latest state + history"
+// instead of the same story five times. Mirrors the alert-side dedupe
+// signals: shared status id (wording-independent) or title-token containment.
+type StoryFingerprint = { tokens: Set<string>; statusIds: Set<string> };
+
+const STORY_TOKEN_STOPWORDS = new Set([
+  'A', 'AN', 'AND', 'ARE', 'AS', 'AT', 'BY', 'FOR', 'FROM', 'IN', 'INTO',
+  'IS', 'NEW', 'NOW', 'OF', 'ON', 'OR', 'OVER', 'THE', 'TO', 'VIA', 'WITH',
+]);
+const REPEAT_MIN_OVERLAP = 4;      // shared significant title tokens
+const REPEAT_CONTAINMENT = 0.5;    // overlap / smaller title token set
+const REPEAT_STATUS_MIN_OVERLAP = 2; // token sanity floor for a status-id match
+
+function storyTokens(text: string): Set<string> {
+  const norm = (text || '')
+    .toUpperCase()
+    .replace(/HTTPS?:\/\/\S+/g, ' ')
+    .replace(/(\d)\.(\d)/g, '$1§$2') // protect decimals (5.6) before dot strip
+    .replace(/[^A-Z0-9§$]+/g, ' ')
+    .replace(/§/g, '.');
+  const out = new Set<string>();
+  for (const token of norm.split(/\s+/)) {
+    if (token.length > 1 && !STORY_TOKEN_STOPWORDS.has(token)) out.add(token);
+  }
+  return out;
+}
+
+function statusIdsFrom(urls: string[]): Set<string> {
+  const ids = new Set<string>();
+  for (const url of urls) {
+    // Host-boundary anchor so e.g. netflix.com/…/status/123 can't read as a
+    // tweet id (accepts scheme-full URLs and *.x.com/*.twitter.com hosts).
+    const m = (url || '').match(/(?:^|\/\/|\.)(?:x|twitter)\.com\/[^/\s]+\/status\/(\d+)/);
+    if (m) ids.add(m[1]);
+  }
+  return ids;
+}
+
+function isRepeatOfLaterCycle(fp: StoryFingerprint, seen: StoryFingerprint[]): boolean {
+  for (const prior of seen) {
+    let overlap = 0;
+    for (const token of fp.tokens) if (prior.tokens.has(token)) overlap++;
+    let sharedStatus = false;
+    for (const id of fp.statusIds) {
+      if (prior.statusIds.has(id)) { sharedStatus = true; break; }
+    }
+    if (sharedStatus && overlap >= REPEAT_STATUS_MIN_OVERLAP) return true;
+    const denom = Math.min(fp.tokens.size, prior.tokens.size);
+    if (denom > 0 && overlap >= REPEAT_MIN_OVERLAP && overlap / denom >= REPEAT_CONTAINMENT) return true;
+  }
+  return false;
+}
+
+function wrapRepeatStoryCard(rank: string, titleHtml: string, cardHtml: string): string {
+  return [
+    '<details class="twitter-story-repeat">',
+    '  <summary>',
+    '    <span class="twitter-story-rank">' + escapeHtml(rank) + '</span>',
+    '    <span class="twitter-story-repeat-title">' + titleHtml + '</span>',
+    '    <span class="twitter-story-repeat-chip">↑ updated in a later cycle</span>',
+    '  </summary>',
+    cardHtml,
+    '</details>',
+  ].join('\n');
+}
+
 const TWITTER_MINDSHARE_TERMS: Array<{ label: string; pattern: RegExp }> = [
   { label: 'Anthropic', pattern: /\b(?:Anthropic|Claude|Fable\s*5|Mythos\s*5)\b/gi },
   { label: 'OpenAI', pattern: /\b(?:OpenAI|GPT-?5|GPT-?4\.?1|ChatGPT|Codex)\b/gi },
@@ -340,6 +410,8 @@ function extractSkepticCorner(body: string): string {
 function renderStructuredTwitterStories(
   body: string,
   searchTerm: string,
+  seenEarlier: StoryFingerprint[],
+  cycleFingerprints: StoryFingerprint[],
 ): string {
   if (!/\btwitter-story\b/.test(body)) return '';
   const doc = new DOMParser().parseFromString('<div>' + body + '</div>', 'text/html');
@@ -359,11 +431,20 @@ function renderStructuredTwitterStories(
       bodyHtml ? '<div class="md-content twitter-story-body">' + bodyHtml + '</div>' : '',
     ].filter(Boolean).join('\n');
 
-    return [
+    const titleHtml = highlightPlainText(title, searchTerm);
+    const sourceHrefs = Array.from(story.querySelectorAll('.twitter-story-sources a'))
+      .map((a) => a.getAttribute('href') || '');
+    const fingerprint: StoryFingerprint = {
+      tokens: storyTokens(title),
+      statusIds: statusIdsFrom(sourceHrefs),
+    };
+    cycleFingerprints.push(fingerprint);
+
+    const cardHtml = [
       '<article class="twitter-story-card">',
       '  <div class="twitter-story-rank">' + escapeHtml(rank) + '</div>',
       '  <div class="twitter-story-main">',
-      title ? '    <h3 class="twitter-story-title">' + highlightPlainText(title, searchTerm) + '</h3>' : '',
+      title ? '    <h3 class="twitter-story-title">' + titleHtml + '</h3>' : '',
       lead ? '    <p class="twitter-story-summary">' + highlightPlainText(truncateText(cleanPublicLeadText(lead), 360), searchTerm) + '</p>' : '',
       detailsBits
         ? [
@@ -376,6 +457,12 @@ function renderStructuredTwitterStories(
       '  </div>',
       '</article>',
     ].filter(Boolean).join('\n');
+
+    // Search must keep every occurrence visible — collapse only when idle.
+    if (!searchTerm && isRepeatOfLaterCycle(fingerprint, seenEarlier)) {
+      return wrapRepeatStoryCard(rank, titleHtml, cardHtml);
+    }
+    return cardHtml;
   }).join('\n');
 }
 
@@ -428,6 +515,9 @@ export function renderTwitterReportHtml(md: string, options: TwitterReportRender
   const cards: string[] = [];
   const timelineItems: InfoTimelineItem[] = [];
   const mindshareCycles: TwitterMindshareCycle[] = [];
+  // Fingerprints of stories already rendered in NEWER cycles (sections render
+  // newest-first) — older re-coverage of these collapses to a compact row.
+  const seenStories: StoryFingerprint[] = [];
   if (options.fallbackDate) {
     cards.push(
       '<div class="frontpage-fallback-note">No Twitter report for ' +
@@ -470,7 +560,8 @@ export function renderTwitterReportHtml(md: string, options: TwitterReportRender
       .replace(/\*\*Cycle summary\*\*:[\s\S]*?(?=\n#{1,3}\s|$)/i, '')
       .replace(/###\s+[^\n]*[Ss]keptic[^\n]*\n[\s\S]*?(?=\n#{2,3}\s|$)/i, '')
       .trim();
-    const structuredStoryCards = renderStructuredTwitterStories(section.body, options.searchTerm);
+    const cycleFingerprints: StoryFingerprint[] = [];
+    const structuredStoryCards = renderStructuredTwitterStories(section.body, options.searchTerm, seenStories, cycleFingerprints);
     const storyCards = structuredStoryCards || stories.map((story) => {
       const verification = truncateText(stripMarkdown(extractSectionText(story.body, 'Verification')), 210);
       const watch = truncateText(stripMarkdown(extractSectionText(story.body, 'Watch')), 210);
@@ -480,11 +571,17 @@ export function renderTwitterReportHtml(md: string, options: TwitterReportRender
       const storySummary = isSourceMethodLead(storyIntro) ? '' : truncateText(cleanPublicLeadText(storyIntro), 360);
       const storyLinks = options.renderSourceChips(story.links, 6);
       const storyHandles = options.renderHandleChips(story.handles, 8);
-      return [
+      const titleHtml = highlightPlainText(story.title, options.searchTerm);
+      const fingerprint: StoryFingerprint = {
+        tokens: storyTokens(story.title),
+        statusIds: statusIdsFrom(story.links.slice(0, 4)),
+      };
+      cycleFingerprints.push(fingerprint);
+      const cardHtml = [
         '<article class="twitter-story-card">',
         '  <div class="twitter-story-rank">' + escapeHtml(story.rank) + '</div>',
         '  <div class="twitter-story-main">',
-        '    <h3 class="twitter-story-title">' + highlightPlainText(story.title, options.searchTerm) + '</h3>',
+        '    <h3 class="twitter-story-title">' + titleHtml + '</h3>',
         storySummary ? '    <p class="twitter-story-summary">' + highlightPlainText(storySummary, options.searchTerm) + '</p>' : '',
         '    <details class="twitter-story-details">',
         '      <summary>Full analysis</summary>',
@@ -500,7 +597,14 @@ export function renderTwitterReportHtml(md: string, options: TwitterReportRender
         '  </div>',
         '</article>',
       ].filter(Boolean).join('\n');
+      if (!options.searchTerm && isRepeatOfLaterCycle(fingerprint, seenStories)) {
+        return wrapRepeatStoryCard(story.rank, titleHtml, cardHtml);
+      }
+      return cardHtml;
     }).join('\n');
+
+    // This cycle's stories become "already covered" for every OLDER cycle.
+    seenStories.push(...cycleFingerprints);
 
     const skepticBody = extractSkepticCorner(section.body);
     const skepticHtml = skepticBody

--- a/dashboard/src/style.css
+++ b/dashboard/src/style.css
@@ -2122,6 +2122,61 @@ body.tab-agents .section-nav {
   font-weight: 700;
 }
 
+/* Collapsed re-coverage: a story already rendered in a newer cycle above */
+.twitter-story-repeat > summary {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border: 1px dashed var(--border-light);
+  border-radius: 12px;
+  background: var(--bg);
+  cursor: pointer;
+  list-style: none;
+}
+
+.twitter-story-repeat > summary::-webkit-details-marker {
+  display: none;
+}
+
+.twitter-story-repeat > summary .twitter-story-rank {
+  width: 26px;
+  height: 26px;
+  border-radius: 7px;
+  font-size: 0.7rem;
+  flex: none;
+}
+
+.twitter-story-repeat-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-secondary);
+  font-size: 0.86rem;
+  font-weight: 600;
+}
+
+.twitter-story-repeat-chip {
+  margin-left: auto;
+  flex: none;
+  padding: 2px 8px;
+  border: 1px solid var(--border-light);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  white-space: nowrap;
+}
+
+.twitter-story-repeat[open] > summary {
+  margin-bottom: 10px;
+}
+
+.twitter-story-repeat[open] > summary .twitter-story-repeat-chip {
+  display: none;
+}
+
 .twitter-story-title {
   max-width: 980px;
   margin: 0 0 8px;

--- a/docs/headline-dedupe.md
+++ b/docs/headline-dedupe.md
@@ -68,9 +68,13 @@ flowchart TD
     H -->|yes| R3([duplicate_source_similar_headline]):::supp
     H -->|no| Q
 
-    %% Gate: cross-source pass only runs when a reference time is supplied
+    %% Gate: rebroadcast + cross-source passes only run when a reference time is supplied
     Q{now provided?} -->|"no — legacy / test caller"| SEND
-    Q -->|yes| K
+    Q -->|yes| RB
+
+    %% Pass 1d — same source, earlier cycle (wording-independent)
+    RB{"Any record with the same<br/>external key (status id / exact URL)<br/>delivered in an EARLIER run?<br/>(record timestamp fails open)"} -->|yes| R5([duplicate_rebroadcast]):::supp
+    RB -->|no| K
 
     %% Pass 2 — cross-source semantic duplicate
     K{"Any DIFFERENT-url record where ALL hold:<br/>• delivered within 14 days (fail-open)<br/>• shared tokens ≥ 4<br/>• Jaccard ≥ 0.5"} -->|yes| R4([duplicate_cross_source_similar_headline]):::supp
@@ -90,6 +94,7 @@ flowchart TD
 | 1a | `duplicate_story_key` | same non-empty `story_key` | explicit story grouping (**inert today** — the agent's schema emits no `story_key`; kept for when it does) |
 | 1b | `duplicate_headline` | identical **normalized** headline, **any** source | verbatim re-posts / cross-account copies |
 | 1c | `duplicate_source_similar_headline` | **same URL** + `max(containment, jaccard) ≥ 0.62` | one author rephrasing their own tweet |
+| 1d | `duplicate_rebroadcast` | same **external key** (status id / exact URL) delivered in an **earlier run** (`delivered_at < now`, fails open on a bad record timestamp) | the same tweet re-headlined in a later cycle, **at any wording** — the 0.60/0.615 near-threshold paraphrases and zero-overlap rewrites 1c structurally misses. In-batch appends share `delivered_at == now`, so multi-claim extraction from one thread within a single cycle still delivers. Backtest: 100 of 1730 ledger records (all 6 post-2026-06-22 leaks); the strict `<` is load-bearing — relaxing it to `<=` would additionally eat 42 legitimately-delivered in-batch multi-claim records. |
 | 2 | `duplicate_cross_source_similar_headline` | **different URL** + in 14-day window + `≥ 4` shared tokens + `Jaccard ≥ 0.5` | **the same story from a different account, paraphrased** (the leak this layer was added to close) |
 
 **Normalization** (`normalize_headline`): NFKC, uppercase, strip URLs, drop
@@ -97,6 +102,17 @@ non-decimal dots, collapse to `[A-Z0-9.$]`. **Tokens** (`headline_tokens`):
 the normalized words minus a stopword list, length > 1. Token sets are
 precomputed once per record and cached on `Keys.tokens`, so the Pass-2 scan
 never re-tokenizes history.
+
+**External key** (`external_key`, what layer 1d matches on): one of
+`x:status:<id>` (the tweet's status id — the handle segment is IGNORED, so
+`x.com/alice/status/123` ≡ `twitter.com/bob/status/123`), `x:trend:<id>`,
+`x:search:<sha16 of the query>`, or `url:<sha24>` of the **normalized** URL
+(tracking params stripped, `www.`/`twitter.com` folded) — so "exact URL" means
+post-normalization, not byte-identical. Layer 1d deliberately has **no recency
+window** (unlike Pass 2's 14 days): a repeated key is suppressed for the
+ledger's full 3000-record retention. Backtest supports this — the widest
+genuine rebroadcast gap observed is 11.4 days, and a months-later re-alert of
+the same immutable tweet is still the same alert.
 
 ## Tunable constants (defaults live in the script — no workflow change to tune)
 
@@ -158,8 +174,10 @@ news that merely shares vocabulary. Calibration on the real ledger shows that
 band is ~half true duplicates that leaked and ~half genuinely-distinct items:
 "MICRON CROSSES $900B" vs "SK HYNIX CROSSES $900B" (same metric, different
 subject), appended-fact follow-ups, running-counter progressions. Separating
-those is a *semantic* judgment, so a Claude **Haiku** step adjudicates exactly
-that band — and only that band — as a final gate on the send path.
+those is a *semantic* judgment, so a model step (currently **DeepSeek V4 Flash
+via Fireworks** through the `agent-run` composite; originally Claude Haiku)
+adjudicates exactly that band — and only that band — as a final gate on the
+send path.
 
 It lives in `scripts/headline_judge.py` (two deterministic, unit-tested
 subcommands) bracketing one model step in `hourly-twitter.yml`:
@@ -168,7 +186,7 @@ subcommands) bracketing one model step in `hourly-twitter.yml`:
 flowchart LR
     FILTER["deterministic filter<br/>→ to-send.json"]:::proc --> SHORT["shortlist<br/>survivors in [0.35,0.50)<br/>+ ≤5 nearest priors"]:::proc
     SHORT -->|empty| BLAST
-    SHORT -->|"doubtful.json"| JUDGE{{"Haiku judge<br/>same event?"}}:::model
+    SHORT -->|"doubtful.json"| JUDGE{{"model judge (Fireworks)<br/>same event?"}}:::model
     JUDGE -->|"verdicts.json"| APPLY["apply<br/>drop duplicate+high only"]:::proc
     APPLY --> ALERT["Telegram alert<br/>on every suppression"]:::io
     APPLY --> BLAST["Hooker blast"]:::io

--- a/scripts/dedupe_headline_alerts.py
+++ b/scripts/dedupe_headline_alerts.py
@@ -11,6 +11,13 @@ Full contract + flow diagrams (incl. the downstream agent gate in
 Dedupe layers (see `duplicate_reason`), in priority order:
   1. shared story_key, exact normalized headline (any source), and same-source
      (same URL) paraphrase — time-independent, highest precision.
+  1d. same-source rebroadcast — the SAME tweet/status id (or exact external
+     URL) that already alerted in an EARLIER run, regardless of wording. A
+     re-headlined tweet is the same alert even at zero token overlap; this is
+     wording-independent where layer 1's paraphrase check is not. Records
+     stamped by the current run (in-batch appends) don't qualify, so
+     multi-claim extraction from one thread within a single cycle still
+     delivers. Gated on a reference time like layer 2.
   2. cross-source semantic duplicate — the SAME story reported by a DIFFERENT
      account (different tweet URL) with paraphrased wording. This catches the
      re-reports the same-URL check structurally cannot see. It is gated on a
@@ -289,6 +296,23 @@ def duplicate_reason(
             similarity = headline_similarity(headline, record_headline)
             if similarity >= URL_SIMILARITY_THRESHOLD:
                 return "duplicate_source_similar_headline"
+
+    # Pass 1d — same source, earlier cycle (rebroadcast): a tweet/status id (or
+    # exact external URL) that already alerted in a PREVIOUS run is the same
+    # alert regardless of wording. Re-headlining one tweet hours later is how
+    # near-threshold paraphrases (0.60/0.615 vs the 0.62 floor) and zero-overlap
+    # rewrites of the same tweet kept leaking. Gated on `now` like Pass 2 so
+    # legacy 2-arg callers are unchanged. Records stamped by THIS run (in-batch
+    # appends share `delivered_at == now`) never qualify, so multi-claim
+    # extraction from one thread within a single cycle still delivers; the
+    # per-record timestamp fails OPEN (unparseable → cannot suppress).
+    if now is not None and keys.external_key:
+        for record, record_keys in zip(history, history_keys):
+            if record_keys.external_key != keys.external_key:
+                continue
+            delivered = parse_delivered_at(record.get("delivered_at"))
+            if delivered is not None and delivered < now:
+                return "duplicate_rebroadcast"
 
     # Pass 2 — cross-source semantic duplicate: same story, DIFFERENT account
     # (different tweet URL), paraphrased. Inert unless a reference time `now` is

--- a/scripts/test_dedupe_headline_alerts.py
+++ b/scripts/test_dedupe_headline_alerts.py
@@ -52,6 +52,81 @@ class DedupeHeadlineAlertsTest(unittest.TestCase):
         }
         self.assertEqual(dedupe.duplicate_reason(item, history), "")
 
+    def test_same_tweet_earlier_run_is_rebroadcast_even_with_zero_overlap(self):
+        # The same status id re-headlined in a LATER cycle is a duplicate alert
+        # regardless of wording — this is the wording-independent layer 1d.
+        history = [
+            dedupe.make_record(
+                {
+                    "headline": "GPT-5.6 POSTPONED AGAIN; NEXT MOVE FRAMED AS SONNET 5",
+                    "url": "https://x.com/apples_jimmy/status/2071000000000000001",
+                },
+                "2026-06-24 01:06 UTC",
+            )
+        ]
+        item = {
+            "headline": "COMPLETELY DIFFERENT WORDING ABOUT A MID-JULY SLIP",
+            "url": "https://twitter.com/apples_jimmy/status/2071000000000000001?s=20",
+        }
+        now = dedupe.parse_delivered_at("2026-06-24 03:54 UTC")
+        self.assertEqual(
+            dedupe.duplicate_reason(item, history, None, now),
+            "duplicate_rebroadcast",
+        )
+
+    def test_same_tweet_same_run_multi_claim_still_delivers(self):
+        # In-batch appends carry delivered_at == now; a second distinct claim
+        # extracted from the same thread in the SAME cycle must not be eaten.
+        now_str = "2026-06-29 03:36 UTC"
+        history = [
+            dedupe.make_record(
+                {
+                    "headline": "ELON MUSK ANNOUNCES GROK 4.5 IN PRIVATE BETA",
+                    "url": "https://x.com/elonmusk/status/2071184354756477041",
+                },
+                now_str,
+            )
+        ]
+        item = {
+            "headline": "SPACEX TO RELEASE FROM-SCRATCH AI MODELS EVERY MONTH THIS YEAR",
+            "url": "https://x.com/elonmusk/status/2071184354756477041",
+        }
+        now = dedupe.parse_delivered_at(now_str)
+        self.assertEqual(dedupe.duplicate_reason(item, history, None, now), "")
+
+    def test_rebroadcast_layer_inert_for_legacy_two_arg_callers(self):
+        history = [
+            dedupe.make_record(
+                {
+                    "headline": "ORIGINAL WORDING OF SOME STORY",
+                    "url": "https://x.com/a/status/777",
+                },
+                "2026-06-24 01:06 UTC",
+            )
+        ]
+        item = {
+            "headline": "TOTALLY REWORDED TAKE WITH NO SHARED TOKENS AT ALL",
+            "url": "https://x.com/a/status/777",
+        }
+        self.assertEqual(dedupe.duplicate_reason(item, history), "")
+
+    def test_rebroadcast_fails_open_on_unparseable_record_timestamp(self):
+        history = [
+            dedupe.make_record(
+                {
+                    "headline": "ORIGINAL WORDING OF SOME STORY",
+                    "url": "https://x.com/a/status/888",
+                },
+                "not-a-timestamp",
+            )
+        ]
+        item = {
+            "headline": "TOTALLY REWORDED TAKE WITH NO SHARED TOKENS AT ALL",
+            "url": "https://x.com/a/status/888",
+        }
+        now = dedupe.parse_delivered_at("2026-06-24 03:54 UTC")
+        self.assertEqual(dedupe.duplicate_reason(item, history, None, now), "")
+
     def test_exact_headline_is_duplicate_even_with_different_url(self):
         history = [
             dedupe.make_record(


### PR DESCRIPTION
## Diagnosis (measured on the live ledger + tab data)

**Alerts** — `twitter-announced-history.json`, 1,730 delivered records (Apr 27 → Jul 4):
- Since the Jun 20 layers (#143 cross-source, #146 judge): 201 deliveries, **0 cross-source escapes ≥ 0.5 Jaccard** — that layer works.
- The remaining systematic leak: **the same tweet re-headlined in a later cycle** — 6 escapes in 12 days, including 0.615/0.60 near-misses of the 0.62 same-URL floor and wording-independent cases token similarity can't see (the GPT-5.6 delay pair scored 0.18 — same tweet, same story, fully reworded).
- In-batch multi-claim extraction (7 cases) and appended-fact storyline progression are working as deliberately designed and are untouched.

**Twitter tab** — one day per view, cycles render newest-first, and no cross-cycle story collapse existed: an ongoing storyline renders as a full card in up to 8 cycles/day (measured: 14 repeated status-link citations within a single heavy day file).

## Fixes

1. **Dedupe layer 1d `duplicate_rebroadcast`** (`scripts/dedupe_headline_alerts.py`): an external key (status id — handle-independent — trend/search key, or normalized URL hash) that already alerted in an **earlier run** is suppressed at any wording. Strict `delivered_at < now` keeps same-cycle multi-claim threads delivering; fails open on unparseable timestamps; inert for legacy 2-arg callers.
2. **Cross-cycle story collapse** (`dashboard/src/render/twitter.ts` + CSS): older re-coverage of a story already rendered in a newer cycle collapses to a compact expandable row ("↑ updated in a later cycle"). Signals mirror the alert side: shared status id (+ token sanity floor) or 0.5 title-token containment. Search mode disables collapsing; mindshare/timeline inputs unchanged.
3. **Contract doc lockstep** (`docs/headline-dedupe.md`): layer 1d row + flowchart node, external-key definition (incl. cross-handle matching and the deliberate no-window choice), load-bearing strict-`<` note, and the stale "Haiku" judge reference corrected to the Fireworks backend the workflow actually runs.

## Evidence

- **Backtest replay** of the full ledger: 100/1,730 lifetime rebroadcasts caught — exactly the 6 post-Jun-22 leaks identified by hand, zero in-batch multi-claim pairs eaten (`<=` would eat 42; the strict bound is load-bearing).
- **412 unit tests OK** (4 new for layer 1d: cross-run zero-overlap suppression, in-batch preservation, legacy-caller inertness, fail-open timestamps); `tsc --noEmit` + vite build clean.
- **Browser-verified on the built dist with real data** (2026-07-01): 3 of 14 story cards correctly collapsed — each collapsed row's full card exists in a newer cycle above; storyline progressions (Sonnet 5 leak → release → verdict) correctly stay separate.
- **Independent review pass**: ship-quality verdict; all 3 findings applied (doc backtest phrasing, external-key definition, host-boundary anchor on the status-id regex so `netflix.com/…/status/123` can't parse as a tweet id).

🤖 Generated with [Claude Code](https://claude.com/claude-code)