### PR TITLE
Route ARA production lanes to Claude

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,7 @@ drift. Full per-lane matrix: [`docs/backend-matrix.md`](docs/backend-matrix.md).
 ```mermaid
 flowchart LR
     subgraph runtime["⚙️ Runtime-routed lanes — lane: → data/agent-backends.json"]
-        lanes0["twitter-judge<br/><i>1 lane</i>"]
-        lanes1["arxiv · bluesky · community<br/>digest-audio-script · digest-synthesis · digest-synthesis-fallback<br/>model-timeline · rss · twitter-autoresearch<br/>twitter-primary · wiki-ingest<br/><i>11 lanes</i>"]
+        lanes0["arxiv · bluesky · community<br/>digest-audio-script · digest-synthesis · digest-synthesis-fallback<br/>model-timeline · rss · twitter-autoresearch<br/>twitter-judge · twitter-primary · wiki-ingest<br/><i>12 lanes</i>"]
         strict0["🔒 twitter-deepseek<br/><i>strict — never falls back</i>"]
         strict1["🔒 twitter-zai · zai-canary<br/><i>strict — never falls back</i>"]
         gendef["generative-research-default<br/><i>dispatch default</i>"]
@@ -163,15 +162,13 @@ flowchart LR
         ANT["🅰️ Anthropic<br/><i>native Claude</i>"]
         OAI["🤖 OpenAI Codex CLI<br/><i>ChatGPT auth</i>"]
     end
-    lanes0 -->|"deepseek-v4-flash"| FW
-    lanes1 -->|"glm-5p2"| FW
+    lanes0 -->|"claude-sonnet-5"| ANT
     strict0 -->|"deepseek-v4-flash"| FW
     strict1 -->|"glm-5.2"| ZAI
-    gendef -->|"glm-5p2"| FW
+    gendef -->|"claude-sonnet-5"| ANT
     pi -->|"deepseek-v4-flash · kimi-k2p7"| FW
     native -->|"claude-sonnet-5"| ANT
     gendef -.->|"backend=codex"| OAI
-    FW -. "provider outage → fallback #1" .-> ANT
 ```
 _Generated from [`data/agent-backends.json`](data/agent-backends.json) — fallback chain: `claude`; regenerate with `uv run python scripts/build_backend_matrix.py`._
 <!-- END GENERATED BACKEND DIAGRAM -->

