### PR TITLE
Fix safe-push credential collision and auto-merge fallback PRs

### DIFF
--- a/.github/actions/safe-push/action.yml
+++ b/.github/actions/safe-push/action.yml
@@ -18,11 +18,15 @@ description: >
   HEAD already matches the remote — also count as success and emit
   `pushed=true`, matching the prior behavior of consumers that gated
   downstream notifications on this output). If GitHub rejects a direct push
-  because repository rules require pull requests, the action can publish the
-  generated commit to a run-scoped branch and open a pull request instead.
-  If repository settings block Actions-created pull requests, the generated
-  branch still publishes and the action exits successfully with
-  `publication-mode=branch`.
+  because repository rules require pull requests, the action publishes the
+  generated commit to a run-scoped branch, opens a pull request, and — by
+  default (`pr-merge: true`) — squash-merges it immediately, emitting
+  `pushed=true` + `publication-mode=pull-request-merged` since the content
+  did land on the target branch. If the merge fails (e.g. a same-file
+  conflict with a concurrent writer), the PR is left open for manual review
+  with `publication-mode=pull-request`. If repository settings block
+  Actions-created pull requests, the generated branch still publishes and
+  the action exits successfully with `publication-mode=branch`.
 
 inputs:
   branch:
@@ -71,10 +75,23 @@ inputs:
     description: Prefix for generated protected-branch fallback branches.
     required: false
     default: 'automation/safe-push'
+  pr-merge:
+    description: >
+      If 'true' (default), squash-merge the fallback pull request immediately
+      after opening it, so scheduled publishers stay autonomous under a
+      pull-request-required ruleset (squash is the only merge method the main
+      ruleset allows). The workflows' pre-push diff-scope guards — not the
+      fallback PR — are the review boundary for generated output. Set 'false'
+      to leave fallback PRs open for manual review.
+    required: false
+    default: 'true'
 
 outputs:
   pushed:
-    description: 'true if the push succeeded (including no-op pushes); empty otherwise.'
+    description: >-
+      'true' if the content landed on the target branch: a direct push, a
+      no-op push, or a squash-merged fallback pull request. 'false'/empty
+      when it did not (open fallback PR, branch-only publication, failure).
     value: ${{ steps.do-push.outputs.pushed }}
   pull-request-url:
     description: Pull request URL when protected-branch-fallback opened one.
@@ -83,7 +100,9 @@ outputs:
     description: Generated branch name when protected-branch-fallback opened a pull request.
     value: ${{ steps.do-push.outputs.pull-request-branch }}
   publication-mode:
-    description: direct, noop, pull-request, branch, or empty on hard failure.
+    description: >-
+      direct, noop, pull-request-merged, pull-request, branch, or empty on
+      hard failure.
     value: ${{ steps.do-push.outputs.publication-mode }}
 
 runs:
@@ -103,6 +122,7 @@ runs:
         SAFE_PUSH_NOOP_PUSHED: ${{ inputs.noop-pushed }}
         SAFE_PUSH_PROTECTED_BRANCH_FALLBACK: ${{ inputs.protected-branch-fallback }}
         SAFE_PUSH_PR_BRANCH_PREFIX: ${{ inputs.pr-branch-prefix }}
+        SAFE_PUSH_PR_MERGE: ${{ inputs.pr-merge }}
       run: |
         set -euo pipefail
 
@@ -111,6 +131,7 @@ runs:
         INDEX_MERGE="${SAFE_PUSH_INDEX_MERGE}"
         PROTECTED_BRANCH_FALLBACK="${SAFE_PUSH_PROTECTED_BRANCH_FALLBACK}"
         PR_BRANCH_PREFIX="${SAFE_PUSH_PR_BRANCH_PREFIX}"
+        PR_MERGE="${SAFE_PUSH_PR_MERGE}"
 
         # Safety: refuse to push if the workflow's trigger ref doesn't match
         # the target branch. Without this check, a workflow_dispatch run
@@ -127,8 +148,17 @@ runs:
         fi
 
         AUTH_HEADER=$(printf 'x-access-token:%s' "$SAFE_PUSH_GITHUB_TOKEN" | base64 | tr -d '\n')
