### PR TITLE
Add protected branch fallback to safe-push

### DIFF
--- a/.github/actions/safe-push/action.yml
+++ b/.github/actions/safe-push/action.yml
@@ -17,7 +17,12 @@ description: >
   Outputs `pushed=true` on a successful push attempt (no-op pushes — where
   HEAD already matches the remote — also count as success and emit
   `pushed=true`, matching the prior behavior of consumers that gated
-  downstream notifications on this output).
+  downstream notifications on this output). If GitHub rejects a direct push
+  because repository rules require pull requests, the action can publish the
+  generated commit to a run-scoped branch and open a pull request instead.
+  If repository settings block Actions-created pull requests, the generated
+  branch still publishes and the action exits successfully with
+  `publication-mode=branch`.
 
 inputs:
   branch:
@@ -55,11 +60,31 @@ inputs:
       target. Defaults to 'true' for compatibility with existing callers.
     required: false
     default: 'true'
+  protected-branch-fallback:
+    description: >
+      Behavior when GitHub rejects the target branch push because repository
+      rules require pull requests. Use 'pull-request' to push a generated
+      branch and open a PR, or 'fail' to keep the old hard-fail behavior.
+    required: false
+    default: 'pull-request'
+  pr-branch-prefix:
+    description: Prefix for generated protected-branch fallback branches.
+    required: false
+    default: 'automation/safe-push'
 
 outputs:
   pushed:
     description: 'true if the push succeeded (including no-op pushes); empty otherwise.'
     value: ${{ steps.do-push.outputs.pushed }}
+  pull-request-url:
+    description: Pull request URL when protected-branch-fallback opened one.
+    value: ${{ steps.do-push.outputs.pull-request-url }}
+  pull-request-branch:
+    description: Generated branch name when protected-branch-fallback opened a pull request.
+    value: ${{ steps.do-push.outputs.pull-request-branch }}
+  publication-mode:
+    description: direct, noop, pull-request, branch, or empty on hard failure.
+    value: ${{ steps.do-push.outputs.publication-mode }}
 
 runs:
   using: composite
@@ -76,12 +101,16 @@ runs:
         SAFE_PUSH_REF_NAME: ${{ github.ref_name }}
         SAFE_PUSH_ALLOW_DIVERGENT_REF: ${{ inputs.allow-divergent-ref }}
         SAFE_PUSH_NOOP_PUSHED: ${{ inputs.noop-pushed }}
+        SAFE_PUSH_PROTECTED_BRANCH_FALLBACK: ${{ inputs.protected-branch-fallback }}
+        SAFE_PUSH_PR_BRANCH_PREFIX: ${{ inputs.pr-branch-prefix }}
       run: |
         set -euo pipefail
 
         BRANCH="${SAFE_PUSH_BRANCH}"
         MAX_ATTEMPTS="${SAFE_PUSH_MAX_ATTEMPTS}"
         INDEX_MERGE="${SAFE_PUSH_INDEX_MERGE}"
+        PROTECTED_BRANCH_FALLBACK="${SAFE_PUSH_PROTECTED_BRANCH_FALLBACK}"
+        PR_BRANCH_PREFIX="${SAFE_PUSH_PR_BRANCH_PREFIX}"
 
         # Safety: refuse to push if the workflow's trigger ref doesn't match
         # the target branch. Without this check, a workflow_dispatch run
