### PR TITLE
Remove automatic deterministic summary fallbacks

### DIFF
--- a/.github/workflows/2h-bluesky.yml
+++ b/.github/workflows/2h-bluesky.yml
@@ -121,10 +121,8 @@ jobs:
         id: bluesky-output-base
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      # continue-on-error so a hard agent failure (provider outage, turn-1
-      # API error) still reaches the deterministic fallback below. The agent
-      # writing nothing while exiting green (the 2026-07-01 failure mode) is
-      # caught by the fallback's own file check either way.
+      # continue-on-error lets the append step emit a clear missing-output
+      # error when Claude fails or exits green without writing the section.
       - name: Process Bluesky Feed with GLM-5.2 via Fireworks
         id: bluesky_agent
         continue-on-error: true
@@ -234,27 +232,6 @@ jobs:
 
             Do NOT run git. Writing `.tmp/bluesky-section.md` is your only
             output; the workflow appends and commits it deterministically.
-
-      # Model-free floor: when the agent produced no section (hard failure OR
-      # exited green without writing the file — the 2026-07-01 failure mode),
-      # compose an engagement-ranked section from the staged per-account
-      # JSONs so the cycle is never silently dropped. The append step below
-      # stays the final backstop and still fails the run if this file is
-      # missing after both paths.
-      - name: Deterministic Bluesky fallback
-        env:
-          TIMESTAMP: ${{ steps.datetime.outputs.timestamp }}
-        run: |
-          set -euo pipefail
-          if [ -s .tmp/bluesky-section.md ]; then
-            echo "Agent produced .tmp/bluesky-section.md — no fallback needed"
-            exit 0
-          fi
-          echo "::warning::Bluesky agent path produced no section; composing deterministic engagement-ranked fallback from data/bluesky/*.json."
-          python3 scripts/deterministic_bluesky_digest.py \
-            --input-dir data/bluesky \
-            --out .tmp/bluesky-section.md \
-            --timestamp "$TIMESTAMP"
 
       # Append the agent's section onto the daily file and commit. The post
       # step validates that the agent produced a section, removes any post

--- a/.github/workflows/4h-community.yml
+++ b/.github/workflows/4h-community.yml
@@ -238,20 +238,6 @@ jobs:
             git add research/community/
             git commit -m "Community digest ${{ steps.datetime.outputs.timestamp }}"
 
-      - name: Deterministic community fallback
-        if: steps.community-agent.outcome == 'failure'
-        run: |
-          set -euo pipefail
-          echo "::warning::Community agent path failed; writing deterministic fallback from fetched HN/Reddit data."
-          python3 scripts/deterministic_community_digest.py \
-            --hn-json data/hn/frontpage.json \
-            --reddit-dir data/reddit \
-            --out-dir research/community \
-            --date "${{ steps.datetime.outputs.date }}" \
-            --timestamp "${{ steps.datetime.outputs.timestamp }}"
-          git add research/community/
-          git commit -m "Community deterministic fallback ${{ steps.datetime.outputs.timestamp }}" || echo "No deterministic community changes"
-
       - name: Require community output
         uses: ./.github/actions/require-output
         with:

--- a/.github/workflows/daily-arxiv.yml
+++ b/.github/workflows/daily-arxiv.yml
@@ -50,16 +50,14 @@ jobs:
           EOF
 
       # Base SHA for the standalone output guard below — captured BEFORE the
-      # agent so the guard passes when EITHER the agent or the deterministic
-      # fallback committed under research/arxiv/ (mirrors hourly-rss.yml).
+      # agent so the guard proves Claude committed under research/arxiv/.
       - name: Capture arXiv output base
         id: arxiv-output-base
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      # continue-on-error so a failed agent (provider outage, MCP server
-      # unavailable, nothing committed — the composite's internal
-      # expected-paths guard fails the step in that case) hands off to the
-      # deterministic fallback instead of killing the job.
+      # continue-on-error lets the final require-output step report the
+      # missing Claude artifact clearly instead of hiding the root cause in
+      # the composite action.
       - name: Fetch arXiv AI Papers
         id: arxiv-agent
         continue-on-error: true
@@ -172,40 +170,9 @@ jobs:
             git add research/arxiv/${{ steps.date.outputs.date }}-papers.md research/summaries/${{ steps.date.outputs.date }}-arxiv-summary.txt
             git commit -m "arXiv papers ${{ steps.date.outputs.date }}"
 
