### PR TITLE
DRY Birdy CI account normalization

### DIFF
--- a/.github/actions/birdy-daemon/action.yml
+++ b/.github/actions/birdy-daemon/action.yml
@@ -52,31 +52,7 @@ runs:
         set -euo pipefail
 
         export BIRDY_READ_ONLY=1
-        BIRDY_ACCOUNTS="$(python3 - <<'PY'
-        import json
-        import os
-
-        raw = os.environ.get("BIRDY_ACCOUNTS_JSON", "").strip()
-        if raw:
-            accounts = json.loads(raw)
-            if not isinstance(accounts, list) or not accounts:
-                raise SystemExit("BIRDY_ACCOUNTS must be a non-empty JSON array")
-        else:
-            accounts = [{
-                "name": "ci",
-                "auth_token": os.environ["BIRD_AUTH_TOKEN"],
-                "ct0": os.environ["BIRD_CT0"],
-            }]
-
-        for idx, account in enumerate(accounts, start=1):
-            if not isinstance(account, dict):
-                raise SystemExit("every BIRDY_ACCOUNTS entry must be an object")
-            account.setdefault("name", f"ci-{idx}")
-            account["read_only"] = True
-
-        print(json.dumps(accounts, separators=(",", ":")))
-        PY
-        )"
+        BIRDY_ACCOUNTS="$(python3 scripts/birdy_ci_accounts.py)"
         export BIRDY_ACCOUNTS
 
         STATE_DIR=$(mktemp -d "${RUNNER_TEMP:-/tmp}/birdy-daemon.XXXXXX")

--- a/.github/actions/twitter-fetch/action.yml
+++ b/.github/actions/twitter-fetch/action.yml
@@ -130,31 +130,7 @@ runs:
         set -euo pipefail
         mkdir -p /tmp/bird
         export BIRDY_READ_ONLY=1
-        BIRDY_ACCOUNTS="$(python3 - <<'PY'
-        import json
-        import os
-
-        raw = os.environ.get("BIRDY_ACCOUNTS_JSON", "").strip()
-        if raw:
-            accounts = json.loads(raw)
-            if not isinstance(accounts, list) or not accounts:
-                raise SystemExit("BIRDY_ACCOUNTS must be a non-empty JSON array")
-        else:
-            accounts = [{
-                "name": "ci",
-                "auth_token": os.environ["BIRD_AUTH_TOKEN"],
-                "ct0": os.environ["BIRD_CT0"],
-            }]
-
-        for idx, account in enumerate(accounts, start=1):
-            if not isinstance(account, dict):
-                raise SystemExit("every BIRDY_ACCOUNTS entry must be an object")
-            account.setdefault("name", f"ci-{idx}")
-            account["read_only"] = True
-
-        print(json.dumps(accounts, separators=(",", ":")))
-        PY
-        )"
+        BIRDY_ACCOUNTS="$(python3 scripts/birdy_ci_accounts.py)"
         export BIRDY_ACCOUNTS
 
         # Account and search curation lives in data/sources/twitter_accounts.json.

