### PR TITLE
[codex] Fix Z.ai Twitter output handling

### DIFF
--- a/.github/actions/agent-run/action.yml
+++ b/.github/actions/agent-run/action.yml
@@ -298,6 +298,39 @@ runs:
         claude_args: ${{ inputs.claude-args }}
         prompt: ${{ inputs.prompt }}
 
+    - name: Clean sandbox probe
+      shell: bash
+      run: rm -f .tmp-sandbox-probe.txt
+
+    - name: Commit expected-path changes
+      if: inputs.expected-paths != ''
+      shell: bash
+      env:
+        EXPECTED_PATHS: ${{ inputs.expected-paths }}
+        LABEL: ${{ inputs.label }}
+      run: |
+        set -euo pipefail
+
+        pathspecs=()
+        while IFS= read -r pathspec; do
+          pathspec="${pathspec#"${pathspec%%[![:space:]]*}"}"
+          pathspec="${pathspec%"${pathspec##*[![:space:]]}"}"
+          [ -z "$pathspec" ] && continue
+          pathspecs+=("$pathspec")
+        done <<< "$EXPECTED_PATHS"
+
+        if [ "${#pathspecs[@]}" -eq 0 ]; then
+          exit 0
+        fi
+
+        git add -- "${pathspecs[@]}"
+        if git diff --cached --quiet -- "${pathspecs[@]}"; then
+          echo "${LABEL} left no uncommitted changes under expected path(s)."
+          exit 0
+        fi
+
+        git commit -m "${LABEL} output"
+
     - name: Capture post-run HEAD
       id: post
       shell: bash

--- a/.github/workflows/hourly-twitter.yml
+++ b/.github/workflows/hourly-twitter.yml
@@ -326,6 +326,14 @@ jobs:
           echo "Backend constants for ${BACKEND}:"
           grep -E '^[a-z_]+=' "$GITHUB_OUTPUT" | sed 's/^/  /'
 
+      - name: Prepare output directories
+        if: steps.backend.outputs.skip != 'true'
+        env:
+          OUTPUT_DIR: ${{ steps.const.outputs.output_dir }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$OUTPUT_DIR" research/summaries
+
       # ── Shared fetch (Birdy multi-fetch + optional helpers) ────────
       - name: Fetch twitter snapshot
         if: steps.backend.outputs.skip != 'true'


### PR DESCRIPTION
## Summary
- create the selected Twitter output directory before agent execution
- clean the sandbox probe file before output validation
- auto-commit changes under declared expected output pathspecs before require-output validation

## Validation
- ruby YAML parse for hourly-twitter workflow and agent-run composite action
- actionlint -shellcheck= -pyflakes= .github/workflows/hourly-twitter.yml
- git diff --check