-      # Model-free floor: when the agent path failed (or committed nothing —
-      # same outcome, via the composite's internal guard), query the arXiv
-      # Atom API directly and commit an uncurated per-category listing so the
-      # lane never goes silently dark. Mirrors the hourly-rss.yml pattern.
-      # Two in-step guards keep a curated listing from being overwritten with
-      # the uncurated fallback: a base..HEAD diff (agent committed mid-run,
-      # then a later composite step failed) and a HEAD-file check (today's
-      # listing already landed in a PREVIOUS run — e.g. a manual re-dispatch
-      # on a completed day). In the re-dispatch case nothing new is
-      # committed, so require-output below goes red — the honest outcome.
-      - name: Deterministic arXiv fallback
-        if: steps.arxiv-agent.outcome == 'failure'
-        env:
-          BASE_SHA: ${{ steps.arxiv-output-base.outputs.sha }}
-          DATE: ${{ steps.date.outputs.date }}
-        run: |
-          set -euo pipefail
-          if ! git diff --quiet "${BASE_SHA}..HEAD" -- research/arxiv/; then
-            echo "Agent already committed under research/arxiv/ since ${BASE_SHA} — skipping deterministic fallback."
-            exit 0
-          fi
-          if git cat-file -e "HEAD:research/arxiv/${DATE}-papers.md" 2>/dev/null; then
-            echo "research/arxiv/${DATE}-papers.md already exists in HEAD (previous run) — skipping deterministic fallback."
-            exit 0
-          fi
-          echo "::warning::arXiv agent path failed; writing deterministic arXiv fallback from the arXiv Atom API."
-          python3 scripts/deterministic_arxiv_digest.py \
-            --out-dir research/arxiv \
-            --date "${{ steps.date.outputs.date }}"
-          git add research/arxiv/
-          git commit -m "arXiv deterministic fallback ${{ steps.date.outputs.date }}" || echo "No deterministic arXiv changes"
-
-      # Final hard gate: SOMETHING (agent or fallback) must have committed
-      # under research/arxiv/ since the pre-agent base SHA.
+      # Final hard gate: Claude must have committed under research/arxiv/
+      # since the pre-agent base SHA. A missing output is better than
+      # publishing an uncurated fallback listing as editorial content.
       - name: Require arXiv output
         uses: ./.github/actions/require-output
         with:

--- a/.github/workflows/hourly-rss.yml
+++ b/.github/workflows/hourly-rss.yml
@@ -299,19 +299,6 @@ jobs:
             git add research/rss/
             git commit -m "RSS update ${{ steps.datetime.outputs.timestamp }}" || echo "No changes"
 
-      - name: Deterministic RSS fallback
-        if: steps.rss-agent.outcome == 'failure'
-        run: |
-          set -euo pipefail
-          echo "::warning::RSS agent path failed; writing deterministic RSS fallback from fetched XML."
-          python3 scripts/deterministic_rss_digest.py \
-            --input-dir /tmp/rss \
-            --out-dir research/rss \
-            --date "${{ steps.datetime.outputs.date }}" \
-            --timestamp "${{ steps.datetime.outputs.timestamp }}"
-          git add research/rss/
-          git commit -m "RSS deterministic fallback ${{ steps.datetime.outputs.timestamp }}" || echo "No deterministic RSS changes"
-
       - name: Require RSS output
         uses: ./.github/actions/require-output
         with:

--- a/.github/workflows/hourly-twitter.yml
+++ b/.github/workflows/hourly-twitter.yml
@@ -563,58 +563,6 @@ jobs:
           label: Twitter Z.ai GLM-5.2 comparison processor
           prompt: ${{ steps.render.outputs.prompt }}
 