+        # actions/checkout with persist-credentials (its default) stores its
+        # own AUTHORIZATION value under the same multi-valued config key in
+        # the repo's local git config. A bare `-c` APPENDS to that list, git
+        # then sends BOTH Authorization headers, and GitHub rejects the
+        # request with HTTP 400 "Duplicate header" — killing the very first
+        # `git_auth fetch` before the retry loop or PR fallback can run. The
+        # leading empty -c resets the inherited header list (documented
+        # http.extraHeader semantics) so exactly one header — ours — is sent.
         git_auth() {
-          git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${AUTH_HEADER}" "$@"
+          git -c "http.https://github.com/.extraheader=" \
+              -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${AUTH_HEADER}" "$@"
         }
 
         is_protected_branch_rejection() {
@@ -196,6 +226,35 @@ runs:
               return 0
             fi
             echo "Created fallback PR: ${pr_url}"
+          fi
+
+          # Squash-merge the fallback PR right away (unless opted out) so the
+          # scheduled publishers stay autonomous: the ruleset requires a PR,
+          # but nobody hand-merges 30+ data PRs a day, and unmerged output
+          # never reaches the dashboard prebuild. Retries cover the window
+          # where GitHub is still computing mergeability on a fresh PR or a
+          # concurrent lane just moved the base.
+          if [ "$PR_MERGE" = "true" ]; then
+            local merge_attempt
+            for merge_attempt in 1 2 3 4; do
+              if GH_TOKEN="$SAFE_PUSH_GITHUB_TOKEN" gh pr merge "$pr_branch" \
+                  --repo "$SAFE_PUSH_REPOSITORY" \
+                  --squash; then
+                echo "Squash-merged fallback PR: ${pr_url}"
+                # Best-effort cleanup; a leftover merged branch is harmless.
+                git_auth push origin --delete "refs/heads/${pr_branch}" 2>/dev/null || true
+                {
+                  echo "pushed=true"
+                  echo "publication-mode=pull-request-merged"
+                  echo "pull-request-url=${pr_url}"
+                  echo "pull-request-branch=${pr_branch}"
+                } >> "$GITHUB_OUTPUT"
+                return 0
+              fi
+              echo "Fallback PR merge attempt ${merge_attempt}/4 failed; retrying"
+              sleep $((2 * merge_attempt))
+            done
+            echo "::warning::Fallback PR ${pr_url} was created but could not be squash-merged (same-file conflict with a concurrent writer, or merging is blocked). Merge it manually — this lane's output is not on ${BRANCH} until then."
           fi
 
           {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -497,9 +497,10 @@ output or break the pipeline. Read them before editing.
 12. **Workflow-opened PRs need explicit token semantics.**
     `safe-push` has an automated protected-branch fallback: it pushes a
     generated branch, then attempts `gh pr create` with `GITHUB_TOKEN` when the
-    workflow grants `pull-requests: write`. If repository settings still block
-    Actions-created PRs, it leaves the generated branch in place and emits
-    `publication-mode=branch` instead of failing the workflow. For agent-authored
+    workflow grants `pull-requests: write`, and by default (`pr-merge: true`)
+    immediately squash-merges that PR (see rule 13). If repository settings
+    still block Actions-created PRs, it leaves the generated branch in place
+    and emits `publication-mode=branch` instead of failing the workflow. For agent-authored
     feature PRs, the older working pattern (used by `daily-improve.yml` and
     `twitter-account-explorer.yml`) is still valid: have the agent push the
     branch and run `gh pr create` **from inside the
@@ -510,6 +511,25 @@ output or break the pipeline. Read them before editing.
     in the prompt — not in a downstream plain-`GITHUB_TOKEN`
     `run:` step. (Learned when the explorer's first run curated accounts
     correctly but failed at an external publish step — PR #149.)
+
+13. **`main` is PR-only; scheduled lanes publish via auto-merged safe-push
+    PRs.** A repository ruleset (active since 2026-07-06, no bypass actors,
+    squash merges only) rejects every direct push to `main` — including
+    workflow `GITHUB_TOKEN` pushes — with `GH013`. Scheduled publishers
+    therefore land output through safe-push's fallback: run-scoped
+    `automation/safe-push/*` branch → PR → immediate squash-merge.
+    `pushed=true` now means "content is on `main`" (direct, no-op, or merged
+    fallback PR), and Railway still deploys on each merge because a merge IS
+    a push to `main`. Two operational corollaries: (a) an
+    `automation/safe-push/*` PR left OPEN means the auto-merge failed —
+    usually a same-file conflict with a concurrent writer; resolve and merge
+    it manually (oldest first) or the lane's data never reaches the
+    dashboard, and (b) safe-push resets any checkout-persisted
+    `http.<url>.extraheader` before injecting its own auth — do NOT "simplify"
+    that away, or every fetch/push 400s with `Duplicate header:
+    "Authorization"` (the 2026-07-06 outage: all lanes but hourly-twitter
+    hard-failed at push because persisted credentials + injected header sent
+    two Authorization headers).
 
 ## Code Style
 


### PR DESCRIPTION
## Problem

Since the `main` ruleset started requiring pull requests (2026-07-06 02:28 KST, no bypass actors), the research pipeline stopped landing output on `main`:

1. **Every lane except hourly-twitter hard-failed at `Push changes`** with `remote: Duplicate header: "Authorization"` → HTTP 400. `actions/checkout` persists its own credential as `http.https://github.com/.extraheader` in local git config; safe-push's `git_auth` **appends** a second Authorization header via `-c`, and GitHub rejects the request before the retry loop or PR fallback can run. hourly-twitter survived only because it sets `persist-credentials: false`.
2. **Fallback PRs pile up unmerged** (#209, #212, #213) — the PR fallback publishes the commit but nothing merges it, so lanes go stale on `main`, the dashboard never sees the data, and liveness alerts fire. #207 had to be merged by hand.

## Fix

- `git_auth` now prepends an empty `http.https://github.com/.extraheader=` reset (documented git semantics: an empty value clears the inherited list), so exactly one Authorization header is sent regardless of checkout's persist-credentials. Verified against a header-echo server: persisted+injected sends 2 headers; with the reset, exactly 1.
- The protected-branch fallback now **squash-merges its PR immediately** (new `pr-merge` input, default `true`; squash is the only method the ruleset allows). Success emits `pushed=true` + `publication-mode=pull-request-merged` — correct for downstream Telegram/Vercel gates since the content really is on `main`. Merge failure (e.g. same-file conflict with a concurrent writer) leaves the PR open exactly as today.
- Documented the publication model as load-bearing rule 13 in CLAUDE.md.

No workflow YAML changes needed — all 15 safe-push callers already grant `pull-requests: write`.

## Verification

- Header semantics reproduced + verified locally against an echo server (1 header with reset, 2 without).
- `bash -n` on the embedded script; YAML parse + input/env wiring asserted.
- Post-merge: will dispatch `hourly-rss.yml` and confirm the run publishes via an auto-merged fallback PR and the data lands on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)