### PR TITLE
Add Twitter date navigation

### DIFF
--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -1579,6 +1579,29 @@ function findMostRecentAvailable(tab: DateTab, targetDateStr: string): string | 
   return best;
 }
 
+function offsetDateStr(dateStr: string, days: number): string {
+  const d = ymdToDate(dateStr);
+  d.setDate(d.getDate() + days);
+  return fmtDate(d);
+}
+
+function findAdjacentAvailable(tab: DateTab, targetDateStr: string, direction: -1 | 1): string | null {
+  const dates = manifestDates(tab);
+  if (!dates || dates.length === 0) {
+    return offsetDateStr(targetDateStr, direction);
+  }
+  if (direction < 0) {
+    for (let i = dates.length - 1; i >= 0; i--) {
+      if (dates[i] < targetDateStr) return dates[i];
+    }
+    return null;
+  }
+  for (const d of dates) {
+    if (d > targetDateStr) return d;
+  }
+  return null;
+}
+
 /** Race a promise against a timeout. Returns 'timeout' if exceeded. */
 function withTimeout<T>(p: Promise<T>, ms: number, controller: AbortController): Promise<T | 'timeout'> {
   return new Promise((resolve) => {
@@ -2426,10 +2449,15 @@ function renderWikiNotFound(slug: string): void {
 }
 
 function renderTwitterReport(md: string, fallbackDate: string | null = null): void {
+  const dateStr = fmtDate(currentDate);
+  const shownDate = fallbackDate || dateStr;
   setSafeContent(content, renderTwitterReportHtml(md, {
     fallbackDate,
-    currentDateStr: fmtDate(currentDate),
+    currentDateStr: dateStr,
     currentDateTitle: displayDate(currentDate),
+    shownDateTitle: displayDate(ymdToDate(shownDate)),
+    prevDate: findAdjacentAvailable('twitter', dateStr, -1),
+    nextDate: findAdjacentAvailable('twitter', dateStr, 1),
     searchTerm,
     parseUtcTime,
     clockIcon,
@@ -3484,6 +3512,10 @@ async function load(): Promise<void> {
         requestAnimationFrame(() => scrollToDigestSection(want));
       }
     } else {
+      if (!manifest) {
+        await loadManifest();
+        if (requestId !== loadRequestId) return;
+      }
       const result = await withTimeout(fetchTwitter(dateStr, controller.signal), LOAD_TIMEOUT_MS, controller);
       if (requestId !== loadRequestId) return;
       if (result === 'timeout') {
@@ -3916,6 +3948,18 @@ content.addEventListener('click', (e) => {
     // Browser handles the rest: print stylesheet hides chrome,
     // user picks "Save as PDF" in the system dialog.
     window.print();
+    return;
+  }
+  const twitterDateLink = target.closest('.twitter-date-link') as HTMLAnchorElement | null;
+  if (twitterDateLink && activeTab === 'twitter') {
+    const href = twitterDateLink.getAttribute('href') || '';
+    const match = href.match(/^\/twitter\/(\d{4}-\d{2}-\d{2})$/);
+    if (match) {
+      e.preventDefault();
+      currentDate = ymdToDate(match[1]);
+      calendarMonth = new Date(currentDate.getFullYear(), currentDate.getMonth(), 1);
+      load();
+    }
     return;
   }
   // Ticket status filter pills (only meaningful on the models tab).

--- a/dashboard/src/render/twitter.ts
+++ b/dashboard/src/render/twitter.ts
@@ -47,6 +47,9 @@ export type TwitterReportRenderOptions = {
   fallbackDate: string | null;
   currentDateStr: string;
   currentDateTitle: string;
+  shownDateTitle: string;
+  prevDate: string | null;
+  nextDate: string | null;
   searchTerm: string;
   parseUtcTime: (title: string, dateStr: string) => TimeInfo | null;
   clockIcon: (hours: number, minutes: number) => string;
@@ -423,9 +426,34 @@ export function sanitizePublicReportMarkdown(md: string): string {
   return out.join('\n').replace(/\n{4,}/g, '\n\n\n').trim();
 }
 
+function renderTwitterDateNav(options: TwitterReportRenderOptions): string {
+  const link = (date: string | null, label: string, cls: string): string => {
+    if (!date) {
+      return '<span class="twitter-date-link twitter-date-link--disabled ' + cls + '">' + label + '</span>';
+    }
+    return [
+      '<a class="twitter-date-link ' + cls + '" href="/twitter/' + escapeHtml(date) + '" aria-label="' + escapeHtml(label + ' Twitter summary: ' + date) + '">',
+      '  <span class="twitter-date-link-label">' + label + '</span>',
+      '  <span class="twitter-date-link-date">' + escapeHtml(date) + '</span>',
+      '</a>',
+    ].join('');
+  };
+  return [
+    '<nav class="twitter-date-nav" aria-label="Twitter summary dates">',
+    '  ' + link(options.prevDate, 'Prev day', 'twitter-date-link--prev'),
+    '  <div class="twitter-date-current">',
+    '    <div class="twitter-date-current-label">Twitter summaries</div>',
+    '    <div class="twitter-date-current-date">' + escapeHtml(options.shownDateTitle) + '</div>',
+    options.fallbackDate ? '    <div class="twitter-date-current-note">Showing fallback for ' + escapeHtml(options.currentDateStr) + '</div>' : '',
+    '  </div>',
+    '  ' + link(options.nextDate, 'Next day', 'twitter-date-link--next'),
+    '</nav>',
+  ].filter(Boolean).join('\n');
+}
+
 export function renderTwitterReportHtml(md: string, options: TwitterReportRenderOptions): string {
   const sections = splitSections(sanitizePublicReportMarkdown(md)).reverse();
-  const cards: string[] = [];
+  const cards: string[] = [renderTwitterDateNav(options)];
   const timelineItems: InfoTimelineItem[] = [];
   const mindshareCycles: TwitterMindshareCycle[] = [];
   if (options.fallbackDate) {

--- a/dashboard/src/style.css
+++ b/dashboard/src/style.css
@@ -1670,6 +1670,87 @@ body.tab-agents .section-nav {
   margin: 0 auto;
 }
 
+.twitter-date-nav {
+  display: grid;
+  grid-template-columns: minmax(150px, 1fr) minmax(220px, 1.3fr) minmax(150px, 1fr);
+  align-items: stretch;
+  gap: 10px;
+  margin: 0 0 14px;
+}
+
+.twitter-date-current,
+.twitter-date-link {
+  min-height: 58px;
+  border: 1px solid var(--border-light);
+  background: var(--bg);
+}
+
+.twitter-date-current {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 9px 14px;
+  text-align: center;
+}
+
+.twitter-date-current-label,
+.twitter-date-link-label {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+
+.twitter-date-current-date {
+  margin-top: 3px;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.twitter-date-current-note {
+  margin-top: 3px;
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+}
+
+.twitter-date-link {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 9px 13px;
+  color: var(--text);
+  text-decoration: none;
+  transition: border-color 0.16s ease, background 0.16s ease, transform 0.16s ease;
+}
+
+.twitter-date-link:hover {
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 7%, var(--bg));
+  transform: translateY(-1px);
+}
+
+.twitter-date-link--next {
+  align-items: flex-end;
+  text-align: right;
+}
+
+.twitter-date-link-date {
+  margin-top: 3px;
+  font-family: var(--font-mono);
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+.twitter-date-link--disabled {
+  color: var(--text-tertiary);
+  background: var(--bg-secondary);
+  pointer-events: none;
+}
+
 .twitter-mindshare {
   max-width: 100%;
   margin: 0 0 28px;
@@ -2589,6 +2670,24 @@ body.has-toc .section-nav { display: none; }
   .twitter-mindshare-head span {
     display: block;
     margin-top: 4px;
+  }
+  .twitter-date-nav {
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
+  }
+  .twitter-date-current {
+    grid-column: 1 / -1;
+    grid-row: 1;
+    min-height: 52px;
+  }
+  .twitter-date-link {
+    min-height: 50px;
+  }
+  .twitter-date-current-date {
+    font-size: 0.94rem;
+  }
+  .twitter-date-link-date {
+    font-size: 0.78rem;
   }
   .twitter-mindshare-map {
     grid-template-columns: repeat(2, minmax(0, 1fr));


### PR DESCRIPTION
## Summary

Adds previous/next day navigation to Twitter summary pages so `/twitter/YYYY-MM-DD` can move between archived report dates without using the calendar.

## Details

- Uses the manifest to link to the actual adjacent archived Twitter report dates, so gaps in the archive are skipped.
- Renders a compact date nav above Twitter reports, including fallback-report states.
- Intercepts the nav links in the SPA so route changes update `currentDate`, calendar month state, and content without a full reload.
- Adds responsive styling for desktop and mobile layouts.

## Validation

- `bun run typecheck`
- `bun run build`
- Local Chrome QA against `/twitter/2026-07-08`: Prev linked to `/twitter/2026-07-05`, clicking Prev updated the SPA route and content, and mobile width had no horizontal overflow.

## Release note

Base branch is `main` because this repository does not currently have a remote `staging` branch.