### PR TITLE
[codex] Integrate Z.ai GLM-5.2 Claude Code backend

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -54,6 +54,10 @@
         {
           "name": "FIREWORKS_API_KEY",
           "mode": "deny"
+        },
+        {
+          "name": "ZAI_API_KEY",
+          "mode": "deny"
         }
       ]
     }

--- a/.github/actions/agent-run/action.yml
+++ b/.github/actions/agent-run/action.yml
@@ -1,9 +1,9 @@
 name: ARA agent run
-description: Run a Claude-Code-compatible agent through native Claude or Fireworks and optionally require committed output.
+description: Run a Claude-Code-compatible agent through native Claude, Fireworks, or Z.ai and optionally require committed output.
 
 inputs:
   backend:
-    description: claude, fireworks-deepseek-v4-flash, fireworks-glm-5p2, deepseek-v4-flash, or glm-5p2.
+    description: claude, fireworks-deepseek-v4-flash, fireworks-glm-5p2, zai-glm-5p2, deepseek-v4-flash, or glm-5p2.
     required: false
     default: fireworks-deepseek-v4-flash
   claude-code-oauth-token:
@@ -11,6 +11,10 @@ inputs:
     required: true
   fireworks-api-key:
     description: Fireworks API key for Fireworks-routed backends.
+    required: false
+    default: ""
+  zai-api-key:
+    description: Z.ai Coding Plan API key for Z.ai-routed Claude Code runs.
     required: false
     default: ""
   fireworks-fallback:
@@ -57,7 +61,7 @@ outputs:
     description: "true when a Fireworks backend fell back to Claude"
     value: ${{ steps.effective.outputs.used-fallback }}
   model-id:
-    description: Provider model id for Fireworks backends.
+    description: Provider model id for routed backends.
     value: ${{ steps.profile.outputs.model-id }}
   changed:
     description: "true when expected-paths were provided and changed"
@@ -84,18 +88,27 @@ runs:
         case "$BACKEND" in
           claude)
             normalized="claude"
+            provider="claude"
             model_id=""
             display_name="Claude"
             ;;
           fireworks-deepseek-v4-flash|deepseek-v4-flash|deepseek)
             normalized="fireworks-deepseek-v4-flash"
+            provider="fireworks"
             model_id="accounts/fireworks/models/deepseek-v4-flash"
             display_name="DeepSeek V4 Flash via Fireworks"
             ;;
           fireworks-glm-5p2|glm-5p2|glm)
             normalized="fireworks-glm-5p2"
+            provider="fireworks"
             model_id="accounts/fireworks/models/glm-5p2"
             display_name="GLM 5.2 via Fireworks"
+            ;;
+          zai-glm-5p2|zai-glm-5.2|zai-glm52|zai)
+            normalized="zai-glm-5p2"
+            provider="zai"
+            model_id="glm-5.2"
+            display_name="GLM 5.2 via Z.ai"
             ;;
           *)
             echo "::error::Unsupported ARA agent backend: $BACKEND"
@@ -105,6 +118,7 @@ runs:
 
         {
           echo "backend=$normalized"
+          echo "provider=$provider"
           echo "model-id=$model_id"
           echo "display-name=$display_name"
         } >> "$GITHUB_OUTPUT"
@@ -112,7 +126,7 @@ runs:
 
     - name: Preflight Fireworks backend
       id: fireworks-preflight
-      if: steps.profile.outputs.model-id != ''
+      if: steps.profile.outputs.provider == 'fireworks'
       continue-on-error: true
       shell: bash
       env:
@@ -129,19 +143,21 @@ runs:
       shell: bash
       env:
         REQUESTED_BACKEND: ${{ steps.profile.outputs.backend }}
