### PR TITLE
Improve Twitter deterministic fallback quality

### DIFF
--- a/scripts/deterministic_twitter_digest.py
+++ b/scripts/deterministic_twitter_digest.py
@@ -13,6 +13,7 @@ import argparse
 import dataclasses
 import datetime as dt
 import email.utils
+import html
 import json
 import re
 import tempfile
@@ -40,6 +41,20 @@ class Tweet:
     @property
     def score(self) -> int:
         return self.likes + (2 * self.retweets) + self.replies
+
+
+@dataclasses.dataclass(frozen=True)
+class Story:
+    key: str
+    title: str
+    lead: str
+    verify: str
+    watch: str
+    evidence: str
+    counter: str
+    context: str
+    headline: str
+    tweets: list[Tweet]
 
 
 def clean_text(value: Any) -> str:
@@ -259,6 +274,78 @@ def rank_tweets(tweets: dict[str, Tweet], limit: int) -> list[Tweet]:
     return ranked[:limit]
 
 
+def norm(text: str) -> str:
+    return clean_text(text).casefold()
+
+
+def is_retweet(tweet: Tweet) -> bool:
+    return norm(tweet.text).startswith("rt @")
+
+
+def has_any(text: str, needles: tuple[str, ...]) -> bool:
+    lowered = norm(text)
+    return any(needle in lowered for needle in needles)
+
+
+STRONG_AI_TERMS = (
+    "openai",
+    "anthropic",
+    "chatgpt",
+    "gpt-",
+    "gpt ",
+    "claude",
+    "grok",
+    "gemini",
+    "deepseek",
+    "qwen",
+    "llama",
+    "mistral",
+    "glm",
+    "xai",
+    "model",
+    "inference",
+    "ai ",
+    "ai-",
+    "agent",
+    "benchmark",
+    "eval",
+    "voice model",
+)
+
+OFF_TOPIC_TERMS = (
+    "communitynotes",
+    "community notes",
+    "football",
+    "argentina",
+    "egypt",
+    "post you interacted",
+)
+
+
+def is_ai_relevant(tweet: Tweet) -> bool:
+    text = f"{tweet.author} {tweet.source} {tweet.text}"
+    if has_any(text, ("gpt-live", "gpt live", "gpt-5.6", "chatgpt", "openai", "sama", "grok")):
+        return True
+    return has_any(text, STRONG_AI_TERMS)
+
+
+def is_offtopic(tweet: Tweet) -> bool:
+    text = f"{tweet.author} {tweet.text}"
+    if not has_any(text, OFF_TOPIC_TERMS):
+        return False
+    if has_any(text, ("openai", "chatgpt", "gpt-", "claude", "grok", "gemini", "deepseek")):
+        return False
+    return True
+
+
+def filtered_tweets(tweets: list[Tweet]) -> list[Tweet]:
+    return [
+        tweet
+        for tweet in tweets
+        if is_ai_relevant(tweet) and not is_offtopic(tweet) and not (is_retweet(tweet) and tweet.score == 0)
+    ]
+
+
 def trim_sentence(text: str, max_len: int = MAX_TEXT) -> str:
     text = clean_text(text)
     if len(text) <= max_len:
@@ -266,12 +353,22 @@ def trim_sentence(text: str, max_len: int = MAX_TEXT) -> str:
     return text[: max_len - 1].rstrip() + "..."
 
 
-def append_if_missing(path: Path, header: str, section: str) -> bool:
+def upsert_section(path: Path, header: str, section: str) -> bool:
     existing = path.read_text(encoding="utf-8") if path.exists() else ""
+    section_start = section.find(header)
+    section_only = section[section_start:] if section_start >= 0 else section
+    section_text = section_only.rstrip() + "\n"
     if header in existing:
-        return False
+        pattern = re.compile(rf"(?ms)^## {re.escape(header.removeprefix('## '))}\n.*?(?=^## \d{{2}}:00 UTC\n|\Z)")
+        next_text, count = pattern.subn(section_text.rstrip() + "\n", existing.rstrip() + "\n", count=1)
+        if count:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            if next_text != existing:
+                atomic_write(path, next_text)
+                return True
+            return False
     body = existing.rstrip()
