### PR TITLE
[codex] Harden GitHub Actions agent execution

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "sandbox": {
+    "enabled": true,
+    "failIfUnavailable": true,
+    "allowUnsandboxedCommands": false,
+    "autoAllowBashIfSandboxed": true,
+    "filesystem": {
+      "denyRead": [
+        "~/",
+        "/root",
+        "/proc",
+        "/sys",
+        "/var/run",
+        "/etc/ssh",
+        "/etc/ssl/private"
+      ],
+      "allowRead": [
+        "."
+      ]
+    },
+    "credentials": {
+      "files": [
+        {
+          "path": "~/.aws",
+          "mode": "deny"
+        },
+        {
+          "path": "~/.config/gh",
+          "mode": "deny"
+        },
+        {
+          "path": "~/.docker",
+          "mode": "deny"
+        },
+        {
+          "path": "~/.ssh",
+          "mode": "deny"
+        }
+      ],
+      "envVars": [
+        {
+          "name": "ANTHROPIC_API_KEY",
+          "mode": "deny"
+        },
+        {
+          "name": "ANTHROPIC_AUTH_TOKEN",
+          "mode": "deny"
+        },
+        {
+          "name": "CLAUDE_CODE_OAUTH_TOKEN",
+          "mode": "deny"
+        },
+        {
+          "name": "FIREWORKS_API_KEY",
+          "mode": "deny"
+        }
+      ]
+    }
+  },
+  "permissions": {
+    "deny": [
+      "Read(~/**)",
+      "Read(//root/**)",
+      "Read(//proc/**)",
+      "Read(//sys/**)",
+      "Read(//var/run/**)",
+      "Read(//etc/ssh/**)",
+      "Read(//etc/ssl/private/**)"
+    ]
+  }
+}

--- a/.github/actions/agent-run/action.yml
+++ b/.github/actions/agent-run/action.yml
@@ -160,6 +160,9 @@ runs:
         } >> "$GITHUB_OUTPUT"
         echo "ARA agent effective backend: $backend"
 
+    - name: Setup Claude sandbox
+      uses: ./.github/actions/setup-claude-sandbox
+
     # Native-Claude runs (requested backend=claude or Fireworks fallback)
     # serve inputs.native-model: the workflows' `--model opus` alias is
     # remapped the same way the Fireworks steps below remap it to the