+        REQUESTED_PROVIDER: ${{ steps.profile.outputs.provider }}
         REQUESTED_MODEL_ID: ${{ steps.profile.outputs.model-id }}
         PREFLIGHT_OUTCOME: ${{ steps.fireworks-preflight.outcome }}
         PREFLIGHT_AVAILABLE: ${{ steps.fireworks-preflight.outputs.available }}
         PREFLIGHT_STATUS: ${{ steps.fireworks-preflight.outputs.status }}
         PREFLIGHT_MESSAGE: ${{ steps.fireworks-preflight.outputs.message }}
         FIREWORKS_FALLBACK: ${{ inputs.fireworks-fallback }}
+        ZAI_API_KEY: ${{ inputs.zai-api-key }}
       run: |
         set -euo pipefail
 
         backend="$REQUESTED_BACKEND"
         used_fallback=false
 
-        if [ -n "$REQUESTED_MODEL_ID" ]; then
+        if [ "$REQUESTED_PROVIDER" = "fireworks" ]; then
           if [ "$PREFLIGHT_OUTCOME" = "success" ] && [ "$PREFLIGHT_AVAILABLE" = "true" ]; then
             backend="$REQUESTED_BACKEND"
           elif [ "$FIREWORKS_FALLBACK" = "claude" ]; then
@@ -150,6 +166,11 @@ runs:
             echo "::warning::Fireworks backend ${REQUESTED_BACKEND} is unavailable (status=${PREFLIGHT_STATUS:-unknown}); falling back to native Claude. ${PREFLIGHT_MESSAGE:-}"
           else
             echo "::error::Fireworks backend ${REQUESTED_BACKEND} is unavailable (status=${PREFLIGHT_STATUS:-unknown}) and fireworks-fallback=${FIREWORKS_FALLBACK}."
+            exit 1
+          fi
+        elif [ "$REQUESTED_PROVIDER" = "zai" ]; then
+          if [ -z "${ZAI_API_KEY:-}" ]; then
+            echo "::error::ZAI_API_KEY is required for backend ${REQUESTED_BACKEND}."
             exit 1
           fi
         fi
@@ -196,7 +217,7 @@ runs:
         prompt: ${{ inputs.prompt }}
 
     - name: Run agent with Fireworks
-      if: steps.profile.outputs.model-id != '' && steps.effective.outputs.backend != 'claude' && inputs.allowed-bots == ''
+      if: steps.profile.outputs.provider == 'fireworks' && steps.effective.outputs.backend != 'claude' && inputs.allowed-bots == ''
       uses: anthropics/claude-code-action@v1
       env:
         ANTHROPIC_BASE_URL: https://api.fireworks.ai/inference
@@ -216,7 +237,7 @@ runs:
         prompt: ${{ inputs.prompt }}
 
     - name: Run agent with Fireworks
-      if: steps.profile.outputs.model-id != '' && steps.effective.outputs.backend != 'claude' && inputs.allowed-bots != ''
+      if: steps.profile.outputs.provider == 'fireworks' && steps.effective.outputs.backend != 'claude' && inputs.allowed-bots != ''
       uses: anthropics/claude-code-action@v1
       env:
         ANTHROPIC_BASE_URL: https://api.fireworks.ai/inference
@@ -228,6 +249,47 @@ runs:
         ANTHROPIC_DEFAULT_HAIKU_MODEL: ${{ steps.profile.outputs.model-id }}
         CLAUDE_CODE_SUBAGENT_MODEL: ${{ steps.profile.outputs.model-id }}
         CLAUDE_CODE_EFFORT_LEVEL: max
