### PR TITLE
Add Claude Twitter fallback output guard

### DIFF
--- a/.github/workflows/hourly-twitter.yml
+++ b/.github/workflows/hourly-twitter.yml
@@ -401,6 +401,8 @@ jobs:
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Process tweets with Claude (primary tier)
+        id: twitter-claude-agent
+        continue-on-error: true
         if: >-
           steps.backend.outputs.name == 'claude'
           && !(github.event_name == 'workflow_dispatch' && inputs.dry_run == true)
@@ -424,6 +426,35 @@ jobs:
             research/summaries/
           label: Twitter primary Claude processor
           prompt: ${{ steps.render.outputs.prompt }}
+
+      - name: Deterministic Twitter fallback (claude tier)
+        if: >-
+          steps.backend.outputs.name == 'claude'
+          && steps.twitter-claude-agent.outcome == 'failure'
+          && !(github.event_name == 'workflow_dispatch' && inputs.dry_run == true)
+        env:
+          OUTPUT_DIR: ${{ steps.const.outputs.output_dir }}
+          SUMMARY_SLUG: ${{ steps.const.outputs.summary_slug }}
+          TITLE_SUFFIX: ${{ steps.const.outputs.title_suffix }}
+          DATE: ${{ steps.datetime.outputs.date }}
+          HOUR: ${{ steps.datetime.outputs.hour }}
+          TIMESTAMP: ${{ steps.datetime.outputs.timestamp }}
+          HEADLINES_FILE: ${{ steps.const.outputs.headlines_file }}
+        run: |
+          set -euo pipefail
+          echo "::warning::Claude primary agent path failed; writing deterministic Twitter fallback."
+          python3 scripts/deterministic_twitter_digest.py \
+            --input-dir .twitter-input/bird \
+            --out-dir "$OUTPUT_DIR" \
+            --summaries-dir research/summaries \
+            --date "$DATE" \
+            --hour "$HOUR" \
+            --timestamp "$TIMESTAMP" \
+            --title-suffix "$TITLE_SUFFIX" \
+            --summary-slug "$SUMMARY_SLUG" \
+            --headlines-file "$HEADLINES_FILE"
+          git add "$OUTPUT_DIR/" research/summaries/
+          git commit -m "Twitter deterministic fallback ${TIMESTAMP}" || echo "No deterministic Twitter changes"
 
       - name: Process tweets with DeepSeek v4 Flash via Fireworks (deepseek-claude-code tier)
         id: twitter-deepseek-agent
@@ -524,6 +555,19 @@ jobs:
             --summary-slug "$SUMMARY_SLUG"
           git add "$OUTPUT_DIR/" research/summaries/
           git commit -m "Twitter (Z.ai GLM-5.2) deterministic fallback ${TIMESTAMP}" || echo "No deterministic Twitter changes"
+
+      - name: Require Claude primary output
+        if: >-
+          steps.backend.outputs.name == 'claude'
+          && !(github.event_name == 'workflow_dispatch' && inputs.dry_run == true)
+        uses: ./.github/actions/require-output
+        with:
+          base-sha: ${{ steps.twitter-output-base.outputs.sha }}
+          expected-paths: |
+            ${{ steps.const.outputs.digest_file }}
+            ${{ steps.const.outputs.summary_file }}
+            ${{ steps.const.outputs.headlines_file }}
+          label: Twitter primary Claude workflow output
 
       - name: Require DeepSeek comparison output
         if: steps.backend.outputs.name == 'deepseek-claude-code'