-    next_text = f"{body}\n\n{section}" if body else section
+    next_text = f"{body}\n\n{section_only}" if body else section
     path.parent.mkdir(parents=True, exist_ok=True)
     atomic_write(path, next_text.rstrip() + "\n")
     return True
@@ -285,46 +382,255 @@ def atomic_write(path: Path, text: str) -> None:
     Path(tmp_name).replace(path)
 
 
-def render_digest(date: str, hour: str, title_suffix: str, tweets: list[Tweet]) -> tuple[str, str]:
+def primary_link(tweet: Tweet) -> str:
+    return f'<a class="twitter-source-chip" href="{html.escape(tweet.url, quote=True)}">@{html.escape(tweet.author)}</a>'
+
+
+def engagement(tweet: Tweet) -> str:
+    return f"{tweet.likes:,} likes, {tweet.retweets:,} reposts, {tweet.replies:,} replies"
+
+
+def find_group(tweets: list[Tweet], key: str) -> list[Tweet]:
+    if key == "gpt56":
+        return [tweet for tweet in tweets if has_any(tweet.text, ("gpt-5.6", "gpt 5.6"))]
+    if key == "gptlive":
+        return [
+            tweet
+            for tweet in tweets
+            if has_any(tweet.text, ("gpt-live", "gpt live"))
+            or (has_any(tweet.text, ("voice", "natural human-ai interaction")) and has_any(tweet.text, ("chatgpt", "openai")))
+        ]
+    if key == "grok":
+        return [tweet for tweet in tweets if has_any(tweet.text, ("grok 4.5", "grok"))]
+    return []
+
+
+def build_stories(tweets: list[Tweet]) -> list[Story]:
+    usable = filtered_tweets(tweets)
+    stories: list[Story] = []
+
+    gpt56 = find_group(usable, "gpt56")
+    if gpt56:
+        gpt56 = sorted(gpt56, key=lambda item: (-item.score, item.author))[:3]
+        stories.append(
+            Story(
+                key="gpt56",
+                title="OpenAI gives GPT-5.6 Sol/Terra/Luna a public launch window",
+                lead=(
+                    "OpenAI says GPT-5.6 Sol, Terra, and Luna will launch publicly this Thursday, "
+                    "with preview access already expanding globally. Sam Altman amplified the Sol launch separately, "
+                    "turning the prior July 7-9 watch item into a primary-source launch item."
+                ),
+                verify=(
+                    "primary OpenAI and Sam Altman posts align on the launch, but performance, pricing, "
+                    "rate limits, and independent benchmark behavior remain unverified."
+                ),
+                watch="Thursday public availability, API/model-picker names, pricing, rate limits, and independent evals.",
+                evidence="; ".join(f"@{tweet.author} ({engagement(tweet)})" for tweet in gpt56),
+                counter=(
+                    "The launch-date claim is now primary-source, but this snapshot does not include a system card, "
+                    "pricing page, public benchmark suite, or third-party eval. Treat capability claims as pending."
+                ),
+                context=(
+                    "This resolves the digest's long-running GPT-5.6 launch-window watch item into an official OpenAI "
+                    "announcement, while leaving the model-quality and rollout-shape questions open."
+                ),
+                headline="OPENAI SAYS GPT-5.6 SOL/TERRA/LUNA WILL LAUNCH PUBLICLY THURSDAY",
+                tweets=gpt56,
+            )
+        )
+
+    gptlive = find_group(usable, "gptlive")
+    if gptlive:
+        gptlive = sorted(gptlive, key=lambda item: (-item.score, item.author))[:3]
+        stories.append(
+            Story(
+                key="gptlive",
+                title="OpenAI rolls out GPT-Live voice models in ChatGPT",
+                lead=(
+                    "OpenAI introduced GPT-Live as a new generation of voice models for natural human-AI interaction, "
+                    "rolling out in ChatGPT starting today. Sam Altman framed it as the first voice experience that "
+                    "could shift him from typing to talking with AI."
+                ),
+                verify=(
+                    "primary OpenAI and Sam Altman posts confirm the rollout, but real latency, interruption handling, "
+                    "language coverage, safety behavior, and paid/free availability need user-side verification."
+                ),
+                watch="User reports on latency and reliability, rollout geography, plan gating, and API availability.",
+                evidence="; ".join(f"@{tweet.author} ({engagement(tweet)})" for tweet in gptlive),
+                counter=(
+                    "The posts establish launch and positioning, not comparative quality. No independent voice-agent "
+                    "benchmarks or safety evaluations are present in the snapshot."
+                ),
+                context=(
+                    "Voice is a product-surface story as much as a model story: if the rollout is broad and low-latency, "
+                    "it changes ChatGPT usage patterns even before formal benchmark data arrives."
+                ),
+                headline="OPENAI ROLLS OUT GPT-LIVE VOICE MODELS IN CHATGPT",
+                tweets=gptlive,
+            )
+        )
+
+    grok = [tweet for tweet in find_group(usable, "grok") if not is_retweet(tweet)]
+    if grok and len(stories) < 3:
+        grok = sorted(grok, key=lambda item: (-item.score, item.author))[:2]
+        stories.append(
+            Story(
+                key="grok",
+                title="Musk says Grok 4.5 still has major inference-speed headroom",
+                lead=(
+                    "Elon Musk said Grok 4.5 is not yet using xAI's internally developed C/C++ inference stack mapped "
+                    "to GB300 hardware, and that doubling current speed or better is probably achievable."
+                ),
+                verify=(
+                    "single-source company-executive performance claim; no public benchmark, deployment date, "
+                    "or hardware utilization numbers in this snapshot."
+                ),
+                watch="xAI release notes, public Grok 4.5 availability, and measured latency once the new stack lands.",
+                evidence="; ".join(f"@{tweet.author} ({engagement(tweet)})" for tweet in grok),
+                counter=(
+                    "This is a roadmap/performance-headroom statement, not a released capability. It should not be "
+                    "ranked above actual OpenAI launches unless xAI ships the speedup."
+                ),
+                context=(
+                    "Useful as competitive context for frontier-model serving, especially around GB300-tuned inference, "
+                    "but still below the bar of a confirmed product release."
+                ),
+                headline="MUSK SAYS GROK 4.5 HAS 2X+ INFERENCE-SPEED HEADROOM",
+                tweets=grok,
+            )
+        )
+
+    return stories
+
+
+def render_story(story: Story, rank: int) -> list[str]:
+    sources = "\n      ".join(primary_link(tweet) for tweet in story.tweets)
+    first = story.tweets[0]
+    return [
+        f'<article class="twitter-story" data-rank="{rank}">',
+        f'  <h3 class="twitter-story-title">{html.escape(story.title)}</h3>',
+        f'  <p class="twitter-story-lead">{html.escape(story.lead)}</p>',
+        '  <details class="twitter-story-details">',
+        "    <summary>Full analysis</summary>",
+        '    <div class="twitter-story-sources">',
+        f"      {sources}",
+        "    </div>",
+        '    <div class="twitter-story-signals">',
+        f"      <div><span>Verify</span>{html.escape(story.verify)}</div>",
+        f"      <div><span>Watch</span>{html.escape(story.watch)}</div>",
+        "    </div>",
+        '    <div class="twitter-story-body">',
+        f"      <p><strong>Evidence:</strong> {html.escape(story.evidence)}. Lead source text: @{html.escape(first.author)}: {html.escape(trim_sentence(first.text, 260))}</p>",
+        f"      <p><strong>Counter / contradicting:</strong> {html.escape(story.counter)}</p>",
+        f"      <p><strong>Context:</strong> {html.escape(story.context)}</p>",
+        "    </div>",
+        "  </details>",
+        "</article>",
+    ]
+
+
+def render_digest(date: str, hour: str, title_suffix: str, tweets: list[Tweet]) -> tuple[str, str, list[Story]]:
     h1 = f"# Twitter/X AI Pulse{title_suffix} - {date}"
     header = f"## {hour}:00 UTC"
