### PR TITLE
Add generated per-workflow backend matrix (harness x token provider)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
       - 'dashboard/**'
       - 'data/sources/twitter_accounts.json'
       - 'scripts/**'
+      - 'docs/backend-matrix.md'
   pull_request:
     paths:
       - '.github/workflows/**'
@@ -16,6 +17,7 @@ on:
       - 'dashboard/**'
       - 'data/sources/twitter_accounts.json'
       - 'scripts/**'
+      - 'docs/backend-matrix.md'
   workflow_dispatch:
 
 concurrency:
@@ -121,6 +123,13 @@ jobs:
       # build_wiki_index.py. The ingest workflow regenerates it every run.
       - name: Check wiki index is in sync
         run: uv run python scripts/build_wiki_index.py --check
+
+      # docs/backend-matrix.md carries a generated per-workflow harness/
+      # provider/token table derived from the workflow files. This gate
+      # fails when a workflow edit changed a lane's backend wiring without
+      # regenerating the matrix (build_backend_matrix.py).
+      - name: Check backend matrix is in sync
+        run: uv run python scripts/build_backend_matrix.py --check
 
   hooker-telemetry:
     needs: [actionlint, dashboard, python-scripts]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,12 @@ short pointer plus the few genuinely agent-specific notes.
   was healthy. Check the agent/fallback step logs before drawing provider
   conclusions.
 
+- **Per-workflow backend wiring is defined in `docs/backend-matrix.md`** —
+  a generated harness × provider × token-secret matrix derived from the
+  workflow files (`uv run python scripts/build_backend_matrix.py`; CI runs
+  `--check`). Consult and regenerate it whenever you change which backend a
+  workflow lane runs on.
+
 - **Z.ai GLM-5.2** is available through `agent-run` as `zai-glm-5p2` using
   `ZAI_API_KEY` and Claude Code's Anthropic-compatible route. It is the
   preferred manual `hourly-twitter.yml` backend and writes to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ and opens a PR with methodology fixes.
 | `export_wiki_okf.py` | Export `research/wiki/` as a portable Open Knowledge Format bundle: validates the OKF-native wiki pages and rewrites `[[wikilinks]]` to standard Markdown links. |
 | `check_lane_freshness.py` | Freshness watchdog. Measures git-commit recency per research lane against per-lane cadence thresholds; exits 2 (and emits a hooker/Telegram alert from `liveness-check.yml`) when a lane is stale. Stdlib-only so it runs on both runner tiers. |
 | `build_wiki_index.py` | Rebuilds `research/wiki/index.json` from the wiki pages. **CI-load-bearing**: `ci.yml` runs `--check` (exit 1 if the committed index is stale or any page fails validation); `wiki-ingest.yml` regenerates it every run. |
