### PR TITLE
Require Claude-authored Twitter primary repair

### DIFF
--- a/.github/workflows/hourly-twitter.yml
+++ b/.github/workflows/hourly-twitter.yml
@@ -427,34 +427,87 @@ jobs:
           label: Twitter primary Claude processor
           prompt: ${{ steps.render.outputs.prompt }}
 
-      - name: Deterministic Twitter fallback (claude tier)
+      - name: Repair missing Twitter output with Claude (primary tier)
+        id: twitter-claude-repair
+        continue-on-error: true
         if: >-
           steps.backend.outputs.name == 'claude'
           && steps.twitter-claude-agent.outcome == 'failure'
           && !(github.event_name == 'workflow_dispatch' && inputs.dry_run == true)
+        uses: ./.github/actions/agent-run
         env:
-          OUTPUT_DIR: ${{ steps.const.outputs.output_dir }}
-          SUMMARY_SLUG: ${{ steps.const.outputs.summary_slug }}
-          TITLE_SUFFIX: ${{ steps.const.outputs.title_suffix }}
-          DATE: ${{ steps.datetime.outputs.date }}
-          HOUR: ${{ steps.datetime.outputs.hour }}
-          TIMESTAMP: ${{ steps.datetime.outputs.timestamp }}
-          HEADLINES_FILE: ${{ steps.const.outputs.headlines_file }}
-        run: |
-          set -euo pipefail
-          echo "::warning::Claude primary agent path failed; writing deterministic Twitter fallback."
-          python3 scripts/deterministic_twitter_digest.py \
-            --input-dir .twitter-input/bird \
-            --out-dir "$OUTPUT_DIR" \
-            --summaries-dir research/summaries \
-            --date "$DATE" \
-            --hour "$HOUR" \
-            --timestamp "$TIMESTAMP" \
-            --title-suffix "$TITLE_SUFFIX" \
-            --summary-slug "$SUMMARY_SLUG" \
-            --headlines-file "$HEADLINES_FILE"
-          git add "$OUTPUT_DIR/" research/summaries/
-          git commit -m "Twitter deterministic fallback ${TIMESTAMP}" || echo "No deterministic Twitter changes"
+          BIRDY_READ_ONLY: "1"
+          BIRDY_TOOL_LOG_PATH: ${{ github.workspace }}/.twitter-input/birdy-tool-log.jsonl
+        with:
+          lane: twitter-primary-repair
+          claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          fireworks-api-key: ${{ secrets.FIREWORKS_API_KEY }}
+          zai-api-key: ${{ secrets.ZAI_API_KEY }}
+          claude-args: |
+            --model opus --max-turns 40 --allowedTools "Read,Write,Edit,Bash(git:*),Bash(jq:*),Bash(test:*),Bash(ls:*),Bash(cat:*),Bash(head:*)"
+          expected-paths: |
+            ${{ steps.const.outputs.digest_file }}
+            ${{ steps.const.outputs.summary_file }}
+            ${{ steps.const.outputs.headlines_file }}
+          allowed-paths: |
+            research/twitter/
+            research/summaries/
+          label: Twitter primary Claude repair writer
+          prompt: |
+            The primary Claude Twitter/X monitor returned without writing
+            its required files. Repair that now using only local files.
+            Reason from first principles: for each candidate tweet, decide
+            whether the underlying event is actually AI-specific and
+            publication-worthy, not merely viral or from an AI-adjacent
+            account. Stress-test the premise that there is a story before
+            writing it.
+
+            CONTEXT
+              DATE: ${{ steps.datetime.outputs.date }}
+              HOUR: ${{ steps.datetime.outputs.hour }}
+              TIMESTAMP: ${{ steps.datetime.outputs.timestamp }}
+              DAILY FILE: ${{ steps.const.outputs.digest_file }}
+              SUMMARY FILE: ${{ steps.const.outputs.summary_file }}
+              HEADLINES FILE: ${{ steps.const.outputs.headlines_file }}
+              RAW INPUT: .twitter-input/bird/all.json
+              PRIOR DAY: research/twitter/${{ steps.datetime.outputs.yesterday }}.md
+
+            HARD RULES
+              - This is still the production Claude lane. Do not write a
+                deterministic quick-hit dump.
+              - Use tool calls to read the raw input and write all three
+                output files. Do not merely respond in chat.
+              - The public brief is AI-only. Exclude personal life updates,
+                sports, generic politics, generic outrage, engagement-bait,
+                and unrelated viral tweets unless the item materially changes
+                the AI landscape.
+              - If the daily file already has a section for
+                `## ${{ steps.datetime.outputs.hour }}:00 UTC`, replace that
+                same-hour section instead of appending a duplicate.
+              - If there are fewer than three truly alert-worthy AI stories,
+                write `[]` to the headlines JSON. Do not pad.
+
+            OUTPUT CONTRACT
+              1. Write or update `${{ steps.const.outputs.digest_file }}`.
+                 If no main AI stories exist, use:
+                   ## ${{ steps.datetime.outputs.hour }}:00 UTC
+                   **Cycle summary**: Quiet period — no analyst-grade AI stories this window.
+                   ### Quick hits
+                   - No AI-specific quick hits cleared the publication bar this cycle.
+                   ### Skeptic's corner
+                   - None this cycle.
+                   ### Watch list (next 24h)
+                   - Next scheduled Twitter/X AI monitor run.
+                   ### Research notes
+                   - Source checks issued this cycle: local Twitter/X snapshot only.
+              2. Write `${{ steps.const.outputs.summary_file }}` as a concise
+                 Telegram summary. If quiet, say no major AI updates; do not
+                 list off-topic tweets.
+              3. Write `${{ steps.const.outputs.headlines_file }}` as a JSON
+                 array, usually `[]` for a quiet cycle.
+              4. Commit exactly those outputs:
+                   git add "${{ steps.const.outputs.digest_file }}" "${{ steps.const.outputs.summary_file }}" "${{ steps.const.outputs.headlines_file }}"
+                   git commit -m "Twitter Claude repair ${{ steps.datetime.outputs.timestamp }}" || echo "No changes"
 
       - name: Process tweets with DeepSeek v4 Flash via Fireworks (deepseek-claude-code tier)
         id: twitter-deepseek-agent

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ drift. Full per-lane matrix: [`docs/backend-matrix.md`](docs/backend-matrix.md).
 ```mermaid
 flowchart LR
     subgraph runtime["⚙️ Runtime-routed lanes — lane: → data/agent-backends.json"]
-        lanes0["arxiv · bluesky · community<br/>digest-audio-script · digest-synthesis · digest-synthesis-fallback<br/>model-timeline · rss · twitter-autoresearch<br/>twitter-judge · twitter-primary · wiki-ingest<br/><i>12 lanes</i>"]
+        lanes0["arxiv · bluesky · community<br/>digest-audio-script · digest-synthesis · digest-synthesis-fallback<br/>model-timeline · rss · twitter-autoresearch<br/>twitter-judge · twitter-primary · twitter-primary-repair<br/>wiki-ingest<br/><i>13 lanes</i>"]
         strict0["🔒 twitter-deepseek<br/><i>strict — never falls back</i>"]
         strict1["🔒 twitter-zai · zai-canary<br/><i>strict — never falls back</i>"]
         gendef["generative-research-default<br/><i>dispatch default</i>"]

--- a/data/agent-backends.json
+++ b/data/agent-backends.json
@@ -107,6 +107,13 @@
       "backend": "claude",
       "notes": "Primary 3h Twitter/X processor (tier slot named 'claude' for historical reasons)."
     },
+    "twitter-primary-repair": {
+      "workflow": "hourly-twitter.yml",
+      "tier": "claude",
+      "harness": "agent-run",
+      "backend": "claude",
+      "notes": "Claude-only repair writer for the primary Twitter/X tier when the first Claude pass returns without required files."
+    },
     "twitter-judge": {
       "workflow": "hourly-twitter.yml",
       "tier": "claude",

--- a/docs/backend-matrix.md
+++ b/docs/backend-matrix.md
@@ -89,12 +89,13 @@ Reading notes:
 | research-issue (×2 step variants) | `research-issue.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
 | rss | `hourly-rss.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted); then `deterministic_rss_digest.py` |
 | twitter-account-explorer | `twitter-account-explorer.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
