### PR TITLE
Allow Claude Twitter agents to recover writes

### DIFF
--- a/.github/workflows/hourly-twitter.yml
+++ b/.github/workflows/hourly-twitter.yml
@@ -416,7 +416,7 @@ jobs:
           fireworks-api-key: ${{ secrets.FIREWORKS_API_KEY }}
           zai-api-key: ${{ secrets.ZAI_API_KEY }}
           claude-args: |
-            --model opus --allowedTools "Read,Write,Edit,Bash(git:*),Bash(birdy-fast:*),Bash(curl:*),Bash(jq:*)"
+            --model opus --allowedTools "Read,Write,Edit,MultiEdit,Bash(git:*),Bash(birdy-fast:*),Bash(curl:*),Bash(jq:*),Bash(python3:*),Bash(python:*),Bash(node:*),Bash(ls:*),Bash(cat:*),Bash(head:*),Bash(test:*),Bash(wc:*),Bash(mkdir:*),Bash(sed:*),Bash(rg:*),Bash(printf:*),Bash(touch:*)"
           expected-paths: |
             ${{ steps.const.outputs.digest_file }}
             ${{ steps.const.outputs.summary_file }}
@@ -444,7 +444,7 @@ jobs:
           fireworks-api-key: ${{ secrets.FIREWORKS_API_KEY }}
           zai-api-key: ${{ secrets.ZAI_API_KEY }}
           claude-args: |
-            --model opus --max-turns 40 --allowedTools "Read,Write,Edit,Bash(git:*),Bash(jq:*),Bash(test:*),Bash(ls:*),Bash(cat:*),Bash(head:*)"
+            --model opus --max-turns 40 --allowedTools "Read,Write,Edit,MultiEdit,Bash(git:*),Bash(jq:*),Bash(python3:*),Bash(python:*),Bash(node:*),Bash(test:*),Bash(ls:*),Bash(cat:*),Bash(head:*),Bash(wc:*),Bash(mkdir:*),Bash(sed:*),Bash(rg:*),Bash(printf:*),Bash(touch:*)"
           expected-paths: |
             ${{ steps.const.outputs.digest_file }}
             ${{ steps.const.outputs.summary_file }}
@@ -477,6 +477,12 @@ jobs:
                 deterministic quick-hit dump.
               - Use tool calls to read the raw input and write all three
                 output files. Do not merely respond in chat.
+              - If any tool call is denied, retry with an allowed tool
+                immediately. The allowed local parse/write path includes
+                Read, Write, Edit, jq, python3, cat, and git.
+              - Before your final response, run `git status --short` and
+                confirm the commit changes all three expected output files.
+                If it does not, continue repairing instead of stopping.
               - The public brief is AI-only. Exclude personal life updates,
                 sports, generic politics, generic outrage, engagement-bait,
                 and unrelated viral tweets unless the item materially changes


### PR DESCRIPTION
## Summary
- widen the primary and repair Claude Twitter allowed tools to include safe local parse/write commands (`python3`, `cat`, `jq`, etc.)
- tell the repair agent to retry with allowed tools after permission denials and verify all three expected files before stopping

## Why
After #293, the Claude Twitter rerun failed closed instead of publishing deterministic fallback trash. Logs from run `28940829915` show both Claude passes selected native Claude and ended `is_error: false`, but no output files changed. The repair pass recorded `permission_denials_count: 1`, so this gives the agent the local parser/writer tools it attempted to use while preserving the fail-closed output guard.

## Validation
- `actionlint .github/workflows/hourly-twitter.yml`
- `uv run python scripts/build_backend_matrix.py --check`
- `uv run python -m unittest discover -s scripts -p 'test_*.py'`
- `git diff --check`
