### PR TITLE
[codex] Give Z.ai Twitter lane enough tool budget

### DIFF
--- a/.github/workflows/hourly-twitter.yml
+++ b/.github/workflows/hourly-twitter.yml
@@ -448,7 +448,7 @@ jobs:
           claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           zai-api-key: ${{ secrets.ZAI_API_KEY }}
           claude-args: |
-            --model opus --allowedTools "Read,Write,Edit,Bash(git:*),Bash(birdy-fast:*),Bash(curl:*),Bash(jq:*)"
+            --model opus --max-turns 30 --allowedTools "Read,Write,Edit,Bash(pwd:*),Bash(ls:*),Bash(find:*),Bash(cat:*),Bash(head:*),Bash(test:*),Bash(git:*),Bash(birdy-fast:*),Bash(curl:*),Bash(jq:*)"
           expected-paths: |
             research/twitter-zai/
           label: Twitter Z.ai GLM-5.2 comparison processor


### PR DESCRIPTION
## Summary
- increase the manual Z.ai Twitter lane turn budget to 30
- allow basic read-only file inspection commands needed to navigate prefetched Twitter inputs
- leave scheduled production tiers unchanged

## Validation
- ruby YAML parse for hourly-twitter workflow
- actionlint -shellcheck= -pyflakes= .github/workflows/hourly-twitter.yml
- git diff --check