+        ARA_AGENT_BACKEND: ${{ steps.profile.outputs.backend }}
+        ARA_AGENT_MODEL_ID: ${{ steps.profile.outputs.model-id }}
+      with:
+        claude_code_oauth_token: ${{ inputs.claude-code-oauth-token }}
+        allowed_bots: ${{ inputs.allowed-bots }}
+        claude_args: ${{ inputs.claude-args }}
+        prompt: ${{ inputs.prompt }}
+
+    - name: Run agent with Z.ai
+      if: steps.profile.outputs.provider == 'zai' && inputs.allowed-bots == ''
+      uses: anthropics/claude-code-action@v1
+      env:
+        ANTHROPIC_BASE_URL: https://api.z.ai/api/anthropic
+        ANTHROPIC_AUTH_TOKEN: ${{ inputs.zai-api-key }}
+        ANTHROPIC_MODEL: ${{ steps.profile.outputs.model-id }}
+        ANTHROPIC_DEFAULT_OPUS_MODEL: ${{ steps.profile.outputs.model-id }}
+        ANTHROPIC_DEFAULT_SONNET_MODEL: ${{ steps.profile.outputs.model-id }}
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: ${{ steps.profile.outputs.model-id }}
+        CLAUDE_CODE_SUBAGENT_MODEL: ${{ steps.profile.outputs.model-id }}
+        CLAUDE_CODE_EFFORT_LEVEL: max
+        API_TIMEOUT_MS: "3000000"
+        ARA_AGENT_BACKEND: ${{ steps.profile.outputs.backend }}
+        ARA_AGENT_MODEL_ID: ${{ steps.profile.outputs.model-id }}
+      with:
+        claude_code_oauth_token: ${{ inputs.claude-code-oauth-token }}
+        claude_args: ${{ inputs.claude-args }}
+        prompt: ${{ inputs.prompt }}
+
+    - name: Run agent with Z.ai
+      if: steps.profile.outputs.provider == 'zai' && inputs.allowed-bots != ''
+      uses: anthropics/claude-code-action@v1
+      env:
+        ANTHROPIC_BASE_URL: https://api.z.ai/api/anthropic
+        ANTHROPIC_AUTH_TOKEN: ${{ inputs.zai-api-key }}
+        ANTHROPIC_MODEL: ${{ steps.profile.outputs.model-id }}
+        ANTHROPIC_DEFAULT_OPUS_MODEL: ${{ steps.profile.outputs.model-id }}
+        ANTHROPIC_DEFAULT_SONNET_MODEL: ${{ steps.profile.outputs.model-id }}
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: ${{ steps.profile.outputs.model-id }}
+        CLAUDE_CODE_SUBAGENT_MODEL: ${{ steps.profile.outputs.model-id }}
+        CLAUDE_CODE_EFFORT_LEVEL: max
+        API_TIMEOUT_MS: "3000000"
         ARA_AGENT_BACKEND: ${{ steps.profile.outputs.backend }}
         ARA_AGENT_MODEL_ID: ${{ steps.profile.outputs.model-id }}
       with:

--- a/.github/actions/render-twitter-prompt/action.yml
+++ b/.github/actions/render-twitter-prompt/action.yml
@@ -10,7 +10,7 @@ description: >
 
 inputs:
   backend:
-    description: claude | deepseek-claude-code | deepseek-pi | fireworks-pi
+    description: claude | deepseek-claude-code | zai-glm-5p2 | deepseek-pi | fireworks-pi
     required: true
   template_path:
     description: Path to the prompt template (with `{{placeholders}}`).

--- a/.github/workflows/hourly-twitter.yml
+++ b/.github/workflows/hourly-twitter.yml
@@ -1,9 +1,11 @@
-name: Twitter AI News (matrix — claude / deepseek-claude-code / deepseek-pi / fireworks-pi)
+name: Twitter AI News (matrix — claude / deepseek-claude-code / zai-glm-5p2 / deepseek-pi / fireworks-pi)
 
 # Unified Twitter/X pipeline that fans out across four backend tiers:
 #   - claude            (cron '7 */3 * * *', model: DeepSeek V4 Flash via Fireworks,
 #                        output → research/twitter/)
 #   - deepseek-claude-code (cron '37 */6 * * *', model: deepseek-v4-flash via Fireworks, output → research/twitter-deepseek/)
+#   - zai-glm-5p2      (manual only,        model: glm-5.2 via Z.ai Coding Plan,
+#                        output → research/twitter-zai/)
 #   - deepseek-pi       (manual only,        model: deepseek-v4-flash via Fireworks + pi harness,
 #                        output → research/twitter-deepseek-pi/)
 #   - fireworks-pi      (manual only,        model: Kimi K2.6 via Fireworks + pi,