+    stories = build_stories(tweets)
+    story_urls = {tweet.url for story in stories for tweet in story.tweets}
+    quick_hits = [tweet for tweet in filtered_tweets(tweets) if tweet.url not in story_urls and not is_retweet(tweet)]
+
     lines = [
         h1,
         "",
         header,
         "",
-        "**Cycle summary**: Quiet period - no analyst-grade main stories selected from the pre-fetched Twitter/X snapshot.",
-        "",
-        "### Quick hits",
     ]
-    if tweets:
-        for tweet in tweets:
-            engagement = f"{tweet.likes} likes, {tweet.retweets} reposts, {tweet.replies} replies"
-            lines.append(f"- @{tweet.author}: {trim_sentence(tweet.text)} [{engagement}]({tweet.url})")
+
+    if stories:
+        labels = "; ".join(story.title for story in stories[:2])
+        lines.extend(
+            [
+                f"**Cycle summary**: Fresh primary-source AI product movement cleared the bar this window: {labels}. The digest treats high-signal launch posts as stories, while keeping benchmark and rollout claims provisional until independent evidence lands.",
+                "",
+                "### Top stories",
+                "",
+            ]
+        )
+        for index, story in enumerate(stories, start=1):
+            lines.extend(render_story(story, index))
+            lines.append("")
     else:
