### PR TITLE
Route agent fallback to native Claude during provider outages

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,10 +171,9 @@ flowchart LR
     pi -->|"deepseek-v4-flash · kimi-k2p7"| FW
     native -->|"claude-sonnet-5"| ANT
     gendef -.->|"backend=codex"| OAI
-    FW -. "provider outage → fallback #1" .-> ZAI
-    ZAI -. "provider outage → fallback #2" .-> ANT
+    FW -. "provider outage → fallback #1" .-> ANT
 ```
-_Generated from [`data/agent-backends.json`](data/agent-backends.json) — fallback chain: `zai-glm-5p2` → `claude`; regenerate with `uv run python scripts/build_backend_matrix.py`._
+_Generated from [`data/agent-backends.json`](data/agent-backends.json) — fallback chain: `claude`; regenerate with `uv run python scripts/build_backend_matrix.py`._
 <!-- END GENERATED BACKEND DIAGRAM -->
 
 ## Sources

--- a/data/agent-backends.json
+++ b/data/agent-backends.json
@@ -40,11 +40,10 @@
   "fallback": {
     "harness": "agent-run",
     "chain": [
-      "zai-glm-5p2",
       "claude"
     ],
     "native_model": "claude-sonnet-5",
-    "notes": "ORDERED fallback chain, globally applied to every non-strict agent-run lane. When the lane's requested provider probe fails, scripts/select_backend.py walks this chain in order (skipping the already-failed requested backend if it reappears) and runs the first candidate whose provider is available: zai = Z.ai key + endpoint probe, fireworks = preflight, claude = always available. Keeping `claude` terminal guarantees selection always succeeds when the OAuth token exists. Lanes with \"strict\": true (zai-canary) never walk the chain — unavailability fails the run. `native_model` is the model served whenever the native claude path runs (also what the --model opus alias resolves to)."
+    "notes": "ORDERED fallback chain, globally applied to every non-strict agent-run lane. When the lane's requested provider probe fails, scripts/select_backend.py walks this chain in order (skipping the already-failed requested backend if it reappears) and runs the first candidate whose provider is available. The default outage fallback is the native Claude Code OAuth path, which is treated as available at selection time and serves `native_model`. This preserves committed output during Fireworks account/billing outages instead of selecting a superficially available provider that may exit without artifacts. Lanes with \"strict\": true (zai-canary) never walk the chain — unavailability fails the run. `native_model` is the model served whenever the native claude path runs (also what the --model opus alias resolves to)."
   },
   "lanes": {
     "rss": {

--- a/docs/backend-matrix.md
+++ b/docs/backend-matrix.md
@@ -74,29 +74,29 @@ Reading notes:
 | Lane | Workflow | Harness | Provider | Model | Token secret | Fallback |
 |---|---|---|---|---|---|---|
 | ai-news-research (×2 step variants) | `ai-news-research.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
-| arxiv | `daily-arxiv.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | chain: `zai-glm-5p2` → claude (`claude-sonnet-5`); then `deterministic_arxiv_digest.py` |
-| bluesky | `2h-bluesky.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | chain: `zai-glm-5p2` → claude (`claude-sonnet-5`); then `deterministic_bluesky_digest.py` |
+| arxiv | `daily-arxiv.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | chain: claude (`claude-sonnet-5`); then `deterministic_arxiv_digest.py` |
+| bluesky | `2h-bluesky.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | chain: claude (`claude-sonnet-5`); then `deterministic_bluesky_digest.py` |
 | claude-code-review | `claude-code-review.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
 | claude-interactive | `claude.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
-| community | `4h-community.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | chain: `zai-glm-5p2` → claude (`claude-sonnet-5`); then `deterministic_community_digest.py` |
+| community | `4h-community.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | chain: claude (`claude-sonnet-5`); then `deterministic_community_digest.py` |
 | daily-improve | `daily-improve.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
-| digest-audio-script | `daily-digest.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | chain: `zai-glm-5p2` → claude (`claude-sonnet-5`); then `deterministic_daily_digest.py` |
-| digest-synthesis | `daily-digest.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | chain: `zai-glm-5p2` → claude (`claude-sonnet-5`); then `deterministic_daily_digest.py` |
-| digest-synthesis-fallback | `daily-digest.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | chain: `zai-glm-5p2` → claude (`claude-sonnet-5`); then `deterministic_daily_digest.py` |
+| digest-audio-script | `daily-digest.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | chain: claude (`claude-sonnet-5`); then `deterministic_daily_digest.py` |
+| digest-synthesis | `daily-digest.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | chain: claude (`claude-sonnet-5`); then `deterministic_daily_digest.py` |
+| digest-synthesis-fallback | `daily-digest.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | chain: claude (`claude-sonnet-5`); then `deterministic_daily_digest.py` |
 | generative-research-claude (+1 retry step) | `generative-research.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
 | generative-research-default | `generative-research.yml` | dispatch default (runtime SSOT) | (per chosen backend) | default: `glm-5p2` | (per chosen backend) | workflow-level `fireworks_fallback` input (default `claude`) |