-      - name: Deterministic Twitter fallback (deepseek-claude-code tier)
-        if: >-
-          steps.backend.outputs.name == 'deepseek-claude-code'
-          && steps.twitter-deepseek-agent.outcome == 'failure'
-        env:
-          OUTPUT_DIR: ${{ steps.const.outputs.output_dir }}
-          SUMMARY_SLUG: ${{ steps.const.outputs.summary_slug }}
-          TITLE_SUFFIX: ${{ steps.const.outputs.title_suffix }}
-          DATE: ${{ steps.datetime.outputs.date }}
-          HOUR: ${{ steps.datetime.outputs.hour }}
-          TIMESTAMP: ${{ steps.datetime.outputs.timestamp }}
-        run: |
-          set -euo pipefail
-          echo "::warning::DeepSeek comparison agent path failed; writing deterministic Twitter fallback."
-          python3 scripts/deterministic_twitter_digest.py \
-            --input-dir .twitter-input/bird \
-            --out-dir "$OUTPUT_DIR" \
-            --summaries-dir research/summaries \
-            --date "$DATE" \
-            --hour "$HOUR" \
-            --timestamp "$TIMESTAMP" \
-            --title-suffix "$TITLE_SUFFIX" \
-            --summary-slug "$SUMMARY_SLUG"
-          git add "$OUTPUT_DIR/" research/summaries/
-          git commit -m "Twitter (DeepSeek) deterministic fallback ${TIMESTAMP}" || echo "No deterministic Twitter changes"
-
-      - name: Deterministic Twitter fallback (zai-glm-5p2 tier)
-        if: >-
-          steps.backend.outputs.name == 'zai-glm-5p2'
-          && steps.twitter-zai-agent.outcome == 'failure'
-        env:
-          OUTPUT_DIR: ${{ steps.const.outputs.output_dir }}
-          SUMMARY_SLUG: ${{ steps.const.outputs.summary_slug }}
-          TITLE_SUFFIX: ${{ steps.const.outputs.title_suffix }}
-          DATE: ${{ steps.datetime.outputs.date }}
-          HOUR: ${{ steps.datetime.outputs.hour }}
-          TIMESTAMP: ${{ steps.datetime.outputs.timestamp }}
-        run: |
-          set -euo pipefail
-          echo "::warning::Z.ai GLM-5.2 comparison agent path failed; writing deterministic Twitter fallback."
-          python3 scripts/deterministic_twitter_digest.py \
-            --input-dir .twitter-input/bird \
-            --out-dir "$OUTPUT_DIR" \
-            --summaries-dir research/summaries \
-            --date "$DATE" \
-            --hour "$HOUR" \
-            --timestamp "$TIMESTAMP" \
-            --title-suffix "$TITLE_SUFFIX" \
-            --summary-slug "$SUMMARY_SLUG"
-          git add "$OUTPUT_DIR/" research/summaries/
-          git commit -m "Twitter (Z.ai GLM-5.2) deterministic fallback ${TIMESTAMP}" || echo "No deterministic Twitter changes"
-
       - name: Require Claude primary output
         if: >-
           steps.backend.outputs.name == 'claude'

--- a/README.md
+++ b/README.md
@@ -302,10 +302,10 @@ gh workflow run generative-research.yml \
 The interesting engineering is less "call an LLM" and more "survive every way
 this can break":
 
-- **Deterministic fallbacks.** Every scheduled lane has a model-free composer
-  (`scripts/deterministic_*_digest.py`) that writes the day's artifact from
-  already-fetched data when the agent path fails. A provider outage never
-  means a missing daily file.
+- **Fail-closed publishing.** Scheduled editorial lanes must prove fresh
+  Claude-authored output. If the agent path writes nothing or produces
+  sub-floor content, the workflow goes red instead of publishing a
+  model-free fallback summary.
 - **Output contracts.** Agent lanes must *prove* their work:
   [`require-output`](.github/actions/require-output) asserts the expected
   artifacts changed, and [`require-diff-scope`](.github/actions/require-diff-scope)

--- a/data/agent-backends.json
+++ b/data/agent-backends.json
@@ -50,7 +50,7 @@
       "workflow": "hourly-rss.yml",
       "harness": "agent-run",
       "backend": "claude",
