### PR TITLE
Fix Claude daily pipeline prompts

### DIFF
--- a/.github/workflows/24h-model-timeline.yml
+++ b/.github/workflows/24h-model-timeline.yml
@@ -113,7 +113,7 @@ jobs:
       # surface to job.status (and so hooker-telemetry's `if: always()`
       # step still fires). Without the inspect step, this flag would
       # silently mask timeouts as success — see the inspect step.
-      - name: CRUD model tickets via Fireworks
+      - name: CRUD model tickets via Claude
         id: crud
         timeout-minutes: 90
         continue-on-error: true
@@ -131,7 +131,7 @@ jobs:
             --model opus --max-turns 60 --allowedTools "Read,Write,Edit,Bash(uv:*),Bash(git:*),Bash(ls:*),Bash(cat:*),Bash(grep:*),Bash(jq:*),Bash(curl:*),Task,TodoWrite"
           expected-paths: |
             research/models/
-          label: Model-ticket Fireworks CRUD
+          label: Model-ticket Claude CRUD
           prompt: |
             You maintain a persistent set of model-release tickets. Each
             ticket tracks one shipping artifact (a model release, a
@@ -145,14 +145,14 @@ jobs:
             emit.
 
             CONTEXT
-              TODAY:           $DATE_TODAY
-              YESTERDAY:       $DATE_YESTERDAY
-              TIMESTAMP:       $TIMESTAMP
+              TODAY:           ${{ steps.datetime.outputs.date }}
+              YESTERDAY:       ${{ steps.datetime.outputs.yesterday }}
+              TIMESTAMP:       ${{ steps.datetime.outputs.timestamp }}
               SCHEMA / CONTRACT:  docs/model-tickets.md
               TICKETS DIR:        research/models/tickets/
               RAW SIGNAL:         /tmp/bird/*.json
               VALIDATOR:          scripts/check_model_tickets.py
-              DAILY-DIFF TARGET:  research/models/$DATE_TODAY-timeline.md
+              DAILY-DIFF TARGET:  research/models/${{ steps.datetime.outputs.date }}-timeline.md
 
             STEP 0 — READ THE CONTRACT FIRST.
               `Read docs/model-tickets.md` in full. Internalize the 5-state
@@ -192,7 +192,7 @@ jobs:
                    create a successor ticket whose body links to the
                    closed one.
                 d) NO MATCH → CREATE: pick a slug per conventions, set
-                   created_at = updated_at = $DATE_TODAY, status per
+                   created_at = updated_at = ${{ steps.datetime.outputs.date }}, status per
                    the strongest evidence, verification honestly,
                    seed history with one entry "Created — <summary>".
 
@@ -203,7 +203,7 @@ jobs:
                   (no history entry in 15+ days) → `closed_reason: stale-rumor-unverified`
                 - contradicted by today's signal AND a successor exists
                   → `closed_reason: superseded-by:<slug>`
-              When closing: set status=closed, closed_at=$DATE_TODAY,
+              When closing: set status=closed, closed_at=${{ steps.datetime.outputs.date }},
               closed_reason=<...>, bump updated_at, append a final
               history entry describing the closure.
 
@@ -214,11 +214,11 @@ jobs:
               Do NOT proceed past this step with a failing validator.
 
             STEP 6 — EMIT THE DAILY-DIFF.
-              Write `research/models/$DATE_TODAY-timeline.md` summarizing
+              Write `research/models/${{ steps.datetime.outputs.date }}-timeline.md` summarizing
               what you just did. Format:
 
-                # Model Timeline — Diff for $DATE_TODAY
-                *Generated $TIMESTAMP*
+                # Model Timeline — Diff for ${{ steps.datetime.outputs.date }}
+                *Generated ${{ steps.datetime.outputs.timestamp }}*
 
                 ## 🆕 Created (<N>)
                 - `<slug>` — <company> — <status> — <one-line summary>
@@ -239,9 +239,14 @@ jobs:
               empty "Created (0)"). Order each section alphabetically by
               slug.
 
+              Always write the daily-diff file, even when no ticket changed.
+              In that case, include only the "No change today" section with
+              the unchanged-ticket count. The daily-diff file is required
+              workflow output; do not skip it.
+
             STEP 7 — COMMIT (Bash).
-              git add research/models/tickets/ "research/models/$DATE_TODAY-timeline.md"
-              git commit -m "Model tickets update $TIMESTAMP" || echo "No changes"
+              git add research/models/tickets/ "research/models/${{ steps.datetime.outputs.date }}-timeline.md"
+              git commit -m "Model tickets update ${{ steps.datetime.outputs.timestamp }}" || echo "No changes"
 
               Do NOT run `git push`. A later workflow step publishes.
 
@@ -267,16 +272,16 @@ jobs:
       # hooker-telemetry would report a green run. exit 1 here lets
       # later `if: always()` steps (telemetry) still fire while flipping
       # job.status to failure when it should be.
-      - name: Inspect Fireworks outcome
+      - name: Inspect Claude outcome
         if: always()
         env:
           OUTCOME: ${{ steps.crud.outcome }}
         run: |
           if [ "$OUTCOME" = "failure" ]; then
-            echo "::error::Model-ticket Fireworks CRUD step failed (timeout, model error, or missing output); failing the job so telemetry reports honestly."
+            echo "::error::Model-ticket Claude CRUD step failed (timeout, model error, or missing output); failing the job so telemetry reports honestly."
             exit 1
           fi
-          echo "Model-ticket Fireworks CRUD step succeeded."
+          echo "Model-ticket Claude CRUD step succeeded."
 
       # Use the shared safe-push composite action (post-PR-#58 algorithm):
       # stash any leftover working-tree state before rebasing, so the

--- a/.github/workflows/daily-digest.yml
+++ b/.github/workflows/daily-digest.yml
@@ -162,7 +162,7 @@ jobs:
           expected-paths: |
             research/digest/
             research/summaries/
-          label: Daily digest Fireworks synthesizer
+          label: Daily digest Claude synthesizer
           prompt: |
             You are the AI News Editor. Create a comprehensive DAILY DIGEST.
 
@@ -269,7 +269,7 @@ jobs:
           expected-paths: |
             research/digest/
             research/summaries/
-          label: Daily digest Fireworks local-source synthesizer
+          label: Daily digest Claude local-source synthesizer
           prompt: |
             You are the AI News Editor. Create a comprehensive DAILY DIGEST.
 
@@ -441,7 +441,7 @@ jobs:
             research/digest/
           label: Daily digest workflow output
 
-      - name: Rewrite summary as ARA spoken script (GLM-5.2 via Fireworks)
+      - name: Rewrite summary as ARA spoken script (Claude)
         if: success()
         continue-on-error: true
         uses: ./.github/actions/agent-run
@@ -454,7 +454,7 @@ jobs:
             --model opus --allowedTools "Read,Write,Edit,Bash(git:*)"
           expected-paths: |
             research/summaries/
-          label: Digest spoken-script GLM-5.2 Fireworks rewrite
+          label: Digest spoken-script Claude rewrite
           prompt: |
             You are writing the daily ARA broadcast — a TWO-HOST AI-news podcast
             with banter between Speaker 1 (anchor, deep voice) and Speaker 2
@@ -523,7 +523,7 @@ jobs:
 
             STEP 4 — Commit:
             git add research/summaries/${{ steps.date.outputs.date }}-digest-spoken.txt
-            git commit -m "Spoken script ${{ steps.date.outputs.date }} (ARA two-host Fireworks rewrite)" || echo "No changes"
+            git commit -m "Spoken script ${{ steps.date.outputs.date }} (ARA two-host Claude rewrite)" || echo "No changes"
 
       - name: Generate audio digest with Gemini 3.1 Flash TTS
         if: success()

--- a/.github/workflows/hourly-twitter.yml
+++ b/.github/workflows/hourly-twitter.yml
@@ -1,7 +1,7 @@
 name: Twitter AI News (matrix — claude / deepseek-claude-code / zai-glm-5p2 / deepseek-pi / fireworks-pi)
 
 # Unified Twitter/X pipeline that fans out across five backend tiers:
-#   - claude            (cron '7 */3 * * *', primary tier, model: GLM 5.2 via Fireworks,
+#   - claude            (cron '7 */3 * * *', primary tier, model routed by data/agent-backends.json,
 #                        output → research/twitter/)
 #   - deepseek-claude-code (cron '37 */6 * * *', model: deepseek-v4-flash via Fireworks, output → research/twitter-deepseek/)
 #   - zai-glm-5p2      (manual only,        model: glm-5.2 via Z.ai Coding Plan,
@@ -30,7 +30,7 @@ name: Twitter AI News (matrix — claude / deepseek-claude-code / zai-glm-5p2 / 
 #
 # Required secrets:
 #   CLAUDE_CODE_OAUTH_TOKEN              — required by claude-code-action wrapper
-#   FIREWORKS_API_KEY                    — primary GLM-5.2 tier and comparison tiers
+#   FIREWORKS_API_KEY                    — comparison tiers and fallback-capable agent-run lanes
 #   ZAI_API_KEY                          — preferred manual Z.ai GLM-5.2 Claude Code comparison tier
 #   BIRDY_ACCOUNTS                       — optional multi-account rotation JSON; each account is forced read-only
 #   BIRD_AUTH_TOKEN, BIRD_CT0            — fallback single-account cookies when BIRDY_ACCOUNTS is absent
@@ -400,7 +400,7 @@ jobs:
         id: twitter-output-base
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Process tweets with GLM-5.2 via Fireworks (primary tier)
+      - name: Process tweets with Claude (primary tier)
         if: >-
           steps.backend.outputs.name == 'claude'
           && !(github.event_name == 'workflow_dispatch' && inputs.dry_run == true)
@@ -422,7 +422,7 @@ jobs:
           allowed-paths: |
             research/twitter/
             research/summaries/
-          label: Twitter primary GLM-5.2 Fireworks processor
+          label: Twitter primary Claude processor
           prompt: ${{ steps.render.outputs.prompt }}
 
       - name: Process tweets with DeepSeek v4 Flash via Fireworks (deepseek-claude-code tier)
@@ -738,13 +738,13 @@ jobs:
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
           echo "Shortlisted $COUNT contested-band headline(s) for the judge."
 
-      # ── primary-tier agent dedupe gate (steps 2/4: Fireworks adjudicates) ──
-      # Final gate: the Fireworks-backed agent rules on each shortlisted headline vs its <=5
+      # ── primary-tier agent dedupe gate (steps 2/4: Claude adjudicates) ──
+      # Final gate: the Claude-backed agent rules on each shortlisted headline vs its <=5
       # nearest priors. Bias is hard toward KEEP — it may only turn a
       # would-be send into a suppress, on a HIGH-confidence duplicate.
       # continue-on-error so a model hiccup fails OPEN (no verdicts -> nothing
       # suppressed). Skipped when the shortlist is empty.
-      - name: Adjudicate near-duplicate headlines with Fireworks (primary tier)
+      - name: Adjudicate near-duplicate headlines with Claude (primary tier)
         id: judge_adjudicate
         if: >-
           steps.backend.outputs.name == 'claude'
@@ -759,7 +759,7 @@ jobs:
           zai-api-key: ${{ secrets.ZAI_API_KEY }}
           claude-args: |
             --model opus --max-turns 12 --allowedTools "Read,Write"
-          label: Twitter headline Fireworks judge
+          label: Twitter headline Claude judge
           prompt: |
             You are the final duplicate gate for an AI-news headline alert
             feed. Reason from FIRST PRINCIPLES: judge whether two headlines
@@ -1364,7 +1364,7 @@ jobs:
             echo "Auto-research budget available — proceeding to topic selection."
           fi
 
-      - name: Auto-research topic selection (primary Fireworks tier)
+      - name: Auto-research topic selection (primary Claude tier)
         id: autoresearch_select
         if: >-
           steps.backend.outputs.name == 'claude'
@@ -1378,7 +1378,7 @@ jobs:
           zai-api-key: ${{ secrets.ZAI_API_KEY }}
           claude-args: |
             --model opus --max-turns 10 --allowedTools "Read,Bash(ls:*),Bash(cat:*),Bash(jq:*),Bash(date:*),Write"
-          label: Twitter auto-research Fireworks selector
+          label: Twitter auto-research Claude selector
           prompt: |
             You select AT MOST ONE topic from today's Twitter AI Pulse to
             dispatch to the generative-research deep pipeline (4500–7000

--- a/.github/workflows/wiki-ingest.yml
+++ b/.github/workflows/wiki-ingest.yml
@@ -106,7 +106,7 @@ jobs:
       # to job.status (and so hooker-telemetry's `if: always()` step still
       # fires). Without the inspect step, this flag would silently mask
       # timeouts as success.
-      - name: Ingest digest into wiki via Fireworks
+      - name: Ingest digest into wiki via Claude
         id: ingest
         timeout-minutes: 90
         continue-on-error: true
@@ -124,7 +124,7 @@ jobs:
             --model opus --max-turns 80 --allowedTools "Read,Write,Edit,Bash(uv:*),Bash(git:*),Bash(ls:*),Bash(cat:*),Bash(grep:*),Bash(jq:*),Task,TodoWrite"
           expected-paths: |
             research/wiki/
-          label: Wiki Fireworks ingest
+          label: Wiki Claude ingest
           prompt: |
             You maintain the LLM Wiki: a compounding, interlinked knowledge
             base of markdown pages at research/wiki/. One page per
@@ -139,15 +139,15 @@ jobs:
             already exists is the primary failure mode — guard against it.
 
             CONTEXT
-              TODAY:           $DATE_TODAY
-              YESTERDAY:       $DATE_YESTERDAY
-              TIMESTAMP:       $TIMESTAMP
+              TODAY:           ${{ steps.datetime.outputs.date }}
+              YESTERDAY:       ${{ steps.datetime.outputs.yesterday }}
+              TIMESTAMP:       ${{ steps.datetime.outputs.timestamp }}
               SCHEMA / CONTRACT:  docs/wiki-schema.md
               WIKI ROOT:          research/wiki/
               WIKI INDEX:         research/wiki/index.md
               WIKI LOG:           research/wiki/log.md
               PAGE DIRS:          research/wiki/{entities,concepts,themes}/
-              CURATED INPUT:      research/digest/$DATE_TODAY-digest.md
+              CURATED INPUT:      research/digest/${{ steps.datetime.outputs.date }}-digest.md
               MODEL TICKETS:      research/models/tickets/*.md
               SEARCH CLI:         uv run python scripts/wiki_search.py "<query>"
               VALIDATOR:          uv run python scripts/check_wiki.py
@@ -163,7 +163,7 @@ jobs:
               schema wins.
 
             STEP 1 — READ THE CURATED INPUT (NOT THE FIREHOSE).
-              Read today's digest at research/digest/$DATE_TODAY-digest.md.
+              Read today's digest at research/digest/${{ steps.datetime.outputs.date }}-digest.md.
               If that exact file does not exist (the digest can cross
               midnight UTC and land under yesterday's date, or a manual
               dispatch can run on an off-day), `ls research/digest/` and use
@@ -177,7 +177,7 @@ jobs:
               research/community/, research/arxiv/, or any other raw-source
               directory; the digest is the curated distillation of those and
               reading them again would re-introduce the noise the digest
-              exists to remove. Do not use WebSearch in this Fireworks-routed
+              exists to remove. Do not use WebSearch in this Claude-routed
               lane; if a claim is not supported by the digest or model tickets,
               leave it out or mark it as unresolved rather than expanding the
               research scope.
@@ -237,7 +237,7 @@ jobs:
               structure the schema/index already uses — do not invent a new
               one). Then APPEND exactly ONE entry to research/wiki/log.md:
 
-                ## [$DATE_TODAY] ingest | <one-line summary of what changed>
+                ## [${{ steps.datetime.outputs.date }}] ingest | <one-line summary of what changed>
 
               The summary should name the created vs updated pages at a
               glance (e.g. "created 2 (gpt-5-2, foo-bench), updated 4
@@ -263,7 +263,7 @@ jobs:
 
             STEP 6 — COMMIT (Bash).
               git add research/wiki/
-              git commit -m "Wiki ingest $DATE_TODAY" || echo "No changes"
+              git commit -m "Wiki ingest ${{ steps.datetime.outputs.date }}" || echo "No changes"
 
               (`git add research/wiki/` includes the regenerated index.json.)
               Do NOT run `git push`. A later workflow step publishes.
@@ -298,16 +298,16 @@ jobs:
       # would report a green run. exit 1 here lets later `if: always()`
       # steps (telemetry) still fire while flipping job.status to failure
       # when it should be.
-      - name: Inspect Fireworks outcome
+      - name: Inspect Claude outcome
         if: always()
         env:
           OUTCOME: ${{ steps.ingest.outcome }}
         run: |
           if [ "$OUTCOME" = "failure" ]; then
-            echo "::error::Wiki Fireworks ingest step failed (timeout, model error, or missing output); failing the job so telemetry reports honestly."
+            echo "::error::Wiki Claude ingest step failed (timeout, model error, or missing output); failing the job so telemetry reports honestly."
             exit 1
           fi
-          echo "Wiki Fireworks ingest step succeeded."
+          echo "Wiki Claude ingest step succeeded."
 
       # Mechanically enforce the "never delete a page" invariant. The prompt
       # says it, but a prompt is not a guarantee. Diff exactly the agent's


### PR DESCRIPTION
## Summary
- replace stale literal date placeholders in model timeline and wiki ingest prompts with concrete workflow outputs
- require the model timeline daily diff artifact even when there are no ticket changes
- rename production Claude workflow labels/messages so reruns are easier to audit

## Verification
- uv run python scripts/build_backend_matrix.py --check
- uv run python -m unittest discover -s scripts -p 'test_*.py'
- git diff --check