### PR TITLE
Add deterministic fallback for Z.ai Twitter lane

### DIFF
--- a/.github/workflows/hourly-twitter.yml
+++ b/.github/workflows/hourly-twitter.yml
@@ -449,6 +449,7 @@ jobs:
 
       - name: Process tweets with GLM-5.2 via Z.ai (zai-glm-5p2 tier)
         id: twitter-zai-agent
+        continue-on-error: true
         if: steps.backend.outputs.name == 'zai-glm-5p2'
         uses: ./.github/actions/agent-run
         env:
@@ -495,6 +496,32 @@ jobs:
           git add "$OUTPUT_DIR/" research/summaries/
           git commit -m "Twitter (DeepSeek) deterministic fallback ${TIMESTAMP}" || echo "No deterministic Twitter changes"
 
+      - name: Deterministic Twitter fallback (zai-glm-5p2 tier)
+        if: >-
+          steps.backend.outputs.name == 'zai-glm-5p2'
+          && steps.twitter-zai-agent.outcome == 'failure'
+        env:
+          OUTPUT_DIR: ${{ steps.const.outputs.output_dir }}
+          SUMMARY_SLUG: ${{ steps.const.outputs.summary_slug }}
+          TITLE_SUFFIX: ${{ steps.const.outputs.title_suffix }}
+          DATE: ${{ steps.datetime.outputs.date }}
+          HOUR: ${{ steps.datetime.outputs.hour }}
+          TIMESTAMP: ${{ steps.datetime.outputs.timestamp }}
+        run: |
+          set -euo pipefail
+          echo "::warning::Z.ai GLM-5.2 comparison agent path failed; writing deterministic Twitter fallback."
+          python3 scripts/deterministic_twitter_digest.py \
+            --input-dir .twitter-input/bird \
+            --out-dir "$OUTPUT_DIR" \
+            --summaries-dir research/summaries \
+            --date "$DATE" \
+            --hour "$HOUR" \
+            --timestamp "$TIMESTAMP" \
+            --title-suffix "$TITLE_SUFFIX" \
+            --summary-slug "$SUMMARY_SLUG"
+          git add "$OUTPUT_DIR/" research/summaries/
+          git commit -m "Twitter (Z.ai GLM-5.2) deterministic fallback ${TIMESTAMP}" || echo "No deterministic Twitter changes"
+
       - name: Require DeepSeek comparison output
         if: steps.backend.outputs.name == 'deepseek-claude-code'
         uses: ./.github/actions/require-output
@@ -504,6 +531,16 @@ jobs:
             ${{ steps.const.outputs.digest_file }}
             ${{ steps.const.outputs.summary_file }}
           label: Twitter DeepSeek comparison workflow output
+
+      - name: Require Z.ai comparison output
+        if: steps.backend.outputs.name == 'zai-glm-5p2'
+        uses: ./.github/actions/require-output
+        with:
+          base-sha: ${{ steps.twitter-output-base.outputs.sha }}
+          expected-paths: |
+            ${{ steps.const.outputs.digest_file }}
+            ${{ steps.const.outputs.summary_file }}
+          label: Twitter Z.ai GLM-5.2 comparison workflow output
 
       - name: Process tweets with pi + DeepSeek v4 Flash via Fireworks (deepseek-pi tier)
         if: steps.backend.outputs.name == 'deepseek-pi'


### PR DESCRIPTION
## Summary
- let the Z.ai GLM-5.2 Twitter agent step fail into recovery instead of failing the whole job immediately
- add a deterministic Twitter digest fallback for `backend=zai-glm-5p2`, mirroring the DeepSeek comparison lane
- add a final exact-output guard for the Z.ai lane after fallback so both the digest and Telegram summary must exist before publication

## Evidence
- Follow-up run `28766491429` on merged main failed before safe-push: GLM-5.2 ran for ~15 minutes, left only `.write-test-probe`, and `require-output` reported no changes under `research/twitter-zai/2026-07-06.md` or `research/summaries/2026-07-06-twitter-zai-12h-summary.txt`.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/hourly-twitter.yml"); puts "ok hourly-twitter.yml"'`\n- `actionlint -shellcheck= -pyflakes= .github/workflows/hourly-twitter.yml`\n- `git diff --check`\n- smoke-tested `scripts/deterministic_twitter_digest.py` with Z.ai output paths\n- `uv run --with pytest pytest scripts/test_deterministic_twitter_digest.py`