-| twitter-autoresearch (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted); then `deterministic_twitter_digest.py` |
+| twitter-autoresearch (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted) |
 | twitter-deepseek (tier:deepseek-claude-code) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | DeepSeek V4 Flash via Fireworks | `accounts/fireworks/models/deepseek-v4-flash` | `FIREWORKS_API_KEY` | hard fail (strict — never walks the chain); then `deterministic_twitter_digest.py` |
 | twitter-deepseek-pi (tier:deepseek-pi) | `hourly-twitter.yml` | pi · run-pi-container (CI-enforced mirror) | fireworks (pi built-in) | `accounts/fireworks/models/deepseek-v4-flash` | `FIREWORKS_API_KEY` | — |
 | twitter-fireworks-pi (tier:fireworks-pi) | `hourly-twitter.yml` | pi · run-pi-container (CI-enforced mirror) | fireworks (pi built-in) | `accounts/fireworks/models/kimi-k2p7` | `FIREWORKS_API_KEY` | — |
-| twitter-judge (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted); then `deterministic_twitter_digest.py` |
-| twitter-primary (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted); then `deterministic_twitter_digest.py` |
+| twitter-judge (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted) |
+| twitter-primary (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted) |
+| twitter-primary-repair (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted) |
 | twitter-zai (tier:zai-glm-5p2) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Z.ai | `glm-5.2` | `ZAI_API_KEY` | hard fail (strict — never walks the chain); then `deterministic_twitter_digest.py` |
 | wiki-ingest | `wiki-ingest.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted) |
 | zai-canary · PINNED | `zai-claude-code-canary.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Z.ai | `glm-5.2` | `ZAI_API_KEY` | hard fail (strict — never walks the chain) |