--- a/scripts/birdy_ci_accounts.py
+++ b/scripts/birdy_ci_accounts.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Build read-only Birdy account JSON for CI workflows."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any
+
+
+class BirdyAccountError(ValueError):
+    pass
+
+
+def build_accounts(
+    accounts_json: str | None,
+    auth_token: str | None,
+    ct0: str | None,
+) -> list[dict[str, Any]]:
+    raw = (accounts_json or "").strip()
+    if raw:
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise BirdyAccountError(f"BIRDY_ACCOUNTS must be valid JSON: {exc.msg}") from exc
+        if not isinstance(parsed, list) or not parsed:
+            raise BirdyAccountError("BIRDY_ACCOUNTS must be a non-empty JSON array")
+        accounts = parsed
+    else:
+        if not auth_token or not ct0:
+            raise BirdyAccountError("BIRD_AUTH_TOKEN and BIRD_CT0 are required when BIRDY_ACCOUNTS is empty")
+        accounts = [{"name": "ci", "auth_token": auth_token, "ct0": ct0}]
+
+    normalized = []
+    for idx, account in enumerate(accounts, start=1):
+        if not isinstance(account, dict):
+            raise BirdyAccountError("every BIRDY_ACCOUNTS entry must be an object")
+        item = dict(account)
+        item.setdefault("name", f"ci-{idx}")
+        if not isinstance(item["name"], str) or not item["name"].strip():
+            raise BirdyAccountError(f"BIRDY_ACCOUNTS entry {idx} must have a non-empty string name")
+        for key in ("auth_token", "ct0"):
+            if not isinstance(item.get(key), str) or not item[key].strip():
+                raise BirdyAccountError(f"BIRDY_ACCOUNTS entry {idx} must have a non-empty {key}")
+        item["read_only"] = True
+        normalized.append(item)
+
+    return normalized
+
+
+def main() -> int:
+    try:
+        accounts = build_accounts(
+            os.environ.get("BIRDY_ACCOUNTS_JSON"),
+            os.environ.get("BIRD_AUTH_TOKEN"),
+            os.environ.get("BIRD_CT0"),
+        )
+    except BirdyAccountError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    print(json.dumps(accounts, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_birdy_ci_accounts.py
+++ b/scripts/test_birdy_ci_accounts.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from birdy_ci_accounts import BirdyAccountError, build_accounts
+
+
+class BirdyCiAccountsTests(unittest.TestCase):
+    def test_builds_read_only_fallback_account(self):
+        accounts = build_accounts("", "auth", "ct0")
+
+        self.assertEqual(
+            accounts,
+            [{"name": "ci", "auth_token": "auth", "ct0": "ct0", "read_only": True}],
+        )
+
+    def test_forces_secret_accounts_read_only_and_preserves_fields(self):
+        accounts = build_accounts(
+            json.dumps(
+                [
+                    {"name": "alpha", "auth_token": "a", "ct0": "ca", "read_only": False, "proxy": "p1"},
+                    {"auth_token": "b", "ct0": "cb"},
+                ]
+            ),
+            None,
+            None,
+        )
+
+        self.assertEqual(accounts[0]["name"], "alpha")
+        self.assertEqual(accounts[0]["proxy"], "p1")
+        self.assertEqual(accounts[1]["name"], "ci-2")
+        self.assertTrue(all(account["read_only"] is True for account in accounts))
+
+    def test_rejects_invalid_accounts_json(self):
+        with self.assertRaisesRegex(BirdyAccountError, "valid JSON"):
+            build_accounts("{", "auth", "ct0")
+
+    def test_rejects_empty_accounts_array(self):
+        with self.assertRaisesRegex(BirdyAccountError, "non-empty JSON array"):
+            build_accounts("[]", "auth", "ct0")
+
+    def test_rejects_missing_fallback_cookies(self):
+        with self.assertRaisesRegex(BirdyAccountError, "BIRD_AUTH_TOKEN and BIRD_CT0"):
+            build_accounts("", "", "ct0")
+
+    def test_rejects_account_without_cookie_fields(self):
+        with self.assertRaisesRegex(BirdyAccountError, "entry 1"):
+            build_accounts('[{"name":"alpha","auth_token":"a"}]', None, None)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- move Birdy CI account normalization into scripts/birdy_ci_accounts.py
- replace duplicated inline Python in twitter-fetch and birdy-daemon actions
- add unit coverage for fallback cookies, multi-account rotation, forced read-only mode, and invalid inputs

## Verification
- actionlint .github/workflows/hourly-twitter.yml
- uv run python scripts/curate_twitter_accounts.py validate
- uv run python scripts/curate_twitter_accounts.py build-fetch-manifest --manifest data/sources/twitter_accounts.json --output /tmp/manifest-birdy-dry-check.json --concurrency 8
- uv run python -m unittest scripts/test_birdy_ci_accounts.py scripts/test_curate_twitter_accounts.py scripts/test_explore_twitter_accounts.py
- uv run python -m unittest discover scripts
- extracted composite action run blocks and checked bash -n
- rendered claude and deepseek-pi prompts; confirmed birdy-fast + .twitter-input/bird and no stale direct Bird examples
- smoke-tested birdy-fast wrapper blocks post before daemon and writes redacted telemetry only