--- a/data/agent-backends.json
+++ b/data/agent-backends.json
@@ -49,76 +49,76 @@
     "rss": {
       "workflow": "hourly-rss.yml",
       "harness": "agent-run",
-      "backend": "fireworks-glm-5p2",
+      "backend": "claude",
       "notes": "2h RSS digest; deterministic_rss_digest.py backstops output."
     },
     "bluesky": {
       "workflow": "2h-bluesky.yml",
       "harness": "agent-run",
-      "backend": "fireworks-glm-5p2",
+      "backend": "claude",
       "notes": "Daily Bluesky expert-commentary section."
     },
     "community": {
       "workflow": "4h-community.yml",
       "harness": "agent-run",
-      "backend": "fireworks-glm-5p2",
+      "backend": "claude",
       "notes": "HN + Reddit digests; deterministic_community_digest.py backstops output."
     },
     "arxiv": {
       "workflow": "daily-arxiv.yml",
       "harness": "agent-run",
-      "backend": "fireworks-glm-5p2",
+      "backend": "claude",
       "notes": "Daily arXiv sweep; deterministic_arxiv_digest.py backstops output."
     },
     "digest-synthesis": {
       "workflow": "daily-digest.yml",
       "harness": "agent-run",
-      "backend": "fireworks-glm-5p2",
+      "backend": "claude",
       "notes": "Primary daily digest synthesis (MCP search path)."
     },
     "digest-synthesis-fallback": {
       "workflow": "daily-digest.yml",
       "harness": "agent-run",
-      "backend": "fireworks-glm-5p2",
+      "backend": "claude",
       "notes": "Local-source digest synthesis when MCP keys are absent."
     },
     "digest-audio-script": {
       "workflow": "daily-digest.yml",
       "harness": "agent-run",
-      "backend": "fireworks-glm-5p2",
+      "backend": "claude",
       "notes": "Rewrites the digest summary as the ARA spoken TTS script."
     },
     "model-timeline": {
       "workflow": "24h-model-timeline.yml",
       "harness": "agent-run",
-      "backend": "fireworks-glm-5p2",
+      "backend": "claude",
       "notes": "Model-release ticket CRUD agent."
     },
     "wiki-ingest": {
       "workflow": "wiki-ingest.yml",
       "harness": "agent-run",
-      "backend": "fireworks-glm-5p2",
+      "backend": "claude",
       "notes": "Digest -> LLM wiki page CRUD agent."
     },
     "twitter-primary": {
       "workflow": "hourly-twitter.yml",
       "tier": "claude",
       "harness": "agent-run",
-      "backend": "fireworks-glm-5p2",
+      "backend": "claude",
       "notes": "Primary 3h Twitter/X processor (tier slot named 'claude' for historical reasons)."
     },
     "twitter-judge": {
       "workflow": "hourly-twitter.yml",
       "tier": "claude",
       "harness": "agent-run",
-      "backend": "fireworks-deepseek-v4-flash",
+      "backend": "claude",
       "notes": "Headline-dedupe adjudication gate inside the primary tier (docs/headline-dedupe.md)."
     },
     "twitter-autoresearch": {
       "workflow": "hourly-twitter.yml",
       "tier": "claude",
       "harness": "agent-run",
-      "backend": "fireworks-glm-5p2",
+      "backend": "claude",
       "notes": "Auto-research topic selection inside the primary tier."
     },
     "twitter-deepseek": {
@@ -165,7 +165,7 @@
     "generative-research-default": {
       "workflow": "generative-research.yml",
       "harness": "dispatch-default",
-      "backend": "glm-5p2",
+      "backend": "claude",
       "notes": "Default backend when neither the dispatch input nor an issue-label form specifies one. Runtime-resolved by the workflow's backend-resolution step."
     },
     "generative-research-claude": {

--- a/docs/backend-matrix.md
+++ b/docs/backend-matrix.md
@@ -74,29 +74,29 @@ Reading notes:
 | Lane | Workflow | Harness | Provider | Model | Token secret | Fallback |
 |---|---|---|---|---|---|---|
 | ai-news-research (×2 step variants) | `ai-news-research.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
-| arxiv | `daily-arxiv.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | chain: claude (`claude-sonnet-5`); then `deterministic_arxiv_digest.py` |
-| bluesky | `2h-bluesky.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | chain: claude (`claude-sonnet-5`); then `deterministic_bluesky_digest.py` |
+| arxiv | `daily-arxiv.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted); then `deterministic_arxiv_digest.py` |
+| bluesky | `2h-bluesky.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted); then `deterministic_bluesky_digest.py` |
 | claude-code-review | `claude-code-review.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
 | claude-interactive | `claude.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
-| community | `4h-community.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | chain: claude (`claude-sonnet-5`); then `deterministic_community_digest.py` |
+| community | `4h-community.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted); then `deterministic_community_digest.py` |
 | daily-improve | `daily-improve.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
-| digest-audio-script | `daily-digest.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | chain: claude (`claude-sonnet-5`); then `deterministic_daily_digest.py` |
-| digest-synthesis | `daily-digest.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | chain: claude (`claude-sonnet-5`); then `deterministic_daily_digest.py` |
-| digest-synthesis-fallback | `daily-digest.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | chain: claude (`claude-sonnet-5`); then `deterministic_daily_digest.py` |
+| digest-audio-script | `daily-digest.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted); then `deterministic_daily_digest.py` |
+| digest-synthesis | `daily-digest.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted); then `deterministic_daily_digest.py` |
+| digest-synthesis-fallback | `daily-digest.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted); then `deterministic_daily_digest.py` |
 | generative-research-claude (+1 retry step) | `generative-research.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
-| generative-research-default | `generative-research.yml` | dispatch default (runtime SSOT) | (per chosen backend) | default: `glm-5p2` | (per chosen backend) | workflow-level `fireworks_fallback` input (default `claude`) |
-| model-timeline | `24h-model-timeline.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | chain: claude (`claude-sonnet-5`) |
+| generative-research-default | `generative-research.yml` | dispatch default (runtime SSOT) | (per chosen backend) | default: `claude` | (per chosen backend) | workflow-level `fireworks_fallback` input (default `claude`) |
+| model-timeline | `24h-model-timeline.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted) |
 | research-issue (×2 step variants) | `research-issue.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