@@ -111,7 +112,7 @@ Reading notes:
 - `daily-youtube.yml`
 - `liveness-check.yml`
 
-_Global ordered fallback chain (SSOT `fallback.chain`): `claude`; native path serves `claude-sonnet-5`. 25 SSOT lanes (+2 dispatch execution paths) across 23 workflows; 7 workflows run no model._
+_Global ordered fallback chain (SSOT `fallback.chain`): `claude`; native path serves `claude-sonnet-5`. 26 SSOT lanes (+2 dispatch execution paths) across 23 workflows; 7 workflows run no model._
 
 <!-- END GENERATED BACKEND MATRIX -->
 

--- a/prompts/twitter-analyst.md
+++ b/prompts/twitter-analyst.md
@@ -12,7 +12,10 @@ TIMESTAMP: {{timestamp}}
 
 PRIOR CONTEXT (read these BEFORE writing — multi-day arcs are first-class):
 - Today's file so far: {{output_dir}}/{{date}}.md
-  (may already contain earlier cycles from today; append a new section at the end)
+  (may already contain earlier cycles from today. If a section for
+  `## {{hour}}:00 UTC` already exists because this is a rerun, replace that
+  same-hour section instead of appending a duplicate. Otherwise append a new
+  section at the end.)
 - Yesterday's full digest: {{output_dir}}/{{yesterday}}.md
   (may not exist on the first day; if Read fails, skip)
 {{cross_harness_note}}
@@ -25,12 +28,19 @@ HARD CAPS: {{bird_budget}} {{follow_up_tools}} follow-up calls + {{curl_budget}}
 Use them when verification matters; quiet cycles should use fewer.
 
 INSTRUCTIONS:
+0. Reason from first principles. Stress-test the premise that each candidate
+   tweet is actually AI-specific and publication-worthy before promoting it
+   into the public brief.
 1. Read PRIOR CONTEXT first. Note continuing narratives. A continuing
    thread should not be re-reported from scratch; identify what changed.
    Top Stories must lead with what happened in the current cycle, not with
    prior-cycle recap. If prior context matters, fold it into the Evidence,
    Counter, or Watch text after the current-cycle news is stated.
 2. Read the raw input data and skim for signal. Most tweets are noise.
+   The public brief is AI-only. Do not include personal life updates,
+   sports, generic politics, generic outrage, engagement-bait, or unrelated
+   viral tweets as Top Stories, Quick hits, Watch items, or headline alerts
+   unless they materially change the AI landscape.
 3. Identify 2-5 MAIN STORIES from this {{cycle_window}} window. A main story:
    - Materially changes the AI landscape, OR
    - Adds concrete new data to a continuing thread, AND
@@ -61,7 +71,8 @@ INSTRUCTIONS:
    the tooling failure or command output to readers.
 
 FORMAT: Append to the daily file (create if doesn't exist).
-If the file already exists, append the new section at the end.
+If the file already exists and already has a section for `## {{hour}}:00 UTC`,
+replace that same-hour section. Otherwise append the new section at the end.
 If it doesn't exist, start with:
 `# Twitter/X AI Pulse{{title_suffix}} — {{date}}`
 
@@ -103,7 +114,8 @@ Then repeat the same `<article class="twitter-story" data-rank="2">…</article>
 shape for the next story.
 
 ### Quick hits
-- [Concrete item with @handle + URL. Specific numbers, names, dates.]
+- [Concrete AI item with @handle + URL. Specific numbers, names, dates. Do
+  not pad with non-AI viral tweets.]
 
 ### 🚩 Skeptic's corner
 - [Loud claim that did not corroborate, with reason and URL.]
@@ -121,7 +133,7 @@ If no main stories exist, write:
 ## {{hour}}:00 UTC
 **Cycle summary**: Quiet period — no main stories this window.
 ### Quick hits
-- [Whatever notable items did appear, even if minor]
+- No AI-specific quick hits cleared the publication bar this cycle.
 
 CONSTRAINTS:
 - Be specific. "Big funding round" → "$200M Series C, $2B post-money, led by X."


### PR DESCRIPTION
## Summary
- replace the primary Twitter deterministic fallback with a second Claude repair writer
- add a dedicated `twitter-primary-repair` SSOT lane so workflow routing stays one lane per agent-run call site
- tighten the Twitter analyst prompt to reject off-topic viral/personal/sports/politics tweets and replace same-hour rerun sections

## Why
The current 2026-07-08 Twitter summary was generated by deterministic fallback after the Claude primary path returned no committed files. It was not GLM output, but it published padded non-AI quick hits. Production Claude should either write the public artifact itself or fail closed.

## Validation
- `actionlint .github/workflows/hourly-twitter.yml`
- `uv run python scripts/build_backend_matrix.py --check`
- `uv run python -m unittest discover -s scripts -p 'test_*.py'`
- `git diff --check`