-| model-timeline | `24h-model-timeline.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | chain: `zai-glm-5p2` → claude (`claude-sonnet-5`) |
+| model-timeline | `24h-model-timeline.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | chain: claude (`claude-sonnet-5`) |
 | research-issue (×2 step variants) | `research-issue.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
-| rss | `hourly-rss.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | chain: `zai-glm-5p2` → claude (`claude-sonnet-5`); then `deterministic_rss_digest.py` |
+| rss | `hourly-rss.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | chain: claude (`claude-sonnet-5`); then `deterministic_rss_digest.py` |
 | twitter-account-explorer | `twitter-account-explorer.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
-| twitter-autoresearch (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | chain: `zai-glm-5p2` → claude (`claude-sonnet-5`) |
+| twitter-autoresearch (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | chain: claude (`claude-sonnet-5`) |
 | twitter-deepseek (tier:deepseek-claude-code) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | DeepSeek V4 Flash via Fireworks | `accounts/fireworks/models/deepseek-v4-flash` | `FIREWORKS_API_KEY` | hard fail (strict — never walks the chain); then `deterministic_twitter_digest.py` |
 | twitter-deepseek-pi (tier:deepseek-pi) | `hourly-twitter.yml` | pi · run-pi-container (CI-enforced mirror) | fireworks (pi built-in) | `accounts/fireworks/models/deepseek-v4-flash` | `FIREWORKS_API_KEY` | — |
 | twitter-fireworks-pi (tier:fireworks-pi) | `hourly-twitter.yml` | pi · run-pi-container (CI-enforced mirror) | fireworks (pi built-in) | `accounts/fireworks/models/kimi-k2p7` | `FIREWORKS_API_KEY` | — |
-| twitter-judge (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | DeepSeek V4 Flash via Fireworks | `accounts/fireworks/models/deepseek-v4-flash` | `FIREWORKS_API_KEY` | chain: `zai-glm-5p2` → claude (`claude-sonnet-5`) |
-| twitter-primary (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | chain: `zai-glm-5p2` → claude (`claude-sonnet-5`) |
+| twitter-judge (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | DeepSeek V4 Flash via Fireworks | `accounts/fireworks/models/deepseek-v4-flash` | `FIREWORKS_API_KEY` | chain: claude (`claude-sonnet-5`) |
+| twitter-primary (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | chain: claude (`claude-sonnet-5`) |
 | twitter-zai (tier:zai-glm-5p2) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Z.ai | `glm-5.2` | `ZAI_API_KEY` | hard fail (strict — never walks the chain); then `deterministic_twitter_digest.py` |
-| wiki-ingest | `wiki-ingest.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | chain: `zai-glm-5p2` → claude (`claude-sonnet-5`) |
+| wiki-ingest | `wiki-ingest.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | chain: claude (`claude-sonnet-5`) |
 | zai-canary · PINNED | `zai-claude-code-canary.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Z.ai | `glm-5.2` | `ZAI_API_KEY` | hard fail (strict — never walks the chain) |
 | (dispatch path) backend=fireworks (+2 retry steps) | `generative-research.yml` | Claude Code · claude-code-action (env-rerouted) | Fireworks (Anthropic-compatible endpoint) | dynamic: per fireworks profile step | `FIREWORKS_API_KEY` | workflow-level `fireworks_fallback` input (default `claude`) |
 | (dispatch path) backend=codex | `generative-research.yml` | Codex CLI | OpenAI (ChatGPT subscription auth) | codex CLI default | `CODEX_AUTH_JSON` | — |
@@ -111,7 +111,7 @@ Reading notes:
 - `daily-youtube.yml`
 - `liveness-check.yml`
 
-_Global ordered fallback chain (SSOT `fallback.chain`): `zai-glm-5p2` → `claude`; native path serves `claude-sonnet-5`. 25 SSOT lanes (+2 dispatch execution paths) across 23 workflows; 7 workflows run no model._
+_Global ordered fallback chain (SSOT `fallback.chain`): `claude`; native path serves `claude-sonnet-5`. 25 SSOT lanes (+2 dispatch execution paths) across 23 workflows; 7 workflows run no model._
 
 <!-- END GENERATED BACKEND MATRIX -->
 


### PR DESCRIPTION
## Summary
- Route non-strict agent-run fallback directly to native Claude when the requested provider is unavailable.
- Regenerate the backend matrix and README routing diagram from `data/agent-backends.json`.

## Why
The stale `models` and primary `twitter` lanes are not caused by GitHub-hosted Actions billing or self-hosted runner availability: both watchdog tiers and the affected content jobs started. The live failure path is Fireworks returning HTTP 412 account suspension/spending-limit errors, then the previous fallback selecting Z.ai, which completed without committing required artifacts. Since native Claude is treated as always available at selection time, keeping Z.ai before Claude made these freshness lanes vulnerable to a superficially available provider that produced no output.

## Verification
- `uv run python scripts/build_backend_matrix.py --check`
- `PYTHONPATH=scripts uv run python -m unittest scripts/test_select_backend.py scripts/test_backend_matrix.py`
- `env -u FIREWORKS_API_KEY -u ZAI_API_KEY python3 scripts/select_backend.py --lane twitter-primary --github-output <tmp>` resolves `provider=claude`, `native-model=claude-sonnet-5`, `used-fallback=true`
- same selector check for `model-timeline` resolves `provider=claude`, `native-model=claude-sonnet-5`, `used-fallback=true`

## Operational note
Fireworks billing still needs to be restored separately; this PR is the code-side mitigation so freshness lanes keep committing while Fireworks is suspended.