### PR TITLE
Tighten Twitter agent output guards

### DIFF
--- a/.github/actions/require-output/action.yml
+++ b/.github/actions/require-output/action.yml
@@ -57,11 +57,27 @@ runs:
         fi
 
         changed_files="$(git diff --name-only "${BASE_SHA}..HEAD" -- "${pathspecs[@]}" || true)"
-        if [ -z "$changed_files" ]; then
+        missing_pathspecs=()
+        for pathspec in "${pathspecs[@]}"; do
+          pathspec_changed="$(git diff --name-only "${BASE_SHA}..HEAD" -- "$pathspec" || true)"
+          if [ -z "$pathspec_changed" ]; then
+            missing_pathspecs+=("$pathspec")
+          fi
+        done
+
+        if [ "${#missing_pathspecs[@]}" -gt 0 ]; then
           {
-            echo "::error::${LABEL} did not commit changes under expected path(s):"
+            echo "::error::${LABEL} did not commit changes under every expected path:"
+            printf '  missing: %s\n' "${missing_pathspecs[@]}"
+            echo "Expected path(s):"
             printf '  - %s\n' "${pathspecs[@]}"
             echo "HEAD: $(git rev-parse HEAD)"
+            echo "Changed files under expected path(s):"
+            if [ -n "$changed_files" ]; then
+              echo "$changed_files"
+            else
+              echo "  (none)"
+            fi
             echo "Status:"
             git status --short
           }

--- a/.github/workflows/hourly-twitter.yml
+++ b/.github/workflows/hourly-twitter.yml
@@ -320,6 +320,7 @@ jobs:
             echo "curl_budget=${CURL_BUDGET}"
             echo "harness_label=${HARNESS_LABEL}"
             echo "features=${FEATURES}"
+            echo "digest_file=${OUTPUT_DIR}/${DATE}.md"
             echo "headlines_file=research/summaries/${DATE}-${SUMMARY_SLUG}-${HOUR}h-headlines.json"
             echo "summary_file=research/summaries/${DATE}-${SUMMARY_SLUG}-${HOUR}h-summary.txt"
           } >> "$GITHUB_OUTPUT"
@@ -413,7 +414,9 @@ jobs:
           claude-args: |
             --model opus --allowedTools "Read,Write,Edit,Bash(git:*),Bash(birdy-fast:*),Bash(curl:*),Bash(jq:*)"
           expected-paths: |
-            research/twitter/
+            ${{ steps.const.outputs.digest_file }}
+            ${{ steps.const.outputs.summary_file }}
+            ${{ steps.const.outputs.headlines_file }}
           allowed-paths: |
             research/twitter/
             research/summaries/
@@ -435,7 +438,8 @@ jobs:
           claude-args: |
             --model opus --allowedTools "Read,Write,Edit,Bash(git:*),Bash(birdy-fast:*),Bash(curl:*),Bash(jq:*)"
           expected-paths: |
-            research/twitter-deepseek/
+            ${{ steps.const.outputs.digest_file }}
+            ${{ steps.const.outputs.summary_file }}
           allowed-paths: |
             research/twitter-deepseek/
             research/summaries/
@@ -456,7 +460,8 @@ jobs:
           claude-args: |
             --model opus --max-turns 30 --allowedTools "Read,Write,Edit,Bash(pwd:*),Bash(ls:*),Bash(rg:*),Bash(find:*),Bash(cat:*),Bash(head:*),Bash(test:*),Bash(git:*),Bash(birdy-fast:*),Bash(curl:*),Bash(jq:*)"
           expected-paths: |
-            research/twitter-zai/
+            ${{ steps.const.outputs.digest_file }}
+            ${{ steps.const.outputs.summary_file }}
           allowed-paths: |
             research/twitter-zai/
             research/summaries/
@@ -495,7 +500,8 @@ jobs:
         with:
           base-sha: ${{ steps.twitter-output-base.outputs.sha }}
           expected-paths: |
-            research/twitter-deepseek/
+            ${{ steps.const.outputs.digest_file }}
+            ${{ steps.const.outputs.summary_file }}
           label: Twitter DeepSeek comparison workflow output
 
       - name: Process tweets with pi + DeepSeek v4 Flash via Fireworks (deepseek-pi tier)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,12 +142,13 @@ through Fireworks profiles when Fireworks preflight passes. If Fireworks is
 unavailable (for example billing/spend-limit suspension), the wrapper falls
 back to native Claude by default so scheduled freshness does not hard-stop.
 It also enforces output and commit-scope contracts for agent lanes:
-`.github/actions/require-output` proves the expected output path changed,
+`.github/actions/require-output` proves every expected output pathspec changed,
 while `.github/actions/require-diff-scope` proves the committed diff since
 the pre-agent SHA is limited to the declared allowed pathspecs. Use
-`expected-paths` for the artifact that must exist and `allowed-paths` for the
-full set of paths the agent may commit (for example, a primary digest
-directory plus `research/summaries/`). The RSS, HN/Reddit community, arXiv,
+`expected-paths` for the exact artifact files that must exist when their names
+are known, and `allowed-paths` for the full set of paths the agent may commit
+(for example, a primary digest directory plus `research/summaries/`). The RSS,
+HN/Reddit community, arXiv,
 daily-digest, and Bluesky workflows (plus the twitter-deepseek comparison tier)
 add deterministic model-free fallbacks after the agent step, then run a final
 `.github/actions/require-output` guard — the digest additionally gates its


### PR DESCRIPTION
## Summary
- require every expected output pathspec to change, not just any one path under the set
- make hourly Twitter Claude-Code lanes require exact digest/summary/headline files where names are known
- document that exact artifact files should be used for expected-paths

## Why
Run 28751520928 proved Z.ai Claude Code can execute and commit, but it only committed research/twitter-zai/.write-test.txt. Directory-level expected-paths let that false-positive pass. This makes that impossible.

## Validation
- ruby YAML parse for all workflows and composite actions
- actionlint -shellcheck= -pyflakes= .github/workflows/*.yml
- git diff --check
- bash git simulation: missing one required path fails; both required paths changed passes