+| `build_backend_matrix.py` | Rebuilds the generated per-workflow harness/provider/token table in `docs/backend-matrix.md` from `.github/workflows/*.yml` + the `agent-run` backend profiles. **CI-load-bearing**: `ci.yml` runs `--check` (exit 1 when a workflow's backend wiring changed without regenerating the matrix). |
 | `fetch_ai_blogs.py` | Per-feed AI-blog fetcher used by `daily-ai-blogs.yml`; boundary-handles bad feeds so one failure doesn't crash the run. |
 | `deterministic_rss_digest.py` | Model-free fallback for `hourly-rss.yml`; parses fetched RSS/Atom files and appends a timestamped `research/rss/YYYY-MM-DD.md` section when the agent path fails. |
 | `deterministic_community_digest.py` | Model-free fallback for `4h-community.yml`; parses pre-fetched HN JSON and Reddit RSS into `research/community/*-hn.md` and `*-reddit.md` when the agent path fails. |
@@ -238,6 +239,12 @@ fallbacks. Direct Claude workflows pin
 file rather than assuming one provider everywhere.
 
 ## Backends
+
+The table below is the per-*backend* contract. The per-*workflow* view —
+which harness, provider, model, and token secret each workflow lane
+actually runs, with fallback chains — is the **generated, CI-checked**
+matrix in [`docs/backend-matrix.md`](docs/backend-matrix.md)
+(regenerate with `uv run python scripts/build_backend_matrix.py`).
 
 | Backend | When | Auth | Notes |
 |---|---|---|---|

--- a/docs/backend-matrix.md
+++ b/docs/backend-matrix.md
@@ -1,0 +1,121 @@
+# Backend Matrix — harness × token provider per workflow
+
+This is the **canonical per-workflow mapping** of which agent harness each
+GitHub Actions workflow runs, which provider serves its tokens, under which
+model id, authenticated by which GitHub secret, and what the fallback chain
+is. The per-*backend* contracts (env slots, endpoints, selector tokens) live
+in `CLAUDE.md` → "Backends" and `docs/generative-research-backends.md`; this
+file is the per-*workflow* view that used to exist only implicitly across
+the workflow files.
+
+The table below is **generated, not hand-maintained** — the repo has been
+burned twice by hand-maintained lists drifting (the `runs-on:` list, the
+pre-Z.ai backend table). Rows are derived from `.github/workflows/*.yml`
+plus the backend profile block in `.github/actions/agent-run/action.yml`:
+
+```bash
+uv run python scripts/build_backend_matrix.py          # regenerate after editing a workflow
+uv run python scripts/build_backend_matrix.py --check  # CI gate: exit 1 when stale
+```
+
+CI runs `--check` on every PR that touches workflows, actions, scripts, or
+this file — a workflow edit that changes a lane's harness/provider/token
+fails CI until this table is regenerated in the same PR.
+
+## Harness vocabulary
+
+| Harness | What it means | Where defined |
+|---|---|---|
+| Claude Code · agent-run | `anthropics/claude-code-action@v1` wrapped by the local composite: backend profile selects provider env (Fireworks / Z.ai Anthropic-compatible endpoints, or native), preflights Fireworks, falls back to native Claude, then enforces `expected-paths` / `allowed-paths`. | `.github/actions/agent-run/action.yml` |
+| Claude Code · claude-code-action (direct) | The action invoked directly. Native Anthropic unless the step's `env` reroutes `ANTHROPIC_BASE_URL` (generative-research does this for its Fireworks paths). | each workflow step |
+| pi · run-pi-container | The pi coding-agent harness in a container, with pi's own provider config. Twitter comparison tiers only. | `.github/actions/run-pi-container/action.yml` |
+| Codex CLI | `codex exec` with ChatGPT-managed file auth (subscription entitlement, not API billing). | `generative-research.yml` codex path |
+
+Reading notes:
+
+- **Token secret** is the secret that pays for the tokens on the requested
+  path. Every agent-run and direct-action step *also* receives
+  `CLAUDE_CODE_OAUTH_TOKEN` because the action's input schema requires it —
+  for Fireworks/Z.ai-routed runs it is inert unless the native-Claude
+  fallback fires.
+- **`--model opus` in `claude_args` is an alias**, not a provider model:
+  agent-run remaps it to the profile model id (Fireworks/Z.ai) or to
+  `native-model` (default `claude-sonnet-5`) on the native path.
+- **Fallback** shows the chain: provider fallback first (Fireworks preflight
+  → native Claude unless `fireworks-fallback: none`; Z.ai fails closed),
+  then `; then \`deterministic_*.py\`` where the lane has a model-free
+  composer guarding output freshness.
+- `hourly-twitter.yml` lane names are the *tier* selectors from its matrix.
+  Historical warning: the tier named `claude` is the tier *slot* name — its
+  requested backend is whatever the workflow passes (GLM-5.2 via Fireworks
+  since 2026-07-06), which is exactly why this table exists.
+- `generative-research.yml`'s Fireworks model is `dynamic:` because one env
+  block serves both `deepseek-v4-flash` and `glm-5p2` via its profile step.
+
+<!-- BEGIN GENERATED BACKEND MATRIX (scripts/build_backend_matrix.py — do not edit by hand) -->
+
+### Model lanes
+
+| Workflow | Lane | Harness | Provider | Model | Token secret | Fallback |
+|---|---|---|---|---|---|---|
+| `24h-model-timeline.yml` | crud-model-tickets-via-fireworks | Claude Code · agent-run | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | native Claude (`claude-sonnet-5`) |
+| `2h-bluesky.yml` | process-bluesky-feed-with-glm-5-2-via-fireworks | Claude Code · agent-run | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | native Claude (`claude-sonnet-5`); then `deterministic_bluesky_digest.py` |
+| `4h-community.yml` | process-community-data-with-fireworks | Claude Code · agent-run | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | native Claude (`claude-sonnet-5`); then `deterministic_community_digest.py` |
+| `ai-news-research.yml` | run-ai-news-research-with-claude-with-mcp | Claude Code · claude-code-action (direct) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
+| `ai-news-research.yml` | run-ai-news-research-with-claude-without-mcp | Claude Code · claude-code-action (direct) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
+| `claude-code-review.yml` | run-claude-code-review | Claude Code · claude-code-action (direct) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
+| `claude.yml` | run-claude-code | Claude Code · claude-code-action (direct) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
+| `daily-arxiv.yml` | fetch-arxiv-ai-papers | Claude Code · agent-run | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | native Claude (`claude-sonnet-5`); then `deterministic_arxiv_digest.py` |
+| `daily-digest.yml` | synthesize-daily-digest-with-mcp-tools | Claude Code · agent-run | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | native Claude (`claude-sonnet-5`); then `deterministic_daily_digest.py` |
+| `daily-digest.yml` | synthesize-daily-digest-local-source-fallback | Claude Code · agent-run | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | native Claude (`claude-sonnet-5`); then `deterministic_daily_digest.py` |
+| `daily-digest.yml` | rewrite-summary-as-ara-spoken-script-glm-5-2-via-fireworks | Claude Code · agent-run | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | native Claude (`claude-sonnet-5`); then `deterministic_daily_digest.py` |
+| `daily-improve.yml` | analyze-and-improve-methodology | Claude Code · claude-code-action (direct) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
+| `generative-research.yml` | backend=claude (+1 retry step) | Claude Code · claude-code-action (direct) | Anthropic (native) | `opus` → `claude-sonnet-5` (env pin) | `CLAUDE_CODE_OAUTH_TOKEN` | — |
+| `generative-research.yml` | backend=codex | Codex CLI | OpenAI (ChatGPT subscription auth) | codex CLI default | `CODEX_AUTH_JSON` | — |
+| `generative-research.yml` | backend=fireworks (deepseek-v4-flash / glm-5p2) (+2 retry steps) | Claude Code · claude-code-action (direct) | Fireworks (Anthropic-compatible endpoint) | dynamic: `${{ steps.fireworks.outputs.model_id }}` | `FIREWORKS_API_KEY` | workflow-level `fireworks_fallback` input (default `claude`) |
+| `hourly-rss.yml` | process-rss-feeds-with-glm-5-2-via-fireworks | Claude Code · agent-run | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | native Claude (`claude-sonnet-5`); then `deterministic_rss_digest.py` |
+| `hourly-twitter.yml` | tier:claude · process-tweets-with-glm-5-2-via-fireworks-primary-tier | Claude Code · agent-run | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | native Claude (`claude-sonnet-5`) |
+| `hourly-twitter.yml` | tier:deepseek-claude-code | Claude Code · agent-run | DeepSeek V4 Flash via Fireworks | `accounts/fireworks/models/deepseek-v4-flash` | `FIREWORKS_API_KEY` | native Claude (`claude-sonnet-5`); then `deterministic_twitter_digest.py` |
+| `hourly-twitter.yml` | tier:zai-glm-5p2 | Claude Code · agent-run | GLM 5.2 via Z.ai | `glm-5.2` | `ZAI_API_KEY` | hard fail if key unset (no provider fallback); then `deterministic_twitter_digest.py` |
+| `hourly-twitter.yml` | tier:deepseek-pi | pi · run-pi-container | fireworks (pi built-in) | `accounts/fireworks/models/deepseek-v4-flash` | `FIREWORKS_API_KEY` | — |
+| `hourly-twitter.yml` | tier:fireworks-pi | pi · run-pi-container | fireworks (pi built-in) | `accounts/fireworks/models/kimi-k2p7` | `FIREWORKS_API_KEY` | — |
+| `hourly-twitter.yml` | tier:claude · adjudicate-near-duplicate-headlines-with-fireworks-primary | Claude Code · agent-run | DeepSeek V4 Flash via Fireworks | `accounts/fireworks/models/deepseek-v4-flash` | `FIREWORKS_API_KEY` | native Claude (`claude-sonnet-5`) |
+| `hourly-twitter.yml` | tier:claude · auto-research-topic-selection-primary-fireworks-tier | Claude Code · agent-run | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | native Claude (`claude-sonnet-5`) |
+| `research-issue.yml` | run-deep-research-with-mcp | Claude Code · claude-code-action (direct) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
+| `research-issue.yml` | run-deep-research-without-mcp | Claude Code · claude-code-action (direct) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
+| `twitter-account-explorer.yml` | explore-and-curate-account-list | Claude Code · claude-code-action (direct) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
+| `wiki-ingest.yml` | ingest-digest-into-wiki-via-fireworks | Claude Code · agent-run | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | native Claude (`claude-sonnet-5`) |
+| `zai-claude-code-canary.yml` | run-claude-code-file-write-canary-via-z-ai | Claude Code · agent-run | GLM 5.2 via Z.ai | `glm-5.2` | `ZAI_API_KEY` | hard fail if key unset (no provider fallback) |
+
+### Workflows with no model lane (deterministic / infra)
+
+- `arm-timeline.yml`
+- `auto-rerun-on-runner-loss.yml`
+- `ci.yml`
+- `daily-ai-blogs.yml`
+- `daily-front-page.yml`
+- `daily-youtube.yml`
+- `liveness-check.yml`
+
+_28 model lanes across 23 workflows; 7 workflows run no model._
+
+<!-- END GENERATED BACKEND MATRIX -->
+
+## Model calls outside the harness table
+
+Model usage that is real but is not an agent-harness lane, so the generator
+does not (and should not) row it:
+
+| Lane | What it is | Provider / model | Auth |
+|---|---|---|---|
+| `scripts/run_generative_research_oracle.py` | Local Oracle runner on the developer machine (not GitHub Actions) | GPT-5.5 Pro via `../oracle` (browser engine by default) | local Oracle checkout |
+| Digest TTS audio (inline step in `daily-digest.yml`) + manual `scripts/generate_generative_article_audio.py` | plain TTS API call, not an agent harness | Gemini Flash TTS | `GEMINI_API_KEY` (skipped when unset) |
+| Raw endpoint probe in `zai-claude-code-canary.yml` | 256-token tool-use diagnostics POST straight to `api.z.ai/api/anthropic/v1/messages` before the agent-run canary step | Z.ai `glm-5.2` | `ZAI_API_KEY` |
+
+## Related contracts
+
+- Per-backend env mapping and selector tokens: `CLAUDE.md` → "Backends"
+- Generative-research lane deep dive (Oracle, Codex auth, comparisons):
+  [`generative-research-backends.md`](generative-research-backends.md)
+- Freshness watchdog that alerts when a lane's output goes stale regardless
+  of which backend served it: `scripts/check_lane_freshness.py`

--- a/docs/generative-research-backends.md
+++ b/docs/generative-research-backends.md
@@ -1,5 +1,8 @@
 # Generative Research Backends
 
+> Repo-wide per-workflow harness/provider/token mapping (all lanes, not
+> just generative research): [`backend-matrix.md`](backend-matrix.md).
+
 `generative-research.yml` supports these model backends for the same deep
 research pipeline:
 

--- a/scripts/build_backend_matrix.py
+++ b/scripts/build_backend_matrix.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+"""Build/verify docs/backend-matrix.md — the per-workflow agent harness &
+token-provider matrix.
+
+The matrix answers, for every GitHub Actions workflow: which agent harness
+runs (claude-code-action direct, the agent-run wrapper, run-pi-container,
+or the Codex CLI), which provider serves the tokens (Anthropic, Fireworks,
+Z.ai, ChatGPT/Codex), under which model id, authenticated by which GitHub
+secret, and what the fallback chain is.
+
+It is DERIVED, never hand-maintained: rows are parsed out of
+`.github/workflows/*.yml` plus the backend profile table inside
+`.github/actions/agent-run/action.yml`. This mirrors the
+`build_wiki_index.py --check` pattern — the doc carries a generated block
+between markers, CI fails when the block is stale.
+
+Usage:
+    uv run python scripts/build_backend_matrix.py            # regenerate doc
+    uv run python scripts/build_backend_matrix.py --check    # verify, exit 1 if stale
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+AGENT_RUN_ACTION = REPO_ROOT / ".github" / "actions" / "agent-run" / "action.yml"
+DOC_PATH = REPO_ROOT / "docs" / "backend-matrix.md"
+
+BEGIN_MARKER = "<!-- BEGIN GENERATED BACKEND MATRIX (scripts/build_backend_matrix.py — do not edit by hand) -->"
+END_MARKER = "<!-- END GENERATED BACKEND MATRIX -->"
+
+SECRET_RE = re.compile(r"secrets\.([A-Z0-9_]+)")
+# Both tier regexes take only the FIRST tier of a compound `||` condition; a
+# step gated on two tiers would be attributed to one (none exist today).
+TIER_IF_RE = re.compile(r"steps\.backend\.outputs\.name\s*==\s*'([a-z0-9\-]+)'")
+EFFECTIVE_IF_RE = re.compile(r"steps\.effective\.outputs\.backend\s*==\s*'([a-z0-9\-]+)'")
+MODEL_ARG_RE = re.compile(r"--model\s+([^\s\"']+)")
+DETERMINISTIC_RE = re.compile(r"(deterministic_[a-z_]+\.py)")
+# Loose on purpose (any run block with "codex" then "exec"); a shell `exec`
+# in an unrelated codex-mentioning step would create a phantom lane — if that
+# ever happens, tighten to the actual `codex ... exec` invocation shape.
+CODEX_EXEC_RE = re.compile(r"\bcodex\b[^\n]*(?:\n[^\n]*)*?\bexec\b")
+
+
+@dataclass
+class Row:
+    workflow: str
+    order: int
+    lane: str
+    harness: str
+    provider: str
+    model: str
+    token: str
+    fallback: str
+    step_name: str = ""
+    retry_count: int = 0
+
+    def config_key(self) -> tuple:
+        return (self.workflow, self.harness, self.provider, self.model, self.token, self.fallback)
+
+
+@dataclass
+class Profile:
+    normalized: str
+    provider: str
+    model_id: str
+    display_name: str
+    selectors: list[str] = field(default_factory=list)
+
+
+def fail(msg: str) -> None:
+    print(f"ERROR: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def workflow_files() -> list[Path]:
+    # GitHub accepts both extensions; globbing only *.yml would let a future
+    # *.yaml workflow's lanes silently vanish from the matrix with --check green.
+    return sorted(list(WORKFLOWS_DIR.glob("*.yml")) + list(WORKFLOWS_DIR.glob("*.yaml")))
+
+
+def load_yaml(path: Path) -> dict:
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:  # boundary: malformed workflow file
+        fail(f"cannot parse {path}: {exc}")
+    if not isinstance(data, dict):
+        fail(f"{path} did not parse to a mapping")
+    return data
+
+
+def parse_agent_run_profiles(action: dict) -> dict[str, Profile]:
+    """Extract the backend case-block from agent-run's `Resolve agent backend`
+    step into selector → Profile. Fails loudly if the block shape changes so
+    the matrix can never silently misreport a profile."""
+    steps = action.get("runs", {}).get("steps", [])
+    resolve = next((s for s in steps if s.get("id") == "profile"), None)
+    if resolve is None or "run" not in resolve:
+        fail("agent-run action.yml: could not find the id=profile resolve step")
+
+    profiles: dict[str, Profile] = {}
+    selectors: list[str] = []
+    fields: dict[str, str] = {}
+    for raw_line in resolve["run"].splitlines():
+        line = raw_line.strip()
+        m = re.fullmatch(r"([a-z0-9|.\-]+)\)", line)
+        if m and m.group(1) != "*":
+            selectors = m.group(1).split("|")
+            fields = {}
+            continue
+        m = re.fullmatch(r'(normalized|provider|model_id|display_name)="([^"]*)"', line)
+        if m and selectors:
+            fields[m.group(1)] = m.group(2)
+            continue
+        if line == ";;" and selectors:
+            if "normalized" in fields:
+                profile = Profile(
+                    normalized=fields["normalized"],
+                    provider=fields.get("provider", "?"),
+                    model_id=fields.get("model_id", ""),
+                    display_name=fields.get("display_name", fields["normalized"]),
+                    selectors=selectors,
+                )
+                for sel in selectors:
+                    profiles[sel] = profile
+            selectors = []
+            fields = {}
+    if len({p.normalized for p in profiles.values()}) < 3:
+        fail("agent-run action.yml: parsed fewer than 3 backend profiles — case block shape changed?")
+    return profiles
+
+
+def agent_run_defaults(action: dict) -> dict[str, str]:
+    inputs = action.get("inputs", {})
+    return {
+        "backend": inputs.get("backend", {}).get("default", ""),
+        "native-model": inputs.get("native-model", {}).get("default", ""),
+        "fireworks-fallback": inputs.get("fireworks-fallback", {}).get("default", ""),
+    }
+
+
+def slugify(name: str, limit: int = 60) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+    if len(slug) > limit:
+        slug = slug[:limit].rsplit("-", 1)[0]
+    return slug or "step"
+
+
+def first_secret(value: object) -> str:
+    m = SECRET_RE.search(str(value or ""))
+    return m.group(1) if m else ""
+
+
+def lane_for(step: dict) -> str:
+    cond = str(step.get("if", ""))
+    m = TIER_IF_RE.search(cond)
+    if m:
+        return f"tier:{m.group(1)}"
+    m = EFFECTIVE_IF_RE.search(cond)
+    if m:
+        return f"backend={m.group(1)}"
+    if "fireworks_active" in cond:
+        return "backend=fireworks (deepseek-v4-flash / glm-5p2)"
+    return slugify(str(step.get("name", "step")))
+
+
+def native_model_from_args(with_block: dict) -> str:
+    m = MODEL_ARG_RE.search(str(with_block.get("claude_args", "")))
+    return m.group(1) if m else "(action default)"
+
+
+def collect_deterministic_fallbacks(job: dict) -> tuple[dict[str, str], list[str]]:
+    """Map tier → deterministic fallback script for steps gated on a tier,
+    plus job-wide scripts for ungated fallback steps."""
+    by_tier: dict[str, str] = {}
+    job_wide: list[str] = []
+    for step in job.get("steps", []) or []:
+        run = str(step.get("run", ""))
+        scripts = sorted(set(DETERMINISTIC_RE.findall(run)))
+        if not scripts:
+            continue
+        tier = TIER_IF_RE.search(str(step.get("if", "")))
+        for script in scripts:
+            if tier:
+                by_tier.setdefault(tier.group(1), script)
+            elif script not in job_wide:
+                job_wide.append(script)
+    return by_tier, job_wide
+
+
+def rows_for_workflow(
+    wf_path: Path, profiles: dict[str, Profile], defaults: dict[str, str]
+) -> list[Row]:
+    wf = load_yaml(wf_path)
+    rows: list[Row] = []
+    order = 0
+    for job in (wf.get("jobs") or {}).values():
+        det_by_tier, det_job_wide = collect_deterministic_fallbacks(job)
+
+        def det_suffix(lane: str) -> str:
+            tier = lane.removeprefix("tier:")
+            script = det_by_tier.get(tier)
+            if script is None and det_job_wide:
+                script = det_job_wide[0]
+            return f"; then `{script}`" if script else ""
+
+        for step in job.get("steps", []) or []:
+            uses = str(step.get("uses", ""))
+            with_block = step.get("with") or {}
+            env = step.get("env") or {}
+            lane = lane_for(step)
+            row = None
+
+            if uses.startswith("./.github/actions/agent-run"):
+                backend = str(with_block.get("backend", "") or defaults["backend"]).strip()
+                if "${{" in backend:
+                    row = Row(wf_path.name, order, lane, "Claude Code · agent-run",
+                              "resolved at runtime", f"dynamic: `{backend}`",
+                              "(per resolved backend)", "(per resolved backend)")
+                else:
+                    profile = profiles.get(backend)
+                    if profile is None:
+                        fail(f"{wf_path.name}: agent-run backend '{backend}' has no profile in agent-run/action.yml")
+                    fallback_setting = str(with_block.get("fireworks-fallback", "") or defaults["fireworks-fallback"]).strip()
+                    native_model = str(with_block.get("native-model", "") or defaults["native-model"]).strip()
+                    if profile.provider == "fireworks":
+                        token = first_secret(with_block.get("fireworks-api-key")) or "(none passed!)"
+                        # agent-run hard-fails on ANY non-"claude" fallback value.
+                        fallback = (
+                            f"native Claude (`{native_model}`)" if fallback_setting == "claude"
+                            else f"hard fail (`fireworks-fallback: {fallback_setting}`)"
+                        )
+                        model = profile.model_id
+                    elif profile.provider == "zai":
+                        token = first_secret(with_block.get("zai-api-key")) or "(none passed!)"
+                        fallback = "hard fail if key unset (no provider fallback)"
+                        model = profile.model_id
+                    else:  # native claude through the wrapper
+                        token = "CLAUDE_CODE_OAUTH_TOKEN"
+                        fallback = "—"
+                        model = native_model
+                    row = Row(wf_path.name, order, lane, "Claude Code · agent-run",
+                              profile.display_name, f"`{model}`", token,
+                              fallback + det_suffix(lane))
+
+            elif uses.startswith("anthropics/claude-code-action"):
+                base_url = str(env.get("ANTHROPIC_BASE_URL", ""))
+                if "fireworks" in base_url:
+                    provider = "Fireworks (Anthropic-compatible endpoint)"
+                    model = str(env.get("ANTHROPIC_MODEL", "?"))
+                    model = f"dynamic: `{model}`" if "${{" in model else f"`{model}`"
+                    token = first_secret(env.get("ANTHROPIC_AUTH_TOKEN")) or "(none!)"
+                elif "z.ai" in base_url:
+                    provider = "Z.ai (Anthropic-compatible endpoint)"
+                    model = f"`{env.get('ANTHROPIC_MODEL', '?')}`"
+                    token = first_secret(env.get("ANTHROPIC_AUTH_TOKEN")) or "(none!)"
+                else:
+                    provider = "Anthropic (native)"
+                    arg_model = native_model_from_args(with_block)
+                    if arg_model in {"opus", "sonnet", "haiku"}:
+                        pin = str(env.get(f"ANTHROPIC_DEFAULT_{arg_model.upper()}_MODEL")
+                                  or env.get("ANTHROPIC_MODEL") or "")
+                        if pin and "${{" not in pin:
+                            model = f"`{arg_model}` → `{pin}` (env pin)"
+                        else:
+                            model = f"`{arg_model}` (claude_args alias)"
+                    else:
+                        model = f"`{arg_model}`"
+                    token = first_secret(with_block.get("claude_code_oauth_token")) or "(none!)"
+                on_block = wf.get("on") or wf.get(True) or {}
+                dispatch_inputs = ((on_block.get("workflow_dispatch") or {}).get("inputs") or {})
+                fallback = "—"
+                if provider.startswith("Fireworks") and "fireworks_fallback" in dispatch_inputs:
+                    default = dispatch_inputs["fireworks_fallback"].get("default", "?")
+                    fallback = f"workflow-level `fireworks_fallback` input (default `{default}`)"
+                row = Row(wf_path.name, order, lane, "Claude Code · claude-code-action (direct)",
+                          provider, model, token, fallback + det_suffix(lane))
+
+            elif uses.startswith("./.github/actions/run-pi-container"):
+                row = Row(wf_path.name, order, lane, "pi · run-pi-container",
+                          f"{with_block.get('provider', '?')} (pi built-in)",
+                          f"`{with_block.get('model', '?')}`",
+                          first_secret(with_block.get("fireworks-api-key")) or "(none!)",
+                          "—" + det_suffix(lane))
+
+            elif "run" in step and CODEX_EXEC_RE.search(str(step["run"])):
+                wf_text = wf_path.read_text(encoding="utf-8")
+                token = "CODEX_AUTH_JSON" if "CODEX_AUTH_JSON" in wf_text else "(unknown)"
+                row = Row(wf_path.name, order, lane, "Codex CLI",
+                          "OpenAI (ChatGPT subscription auth)", "codex CLI default",
+                          token, "—")
+
+            if row is not None:
+                row.step_name = str(step.get("name", ""))
+                rows.append(row)
+                order += 1
+
+    # Fold explicit retry steps into their config-identical base row. Steps
+    # that merely share a config but do different jobs (e.g. the Twitter
+    # primary processor vs. its auto-research selector) stay separate.
+    folded: list[Row] = []
+    for row in rows:
+        if re.search(r"retry", row.step_name, re.IGNORECASE):
+            base = next((r for r in folded if r.config_key() == row.config_key()
+                         and not re.search(r"retry", r.step_name, re.IGNORECASE)), None)
+            if base is not None:
+                base.retry_count += 1
+                continue
+        folded.append(row)
+
+    # Disambiguate repeated lane labels (a tier can host several model
+    # steps) by appending the step slug.
+    by_lane: dict[str, int] = {}
+    for row in folded:
+        by_lane[row.lane] = by_lane.get(row.lane, 0) + 1
+    for row in folded:
+        if by_lane[row.lane] > 1:
+            row.lane = f"{row.lane} · {slugify(row.step_name)}"
+    for row in folded:
+        if row.retry_count:
+            row.lane += f" (+{row.retry_count} retry step{'s' if row.retry_count > 1 else ''})"
+    return folded
+
+
+def build_generated_block() -> str:
+    action = load_yaml(AGENT_RUN_ACTION)
+    profiles = parse_agent_run_profiles(action)
+    defaults = agent_run_defaults(action)
+
+    all_rows: list[Row] = []
+    no_model: list[str] = []
+    for wf_path in workflow_files():
+        rows = rows_for_workflow(wf_path, profiles, defaults)
+        if rows:
+            all_rows.extend(rows)
+        else:
+            no_model.append(wf_path.name)
+
+    lines = [BEGIN_MARKER, ""]
+    lines.append("### Model lanes")
+    lines.append("")
+    lines.append("| Workflow | Lane | Harness | Provider | Model | Token secret | Fallback |")
+    lines.append("|---|---|---|---|---|---|---|")
+    for row in all_rows:
+        cells = [f"`{row.workflow}`", row.lane, row.harness, row.provider,
+                 row.model, f"`{row.token}`", row.fallback]
+        lines.append("| " + " | ".join(c.replace("|", "\\|") for c in cells) + " |")
+    lines.append("")
+    lines.append("### Workflows with no model lane (deterministic / infra)")
+    lines.append("")
+    for name in no_model:
+        lines.append(f"- `{name}`")
+    lines.append("")
+    lines.append(f"_{len(all_rows)} model lanes across {len(workflow_files())} workflows;"
+                 f" {len(no_model)} workflows run no model._")
+    lines.append("")
+    lines.append(END_MARKER)
+    return "\n".join(lines)
+
+
+def splice(doc_text: str, block: str) -> str:
+    begin = doc_text.find(BEGIN_MARKER)
+    end = doc_text.find(END_MARKER)
+    if begin == -1 or end == -1 or end < begin:
+        fail(f"{DOC_PATH}: generated-block markers missing or malformed")
+    return doc_text[:begin] + block + doc_text[end + len(END_MARKER):]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true",
+                        help="verify the committed doc matches the workflows; exit 1 if stale")
+    args = parser.parse_args()
+
+    if not DOC_PATH.exists():
+        fail(f"{DOC_PATH} does not exist — create it with the generated-block markers first")
+
+    doc_text = DOC_PATH.read_text(encoding="utf-8")
+    updated = splice(doc_text, build_generated_block())
+
+    if args.check:
+        if updated != doc_text:
+            print(
+                "docs/backend-matrix.md is STALE relative to .github/workflows/ — "
+                "regenerate with: uv run python scripts/build_backend_matrix.py",
+                file=sys.stderr,
+            )
+            return 1
+        print("docs/backend-matrix.md is in sync with the workflows.")
+        return 0
+
+    if updated != doc_text:
+        tmp = DOC_PATH.with_suffix(".md.tmp")
+        tmp.write_text(updated, encoding="utf-8")
+        tmp.replace(DOC_PATH)
+        print(f"Updated {DOC_PATH.relative_to(REPO_ROOT)}")
+    else:
+        print(f"{DOC_PATH.relative_to(REPO_ROOT)} already up to date")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_backend_matrix.py
+++ b/scripts/test_backend_matrix.py
@@ -1,0 +1,86 @@
+"""Invariant tests for scripts/build_backend_matrix.py.
+
+These pin the load-bearing facts the matrix must keep reporting correctly —
+if a workflow edit changes one of these, the test failing is the signal to
+update BOTH the workflow intent and this pin, not to loosen the parser.
+(The doc-sync gate itself is the separate `--check` step in ci.yml.)
+"""
+
+import unittest
+
+from build_backend_matrix import (
+    AGENT_RUN_ACTION,
+    agent_run_defaults,
+    load_yaml,
+    parse_agent_run_profiles,
+    rows_for_workflow,
+    workflow_files,
+)
+
+
+def all_rows():
+    action = load_yaml(AGENT_RUN_ACTION)
+    profiles = parse_agent_run_profiles(action)
+    defaults = agent_run_defaults(action)
+    rows = []
+    for wf_path in workflow_files():
+        rows.extend(rows_for_workflow(wf_path, profiles, defaults))
+    return rows
+
+
+class BackendMatrixInvariants(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.rows = all_rows()
+
+    def rows_for(self, workflow):
+        return [r for r in self.rows if r.workflow == workflow]
+
+    def test_profiles_cover_known_backends(self):
+        profiles = parse_agent_run_profiles(load_yaml(AGENT_RUN_ACTION))
+        normalized = {p.normalized for p in profiles.values()}
+        self.assertLessEqual(
+            {"claude", "fireworks-glm-5p2", "fireworks-deepseek-v4-flash", "zai-glm-5p2"},
+            normalized,
+        )
+
+    def test_zai_lanes_use_zai_key_and_fail_closed(self):
+        zai_rows = [r for r in self.rows if "Z.ai" in r.provider]
+        self.assertGreaterEqual(len(zai_rows), 2)  # twitter tier + canary
+        for row in zai_rows:
+            self.assertEqual(row.token, "ZAI_API_KEY", row)
+            self.assertIn("hard fail", row.fallback, row)
+
+    def test_fireworks_lanes_use_fireworks_key(self):
+        fw_rows = [r for r in self.rows if "Fireworks" in r.provider or "fireworks" in r.provider]
+        self.assertGreaterEqual(len(fw_rows), 10)
+        for row in fw_rows:
+            self.assertEqual(row.token, "FIREWORKS_API_KEY", row)
+
+    def test_hourly_twitter_covers_all_five_tiers(self):
+        tiers = {r.lane.split(" ")[0] for r in self.rows_for("hourly-twitter.yml")}
+        self.assertLessEqual(
+            {"tier:claude", "tier:deepseek-claude-code", "tier:zai-glm-5p2",
+             "tier:deepseek-pi", "tier:fireworks-pi"},
+            tiers,
+        )
+
+    def test_hourly_twitter_pi_tiers_use_pi_harness(self):
+        pi_rows = [r for r in self.rows_for("hourly-twitter.yml") if "pi ·" in r.harness]
+        self.assertEqual(len(pi_rows), 2)
+        models = {r.model for r in pi_rows}
+        self.assertIn("`accounts/fireworks/models/kimi-k2p7`", models)
+
+    def test_generative_research_has_codex_lane(self):
+        codex_rows = [r for r in self.rows_for("generative-research.yml") if r.harness == "Codex CLI"]
+        self.assertEqual(len(codex_rows), 1)
+        self.assertEqual(codex_rows[0].token, "CODEX_AUTH_JSON")
+
+    def test_native_lanes_use_oauth_token(self):
+        native = [r for r in self.rows if r.provider == "Anthropic (native)"]
+        self.assertGreaterEqual(len(native), 5)
+        for row in native:
+            self.assertEqual(row.token, "CLAUDE_CODE_OAUTH_TOKEN", row)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Adds the dedicated, drift-proof definition of **which harness and token provider every workflow lane runs** — previously scattered across the `agent-run` profile block, per-workflow `backend:` inputs, `hourly-twitter.yml`'s inline 5-tier case block, and a gen-research-only doc.

- **`docs/backend-matrix.md`** — per-workflow lane table: harness (claude-code-action direct / agent-run / pi / Codex CLI) × provider × model id × token secret × fallback chain (incl. deterministic composers), plus harness vocabulary and non-harness model calls (Oracle, Gemini TTS, Z.ai canary probe).
- **`scripts/build_backend_matrix.py`** — generates the table from `.github/workflows/*.{yml,yaml}` + the agent-run backend profiles; `--check` exits 1 when stale (same pattern as `build_wiki_index.py`).
- **`scripts/test_backend_matrix.py`** — 7 invariant tests (Z.ai lanes fail closed on `ZAI_API_KEY`, all five hourly-twitter tiers present, pi models, codex auth, native lanes on the OAuth token).
- **`ci.yml`** — new `Check backend matrix is in sync` gate in `python-scripts`; `docs/backend-matrix.md` added to CI paths.
- Pointers from `CLAUDE.md` (Backends + Scripts table), `AGENTS.md`, and `docs/generative-research-backends.md`.

## Why generated instead of hand-written

This repo has been burned twice by hand-maintained mappings drifting (the `runs-on:` list, the pre-Z.ai backend table). The matrix is derived from the workflow YAMLs, so a PR that changes a lane's backend wiring fails CI until the matrix is regenerated in the same PR.

## What the matrix surfaced while being built

`hourly-twitter.yml`'s tier named `claude` actually runs **three** model lanes: the primary processor (GLM-5.2/Fireworks), the headline-dedupe judge (DeepSeek-V4-Flash/Fireworks), and auto-research topic selection (GLM-5.2/Fireworks) — none of this was written down anywhere. The table also makes visible that the primary tier has **no deterministic fallback** while both comparison tiers do (only agent-run's native-Claude fallback); flagging in case that asymmetry is unintentional.

## Verification

- `uv run python scripts/build_backend_matrix.py --check` → in sync, exit 0
- `unittest discover -s scripts -p 'test_backend_matrix.py'` → 7/7 pass
- Independent adversarial review: reconciled all 31 model-harness steps across 23 workflows against the 28 generated rows (3 retry folds); grepped every `ANTHROPIC_`/`FIREWORKS_`/`ZAI_`/`GEMINI_`/`OPENAI` reference for missed lanes (none); empirically confirmed `--check` fails on a mutated workflow copy; verified generation is byte-deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