@@ -100,6 +129,82 @@ runs:
         AUTH_HEADER=$(printf 'x-access-token:%s' "$SAFE_PUSH_GITHUB_TOKEN" | base64 | tr -d '\n')
         git_auth() {
           git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${AUTH_HEADER}" "$@"
+        }
+
+        is_protected_branch_rejection() {
+          local log_path="$1"
+          grep -Eiq 'GH013|Repository rule violations|Changes must be made through a pull request|protected branch' "$log_path"
+        }
+
+        sanitize_branch_part() {
+          printf '%s' "$1" \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed -E 's#[^a-z0-9._/-]+#-#g; s#/{2,}#/#g; s#-+/#/#g; s#/-+#/#g; s#(^[./-]+|[./-]+$)##g'
+        }
+
+        create_pull_request_fallback() {
+          if [ "$PROTECTED_BRANCH_FALLBACK" != "pull-request" ]; then
+            return 1
+          fi
+
+          local workflow_part run_part pr_branch title body pr_url
+          workflow_part="$(sanitize_branch_part "${GITHUB_WORKFLOW:-workflow}")"
+          run_part="${GITHUB_RUN_ID:-manual}-${GITHUB_RUN_ATTEMPT:-1}"
+          pr_branch="$(sanitize_branch_part "${PR_BRANCH_PREFIX}/${BRANCH}/${workflow_part}-${run_part}")"
+          title="$(git log -1 --pretty=%s)"
+          body="$(printf '%s\n\n%s\n\n- Run: %s\n- Source ref: %s\n- Target branch: %s\n- Commit: %s' \
+            "Automated publish fallback for \`${GITHUB_WORKFLOW:-workflow}\`." \
+            "Direct push to \`${BRANCH}\` was rejected by repository rules requiring pull requests, so this run published the generated commit to \`${pr_branch}\` instead." \
+            "${GITHUB_SERVER_URL:-https://github.com}/${SAFE_PUSH_REPOSITORY}/actions/runs/${GITHUB_RUN_ID:-}" \
+            "${SAFE_PUSH_REF_NAME}" \
+            "${BRANCH}" \
+            "$(git rev-parse HEAD)")"
+
+          echo "Direct push to ${BRANCH} is blocked by repository rules; publishing fallback PR branch ${pr_branch}."
+          git_auth push origin "HEAD:refs/heads/${pr_branch}"
+
+          if ! command -v gh >/dev/null 2>&1; then
+            echo "::warning::Published fallback branch ${pr_branch}, but gh is unavailable so no pull request was opened."
+            {
+              echo "pushed=false"
+              echo "publication-mode=branch"
+              echo "pull-request-url="
+              echo "pull-request-branch=${pr_branch}"
+            } >> "$GITHUB_OUTPUT"
+            return 0
+          fi
+
+          if pr_url="$(GH_TOKEN="$SAFE_PUSH_GITHUB_TOKEN" gh pr view "$pr_branch" \
+              --repo "$SAFE_PUSH_REPOSITORY" \
+              --json url \
+              --jq .url 2>/dev/null)"; then
+            echo "Existing fallback PR: ${pr_url}"
+          else
+            if ! pr_url="$(GH_TOKEN="$SAFE_PUSH_GITHUB_TOKEN" gh pr create \
+              --repo "$SAFE_PUSH_REPOSITORY" \
+              --base "$BRANCH" \
+              --head "$pr_branch" \
+              --title "$title" \
+              --body "$body")"; then
+              echo "::warning::Published fallback branch ${pr_branch}, but opening a pull request failed. Check whether Actions is allowed to create pull requests for this repository."
+              {
+                echo "pushed=false"
+                echo "publication-mode=branch"
+                echo "pull-request-url="
+                echo "pull-request-branch=${pr_branch}"
+              } >> "$GITHUB_OUTPUT"
+              return 0
+            fi
+            echo "Created fallback PR: ${pr_url}"
+          fi
+
+          {
+            echo "pushed=false"
+            echo "publication-mode=pull-request"
+            echo "pull-request-url=${pr_url}"
+            echo "pull-request-branch=${pr_branch}"
+          } >> "$GITHUB_OUTPUT"
+          return 0
         }
 
         # Concurrent writers can land on $BRANCH while this job runs. Retry
@@ -256,15 +361,31 @@ runs:
             echo "::endgroup::"
             echo "Nothing to push -- HEAD matches origin/$BRANCH"
             echo "pushed=${SAFE_PUSH_NOOP_PUSHED}" >> "$GITHUB_OUTPUT"
+            echo "publication-mode=noop" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          if git_auth push origin "HEAD:$BRANCH"; then
+          PUSH_LOG="$(mktemp)"
+          if git_auth push origin "HEAD:$BRANCH" >"$PUSH_LOG" 2>&1; then
             echo "::endgroup::"
             echo "Pushed successfully on attempt $ATTEMPTS"
             echo "pushed=true" >> "$GITHUB_OUTPUT"
+            echo "publication-mode=direct" >> "$GITHUB_OUTPUT"
+            rm -f "$PUSH_LOG"
             exit 0
           fi
+
+          cat "$PUSH_LOG"
+          if is_protected_branch_rejection "$PUSH_LOG"; then
+            rm -f "$PUSH_LOG"
+            echo "::endgroup::"
+            if create_pull_request_fallback; then
+              exit 0
+            fi
+            echo "::error::Direct push to ${BRANCH} is blocked by repository rules and PR fallback failed."
+            exit 1
+          fi
+          rm -f "$PUSH_LOG"
 
           echo "::endgroup::"
           echo "Push rejected ($BRANCH moved during attempt $ATTEMPTS); retrying"

--- a/.github/workflows/24h-model-timeline.yml
+++ b/.github/workflows/24h-model-timeline.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: [self-hosted, Linux]
     permissions:
       contents: write
+      pull-requests: write
       id-token: write
 
     steps:

--- a/.github/workflows/2h-bluesky.yml
+++ b/.github/workflows/2h-bluesky.yml
@@ -18,6 +18,7 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: write
+      pull-requests: write
       id-token: write
 
     steps:

--- a/.github/workflows/4h-community.yml
+++ b/.github/workflows/4h-community.yml
@@ -18,6 +18,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: write
+      pull-requests: write
       id-token: write
 
     steps:

--- a/.github/workflows/arm-timeline.yml
+++ b/.github/workflows/arm-timeline.yml
@@ -27,6 +27,7 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/daily-ai-blogs.yml
+++ b/.github/workflows/daily-ai-blogs.yml
@@ -17,6 +17,7 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/daily-arxiv.yml
+++ b/.github/workflows/daily-arxiv.yml
@@ -16,6 +16,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: write
+      pull-requests: write
       id-token: write
 
     steps:

--- a/.github/workflows/daily-digest.yml
+++ b/.github/workflows/daily-digest.yml
@@ -19,6 +19,7 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: write
+      pull-requests: write
       id-token: write
 
     steps:

--- a/.github/workflows/daily-front-page.yml
+++ b/.github/workflows/daily-front-page.yml
@@ -36,6 +36,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     permissions:
       contents: write
+      pull-requests: write
       id-token: write
 
     steps:

--- a/.github/workflows/daily-youtube.yml
+++ b/.github/workflows/daily-youtube.yml
@@ -16,6 +16,7 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/generative-research.yml
+++ b/.github/workflows/generative-research.yml
@@ -129,6 +129,7 @@ jobs:
     runs-on: [self-hosted, Linux]
     permissions:
       contents: write
+      pull-requests: write
       issues: write
       id-token: write
 

--- a/.github/workflows/hourly-rss.yml
+++ b/.github/workflows/hourly-rss.yml
@@ -16,6 +16,7 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: write
+      pull-requests: write
       id-token: write
 
     steps:

--- a/.github/workflows/hourly-twitter.yml
+++ b/.github/workflows/hourly-twitter.yml
@@ -92,6 +92,7 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: write
+      pull-requests: write
       actions: write
       id-token: write
     strategy:
@@ -1077,7 +1078,9 @@ jobs:
       # ── Comparison-tier Telegram notification ──────────────────────
       - name: Read summary for Telegram (comparison tiers)
         id: summary
-        if: contains(fromJSON('["deepseek-claude-code","zai-glm-5p2","deepseek-pi","fireworks-pi"]'), steps.backend.outputs.name)
+        if: >-
+          steps.push.outputs.pushed == 'true'
+          && contains(fromJSON('["deepseek-claude-code","zai-glm-5p2","deepseek-pi","fireworks-pi"]'), steps.backend.outputs.name)
         env:
           SUMMARY_FILE: ${{ steps.const.outputs.summary_file }}
         run: |
@@ -1097,7 +1100,10 @@ jobs:
       # hooker handles the bot token, so this job no longer needs
       # TELEGRAM_BOT_TOKEN / TELEGRAM_CHAT_ID.
       - name: Send notification via hooker (deepseek-claude-code)
-        if: success() && steps.backend.outputs.name == 'deepseek-claude-code'
+        if: >-
+          success()
+          && steps.push.outputs.pushed == 'true'
+          && steps.backend.outputs.name == 'deepseek-claude-code'
         continue-on-error: true
         env:
           HOOKER_URL: ${{ secrets.HOOKER_URL }}
@@ -1138,7 +1144,10 @@ jobs:
             --data-binary "@/tmp/hooker-twitter-deepseek-claude-code.json"
 
       - name: Send notification via hooker (zai-glm-5p2)
-        if: success() && steps.backend.outputs.name == 'zai-glm-5p2'
+        if: >-
+          success()
+          && steps.push.outputs.pushed == 'true'
+          && steps.backend.outputs.name == 'zai-glm-5p2'
         continue-on-error: true
         env:
           HOOKER_URL: ${{ secrets.HOOKER_URL }}
@@ -1181,7 +1190,10 @@ jobs:
       # hooker handles the bot token, so this job no longer needs
       # TELEGRAM_BOT_TOKEN / TELEGRAM_CHAT_ID.
       - name: Send notification via hooker (deepseek-pi)
-        if: success() && steps.backend.outputs.name == 'deepseek-pi'
+        if: >-
+          success()
+          && steps.push.outputs.pushed == 'true'
+          && steps.backend.outputs.name == 'deepseek-pi'
         continue-on-error: true
         env:
           HOOKER_URL: ${{ secrets.HOOKER_URL }}
@@ -1223,7 +1235,10 @@ jobs:
 
       # Notify via hooker for the Fireworks-backed pi comparison lane.
       - name: Send notification via hooker (fireworks-pi)
-        if: success() && steps.backend.outputs.name == 'fireworks-pi'
+        if: >-
+          success()
+          && steps.push.outputs.pushed == 'true'
+          && steps.backend.outputs.name == 'fireworks-pi'
         continue-on-error: true
         env:
           HOOKER_URL: ${{ secrets.HOOKER_URL }}

--- a/.github/workflows/research-issue.yml
+++ b/.github/workflows/research-issue.yml
@@ -18,6 +18,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: write
+      pull-requests: write
       issues: write
       id-token: write
 

--- a/.github/workflows/wiki-ingest.yml
+++ b/.github/workflows/wiki-ingest.yml
@@ -30,6 +30,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     permissions:
       contents: write
+      pull-requests: write
       id-token: write
 
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,15 @@ Claude workflows may still call the Claude action directly; when they do, pass
 the model via `claude_args` (e.g. `"--model claude-sonnet-5"`) — never as a
 separate `model:` input.
 
+Publishing generated commits uses `.github/actions/safe-push`. Direct pushes
+to protected branches may be rejected by repository rules requiring pull
+requests; in that case `safe-push` publishes the commit to a run-scoped
+`automation/safe-push/...` branch and attempts to open a PR. It emits
+`pushed=false` and `publication-mode=pull-request` (or `branch` if repository
+settings block Actions-created PRs), so downstream deploys and public
+notifications must continue to gate on `steps.push.outputs.pushed == 'true'`
+when they link to `main`.
+
 Claude Code runs are protected by the checked-in `.claude/settings.json`
 sandbox policy. On Linux this requires `bubblewrap` and `socat`; workflows
 that call Claude directly must run `.github/actions/setup-claude-sandbox`
@@ -468,18 +477,20 @@ output or break the pipeline. Read them before editing.
     out the recovery path too). Adding its name to the trigger list, or
     moving it to self-hosted, breaks both protections.
 
-12. **Workflow-opened PRs must be created inside `claude-code-action`.**
-    The default `GITHUB_TOKEN` cannot open pull requests in this repo: a
-    standalone `run: gh pr create` step fails with `GitHub Actions is not
-    permitted to create or approve pull requests (createPullRequest)`. The
-    working pattern (used by `daily-improve.yml` and
-    `twitter-account-explorer.yml`) is to have the agent push the branch and
-    run `gh pr create` **from inside the `anthropics/claude-code-action@v1`
-    step** — those PRs are authored as `app/claude` and succeed (and, unlike
-    `GITHUB_TOKEN`-authored PRs, they trigger `pull_request` workflows such as
-    CI). So: set `env: GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` on the claude
-    step, include `Bash(git push:*),Bash(gh:*)` in `--allowedTools`, and do the
-    `gh pr create` in the prompt — never in a downstream plain-`GITHUB_TOKEN`
+12. **Workflow-opened PRs need explicit token semantics.**
+    `safe-push` has an automated protected-branch fallback: it pushes a
+    generated branch, then attempts `gh pr create` with `GITHUB_TOKEN` when the
+    workflow grants `pull-requests: write`. If repository settings still block
+    Actions-created PRs, it leaves the generated branch in place and emits
+    `publication-mode=branch` instead of failing the workflow. For agent-authored
+    feature PRs, the older working pattern (used by `daily-improve.yml` and
+    `twitter-account-explorer.yml`) is still valid: have the agent push the
+    branch and run `gh pr create` **from inside the
+    `anthropics/claude-code-action@v1` step** so the PR is authored as
+    `app/claude` and triggers `pull_request` CI. In that case, set
+    `env: GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` on the claude step, include
+    `Bash(git push:*),Bash(gh:*)` in `--allowedTools`, and do the `gh pr create`
+    in the prompt — not in a downstream plain-`GITHUB_TOKEN`
     `run:` step. (Learned when the explorer's first run curated accounts
     correctly but failed at an external publish step — PR #149.)
 


### PR DESCRIPTION
## Summary
- add a protected-branch fallback to `.github/actions/safe-push` that publishes generated workflow commits to `automation/safe-push/...` and attempts to open a PR when direct push to `main` is blocked by repository rules
- grant `pull-requests: write` to workflows that use `safe-push`
- gate hourly Twitter public notifications on an actual direct push so PR/branch fallback mode does not link to stale `main` content
- document the new publication modes and token semantics in `CLAUDE.md`

## Validation
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml", ".github/actions/*/action.yml"].each { |f| YAML.load_file(f); puts "ok #{f}" }'`\n- `actionlint -shellcheck= -pyflakes= .github/workflows/*.yml`\n- `git diff --check`\n- extracted `.github/actions/safe-push/action.yml` embedded shell and ran `bash -n`\n- simulated GH013 detection and fallback branch-name sanitization\n- checked every workflow using `.github/actions/safe-push` grants `pull-requests: write`