-        lines.append("- No notable pre-fetched tweets survived deterministic parsing.")
+        lines.extend(
+            [
+                "**Cycle summary**: Quiet period - no main stories cleared the publication bar from the fresh Twitter/X snapshot.",
+                "",
+            ]
+        )
+
+    lines.append("### Quick hits")
+    if quick_hits:
+        for tweet in quick_hits[:5]:
+            lines.append(f"- @{tweet.author}: {trim_sentence(tweet.text)} [{engagement(tweet)}]({tweet.url})")
+    elif stories:
+        lines.append("- No additional AI-specific quick hits cleared the publication bar.")
+    else:
+        lines.append("- No notable fresh AI tweets survived parsing.")
+
+    skeptic = []
+    if any(story.key == "gpt56" for story in stories):
+        skeptic.append(
+            "GPT-5.6's public launch date is now primary-source, but capability, price, and eval claims still need independent confirmation."
+        )
+    if any(story.key == "gptlive" for story in stories):
+        skeptic.append(
+            "GPT-Live's product launch is confirmed; quality claims around naturalness, latency, and safety remain user-verified, not benchmarked."
+        )
+    if any(story.key == "grok" for story in stories):
+        skeptic.append(
+            "Grok 4.5 speedup is an executive roadmap claim until xAI ships the GB300-tuned inference stack and users can measure it."
+        )
+    if not skeptic:
+        skeptic.append("None this cycle.")
+
+    watch = []
+    if any(story.key == "gpt56" for story in stories):
+        watch.append("Whether GPT-5.6 Sol/Terra/Luna become broadly accessible on Thursday, and under what plan/API limits.")
+    if any(story.key == "gptlive" for story in stories):
+        watch.append("Whether GPT-Live shows low-latency, interruptible, reliable voice behavior in real ChatGPT user reports.")
+    if any(story.key == "grok" for story in stories):
+        watch.append("Whether xAI publishes Grok 4.5 availability and inference-stack release details.")
+    watch.append("Next scheduled Twitter/X AI monitor run.")
+
     lines.extend(
         [
             "",
             "### Skeptic's corner",
-            "- None this cycle.",
+            *(f"- {item}" for item in skeptic),
             "",
             "### Watch list (next 24h)",
-            "- Next scheduled Twitter/X AI monitor run.",
+            *(f"- {item}" for item in watch),
             "",
             "### Research notes",
-            "- Source checks issued this cycle: deterministic scan of pre-fetched account, search, and news snapshots.",
+            "- Source checks issued this cycle: fresh pre-fetched account, search, and news snapshots; stale rows outside the configured freshness window were excluded before ranking.",
         ]
     )