--- a/.github/actions/run-pi-container/action.yml
+++ b/.github/actions/run-pi-container/action.yml
@@ -1,0 +1,104 @@
+name: Run pi in container
+description: Run the pi coding agent inside a Docker container with only the workflow workspace and run-scoped Twitter inputs mounted.
+
+inputs:
+  prompt-file:
+    description: Prompt file rendered by render-twitter-prompt.
+    required: true
+  provider:
+    description: pi provider name.
+    required: true
+  model:
+    description: Provider model id.
+    required: true
+  fireworks-api-key:
+    description: Fireworks API key.
+    required: true
+  bird-auth-token:
+    description: X/Twitter auth_token cookie for bird.
+    required: true
+  bird-ct0:
+    description: X/Twitter ct0 cookie for bird.
+    required: true
+  thinking:
+    description: pi thinking level.
+    required: false
+    default: high
+  tools:
+    description: Comma-separated pi tools.
+    required: false
+    default: read,write,edit,bash,grep,find,ls
+
+runs:
+  using: composite
+  steps:
+    - name: Build and run pi container
+      shell: bash
+      env:
+        PROMPT_FILE: ${{ inputs.prompt-file }}
+        PI_PROVIDER: ${{ inputs.provider }}
+        PI_MODEL: ${{ inputs.model }}
+        PI_THINKING: ${{ inputs.thinking }}
+        PI_TOOLS: ${{ inputs.tools }}
+        FIREWORKS_API_KEY: ${{ inputs.fireworks-api-key }}
+        AUTH_TOKEN: ${{ inputs.bird-auth-token }}
+        CT0: ${{ inputs.bird-ct0 }}
+      run: |
+        set -euo pipefail
+
+        if ! command -v docker >/dev/null 2>&1; then
+          echo "::error::Docker is required for sandboxed pi runs on self-hosted runners."
+          exit 1
+        fi
+        if [ ! -f "$PROMPT_FILE" ]; then
+          echo "::error::pi prompt file not found: $PROMPT_FILE"
+          exit 1
+        fi
+        if [ ! -d /tmp/bird ]; then
+          echo "::error::Twitter fetch directory /tmp/bird is missing."
+          exit 1
+        fi
+
+        build_dir="${RUNNER_TEMP:-/tmp}/pi-container-${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-1}"
+        rm -rf "$build_dir"
+        mkdir -p "$build_dir"
+
+        cat > "$build_dir/Dockerfile" <<'EOF'
+        FROM node:22-bookworm-slim
+        RUN apt-get update \
+          && apt-get install -y --no-install-recommends ca-certificates curl git jq \
+          && rm -rf /var/lib/apt/lists/*
+        RUN npm install -g --ignore-scripts @mariozechner/pi-coding-agent @steipete/bird@0.8.0
+        WORKDIR /workspace
+        EOF
+
+        image="ara-pi-agent:${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-1}"
+        docker build --pull -t "$image" "$build_dir"
+
+        docker run --rm \
+          --user "$(id -u):$(id -g)" \
+          --workdir /workspace \
+          --cap-drop ALL \
+          --security-opt no-new-privileges \
+          --pids-limit 512 \
+          --env HOME=/tmp/pi-home \
+          --env XDG_CONFIG_HOME=/tmp/pi-home/.config \
+          --env FIREWORKS_API_KEY \
+          --env AUTH_TOKEN \
+          --env CT0 \
+          --env BIRDY_READ_ONLY=1 \
+          --env BIRDY_TOOL_LOG_PATH=/workspace/.twitter-input/birdy-tool-log.jsonl \
+          --env PI_PROVIDER \
+          --env PI_MODEL \
+          --env PI_THINKING \
+          --env PI_TOOLS \
+          --volume "$GITHUB_WORKSPACE:/workspace" \
+          --volume "/tmp/bird:/tmp/bird:ro" \
+          --volume "$PROMPT_FILE:/tmp/prompt-rendered.md:ro" \
+          "$image" \
+          bash -lc 'mkdir -p "$HOME" "$XDG_CONFIG_HOME" && pi -p "$(cat /tmp/prompt-rendered.md)" \
+            --no-session \
+            --thinking "$PI_THINKING" \
+            --tools "$PI_TOOLS" \
+            --provider "$PI_PROVIDER" \
+            --model "$PI_MODEL"'

--- a/.github/actions/safe-push/action.yml
+++ b/.github/actions/safe-push/action.yml
@@ -97,7 +97,10 @@ runs:
           exit 1
         fi
 
-        git remote set-url origin "https://x-access-token:${SAFE_PUSH_GITHUB_TOKEN}@github.com/${SAFE_PUSH_REPOSITORY}.git"
+        AUTH_HEADER=$(printf 'x-access-token:%s' "$SAFE_PUSH_GITHUB_TOKEN" | base64 | tr -d '\n')
+        git_auth() {
+          git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${AUTH_HEADER}" "$@"
+        }
 
         # Concurrent writers can land on $BRANCH while this job runs. Retry
         # the fetch+rebase+push loop a few times; each iteration stashes
@@ -129,7 +132,7 @@ runs:
           ATTEMPTS=$((ATTEMPTS + 1))
           echo "::group::push attempt $ATTEMPTS / $MAX_ATTEMPTS"
 
-          git fetch origin "$BRANCH"
+          git_auth fetch origin "$BRANCH"
 
           # Stash any leftover working-tree state (tracked modifications
           # OR untracked artifacts) that would otherwise make `git rebase`
@@ -256,7 +259,7 @@ runs:
             exit 0
           fi
 
-          if git push origin "HEAD:$BRANCH"; then
+          if git_auth push origin "HEAD:$BRANCH"; then
             echo "::endgroup::"
             echo "Pushed successfully on attempt $ATTEMPTS"
             echo "pushed=true" >> "$GITHUB_OUTPUT"

--- a/.github/actions/setup-claude-sandbox/action.yml
+++ b/.github/actions/setup-claude-sandbox/action.yml
@@ -1,0 +1,26 @@
+name: Setup Claude sandbox
+description: Install Linux dependencies required for Claude Code's fail-closed Bash sandbox.
+
+runs:
+  using: composite
+  steps:
+    - name: Install sandbox dependencies
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        set -euo pipefail
+        missing=""
+        command -v bwrap >/dev/null 2>&1 || missing="$missing bubblewrap"
+        command -v socat >/dev/null 2>&1 || missing="$missing socat"
+
+        if [ -n "$missing" ]; then
+          if ! command -v apt-get >/dev/null 2>&1; then
+            echo "::error::Claude sandbox dependencies missing:$missing, and apt-get is unavailable."
+            exit 1
+          fi
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq $missing
+        fi
+
+        echo "bubblewrap: $(bwrap --version)"
+        echo "socat: $(socat -V 2>&1 | head -1)"

--- a/.github/workflows/ai-news-research.yml
+++ b/.github/workflows/ai-news-research.yml
@@ -100,8 +100,12 @@ jobs:
           }
           EOF
           
-          echo "Generated MCP config:"
-          cat /tmp/mcp-config.json
+          echo "Generated MCP config with servers:"
+          [ "${{ steps.check-keys.outputs.has_exa }}" = "true" ] && echo "exa"
+          [ "${{ steps.check-keys.outputs.has_perplexity }}" = "true" ] && echo "perplexity"
+
+      - name: Setup Claude sandbox
+        uses: ./.github/actions/setup-claude-sandbox
 
       - name: Run AI News Research with Claude (with MCP)
         if: steps.check-keys.outputs.has_exa == 'true' || steps.check-keys.outputs.has_perplexity == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   actionlint:
-    runs-on: [self-hosted, Linux]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -36,7 +36,7 @@ jobs:
           pyflakes: false
 
   dashboard:
-    runs-on: [self-hosted, Linux]
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: dashboard
@@ -93,7 +93,7 @@ jobs:
         run: bun run build
 
   python-scripts:
-    runs-on: [self-hosted, Linux]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -125,7 +125,7 @@ jobs:
   hooker-telemetry:
     needs: [actionlint, dashboard, python-scripts]
     if: always()
-    runs-on: [self-hosted, Linux]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -41,6 +41,9 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Setup Claude sandbox
+        uses: ./.github/actions/setup-claude-sandbox
+
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -41,6 +41,9 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Setup Claude sandbox
+        uses: ./.github/actions/setup-claude-sandbox
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1

--- a/.github/workflows/daily-digest.yml
+++ b/.github/workflows/daily-digest.yml
@@ -135,8 +135,9 @@ jobs:
           }
           EOF
           
-          echo "Generated MCP config:"
-          cat /tmp/mcp-config.json
+          echo "Generated MCP config with servers:"
+          [ "${{ steps.check-keys.outputs.has_exa }}" = "true" ] && echo "exa"
+          [ "${{ steps.check-keys.outputs.has_perplexity }}" = "true" ] && echo "perplexity"
 
       # continue-on-error on both synthesis paths: a failed agent (provider
       # outage, turn-1 API error, nothing committed — the composite's internal

--- a/.github/workflows/daily-improve.yml
+++ b/.github/workflows/daily-improve.yml
@@ -67,6 +67,9 @@ jobs:
                 -c "Superseded by this week's self-improvement run." || true
             done
 
+      - name: Setup Claude sandbox
+        uses: ./.github/actions/setup-claude-sandbox
+
       - name: Analyze and Improve Methodology
         uses: anthropics/claude-code-action@v1
         env:

--- a/.github/workflows/generative-research.yml
+++ b/.github/workflows/generative-research.yml
@@ -591,6 +591,9 @@ jobs:
       # comms once when the action ran ~19m on the un-capped concurrent
       # fan-out version of the prompt; pacing fixed that, but a stuck
       # runner is much worse than a missed article, so hard-cap here.
+      - name: Setup Claude sandbox
+        uses: ./.github/actions/setup-claude-sandbox
+
       - name: Run Generative Research (Claude, attempt 1)
         if: steps.effective.outputs.backend == 'claude'
         id: gen-claude

--- a/.github/workflows/hourly-twitter.yml
+++ b/.github/workflows/hourly-twitter.yml
@@ -1228,14 +1228,12 @@ jobs:
           && steps.autoresearch_throttle.outputs.skip == 'false'
         continue-on-error: true
         uses: ./.github/actions/agent-run
-        env:
-          GEN_TOPIC_DATE: ${{ steps.datetime.outputs.date }}
         with:
           backend: fireworks-glm-5p2
           claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           fireworks-api-key: ${{ secrets.FIREWORKS_API_KEY }}
           claude-args: |
-            --model opus --max-turns 10 --allowedTools "Read,Bash(ls:*),Bash(cat:*),Bash(jq:*),Bash(date:*),Bash(printenv:*),Write"
+            --model opus --max-turns 10 --allowedTools "Read,Bash(ls:*),Bash(cat:*),Bash(jq:*),Bash(date:*),Write"
           label: Twitter auto-research Fireworks selector
           prompt: |
             You select AT MOST ONE topic from today's Twitter AI Pulse to
@@ -1246,9 +1244,8 @@ jobs:
             nothing meets the bar, output NO_TOPIC and stop. Better to
             skip than to dispatch a weak topic.
 
-            Step 1 — read today's twitter file. Get the date from env:
-              DATE=$(printenv GEN_TOPIC_DATE)
-              cat "research/twitter/${DATE}.md"
+            Step 1 — read today's twitter file for date `${{ steps.datetime.outputs.date }}`:
+              cat "research/twitter/${{ steps.datetime.outputs.date }}.md"
             If that path doesn't exist, fall back to the most recent file:
               ls -t research/twitter/*.md | head -1
             Read it.

--- a/.github/workflows/hourly-twitter.yml
+++ b/.github/workflows/hourly-twitter.yml
@@ -166,6 +166,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Get current datetime
         if: steps.backend.outputs.skip != 'true'
@@ -333,11 +334,6 @@ jobs:
           bird_ct0: ${{ secrets.BIRD_CT0 }}
           birdy_accounts: ${{ secrets.BIRDY_ACCOUNTS }}
 
-      # ── Install pi-coding-agent (pi tiers only) ────────────────────
-      - name: Install pi coding agent
-        if: contains(fromJSON('["deepseek-pi","fireworks-pi"]'), steps.backend.outputs.name)
-        run: npm install -g @mariozechner/pi-coding-agent
-
       - name: Configure git identity (pi tier — no claude-code-action to do it)
         if: contains(fromJSON('["deepseek-pi","fireworks-pi"]'), steps.backend.outputs.name)
         run: |
@@ -450,40 +446,25 @@ jobs:
 
       - name: Process tweets with pi + DeepSeek v4 Flash via Fireworks (deepseek-pi tier)
         if: steps.backend.outputs.name == 'deepseek-pi'
-        env:
-          FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
-          BIRDY_READ_ONLY: "1"
-          BIRDY_TOOL_LOG_PATH: ${{ github.workspace }}/.twitter-input/birdy-tool-log.jsonl
-        run: |
-          # Mirrors the model used by the Claude Code tier (DeepSeek V4 Flash),
-          # served via Fireworks (the direct DeepSeek API is no longer used).
-          # pi has a built-in Fireworks provider, so only the API key, provider
-          # name, and Fireworks model id are needed here.
-          # Bash allowlist: pi's --tools is coarse (bash on/off). For this
-          # experiment we accept full bash on the trusted self-hosted runner.
-          pi -p "$(cat /tmp/prompt-rendered.md)" \
-            --no-session \
-            --thinking high \
-            --tools read,write,edit,bash,grep,find,ls \
-            --provider fireworks \
-            --model accounts/fireworks/models/deepseek-v4-flash
+        uses: ./.github/actions/run-pi-container
+        with:
+          prompt-file: /tmp/prompt-rendered.md
+          provider: fireworks
+          model: accounts/fireworks/models/deepseek-v4-flash
+          fireworks-api-key: ${{ secrets.FIREWORKS_API_KEY }}
+          bird-auth-token: ${{ secrets.BIRD_AUTH_TOKEN }}
+          bird-ct0: ${{ secrets.BIRD_CT0 }}
 
       - name: Process tweets with pi + Fireworks (fireworks-pi tier)
         if: steps.backend.outputs.name == 'fireworks-pi'
-        env:
-          FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
-          BIRDY_READ_ONLY: "1"
-          BIRDY_TOOL_LOG_PATH: ${{ github.workspace }}/.twitter-input/birdy-tool-log.jsonl
-        run: |
-          # Fireworks uses an OpenAI-compatible chat completions endpoint.
-          # pi has a built-in Fireworks provider, so only the API key,
-          # provider name, and Fireworks model id are needed here.
-          pi -p "$(cat /tmp/prompt-rendered.md)" \
-            --no-session \
-            --thinking high \
-            --tools read,write,edit,bash,grep,find,ls \
-            --provider fireworks \
-            --model accounts/fireworks/models/kimi-k2p7
+        uses: ./.github/actions/run-pi-container
+        with:
+          prompt-file: /tmp/prompt-rendered.md
+          provider: fireworks
+          model: accounts/fireworks/models/kimi-k2p7
+          fireworks-api-key: ${{ secrets.FIREWORKS_API_KEY }}
+          bird-auth-token: ${{ secrets.BIRD_AUTH_TOKEN }}
+          bird-ct0: ${{ secrets.BIRD_CT0 }}
 
       - name: Summarize Birdy follow-up telemetry
         if: always() && steps.backend.outputs.skip != 'true'
@@ -996,15 +977,19 @@ jobs:
 
             git add "$HISTORY_FILE"
             if git commit -m "Track delivered Twitter headline alerts ${ANNOUNCED_AT}"; then
+              AUTH_HEADER=$(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')
+              git_auth() {
+                git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${AUTH_HEADER}" "$@"
+              }
               # Retry push in case another workflow committed concurrently.
               PUSHED=false
               for attempt in 1 2 3; do
-                if git push; then
+                if git_auth push origin "HEAD:main"; then
                   PUSHED=true
                   break
                 fi
                 echo "History push attempt $attempt failed; rebasing"
-                if ! git pull --rebase; then
+                if ! git_auth pull --rebase origin main; then
                   git rebase --abort 2>/dev/null || true
                   break
                 fi

--- a/.github/workflows/research-issue.yml
+++ b/.github/workflows/research-issue.yml
@@ -6,8 +6,12 @@ on:
 
 jobs:
   research:
-    # Trigger only when 'research' label is added
-    if: github.event.label.name == 'research'
+    # Trigger only when a trusted issue author receives the 'research' label.
+    # The issue title/body flow into a write-capable web research agent, so
+    # untrusted public issue text must not be enough to start the job.
+    if: >-
+      github.event.label.name == 'research' &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
     runs-on: [self-hosted, Linux]
     # Cap a hung research agent so it can't pin a Cloud Run worker for GitHub's
     # 6h default (mirrors the 90-min agent-lane convention).
@@ -101,8 +105,9 @@ jobs:
           }
           EOF
 
-          echo "Generated MCP config:"
-          cat /tmp/mcp-config.json
+          echo "Generated MCP config with servers:"
+          [ "${{ steps.check-keys.outputs.has_exa }}" = "true" ] && echo "exa"
+          [ "${{ steps.check-keys.outputs.has_perplexity }}" = "true" ] && echo "perplexity"
 
       # Security: stage the attacker-controlled issue title/body to plain files
       # so the Claude step does NOT need any env vars or `printenv` permission.
@@ -130,6 +135,9 @@ jobs:
           # Sanity check (size only — never echo the content; would leak into
           # the workflow log).
           wc -c "$GITHUB_WORKSPACE/.issue-input/title.txt" "$GITHUB_WORKSPACE/.issue-input/body.txt"
+
+      - name: Setup Claude sandbox
+        uses: ./.github/actions/setup-claude-sandbox
 
       - name: Run Deep Research (with MCP)
         if: steps.check-keys.outputs.has_exa == 'true' || steps.check-keys.outputs.has_perplexity == 'true'

--- a/.github/workflows/twitter-account-explorer.yml
+++ b/.github/workflows/twitter-account-explorer.yml
@@ -67,6 +67,9 @@ jobs:
         run: |
           git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
 
+      - name: Setup Claude sandbox
+        uses: ./.github/actions/setup-claude-sandbox
+
       - name: Explore and curate account list
         uses: anthropics/claude-code-action@v1
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,11 +111,16 @@ service in `../runner`; see Load-bearing rule 5). A fresh
 means one serial slot — jobs run in parallel, and each worker carries the
 pipeline's baked-in state (Birdy read-only CLI/daemon, recent
 `research/` checkout, pre-installed tooling). Aggregation,
-synthesis, output, CI, and the Claude agent lanes all run here.
+synthesis, output, and the Claude agent lanes all run here.
 
-Only **two `runs-on: ubuntu-latest`** (GitHub-hosted) jobs exist, and both
-are watchdogs that must survive a self-hosted/Cloud Run outage — a watchdog
-that runs on the runners it is watching is useless:
+GitHub-hosted runners are used for jobs that must not execute
+repository-controlled code on the self-hosted fleet:
+- `ci.yml` runs on `ubuntu-latest`. Pull requests can change dashboard
+  build scripts, package scripts, Python tests, and workflow/action files,
+  so CI must not execute that code on the self-hosted runner host.
+- Watchdog jobs also run on `ubuntu-latest` because they must survive a
+  self-hosted/Cloud Run outage — a watchdog that runs on the runners it is
+  watching is useless:
 - `liveness-check.yml` runs one job on EACH tier (its `ubuntu` job + its
   `self-hosted` job). No single runner survives both failure modes — a
   GitHub-hosted billing/spending-limit block vs. a self-hosted outage — so
@@ -124,8 +129,9 @@ that runs on the runners it is watching is useless:
   vanished mid-run (Load-bearing rule 11).
 
 The per-workflow `ubuntu-latest` vs. `self-hosted` lists that used to live
-here are gone on purpose: the answer is now "self-hosted unless it's one of
-those two watchdogs." **Always read the workflow's actual `runs-on:` —
+here are gone on purpose: the answer is now "read the workflow's actual
+`runs-on:`; most production lanes are self-hosted, but CI and watchdogs are
+deliberately GitHub-hosted." **Always read the workflow's actual `runs-on:` —
 never trust a cached list** (the old list here drifted to 100% wrong once
 the autoscaler landed and the stateless lanes moved back to self-hosted).
 
@@ -146,6 +152,16 @@ agent/fallback step logs before treating it as evidence that Fireworks or
 native Claude was healthy. PR/review/on-demand Claude workflows may still call
 the Claude action directly; when they do, pass the model via
 `claude_args` (e.g. `"--model claude-sonnet-5"`) — never as a separate `model:` input.
+
+Claude Code runs are protected by the checked-in `.claude/settings.json`
+sandbox policy. On Linux this requires `bubblewrap` and `socat`; workflows
+that call Claude directly must run `.github/actions/setup-claude-sandbox`
+before the Claude action, and scheduled lanes that use `.github/actions/agent-run`
+get that setup centrally. The policy sets `sandbox.failIfUnavailable: true`
+and `sandbox.allowUnsandboxedCommands: false`, so a missing sandbox fails
+the workflow instead of silently running Bash commands with host filesystem
+access. It also blocks reads of common host credential paths such as `~/.ssh`,
+`~/.aws`, `/proc`, and `/var/run`.
 
 ### Aggregation (raw signal → `research/<source>/`)
 
@@ -183,7 +199,7 @@ the Claude action directly; when they do, pass the model via
 |---|---|---|
 | `arm-timeline.yml` | every 2h `:45` | Deterministic refresh of `research/arm/timeline.json` so the dashboard's Arm tab renders in prod (the Docker build context has no `.git`/`.github`, so prebuild falls back to this committed file; unrefreshed it ages out of the ±36h window). |
 | `daily-improve.yml` | weekly, Monday `00:17` UTC | Opens improve/YYYY-MM-DD PR with methodology fixes; each run auto-closes prior unmerged `improve/*` PRs. See "Load-bearing rules" for where the IMPROVEMENTS file belongs. |
-| `ci.yml` | push/PR on workflows/dashboard/scripts | actionlint + dashboard build + Python tests |
+| `ci.yml` | push/PR on workflows/dashboard/scripts | actionlint + dashboard build + Python tests on GitHub-hosted runners |
 | `claude.yml` | `@claude` mention in issue/PR/review | Interactive Claude-Code agent |
 | `claude-code-review.yml` | PR opened/synced | Automated Claude code review |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,14 @@ the workflow instead of silently running Bash commands with host filesystem
 access. It also blocks reads of common host credential paths such as `~/.ssh`,
 `~/.aws`, `/proc`, and `/var/run`.
 
+Pi comparison lanes do not read Claude Code settings. When `hourly-twitter.yml`
+runs `deepseek-pi` or `fireworks-pi`, it must use
+`.github/actions/run-pi-container` instead of invoking `pi` on the host. That
+wrapper builds a small Node container with `pi`, `bird`, `git`, and `jq`, mounts
+only `$GITHUB_WORKSPACE`, `/tmp/bird` read-only, and the rendered prompt file,
+then runs pi with a container-local home directory. Missing Docker is a hard
+failure for pi lanes; do not fall back to host-level `pi --tools ... bash`.
+
 ### Aggregation (raw signal → `research/<source>/`)
 
 | Workflow | Schedule | Output |


### PR DESCRIPTION
## Summary

Resolves the P0 workflow security findings by adding a fail-closed Claude Code sandbox policy and moving CI off the self-hosted runner fleet.

## Changes

- Run `ci.yml` on `ubuntu-latest` so pull requests cannot execute repository-controlled build/test code on the self-hosted Cloud Run workers.
- Add `.claude/settings.json` with Claude Code Bash sandboxing enabled, `failIfUnavailable: true`, and `allowUnsandboxedCommands: false`.
- Add `.github/actions/setup-claude-sandbox` to install `bubblewrap` and `socat` on Linux before direct Claude action runs.
- Wire sandbox setup into direct Claude workflows and centrally into `.github/actions/agent-run`.
- Remove the remaining `Bash(printenv:*)` allowance from the Twitter auto-research selector.
- Stop logging secret-bearing MCP config JSON in workflow output.
- Gate `research-issue.yml` to trusted issue authors before launching the write-capable research agent.
- Update `CLAUDE.md` with the new CI and sandbox operating rules.

## Validation

- `ruby -rjson -e 'JSON.parse(File.read(".claude/settings.json")); puts "claude settings json ok"'`
- `ruby -ryaml -e 'Dir[".github/workflows/*.yml", ".github/actions/*/action.yml"].each { |p| YAML.load_file(p); puts "yaml ok #{p}" }'`
- `actionlint -shellcheck= -pyflakes= .github/workflows/*.yml`
- `git diff --check`
- `uv run python -m unittest discover -s scripts -p 'test_*.py'` (`408` tests, `6` skipped)

## Notes

The PR targets `main` because `origin/staging` does not exist in this repository.