@@ -29,6 +31,7 @@ name: Twitter AI News (matrix — claude / deepseek-claude-code / deepseek-pi / 
 # Required secrets:
 #   CLAUDE_CODE_OAUTH_TOKEN              — required by claude-code-action wrapper
 #   FIREWORKS_API_KEY                    — primary claude-labeled tier and comparison tiers
+#   ZAI_API_KEY                          — manual Z.ai GLM-5.2 Claude Code comparison tier
 #   BIRDY_ACCOUNTS                       — optional multi-account rotation JSON; each account is forced read-only
 #   BIRD_AUTH_TOKEN, BIRD_CT0            — fallback single-account cookies when BIRDY_ACCOUNTS is absent
 #   HOOKER_URL, HOOKER_TOKEN             — primary tier (headline-alert blast + telemetry) and comparison tiers (per-cycle notification, relayed to Telegram)
@@ -52,6 +55,7 @@ on:
         options:
           - claude
           - deepseek-claude-code
+          - zai-glm-5p2
           - deepseek-pi
           - fireworks-pi
       dry_run:
@@ -152,7 +156,7 @@ jobs:
             BACKEND="$MATRIX_BACKEND"
           fi
           case "$BACKEND" in
-            claude|deepseek-claude-code|deepseek-pi|fireworks-pi) ;;
+            claude|deepseek-claude-code|zai-glm-5p2|deepseek-pi|fireworks-pi) ;;
             *) echo "::error::Unknown backend '$BACKEND'"; exit 1 ;;
           esac
           {
@@ -254,6 +258,21 @@ jobs:
               BIRD_BUDGET=30
               CURL_BUDGET=5
               HARNESS_LABEL="on DeepSeek v4 Flash via Fireworks"
+              FEATURES="telegram"
+              ;;
+            zai-glm-5p2)
+              OUTPUT_DIR="research/twitter-zai"
+              SUMMARY_SLUG="twitter-zai"
+              TITLE_SUFFIX=" (GLM-5.2 · Z.ai)"
+              CYCLE_HOURS=6
+              COMMIT_PREFIX="Twitter (Z.ai GLM-5.2) update"
+              FETCH_CONCURRENCY=6
+              PRE_FILTER=true
+              AGGREGATE=false
+              ENABLE_DAEMON=true
+              BIRD_BUDGET=30
+              CURL_BUDGET=5
+              HARNESS_LABEL="on GLM-5.2 via Z.ai Coding Plan through Claude Code"
               FEATURES="telegram"
               ;;
             deepseek-pi)
@@ -407,6 +426,24 @@ jobs:
           expected-paths: |
             research/twitter-deepseek/
           label: Twitter DeepSeek comparison processor
+          prompt: ${{ steps.render.outputs.prompt }}
+
+      - name: Process tweets with GLM-5.2 via Z.ai (zai-glm-5p2 tier)
+        id: twitter-zai-agent
+        if: steps.backend.outputs.name == 'zai-glm-5p2'
+        uses: ./.github/actions/agent-run
+        env:
+          BIRDY_READ_ONLY: "1"
+          BIRDY_TOOL_LOG_PATH: ${{ github.workspace }}/.twitter-input/birdy-tool-log.jsonl
+        with:
+          backend: zai-glm-5p2
+          claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          zai-api-key: ${{ secrets.ZAI_API_KEY }}
+          claude-args: |
+            --model opus --allowedTools "Read,Write,Edit,Bash(git:*),Bash(birdy-fast:*),Bash(curl:*),Bash(jq:*)"
+          expected-paths: |
+            research/twitter-zai/
+          label: Twitter Z.ai GLM-5.2 comparison processor
           prompt: ${{ steps.render.outputs.prompt }}
 
       - name: Deterministic Twitter fallback (deepseek-claude-code tier)
@@ -785,7 +822,9 @@ jobs:
       # Hooker/Telegram steps notify users about content that never
       # actually landed on main. The shared safe-push action handles
       # concurrent main writers with the same rebase/retry behavior used by