--- a/docs/backend-matrix.md
+++ b/docs/backend-matrix.md
@@ -89,12 +89,12 @@ Reading notes:
 | research-issue (×2 step variants) | `research-issue.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
 | rss | `hourly-rss.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted); then `deterministic_rss_digest.py` |
 | twitter-account-explorer | `twitter-account-explorer.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
-| twitter-autoresearch (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted) |
+| twitter-autoresearch (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted); then `deterministic_twitter_digest.py` |
 | twitter-deepseek (tier:deepseek-claude-code) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | DeepSeek V4 Flash via Fireworks | `accounts/fireworks/models/deepseek-v4-flash` | `FIREWORKS_API_KEY` | hard fail (strict — never walks the chain); then `deterministic_twitter_digest.py` |
 | twitter-deepseek-pi (tier:deepseek-pi) | `hourly-twitter.yml` | pi · run-pi-container (CI-enforced mirror) | fireworks (pi built-in) | `accounts/fireworks/models/deepseek-v4-flash` | `FIREWORKS_API_KEY` | — |
 | twitter-fireworks-pi (tier:fireworks-pi) | `hourly-twitter.yml` | pi · run-pi-container (CI-enforced mirror) | fireworks (pi built-in) | `accounts/fireworks/models/kimi-k2p7` | `FIREWORKS_API_KEY` | — |
-| twitter-judge (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted) |
-| twitter-primary (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted) |
+| twitter-judge (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted); then `deterministic_twitter_digest.py` |
+| twitter-primary (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted); then `deterministic_twitter_digest.py` |
 | twitter-zai (tier:zai-glm-5p2) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Z.ai | `glm-5.2` | `ZAI_API_KEY` | hard fail (strict — never walks the chain); then `deterministic_twitter_digest.py` |
 | wiki-ingest | `wiki-ingest.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted) |
 | zai-canary · PINNED | `zai-claude-code-canary.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Z.ai | `glm-5.2` | `ZAI_API_KEY` | hard fail (strict — never walks the chain) |

--- a/scripts/deterministic_twitter_digest.py
+++ b/scripts/deterministic_twitter_digest.py
@@ -275,6 +275,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--timestamp", required=True)
     parser.add_argument("--title-suffix", default="")
     parser.add_argument("--summary-slug", required=True)
+    parser.add_argument("--headlines-file", type=Path)
     parser.add_argument("--limit", type=int, default=8)
     args = parser.parse_args(argv)
 
@@ -285,9 +286,13 @@ def main(argv: list[str] | None = None) -> int:
     header, digest = render_digest(args.date, args.hour, args.title_suffix, tweets)
     changed = append_if_missing(digest_path, header, digest)
     atomic_write(summary_path, render_summary(args.timestamp, args.title_suffix, tweets))
+    if args.headlines_file is not None:
+        atomic_write(args.headlines_file, "[]\n")
 
     print(f"wrote {digest_path} ({'changed' if changed else 'already had section'})")
     print(f"wrote {summary_path}")
+    if args.headlines_file is not None:
+        print(f"wrote {args.headlines_file}")
     return 0
 
 

--- a/scripts/test_deterministic_twitter_digest.py
+++ b/scripts/test_deterministic_twitter_digest.py
@@ -16,6 +16,7 @@ class DeterministicTwitterDigestTest(unittest.TestCase):
             input_dir = root / "bird"
             out_dir = root / "research" / "twitter-deepseek"
             summaries_dir = root / "research" / "summaries"
+            headlines_file = summaries_dir / "2026-06-29-twitter-deepseek-10h-headlines.json"
             input_dir.mkdir()
             (input_dir / "search-ai.json").write_text(
                 json.dumps(
@@ -52,6 +53,8 @@ class DeterministicTwitterDigestTest(unittest.TestCase):
                     " (DeepSeek v4 Flash)",
                     "--summary-slug",
                     "twitter-deepseek",
+                    "--headlines-file",
+                    str(headlines_file),
                 ]
             )
 
@@ -62,6 +65,7 @@ class DeterministicTwitterDigestTest(unittest.TestCase):
             self.assertIn("@openai", digest)
             self.assertIn("https://x.com/openai/status/123", digest)
             self.assertIn("Twitter/X AI Pulse (DeepSeek v4 Flash)", summary)
+            self.assertEqual(json.loads(headlines_file.read_text(encoding="utf-8")), [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- make the primary Claude Twitter step recoverable instead of failing the job before fallback
- add deterministic fallback output for the primary lane, including an empty headline JSON contract file
- add a final required-output guard so the workflow cannot proceed to push/deploy/alerts without all primary files

## Verification
- uv run python -m unittest scripts.test_deterministic_twitter_digest
- uv run python -m unittest discover -s scripts -p 'test_*.py'
- actionlint .github/workflows/hourly-twitter.yml
- git diff --check