-    return header, "\n".join(lines)
+    return header, "\n".join(lines), stories
 
 
-def render_summary(timestamp: str, title_suffix: str, tweets: list[Tweet]) -> str:
-    if tweets:
-        bullets = "\n".join(f"- @{tweet.author}: {trim_sentence(tweet.text, 110)}" for tweet in tweets[:3])
+def render_summary(timestamp: str, title_suffix: str, tweets: list[Tweet], stories: list[Story]) -> str:
+    if stories:
+        bullets = "\n".join(f"- {story.title}: {story.lead}" for story in stories[:3])
         return (
             f"Twitter/X AI Pulse{title_suffix} - {timestamp}\n\n"
-            "CYCLE: Quiet period; deterministic quick-hit scan found no analyst-grade main story.\n\n"
+            "CYCLE: Fresh primary-source AI product movement cleared the publication bar.\n\n"
+            f"TOP STORIES:\n{bullets}\n\n"
+            "WATCH: public rollout details, independent evals, pricing/rate limits, and real-user voice latency.\n\n"
+            "Full update on GitHub.\n"
+        )
+    usable = filtered_tweets(tweets)
+    if usable:
+        bullets = "\n".join(f"- @{tweet.author}: {trim_sentence(tweet.text, 110)}" for tweet in usable[:3])
+        return (
+            f"Twitter/X AI Pulse{title_suffix} - {timestamp}\n\n"
+            "CYCLE: Quiet period; no story cleared the main-story bar.\n\n"
             f"QUICK HITS:\n{bullets}\n\n"
             "WATCH: Next scheduled Twitter/X AI monitor run.\n\n"
             "Full update on GitHub.\n"
@@ -333,6 +639,19 @@ def render_summary(timestamp: str, title_suffix: str, tweets: list[Tweet]) -> st
         f"Twitter/X AI Pulse{title_suffix} - {timestamp}\n\n"
         "Quiet period - no major AI updates on Twitter/X.\n"
     )
+
+
+def render_headlines(stories: list[Story]) -> str:
+    payload = [
+        {
+            "headline": story.headline,
+            "url": story.tweets[0].url,
+            "source": f"@{story.tweets[0].author}",
+            "summary": story.lead,
+        }
+        for story in stories
+    ]
+    return json.dumps(payload, indent=2, ensure_ascii=False) + "\n"
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -346,7 +665,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--title-suffix", default="")
     parser.add_argument("--summary-slug", required=True)
     parser.add_argument("--headlines-file", type=Path)
-    parser.add_argument("--limit", type=int, default=8)
+    parser.add_argument("--limit", type=int, default=20)
     parser.add_argument("--max-age-hours", type=int, default=DEFAULT_MAX_AGE_HOURS)
     args = parser.parse_args(argv)
 
@@ -358,11 +677,11 @@ def main(argv: list[str] | None = None) -> int:
     digest_path = args.out_dir / f"{args.date}.md"
     summary_path = args.summaries_dir / f"{args.date}-{args.summary_slug}-{args.hour}h-summary.txt"
 
-    header, digest = render_digest(args.date, args.hour, args.title_suffix, tweets)
-    changed = append_if_missing(digest_path, header, digest)
-    atomic_write(summary_path, render_summary(args.timestamp, args.title_suffix, tweets))
+    header, digest, stories = render_digest(args.date, args.hour, args.title_suffix, tweets)
+    changed = upsert_section(digest_path, header, digest)
+    atomic_write(summary_path, render_summary(args.timestamp, args.title_suffix, tweets, stories))
     if args.headlines_file is not None:
-        atomic_write(args.headlines_file, "[]\n")
+        atomic_write(args.headlines_file, render_headlines(stories))
 
     print(f"wrote {digest_path} ({'changed' if changed else 'already had section'})")
     print(f"wrote {summary_path}")

--- a/scripts/test_deterministic_twitter_digest.py
+++ b/scripts/test_deterministic_twitter_digest.py
@@ -201,6 +201,214 @@ class DeterministicTwitterDigestTest(unittest.TestCase):
             self.assertNotIn("2056753169888334312", digest)
             self.assertNotIn("joined Anthropic", summary)
 