-      "notes": "2h RSS digest; deterministic_rss_digest.py backstops output."
+      "notes": "2h RSS digest. Fails closed when Claude produces no output; no automatic deterministic fallback."
     },
     "bluesky": {
       "workflow": "2h-bluesky.yml",
@@ -62,13 +62,13 @@
       "workflow": "4h-community.yml",
       "harness": "agent-run",
       "backend": "claude",
-      "notes": "HN + Reddit digests; deterministic_community_digest.py backstops output."
+      "notes": "HN + Reddit digests. Fails closed when Claude produces no output; no automatic deterministic fallback."
     },
     "arxiv": {
       "workflow": "daily-arxiv.yml",
       "harness": "agent-run",
       "backend": "claude",
-      "notes": "Daily arXiv sweep; deterministic_arxiv_digest.py backstops output."
+      "notes": "Daily arXiv sweep. Fails closed when Claude produces no output; no automatic deterministic fallback."
     },
     "digest-synthesis": {
       "workflow": "daily-digest.yml",
@@ -134,7 +134,7 @@
       "harness": "agent-run",
       "backend": "fireworks-deepseek-v4-flash",
       "strict": true,
-      "notes": "6h DeepSeek comparison tier. STRICT: comparison artifacts must be attributable to the labeled backend, so this lane never walks the fallback chain (fixes a pre-SSOT bug where a Fireworks outage silently produced native-Claude output labeled DeepSeek); deterministic_twitter_digest.py backstops output freshness with honest labeling."
+      "notes": "6h DeepSeek comparison tier. STRICT: comparison artifacts must be attributable to the labeled backend, so this lane never walks the fallback chain and has no automatic deterministic fallback."
     },
     "twitter-zai": {
       "workflow": "hourly-twitter.yml",
@@ -142,7 +142,7 @@
       "harness": "agent-run",
       "backend": "zai-glm-5p2",
       "strict": true,
-      "notes": "Manual-default Z.ai comparison tier. STRICT: comparison artifacts must be attributable to Z.ai, so this lane never walks the fallback chain; deterministic_twitter_digest.py backstops output freshness with honest labeling."
+      "notes": "Manual-default Z.ai comparison tier. STRICT: comparison artifacts must be attributable to Z.ai, so this lane never walks the fallback chain and has no automatic deterministic fallback."
     },
     "zai-canary": {
       "workflow": "zai-claude-code-canary.yml",

--- a/docs/backend-matrix.md
+++ b/docs/backend-matrix.md
@@ -57,10 +57,10 @@ Reading notes:
 - **`--model opus` in `claude_args` is an alias**, not a provider model:
   agent-run remaps it to the effective profile's model id (Fireworks/Z.ai)
   or to the SSOT's global `fallback.native_model` on the native path.
-- **Fallback** shows the lane's chain (already excluding its own backend);
-  strict lanes show `hard fail` instead. A trailing `deterministic_*.py`
-  names the model-free composer that guards output freshness after the
-  agent path is exhausted.
+- **Fallback** shows the provider-selection chain (already excluding the
+  lane's own backend); strict lanes show `hard fail` instead. Editorial lanes
+  are expected to fail closed when Claude produces no output. Manual emergency
+  workflow-dispatch fallbacks are not shown as scheduled/default behavior.
 - `hourly-twitter.yml` tier names are dispatch/cron *slots*, not routing:
   the tier named `claude` hosts three lanes (`twitter-primary`,
   `twitter-judge`, `twitter-autoresearch`) whose backends come from the
@@ -74,29 +74,29 @@ Reading notes:
 | Lane | Workflow | Harness | Provider | Model | Token secret | Fallback |
 |---|---|---|---|---|---|---|
 | ai-news-research (×2 step variants) | `ai-news-research.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
-| arxiv | `daily-arxiv.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted); then `deterministic_arxiv_digest.py` |
-| bluesky | `2h-bluesky.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted); then `deterministic_bluesky_digest.py` |
+| arxiv | `daily-arxiv.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted) |
+| bluesky | `2h-bluesky.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted) |
 | claude-code-review | `claude-code-review.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
 | claude-interactive | `claude.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
-| community | `4h-community.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted); then `deterministic_community_digest.py` |
+| community | `4h-community.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted) |
 | daily-improve | `daily-improve.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
-| digest-audio-script | `daily-digest.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted); then `deterministic_daily_digest.py` |
-| digest-synthesis | `daily-digest.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted); then `deterministic_daily_digest.py` |
-| digest-synthesis-fallback | `daily-digest.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted); then `deterministic_daily_digest.py` |
+| digest-audio-script | `daily-digest.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted) |
+| digest-synthesis | `daily-digest.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted) |
+| digest-synthesis-fallback | `daily-digest.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted) |
 | generative-research-claude (+1 retry step) | `generative-research.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
 | generative-research-default | `generative-research.yml` | dispatch default (runtime SSOT) | (per chosen backend) | default: `claude` | (per chosen backend) | workflow-level `fireworks_fallback` input (default `claude`) |
 | model-timeline | `24h-model-timeline.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted) |
 | research-issue (×2 step variants) | `research-issue.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
-| rss | `hourly-rss.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted); then `deterministic_rss_digest.py` |
+| rss | `hourly-rss.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted) |
 | twitter-account-explorer | `twitter-account-explorer.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
 | twitter-autoresearch (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted) |