-      # the other scheduled publishers.
+      # the other scheduled publishers. Push back to github.ref_name so
+      # workflow_dispatch tests on PR branches publish to the PR branch
+      # instead of attempting to land generated output on main.
       - name: Push changes
         if: >-
           steps.backend.outputs.skip != 'true'
@@ -793,6 +832,7 @@ jobs:
         id: push
         uses: ./.github/actions/safe-push
         with:
+          branch: ${{ github.ref_name }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           noop-pushed: 'false'
 
@@ -1014,7 +1054,7 @@ jobs:
       # ── Comparison-tier Telegram notification ──────────────────────
       - name: Read summary for Telegram (comparison tiers)
         id: summary
-        if: contains(fromJSON('["deepseek-claude-code","deepseek-pi","fireworks-pi"]'), steps.backend.outputs.name)
+        if: contains(fromJSON('["deepseek-claude-code","zai-glm-5p2","deepseek-pi","fireworks-pi"]'), steps.backend.outputs.name)
         env:
           SUMMARY_FILE: ${{ steps.const.outputs.summary_file }}
         run: |
@@ -1073,6 +1113,45 @@ jobs:
             -H "Content-Type: application/json" \
             -H "Idempotency-Key: twitter-deepseek-claude-code-${GH_RUN_ID}-${GH_RUN_ATTEMPT}" \
             --data-binary "@/tmp/hooker-twitter-deepseek-claude-code.json"
+
+      - name: Send notification via hooker (zai-glm-5p2)
+        if: success() && steps.backend.outputs.name == 'zai-glm-5p2'
+        continue-on-error: true
+        env:
+          HOOKER_URL: ${{ secrets.HOOKER_URL }}
+          HOOKER_TOKEN: ${{ secrets.HOOKER_TOKEN }}
+          SUMMARY: ${{ steps.summary.outputs.content }}
+          REPO: ${{ github.repository }}
+          DATE: ${{ steps.datetime.outputs.date }}
+          GH_RUN_ID: ${{ github.run_id }}
+          GH_RUN_ATTEMPT: ${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+          if [ -z "${HOOKER_URL:-}" ] || [ -z "${HOOKER_TOKEN:-}" ]; then
+            echo "Hooker credentials missing — skipping notification"
+            exit 0
+          fi
+          SAFE=$(printf '%s' "$SUMMARY" \
+            | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g')
+          REPORT_URL="https://github.com/${REPO}/blob/main/research/twitter-zai/${DATE}.md"
+          jq -n \
+            --arg title "🐦 Twitter/X AI Pulse — Z.ai GLM-5.2" \
+            --arg text "$SAFE" \
+            --arg btn "Full Update on GitHub" \
+            --arg url "$REPORT_URL" \
+            '{
+              title: $title,
+              text: $text,
+              priority: 3,
+              tags: ["ara", "twitter"],
+              parse_mode: "HTML",
+              reply_markup: { inline_keyboard: [[{ text: $btn, url: $url }]] }
+            }' > /tmp/hooker-twitter-zai-glm-5p2.json
+          curl -sS --fail-with-body -X POST "${HOOKER_URL%/}/publish/ara-research" \
+            -H "Authorization: Bearer ${HOOKER_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -H "Idempotency-Key: twitter-zai-glm-5p2-${GH_RUN_ID}-${GH_RUN_ATTEMPT}" \
+            --data-binary "@/tmp/hooker-twitter-zai-glm-5p2.json"
 
       # Notify via hooker (relays to Telegram). Replaces the Docker-based
       # appleboy/telegram-action, which fails on the Cloud Run runner.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,11 @@ short pointer plus the few genuinely agent-specific notes.
   the model provider was healthy. Check the agent/fallback step logs before
   drawing provider conclusions.
 
+- **Z.ai GLM-5.2** is available through `agent-run` as `zai-glm-5p2` using
+  `ZAI_API_KEY` and Claude Code's Anthropic-compatible route. Keep it manual
+  until quota behavior is measured; `hourly-twitter.yml backend=zai-glm-5p2`
+  is the smoke-test lane and writes to `research/twitter-zai/`.
+
 - **Codex generative-research workflows** use the Codex CLI with
   ChatGPT-managed file auth, not OpenAI API billing. Seed the workflow
   from `CODEX_AUTH_JSON`, whose value is the file-backed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,9 +214,10 @@ failure for pi lanes; do not fall back to host-level `pi --tools ... bash`.
 Model convention: scheduled content workflows pass `--model opus` to the
 Claude-Code-compatible CLI, but that alias is remapped by `agent-run`: to
 the Fireworks profile model (`fireworks-deepseek-v4-flash` or
-`fireworks-glm-5p2`) when preflight passes, or to the action's
-`native-model` input (default **`claude-sonnet-5`**) on native-Claude
-runs and Fireworks fallbacks. Direct Claude workflows pin
+`fireworks-glm-5p2`) when preflight passes, to `zai-glm-5p2` for the
+Z.ai Coding Plan route, or to the action's `native-model` input
+(default **`claude-sonnet-5`**) on native-Claude runs and Fireworks
+fallbacks. Direct Claude workflows pin
 `--model claude-sonnet-5` through `claude_args`; defer to the workflow
 file rather than assuming one provider everywhere.
 
@@ -228,6 +229,7 @@ file rather than assuming one provider everywhere.
 | **Codex** | `generative-research backend=codex` | `CODEX_AUTH_JSON` | Runs Codex CLI with ChatGPT-managed file auth (`auth.json` from `codex login`), so usage follows the ChatGPT/Codex subscription entitlement rather than API billing. Publishes through the same writer/verifier contract and records `codex` metadata. |
 | **DeepSeek V4 Flash (via Fireworks)** | High-frequency scheduled lanes through `.github/actions/agent-run`; `generative-research backend=deepseek-v4-flash`; `hourly-twitter.yml` comparison lanes | `FIREWORKS_API_KEY` | Uses Fireworks' Anthropic-compatible endpoint at `https://api.fireworks.ai/inference` with model `accounts/fireworks/models/deepseek-v4-flash` (base URL omits `/v1`; the client appends `/v1/messages`). Overrides `ANTHROPIC_BASE_URL`/`ANTHROPIC_AUTH_TOKEN`/`ANTHROPIC_MODEL` so the Claude Code action transparently calls Fireworks. The direct DeepSeek API (`api.deepseek.com`) is retired (billing/credits). Selector token: `fireworks-deepseek-v4-flash`, `deepseek-v4-flash`, or `deepseek`. In scheduled `agent-run` lanes AND in `generative-research.yml`, a non-retryable Fireworks preflight failure falls back to native Claude by default (`generative-research` dispatch input `fireworks_fallback=none` opts back into hard failure for strict comparisons; fallback articles record `model claude-opus-4-8` + tags `fireworks-fallback,requested-<backend>`). Generative-research retries up to 2x on socket drops before commit. |
 | **GLM 5.2 (via Fireworks)** | Higher-reasoning scheduled lanes through `.github/actions/agent-run`; `generative-research backend=glm-5p2` | `FIREWORKS_API_KEY` | Uses the same Fireworks Anthropic-compatible env slots with model `accounts/fireworks/models/glm-5p2`. Selector token: `fireworks-glm-5p2`, `glm-5p2`, or `glm`. In scheduled `agent-run` lanes AND in `generative-research.yml`, a non-retryable Fireworks preflight failure falls back to native Claude by default (same `fireworks_fallback` input and provenance tagging as the DeepSeek row). |
+| **GLM 5.2 (via Z.ai Coding Plan)** | Manual comparison runs through `.github/actions/agent-run`; `hourly-twitter.yml backend=zai-glm-5p2` | `ZAI_API_KEY` | Uses Z.ai's Anthropic-compatible Claude Code endpoint at `https://api.z.ai/api/anthropic` with model `glm-5.2`. Selector token: `zai-glm-5p2`, `zai-glm-5.2`, `zai-glm52`, or `zai`. This path is intentionally manual while quota behavior is being measured; it fails closed if `ZAI_API_KEY` is unset. |
 | **Fireworks pi** | `hourly-twitter.yml backend=fireworks-pi` manual comparison lane | `FIREWORKS_API_KEY` | Uses pi's built-in Fireworks provider with `accounts/fireworks/models/kimi-k2p7`; writes `research/twitter-fireworks-pi/` plus a Telegram summary. |
 | **Local Oracle (GPT-5.5 Pro)** | `scripts/run_generative_research_oracle.py` | Local `../oracle` checkout (browser engine by default) | Runs entirely on the developer machine; outputs go through the same `check_generative_research.py` → `write_generative_research.py` contract. Source metadata: `local-oracle`. |
 
@@ -299,6 +301,7 @@ Secrets are configured in GitHub Actions. None are committed.
 | `CODEX_AUTH_JSON` | `generative-research backend=codex` | Required for the Codex CLI ChatGPT-auth path. Store the file-backed `~/.codex/auth.json` produced by `codex login`; treat it like a password and use one auth file per serialized runner stream. |
 | `DEEPSEEK_API_KEY` | _Retired_ — DeepSeek lanes now route through Fireworks | No longer referenced by any workflow. |
 | `FIREWORKS_API_KEY` | Scheduled content lanes through `.github/actions/agent-run`; `generative-research backend=deepseek-v4-flash` / `backend=glm-5p2`; all `hourly-twitter.yml` non-primary comparison lanes (`deepseek-claude-code`, `deepseek-pi`, `fireworks-pi`) | Required for the DeepSeek-V4-Flash/GLM-via-Fireworks and Kimi lanes. |
+| `ZAI_API_KEY` | `.github/actions/agent-run` when `backend=zai-glm-5p2`; `hourly-twitter.yml backend=zai-glm-5p2` | Z.ai Coding Plan API key for Claude Code's Anthropic-compatible route. |
 | `BIRD_AUTH_TOKEN`, `BIRD_CT0` | All bird-CLI workflows (`hourly-twitter*`, `24h-model-timeline`) | X/Twitter cookies. |
 | `EXA_API_KEY`, `PERPLEXITY_API_KEY` | `daily-digest`, `ai-news-research`, `research-issue` | Optional; enhance MCP search. **Currently unset in the repo** (verified absent 2026-07-02) — `daily-digest` detects the absence, emits a run warning, and uses its local-source synthesis path until they are restored. |
 | `GEMINI_API_KEY` | `daily-digest` (inline Gemini Flash TTS for digest audio); also the manual `generate_generative_article_audio.py` | Optional; without it, audio generation is skipped. |


### PR DESCRIPTION
## Summary
- Add `zai-glm-5p2` as a first-class `.github/actions/agent-run` backend using Claude Code's Anthropic-compatible route.
- Add a manual `hourly-twitter.yml backend=zai-glm-5p2` comparison lane that writes to `research/twitter-zai/`.
- Add `ZAI_API_KEY` to docs and the Claude sandbox credential deny list.
- Let `hourly-twitter.yml` push workflow-dispatch output back to the dispatch ref, so PR-branch smoke tests do not land generated output on `main`.

## Notes
- Z.ai documents Claude Code integration through `ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic` and `ANTHROPIC_AUTH_TOKEN`.
- The selected model id is `glm-5.2`.
- The lane is intentionally manual while quota/latency behavior is measured.

## Validation
- Parsed all workflow/action YAML.
- Ran `actionlint -shellcheck= -pyflakes= .github/workflows/*.yml`.
- Ran `bash -n` over embedded `agent-run` scripts.
- Ran `git diff --check`.
- Ran `uv run python -m unittest discover -s scripts -p 'test_*.py'` before the final workflow-only push-target tweak: 414 tests, 6 skipped.
- Confirmed the Z.ai secret value is not present in the worktree.