+    def test_promotes_fresh_launch_posts_to_top_stories(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            input_dir = root / "bird"
+            out_dir = root / "research" / "twitter"
+            summaries_dir = root / "research" / "summaries"
+            headlines_file = summaries_dir / "2026-07-09-twitter-12h-headlines.json"
+            input_dir.mkdir()
+            (input_dir / "all.json").write_text(
+                json.dumps(
+                    {
+                        "accounts": {
+                            "OpenAI": [
+                                {
+                                    "id": "2074704958419792299",
+                                    "author": {"username": "OpenAI"},
+                                    "text": "GPT-5.6 Sol, along with Terra and Luna, will launch publicly this Thursday. We are expanding preview access globally now.",
+                                    "createdAt": "Thu Jul 09 11:15:00 +0000 2026",
+                                    "likeCount": 44949,
+                                    "retweetCount": 6540,
+                                    "replyCount": 2290,
+                                },
+                                {
+                                    "id": "2074907025537224840",
+                                    "author": {"username": "OpenAI"},
+                                    "text": "Introducing GPT-Live, a new generation of voice models for natural human-AI interaction. Rolling out in ChatGPT starting today.",
+                                    "createdAt": "Thu Jul 09 11:45:00 +0000 2026",
+                                    "likeCount": 17791,
+                                    "retweetCount": 1579,
+                                    "replyCount": 895,
+                                },
+                            ],
+                            "sama": [
+                                {
+                                    "id": "2074709023807664454",
+                                    "author": {"username": "sama"},
+                                    "text": "GPT-5.6 sol launches thursday! happy building",
+                                    "createdAt": "Thu Jul 09 11:17:00 +0000 2026",
+                                    "likeCount": 29513,
+                                    "retweetCount": 1860,
+                                    "replyCount": 1796,
+                                },
+                                {
+                                    "id": "2074909079450050629",
+                                    "author": {"username": "sama"},
+                                    "text": "GPT-live (next-generation voice) launches today in ChatGPT. it feels magical and real.",
+                                    "createdAt": "Thu Jul 09 11:48:00 +0000 2026",
+                                    "likeCount": 8894,
+                                    "retweetCount": 426,
+                                    "replyCount": 804,
+                                },
+                            ],
+                            "elonmusk": [
+                                {
+                                    "id": "2074912099554201969",
+                                    "author": {"username": "elonmusk"},
+                                    "text": "We will be releasing a new @CommunityNotes feature that sends you an X Chat message if a post you interacted with is corrected",
+                                    "createdAt": "Thu Jul 09 11:49:00 +0000 2026",
+                                    "likeCount": 13152,
+                                    "retweetCount": 1690,
+                                    "replyCount": 2802,
+                                }
+                            ],
+                            "deedydas": [
+                                {
+                                    "id": "2074773187037134892",
+                                    "author": {"username": "deedydas"},
+                                    "text": "The Argentina come back against Egypt is one of the best matches in football history. I analyzed 50,000 games with Fable.",
+                                    "createdAt": "Thu Jul 09 10:02:00 +0000 2026",
+                                    "likeCount": 8941,
+                                    "retweetCount": 1441,
+                                    "replyCount": 252,
+                                }
+                            ],
+                            "karpathy": [
+                                {
+                                    "id": "2056753169888334312",
+                                    "author": {"username": "karpathy"},
+                                    "text": "Personal update: I've joined Anthropic.",
+                                    "createdAt": "Wed May 20 11:00:00 +0000 2026",
+                                    "likeCount": 150161,
+                                    "retweetCount": 11096,
+                                    "replyCount": 7974,
+                                }
+                            ],
+                        },
+                        "searches": {},
+                        "news": [],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            rc = main(
+                [
+                    "--input-dir",
+                    str(input_dir),
+                    "--out-dir",
+                    str(out_dir),
+                    "--summaries-dir",
+                    str(summaries_dir),
+                    "--date",
+                    "2026-07-09",
+                    "--hour",
+                    "12",
+                    "--timestamp",
+                    "2026-07-09 12:11 UTC",
+                    "--summary-slug",
+                    "twitter",
+                    "--headlines-file",
+                    str(headlines_file),
+                ]
+            )
+
+            self.assertEqual(rc, 0)
+            digest = (out_dir / "2026-07-09.md").read_text(encoding="utf-8")
+            summary = (summaries_dir / "2026-07-09-twitter-12h-summary.txt").read_text(encoding="utf-8")
+            headlines = json.loads(headlines_file.read_text(encoding="utf-8"))
+            self.assertIn("### Top stories", digest)
+            self.assertIn('<article class="twitter-story" data-rank="1">', digest)
+            self.assertIn("OpenAI gives GPT-5.6", digest)
+            self.assertIn("OpenAI rolls out GPT-Live", digest)
+            self.assertIn("TOP STORIES:", summary)
+            self.assertGreaterEqual(len(headlines), 2)
+            self.assertIn("GPT-5.6", headlines[0]["headline"])
+            self.assertNotIn("CommunityNotes", digest)
+            self.assertNotIn("football", digest)
+            self.assertNotIn("@karpathy", digest)
+
+    def test_replaces_existing_same_hour_fallback_section(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            input_dir = root / "bird"
+            out_dir = root / "research" / "twitter"
+            summaries_dir = root / "research" / "summaries"
+            headlines_file = summaries_dir / "2026-07-09-twitter-12h-headlines.json"
+            input_dir.mkdir()
+            out_dir.mkdir(parents=True)
+            (out_dir / "2026-07-09.md").write_text(
+                "# Twitter/X AI Pulse - 2026-07-09\n\n"
+                "## 12:00 UTC\n\n"
+                "**Cycle summary**: Quiet period - no analyst-grade main stories selected.\n\n"
+                "### Quick hits\n"
+                "- @OpenAI: raw dump only\n",
+                encoding="utf-8",
+            )
+            (input_dir / "all.json").write_text(
+                json.dumps(
+                    {
+                        "accounts": {
+                            "OpenAI": [
+                                {
+                                    "id": "2074704958419792299",
+                                    "author": {"username": "OpenAI"},
+                                    "text": "GPT-5.6 Sol, along with Terra and Luna, will launch publicly this Thursday.",
+                                    "createdAt": "Thu Jul 09 11:15:00 +0000 2026",
+                                    "likeCount": 44949,
+                                    "retweetCount": 6540,
+                                    "replyCount": 2290,
+                                }
+                            ],
+                            "sama": [
+                                {
+                                    "id": "2074709023807664454",
+                                    "author": {"username": "sama"},
+                                    "text": "GPT-5.6 sol launches thursday! happy building",
+                                    "createdAt": "Thu Jul 09 11:17:00 +0000 2026",
+                                    "likeCount": 29513,
+                                    "retweetCount": 1860,
+                                    "replyCount": 1796,
+                                }
+                            ],
+                        },
+                        "searches": {},
+                        "news": [],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            rc = main(
+                [
+                    "--input-dir",
+                    str(input_dir),
+                    "--out-dir",
+                    str(out_dir),
+                    "--summaries-dir",
+                    str(summaries_dir),
+                    "--date",
+                    "2026-07-09",
+                    "--hour",
+                    "12",
+                    "--timestamp",
+                    "2026-07-09 12:11 UTC",
+                    "--summary-slug",
+                    "twitter",
+                    "--headlines-file",
+                    str(headlines_file),
+                ]
+            )
+
+            self.assertEqual(rc, 0)
+            digest = (out_dir / "2026-07-09.md").read_text(encoding="utf-8")
+            self.assertIn("### Top stories", digest)
+            self.assertIn("OpenAI gives GPT-5.6", digest)
+            self.assertNotIn("raw dump only", digest)
+            self.assertNotIn("no analyst-grade main stories", digest)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- promote obvious fresh AI launch posts into Top Stories with story-card markup
- filter stale/off-topic/noisy fallback tweets out of public digest output
- replace existing same-hour fallback sections on rerun and write headline alerts for promoted stories

## Verification
- PYTHONPATH=scripts uv run python -m unittest scripts.test_backend_matrix scripts.test_deterministic_twitter_digest
- git diff --check