-| twitter-deepseek (tier:deepseek-claude-code) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | DeepSeek V4 Flash via Fireworks | `accounts/fireworks/models/deepseek-v4-flash` | `FIREWORKS_API_KEY` | hard fail (strict — never walks the chain); then `deterministic_twitter_digest.py` |
+| twitter-deepseek (tier:deepseek-claude-code) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | DeepSeek V4 Flash via Fireworks | `accounts/fireworks/models/deepseek-v4-flash` | `FIREWORKS_API_KEY` | hard fail (strict — never walks the chain) |
 | twitter-deepseek-pi (tier:deepseek-pi) | `hourly-twitter.yml` | pi · run-pi-container (CI-enforced mirror) | fireworks (pi built-in) | `accounts/fireworks/models/deepseek-v4-flash` | `FIREWORKS_API_KEY` | — |
 | twitter-fireworks-pi (tier:fireworks-pi) | `hourly-twitter.yml` | pi · run-pi-container (CI-enforced mirror) | fireworks (pi built-in) | `accounts/fireworks/models/kimi-k2p7` | `FIREWORKS_API_KEY` | — |
 | twitter-judge (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted) |
 | twitter-primary (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted) |
 | twitter-primary-repair (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted) |
-| twitter-zai (tier:zai-glm-5p2) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Z.ai | `glm-5.2` | `ZAI_API_KEY` | hard fail (strict — never walks the chain); then `deterministic_twitter_digest.py` |
+| twitter-zai (tier:zai-glm-5p2) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Z.ai | `glm-5.2` | `ZAI_API_KEY` | hard fail (strict — never walks the chain) |
 | wiki-ingest | `wiki-ingest.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (chain exhausted) |
 | zai-canary · PINNED | `zai-claude-code-canary.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Z.ai | `glm-5.2` | `ZAI_API_KEY` | hard fail (strict — never walks the chain) |
 | (dispatch path) backend=fireworks (+2 retry steps) | `generative-research.yml` | Claude Code · claude-code-action (env-rerouted) | Fireworks (Anthropic-compatible endpoint) | dynamic: per fireworks profile step | `FIREWORKS_API_KEY` | workflow-level `fireworks_fallback` input (default `claude`) |

--- a/scripts/build_backend_matrix.py
+++ b/scripts/build_backend_matrix.py
@@ -257,7 +257,11 @@ def observe_workflow(wf_path: Path) -> Observation:
 
             if run:
                 obs.resolver_lanes.update(RESOLVER_CALL_RE.findall(run))
-                scripts = sorted(set(DETERMINISTIC_RE.findall(run)))
+                # Manual emergency fallback is not an automatic lane backstop.
+                # The matrix's Fallback column documents what happens in the
+                # scheduled/default path, so opt-in workflow_dispatch fallbacks
+                # must not be rendered as "then deterministic_*.py".
+                scripts = [] if "allow_deterministic_fallback" in cond else sorted(set(DETERMINISTIC_RE.findall(run)))
                 for script in scripts:
                     if tier:
                         obs.det_by_tier.setdefault(tier, script)


### PR DESCRIPTION
## Summary
- remove automatic deterministic fallback writers from RSS, community, arXiv, Bluesky, and Twitter comparison workflows
- keep require-output / append guards so missing Claude output makes the run fail instead of publishing fallback summaries
- update backend SSOT notes, backend matrix docs, README contract, and matrix generator fallback detection

## Why
Fallback summaries are worse than no summary: they can look like editorial output while being unranked/model-free lane dumps. Production editorial lanes should fail closed.

## Verification
- actionlint -shellcheck= -pyflakes= .github/workflows/hourly-rss.yml .github/workflows/4h-community.yml .github/workflows/daily-arxiv.yml .github/workflows/2h-bluesky.yml .github/workflows/hourly-twitter.yml .github/workflows/daily-digest.yml
- uv run python scripts/build_backend_matrix.py --check
- uv run python -m unittest discover -s scripts -p 'test_backend_matrix.py'
- uv run python -m unittest discover -s scripts -p 'test_select_backend.py'
- git diff --check