### PR TITLE
Allow unchanged Twitter headlines on rerun

### DIFF
--- a/.github/workflows/hourly-twitter.yml
+++ b/.github/workflows/hourly-twitter.yml
@@ -622,8 +622,21 @@ jobs:
           expected-paths: |
             ${{ steps.const.outputs.digest_file }}
             ${{ steps.const.outputs.summary_file }}
-            ${{ steps.const.outputs.headlines_file }}
           label: Twitter primary Claude workflow output
+
+      - name: Require Claude headline file
+        if: >-
+          steps.backend.outputs.name == 'claude'
+          && !(github.event_name == 'workflow_dispatch' && inputs.dry_run == true)
+        env:
+          HEADLINES_FILE: ${{ steps.const.outputs.headlines_file }}
+        run: |
+          set -euo pipefail
+          if [ ! -f "$HEADLINES_FILE" ]; then
+            echo "::error::Missing Claude headline output: $HEADLINES_FILE"
+            exit 1
+          fi
+          jq -e 'type == "array"' "$HEADLINES_FILE" >/dev/null
 
       - name: Require DeepSeek comparison output
         if: steps.backend.outputs.name == 'deepseek-claude-code'


### PR DESCRIPTION
## Summary
- let Twitter reruns pass when headlines.json is unchanged but present and valid
- keep digest and summary under require-output so the rerun still proves fresh output was generated
- add an explicit headline JSON existence/type check for the Claude lane

## Verification
- PYTHONPATH=scripts uv run python -m unittest scripts.test_backend_matrix scripts.test_deterministic_twitter_digest
- git diff --check
- actionlint .github/workflows/hourly-twitter.yml