-| rss | `hourly-rss.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | chain: claude (`claude-sonnet-5`); then `deterministic_rss_digest.py` |
+| rss | `hourly-rss.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted); then `deterministic_rss_digest.py` |
 | twitter-account-explorer | `twitter-account-explorer.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
-| twitter-autoresearch (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | chain: claude (`claude-sonnet-5`) |
+| twitter-autoresearch (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted) |
 | twitter-deepseek (tier:deepseek-claude-code) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | DeepSeek V4 Flash via Fireworks | `accounts/fireworks/models/deepseek-v4-flash` | `FIREWORKS_API_KEY` | hard fail (strict — never walks the chain); then `deterministic_twitter_digest.py` |
 | twitter-deepseek-pi (tier:deepseek-pi) | `hourly-twitter.yml` | pi · run-pi-container (CI-enforced mirror) | fireworks (pi built-in) | `accounts/fireworks/models/deepseek-v4-flash` | `FIREWORKS_API_KEY` | — |
 | twitter-fireworks-pi (tier:fireworks-pi) | `hourly-twitter.yml` | pi · run-pi-container (CI-enforced mirror) | fireworks (pi built-in) | `accounts/fireworks/models/kimi-k2p7` | `FIREWORKS_API_KEY` | — |
-| twitter-judge (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | DeepSeek V4 Flash via Fireworks | `accounts/fireworks/models/deepseek-v4-flash` | `FIREWORKS_API_KEY` | chain: claude (`claude-sonnet-5`) |
-| twitter-primary (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | chain: claude (`claude-sonnet-5`) |
+| twitter-judge (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted) |
+| twitter-primary (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted) |
 | twitter-zai (tier:zai-glm-5p2) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Z.ai | `glm-5.2` | `ZAI_API_KEY` | hard fail (strict — never walks the chain); then `deterministic_twitter_digest.py` |
-| wiki-ingest | `wiki-ingest.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Fireworks | `accounts/fireworks/models/glm-5p2` | `FIREWORKS_API_KEY` | chain: claude (`claude-sonnet-5`) |
+| wiki-ingest | `wiki-ingest.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted) |
 | zai-canary · PINNED | `zai-claude-code-canary.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Z.ai | `glm-5.2` | `ZAI_API_KEY` | hard fail (strict — never walks the chain) |
 | (dispatch path) backend=fireworks (+2 retry steps) | `generative-research.yml` | Claude Code · claude-code-action (env-rerouted) | Fireworks (Anthropic-compatible endpoint) | dynamic: per fireworks profile step | `FIREWORKS_API_KEY` | workflow-level `fireworks_fallback` input (default `claude`) |
 | (dispatch path) backend=codex | `generative-research.yml` | Codex CLI | OpenAI (ChatGPT subscription auth) | codex CLI default | `CODEX_AUTH_JSON` | — |

--- a/scripts/test_backend_matrix.py
+++ b/scripts/test_backend_matrix.py
@@ -75,8 +75,9 @@ class RoutingInvariants(unittest.TestCase):
             tiers,
         )
 
-    def test_judge_lane_routes_to_deepseek(self):
-        self.assertEqual(self.lanes["twitter-judge"]["backend"], "fireworks-deepseek-v4-flash")
+    def test_primary_twitter_lanes_route_to_claude(self):
+        for lane in ("twitter-primary", "twitter-judge", "twitter-autoresearch"):
+            self.assertEqual(self.lanes[lane]["backend"], "claude", lane)
 
     def test_pi_mirror_matches_workflow(self):
         pi_models = {s.model for s in self.obs["hourly-twitter.yml"].pi}
@@ -108,7 +109,8 @@ class RoutingInvariants(unittest.TestCase):
         _, diagram2 = build_generated_blocks()
         self.assertEqual(diagram1, diagram2)
         self.assertIn("flowchart LR", diagram1)
-        self.assertIn("provider outage → fallback #1", diagram1)
+        self.assertIn("claude-sonnet-5", diagram1)
+        self.assertIn("fallback chain: `claude`", diagram1)
         self.assertIn("zai-canary", diagram1)
 
 


### PR DESCRIPTION
## Summary
- route production ARA agent-run lanes from GLM/Fireworks to native Claude
- keep strict comparison lanes on their labeled backends
- regenerate the backend matrix and README diagram

## Verification
- uv run python scripts/build_backend_matrix.py --check
- git diff --check