### PR TITLE
Keep empty Twitter cycles out of the public feed

### DIFF
--- a/.github/actions/render-twitter-prompt/action.yml
+++ b/.github/actions/render-twitter-prompt/action.yml
@@ -53,6 +53,12 @@ inputs:
   timestamp:
     description: Full timestamp string for the digest header.
     required: true
+  run_id:
+    description: GitHub Actions run ID for the per-attempt status heartbeat.
+    required: true
+  run_attempt:
+    description: GitHub Actions run attempt for the per-attempt status heartbeat.
+    required: true
   yesterday:
     description: YYYY-MM-DD for yesterday (used for prior-context Read).
     required: true
@@ -94,6 +100,8 @@ runs:
         DATE: ${{ inputs.date }}
         HOUR: ${{ inputs.hour }}
         TIMESTAMP: ${{ inputs.timestamp }}
+        RUN_ID: ${{ inputs.run_id }}
+        RUN_ATTEMPT: ${{ inputs.run_attempt }}
         YESTERDAY: ${{ inputs.yesterday }}
         COMMIT_PREFIX: ${{ inputs.commit_prefix }}
       run: |
@@ -115,36 +123,35 @@ runs:
         date = os.environ["DATE"]
         hour = os.environ["HOUR"]
         ts = os.environ["TIMESTAMP"]
+        run_id = os.environ["RUN_ID"]
+        run_attempt = os.environ["RUN_ATTEMPT"]
         yesterday = os.environ["YESTERDAY"]
         template_path = os.environ["TEMPLATE_PATH"]
         output_path = os.environ["OUTPUT_PATH"]
         birdy_input_dir = ".twitter-input/bird"
+        status_file = f"{output_dir}/status/{date}-{hour}h.json"
 
         # cycle window phrase: "~3-hour" for claude, "6-hour" for the others.
         cycle_window = "~3-hour" if cycle_hours == 3 else f"{cycle_hours}-hour"
 
-        # outputs_overview — claude writes three files (markdown + summary +
-        # headlines.json); other tiers write two (markdown + summary).
+        # outputs_overview — every tier writes status + summary; claude also
+        # writes headlines.json. The public digest is conditional on signal.
         if "headlines" in features:
             outputs_overview = (
-                "YOU WILL WRITE THREE OUTPUT FILES (all three are mandatory — do NOT skip the third):\n"
-                f"1. {output_dir}/{date}.md (daily markdown digest, append section)\n"
-                f"2. research/summaries/{date}-{summary_slug}-{hour}h-summary.txt (Telegram-friendly text rollup)\n"
-                f"3. research/summaries/{date}-{summary_slug}-{hour}h-headlines.json (structured headline alerts — REQUIRED for downstream Telegram blast)\n"
-                "\n"
-                "All three exist in every cycle, including quiet ones. For a quiet cycle the\n"
-                "JSON file is `[]` (empty array) but the file is still created.\n"
+                "YOU WILL WRITE THREE REQUIRED RUN ARTIFACTS, plus a public digest section only when signal exists:\n"
+                f"1. {status_file} (machine status; always write)\n"
+                f"2. research/summaries/{date}-{summary_slug}-{hour}h-summary.txt (concrete rollup, or empty for no_update)\n"
+                f"3. research/summaries/{date}-{summary_slug}-{hour}h-headlines.json (structured headline alerts; `[]` for no_update)\n"
+                f"4. {output_dir}/{date}.md (update only when at least one concrete story or Quick hit is publishable)\n"
                 "\n"
                 f"OUTPUT (markdown digest): {output_dir}/{date}.md"
             )
         else:
             outputs_overview = (
-                "YOU WILL WRITE TWO OUTPUT FILES (both are mandatory):\n"
-                f"1. {output_dir}/{date}.md (daily markdown digest, append section)\n"
-                f"2. research/summaries/{date}-{summary_slug}-{hour}h-summary.txt (Telegram-friendly text rollup)\n"
-                "\n"
-                "Both files exist in every cycle, including quiet ones. Do not commit until\n"
-                "both files have been created or updated.\n"
+                "YOU WILL WRITE TWO REQUIRED RUN ARTIFACTS, plus a public digest section only when signal exists:\n"
+                f"1. {status_file} (machine status; always write)\n"
+                f"2. research/summaries/{date}-{summary_slug}-{hour}h-summary.txt (concrete rollup, or empty for no_update)\n"
+                f"3. {output_dir}/{date}.md (update only when at least one concrete story or Quick hit is publishable)\n"
                 "\n"
                 f"OUTPUT (markdown digest): {output_dir}/{date}.md"
             )
@@ -248,18 +255,20 @@ runs:
         # final_step — what to verify and how to commit.
         if "headlines" in features:
             final_step = (
-                "STEP 4 — Verify ALL THREE files exist before committing. If headlines.json\n"
-                "is missing, go back and create it (even if just `[]`). Then commit:\n"
+                "STEP 4 — Verify status, summary, and headlines files exist before committing.\n"
+                "When status is `published`, also verify the same-hour digest section exists.\n"
+                "When status is `no_update`, verify that public section is absent and headlines\n"
+                "is `[]`. Then commit:\n"
                 f"git add {output_dir}/ research/summaries/\n"
                 f"git commit -m \"{commit_prefix} {ts}\" || echo \"No changes\"\n"
                 "\n"
-                "CRITICAL: A run without headlines.json blocks the downstream Telegram alert\n"
-                "blast. ALWAYS write the JSON file, even if it's `[]`."
+                "CRITICAL: ALWAYS write status and headlines, even for `no_update`."
             )
         else:
             final_step = (
-                "STEP 3 — Verify BOTH files exist before committing. If the Telegram\n"
-                "summary is missing, go back and create it. Then commit:\n"
+                "STEP 3 — Verify status and summary files exist before committing. When status\n"
+                "is `published`, also verify the digest section exists; for `no_update`, verify\n"
+                "the public same-hour section is absent. Then commit:\n"
                 f"git add {output_dir}/ research/summaries/\n"
                 f"git commit -m \"{commit_prefix} {ts}\" || echo \"No changes\""
             )
@@ -269,6 +278,8 @@ runs:
             "{{harness_label}}":     harness_label,
             "{{cycle_window}}":      cycle_window,
             "{{timestamp}}":         ts,
+            "{{run_id}}":           run_id,
+            "{{run_attempt}}":      run_attempt,
             "{{outputs_overview}}":  outputs_overview,
             "{{output_dir}}":        output_dir,
             "{{date}}":              date,
@@ -282,6 +293,7 @@ runs:
             "{{title_suffix}}":      title_suffix,
             "{{hour}}":              hour,
             "{{summary_slug}}":      summary_slug,
+            "{{status_file}}":       status_file,
             "{{headlines_section}}": headlines_section,
             "{{final_step}}":        final_step,
         }

--- a/.github/workflows/hourly-twitter.yml
+++ b/.github/workflows/hourly-twitter.yml
@@ -178,9 +178,9 @@ jobs:
         id: datetime
         run: |
           {
-            echo "date=$(date +'%Y-%m-%d')"
-            echo "hour=$(date +'%H')"
-            echo "timestamp=$(date +'%Y-%m-%d %H:%M UTC')"
+            echo "date=$(date -u +'%Y-%m-%d')"
+            echo "hour=$(date -u +'%H')"
+            echo "timestamp=$(date -u +'%Y-%m-%d %H:%M:%S UTC')"
             echo "yesterday=$(date -u -d 'yesterday' +'%Y-%m-%d')"
           } >> "$GITHUB_OUTPUT"
 
@@ -322,6 +322,7 @@ jobs:
             echo "harness_label=${HARNESS_LABEL}"
             echo "features=${FEATURES}"
             echo "digest_file=${OUTPUT_DIR}/${DATE}.md"
+            echo "status_file=${OUTPUT_DIR}/status/${DATE}-${HOUR}h.json"
             echo "headlines_file=research/summaries/${DATE}-${SUMMARY_SLUG}-${HOUR}h-headlines.json"
             echo "summary_file=research/summaries/${DATE}-${SUMMARY_SLUG}-${HOUR}h-summary.txt"
           } >> "$GITHUB_OUTPUT"
@@ -334,7 +335,7 @@ jobs:
           OUTPUT_DIR: ${{ steps.const.outputs.output_dir }}
         run: |
           set -euo pipefail
-          mkdir -p "$OUTPUT_DIR" research/summaries
+          mkdir -p "$OUTPUT_DIR/status" research/summaries
 
       # ── Shared fetch (Birdy multi-fetch + optional helpers) ────────
       - name: Fetch twitter snapshot
@@ -391,6 +392,8 @@ jobs:
           date: ${{ steps.datetime.outputs.date }}
           hour: ${{ steps.datetime.outputs.hour }}
           timestamp: ${{ steps.datetime.outputs.timestamp }}
+          run_id: ${{ github.run_id }}
+          run_attempt: ${{ github.run_attempt }}
           yesterday: ${{ steps.datetime.outputs.yesterday }}
 
       # ── LLM step (one per backend) ─────────────────────────────────
@@ -418,9 +421,7 @@ jobs:
           claude-args: |
             --model opus --allowedTools "Read,Write,Edit,MultiEdit,Bash(git:*),Bash(birdy-fast:*),Bash(curl:*),Bash(jq:*),Bash(python3:*),Bash(python:*),Bash(node:*),Bash(ls:*),Bash(cat:*),Bash(head:*),Bash(test:*),Bash(wc:*),Bash(mkdir:*),Bash(sed:*),Bash(rg:*),Bash(printf:*),Bash(touch:*)"
           expected-paths: |
-            ${{ steps.const.outputs.digest_file }}
-            ${{ steps.const.outputs.summary_file }}
-            ${{ steps.const.outputs.headlines_file }}
+            ${{ steps.const.outputs.status_file }}
           allowed-paths: |
             research/twitter/
             research/summaries/
@@ -446,9 +447,7 @@ jobs:
           claude-args: |
             --model opus --max-turns 40 --allowedTools "Read,Write,Edit,MultiEdit,Bash(git:*),Bash(jq:*),Bash(python3:*),Bash(python:*),Bash(node:*),Bash(test:*),Bash(ls:*),Bash(cat:*),Bash(head:*),Bash(wc:*),Bash(mkdir:*),Bash(sed:*),Bash(rg:*),Bash(printf:*),Bash(touch:*)"
           expected-paths: |
-            ${{ steps.const.outputs.digest_file }}
-            ${{ steps.const.outputs.summary_file }}
-            ${{ steps.const.outputs.headlines_file }}
+            ${{ steps.const.outputs.status_file }}
           allowed-paths: |
             research/twitter/
             research/summaries/
@@ -467,6 +466,7 @@ jobs:
               HOUR: ${{ steps.datetime.outputs.hour }}
               TIMESTAMP: ${{ steps.datetime.outputs.timestamp }}
               DAILY FILE: ${{ steps.const.outputs.digest_file }}
+              STATUS FILE: ${{ steps.const.outputs.status_file }}
               SUMMARY FILE: ${{ steps.const.outputs.summary_file }}
               HEADLINES FILE: ${{ steps.const.outputs.headlines_file }}
               RAW INPUT: .twitter-input/bird/all.json
@@ -475,54 +475,64 @@ jobs:
             HARD RULES
               - This is still the production Claude lane. Do not write a
                 deterministic quick-hit dump.
-              - Use tool calls to read the raw input and write all three
-                output files. Do not merely respond in chat.
+              - Use tool calls to read the raw input and write the required
+                run artifacts. Do not merely respond in chat.
               - If any tool call is denied, retry with an allowed tool
                 immediately. The allowed local parse/write path includes
                 Read, Write, Edit, jq, python3, cat, and git.
               - Before your final response, run `git status --short` and
-                confirm the commit changes all three expected output files.
-                If it does not, continue repairing instead of stopping.
+                confirm the commit changes the status heartbeat for this run.
+                Summary/headline/digest files may be byte-identical on a
+                same-hour rerun; verify their existence and contract instead.
+                If the contract is incomplete, continue repairing.
               - The public brief is AI-only. Exclude personal life updates,
                 sports, generic politics, generic outrage, engagement-bait,
                 and unrelated viral tweets unless the item materially changes
                 the AI landscape.
-              - If the daily file already has a section for
+              - If publishing and the daily file already has a section for
                 `## ${{ steps.datetime.outputs.hour }}:00 UTC`, replace that
-                same-hour section instead of appending a duplicate.
+                same-hour section instead of appending a duplicate. If there
+                is no publishable item, remove any same-hour filler section.
               - If there are fewer than three truly alert-worthy AI stories,
                 write `[]` to the headlines JSON. Do not pad.
+              - Public output is signal-only. When Quick hits exist, make the
+                Cycle summary name those concrete developments. Never publish
+                scan status, editorial-threshold language, or absence-of-news
+                narration in the digest.
+              - Generic AI hype (for example, "AI agents are the future" or
+                "our AI changes everything") is not a Quick hit. Require a
+                checkable release, price/funding change, research result,
+                benchmark, incident, policy action, or equivalent event.
 
             OUTPUT CONTRACT
-              1. Write or update `${{ steps.const.outputs.digest_file }}`.
-                 If no main AI stories exist, use:
-                   ## ${{ steps.datetime.outputs.hour }}:00 UTC
-                   **Cycle summary**: Quiet period — no analyst-grade AI stories this window.
-                   ### Quick hits
-                   - No AI-specific quick hits cleared the publication bar this cycle.
-                   ### Skeptic's corner
-                   - None this cycle.
-                   ### Watch list (next 24h)
-                   - Next scheduled Twitter/X AI monitor run.
-                   ### Research notes
-                   - Source checks issued this cycle: local Twitter/X snapshot only.
-              2. Write `${{ steps.const.outputs.summary_file }}` as a concise
-                 Telegram summary. If quiet, say no major AI updates; do not
-                 list off-topic tweets.
-              3. Write `${{ steps.const.outputs.headlines_file }}` as a JSON
-                 array, usually `[]` for a quiet cycle.
-              4. Commit exactly those outputs:
-                   git add "${{ steps.const.outputs.digest_file }}" "${{ steps.const.outputs.summary_file }}" "${{ steps.const.outputs.headlines_file }}"
+              1. If at least one concrete Top Story or Quick hit exists, write
+                 or update `${{ steps.const.outputs.digest_file }}` with a
+                 content-derived Cycle summary. Otherwise leave the daily file
+                 without a same-hour section.
+              2. Write `${{ steps.const.outputs.summary_file }}` as a concise,
+                 concrete Telegram summary. When nothing is publishable, create
+                 this as an empty file so no notification is emitted.
+              3. Write `${{ steps.const.outputs.headlines_file }}` as a valid
+                 JSON array; use `[]` when there are no alert-worthy stories.
+              4. Always write `${{ steps.const.outputs.status_file }}` as:
+                   {"schema_version":1,"date":"${{ steps.datetime.outputs.date }}","hour":"${{ steps.datetime.outputs.hour }}:00 UTC","generated_at":"${{ steps.datetime.outputs.timestamp }}","run_id":"${{ github.run_id }}","run_attempt":${{ github.run_attempt }},"status":"published","public_items":N}
+                 Use `status: "no_update"` and `public_items: 0` only when the
+                 public same-hour section is absent. Count `public_items` as
+                 Top Story `twitter-story` cards plus linked bullets under
+                 `### Quick hits`; it must equal the rendered count.
+              5. Commit exactly those outputs:
+                   git add "${{ steps.const.outputs.output_dir }}/" "${{ steps.const.outputs.summary_file }}" "${{ steps.const.outputs.headlines_file }}"
                    git commit -m "Twitter Claude repair ${{ steps.datetime.outputs.timestamp }}" || echo "No changes"
 
-      - name: Deterministic Twitter fallback (Claude primary tier)
+      - name: Validate or recover Claude primary output
         if: >-
           steps.backend.outputs.name == 'claude'
-          && steps.twitter-claude-agent.outcome == 'failure'
+          && (steps.twitter-claude-agent.outcome == 'success' || steps.twitter-claude-agent.outcome == 'failure')
           && !(github.event_name == 'workflow_dispatch' && inputs.dry_run == true)
         env:
           BASE_SHA: ${{ steps.twitter-output-base.outputs.sha }}
           DIGEST_FILE: ${{ steps.const.outputs.digest_file }}
+          STATUS_FILE: ${{ steps.const.outputs.status_file }}
           SUMMARY_FILE: ${{ steps.const.outputs.summary_file }}
           HEADLINES_FILE: ${{ steps.const.outputs.headlines_file }}
           OUTPUT_DIR: ${{ steps.const.outputs.output_dir }}
@@ -531,16 +541,88 @@ jobs:
           DATE: ${{ steps.datetime.outputs.date }}
           HOUR: ${{ steps.datetime.outputs.hour }}
           TIMESTAMP: ${{ steps.datetime.outputs.timestamp }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
 
           missing=0
-          for path in "$DIGEST_FILE" "$SUMMARY_FILE" "$HEADLINES_FILE"; do
-            if git diff --quiet "${BASE_SHA}..HEAD" -- "$path"; then
-              echo "fallback-needed: $path has no committed change since $BASE_SHA"
+          if git diff --quiet "${BASE_SHA}..HEAD" -- "$STATUS_FILE"; then
+            echo "fallback-needed: $STATUS_FILE has no committed change since $BASE_SHA"
+            missing=1
+          fi
+          if [ ! -f "$SUMMARY_FILE" ]; then
+            echo "fallback-needed: summary file is missing"
+            missing=1
+          fi
+          if [ ! -f "$HEADLINES_FILE" ] || ! jq -e 'type == "array"' "$HEADLINES_FILE" >/dev/null; then
+            echo "fallback-needed: headline output is missing or invalid"
+            missing=1
+          fi
+
+          if [ -f "$STATUS_FILE" ]; then
+            if ! jq -e \
+              --arg date "$DATE" \
+              --arg hour "${HOUR}:00 UTC" \
+              --arg generated_at "$TIMESTAMP" \
+              --arg run_id "$RUN_ID" \
+              --argjson run_attempt "$RUN_ATTEMPT" '
+              .schema_version == 1
+              and .date == $date
+              and .hour == $hour
+              and .generated_at == $generated_at
+              and .run_id == $run_id
+              and .run_attempt == $run_attempt
+              and (.status == "published" or .status == "no_update")
+              and (.public_items | type == "number" and . >= 0)
+            ' "$STATUS_FILE" >/dev/null; then
+              echo "fallback-needed: malformed cycle status"
               missing=1
             fi
-          done
+            status=$(jq -r '.status // "invalid"' "$STATUS_FILE" 2>/dev/null || echo invalid)
+            if [ "$status" = "published" ] && ! jq -e '.public_items > 0' "$STATUS_FILE" >/dev/null; then
+              echo "fallback-needed: published status has no public items"
+              missing=1
+            elif [ "$status" = "published" ] && { [ ! -f "$DIGEST_FILE" ] \
+              || ! rg -q "^## ${HOUR}:00 UTC$" "$DIGEST_FILE"; }; then
+              echo "fallback-needed: published status has no public same-hour section"
+              missing=1
+            elif [ "$status" = "published" ] && [ ! -s "$SUMMARY_FILE" ]; then
+              echo "fallback-needed: published status has no concrete summary"
+              missing=1
+            elif [ "$status" = "no_update" ] && ! jq -e '.public_items == 0' "$STATUS_FILE" >/dev/null; then
+              echo "fallback-needed: no_update status reports public items"
+              missing=1
+            elif [ "$status" = "no_update" ] && [ -f "$DIGEST_FILE" ] \
+              && rg -q "^## ${HOUR}:00 UTC$" "$DIGEST_FILE"; then
+              echo "fallback-needed: no_update status still has a public same-hour section"
+              missing=1
+            elif [ "$status" = "no_update" ] && [ -s "$SUMMARY_FILE" ]; then
+              echo "fallback-needed: no_update status has a reader summary"
+              missing=1
+            elif [ "$status" = "no_update" ] && ! jq -e 'length == 0' "$HEADLINES_FILE" >/dev/null; then
+              echo "fallback-needed: no_update status has headline alerts"
+              missing=1
+            elif [ "$status" != "published" ] && [ "$status" != "no_update" ]; then
+              echo "fallback-needed: invalid cycle status '$status'"
+              missing=1
+            fi
+          fi
+
+          if [ "$missing" -eq 0 ] && ! uv run python scripts/validate_twitter_public_output.py \
+            --backend claude \
+            --status-file "$STATUS_FILE" \
+            --digest-file "$DIGEST_FILE" \
+            --summary-file "$SUMMARY_FILE" \
+            --headlines-file "$HEADLINES_FILE" \
+            --date "$DATE" \
+            --hour "$HOUR" \
+            --generated-at "$TIMESTAMP" \
+            --run-id "$RUN_ID" \
+            --run-attempt "$RUN_ATTEMPT"; then
+            echo "fallback-needed: agent output violates the signal-only public contract"
+            missing=1
+          fi
 
           if [ "$missing" -eq 0 ]; then
             echo "Claude repair already produced all required outputs; skipping deterministic fallback."
@@ -557,11 +639,14 @@ jobs:
             --date "$DATE" \
             --hour "$HOUR" \
             --timestamp "$TIMESTAMP" \
+            --run-id "$RUN_ID" \
+            --run-attempt "$RUN_ATTEMPT" \
             --title-suffix "$TITLE_SUFFIX" \
             --summary-slug "$SUMMARY_SLUG" \
+            --status-file "$STATUS_FILE" \
             --headlines-file "$HEADLINES_FILE"
 
-          git add "$DIGEST_FILE" "$SUMMARY_FILE" "$HEADLINES_FILE"
+          git add "$OUTPUT_DIR/" "$SUMMARY_FILE" "$HEADLINES_FILE"
           git commit -m "Twitter deterministic fallback $TIMESTAMP" || echo "No deterministic fallback changes to commit"
 
       - name: Process tweets with DeepSeek v4 Flash via Fireworks (deepseek-claude-code tier)
@@ -580,8 +665,7 @@ jobs:
           claude-args: |
             --model opus --allowedTools "Read,Write,Edit,Bash(git:*),Bash(birdy-fast:*),Bash(curl:*),Bash(jq:*)"
           expected-paths: |
-            ${{ steps.const.outputs.digest_file }}
-            ${{ steps.const.outputs.summary_file }}
+            ${{ steps.const.outputs.status_file }}
           allowed-paths: |
             research/twitter-deepseek/
             research/summaries/
@@ -604,59 +688,12 @@ jobs:
           claude-args: |
             --model opus --max-turns 30 --allowedTools "Read,Write,Edit,Bash(pwd:*),Bash(ls:*),Bash(rg:*),Bash(find:*),Bash(cat:*),Bash(head:*),Bash(test:*),Bash(git:*),Bash(birdy-fast:*),Bash(curl:*),Bash(jq:*)"
           expected-paths: |
-            ${{ steps.const.outputs.digest_file }}
-            ${{ steps.const.outputs.summary_file }}
+            ${{ steps.const.outputs.status_file }}
           allowed-paths: |
             research/twitter-zai/
             research/summaries/
           label: Twitter Z.ai GLM-5.2 comparison processor
           prompt: ${{ steps.render.outputs.prompt }}
-
-      - name: Require Claude primary output
-        if: >-
-          steps.backend.outputs.name == 'claude'
-          && !(github.event_name == 'workflow_dispatch' && inputs.dry_run == true)
-        uses: ./.github/actions/require-output
-        with:
-          base-sha: ${{ steps.twitter-output-base.outputs.sha }}
-          expected-paths: |
-            ${{ steps.const.outputs.digest_file }}
-            ${{ steps.const.outputs.summary_file }}
-          label: Twitter primary Claude workflow output
-
-      - name: Require Claude headline file
-        if: >-
-          steps.backend.outputs.name == 'claude'
-          && !(github.event_name == 'workflow_dispatch' && inputs.dry_run == true)
-        env:
-          HEADLINES_FILE: ${{ steps.const.outputs.headlines_file }}
-        run: |
-          set -euo pipefail
-          if [ ! -f "$HEADLINES_FILE" ]; then
-            echo "::error::Missing Claude headline output: $HEADLINES_FILE"
-            exit 1
-          fi
-          jq -e 'type == "array"' "$HEADLINES_FILE" >/dev/null
-
-      - name: Require DeepSeek comparison output
-        if: steps.backend.outputs.name == 'deepseek-claude-code'
-        uses: ./.github/actions/require-output
-        with:
-          base-sha: ${{ steps.twitter-output-base.outputs.sha }}
-          expected-paths: |
-            ${{ steps.const.outputs.digest_file }}
-            ${{ steps.const.outputs.summary_file }}
-          label: Twitter DeepSeek comparison workflow output
-
-      - name: Require Z.ai comparison output
-        if: steps.backend.outputs.name == 'zai-glm-5p2'
-        uses: ./.github/actions/require-output
-        with:
-          base-sha: ${{ steps.twitter-output-base.outputs.sha }}
-          expected-paths: |
-            ${{ steps.const.outputs.digest_file }}
-            ${{ steps.const.outputs.summary_file }}
-          label: Twitter Z.ai GLM-5.2 comparison workflow output
 
       - name: Process tweets with pi + DeepSeek v4 Flash via Fireworks (deepseek-pi tier)
         if: steps.backend.outputs.name == 'deepseek-pi'
@@ -679,6 +716,60 @@ jobs:
           fireworks-api-key: ${{ secrets.FIREWORKS_API_KEY }}
           bird-auth-token: ${{ secrets.BIRD_AUTH_TOKEN }}
           bird-ct0: ${{ secrets.BIRD_CT0 }}
+
+      - name: Require Twitter producer diff scope
+        if: >-
+          contains(fromJSON('["claude","deepseek-claude-code","zai-glm-5p2","deepseek-pi","fireworks-pi"]'), steps.backend.outputs.name)
+          && !(steps.backend.outputs.name == 'claude' && github.event_name == 'workflow_dispatch' && inputs.dry_run == true)
+        uses: ./.github/actions/require-diff-scope
+        with:
+          base-sha: ${{ steps.twitter-output-base.outputs.sha }}
+          allowed-paths: |
+            ${{ steps.const.outputs.digest_file }}
+            ${{ steps.const.outputs.status_file }}
+            ${{ steps.const.outputs.summary_file }}
+            ${{ steps.const.outputs.headlines_file }}
+          label: Twitter ${{ steps.backend.outputs.name }} producer
+
+      - name: Require Twitter run heartbeat
+        if: >-
+          contains(fromJSON('["claude","deepseek-claude-code","zai-glm-5p2","deepseek-pi","fireworks-pi"]'), steps.backend.outputs.name)
+          && !(steps.backend.outputs.name == 'claude' && github.event_name == 'workflow_dispatch' && inputs.dry_run == true)
+        uses: ./.github/actions/require-output
+        with:
+          base-sha: ${{ steps.twitter-output-base.outputs.sha }}
+          expected-paths: |
+            ${{ steps.const.outputs.status_file }}
+          label: Twitter ${{ steps.backend.outputs.name }} run heartbeat
+
+      - name: Validate Twitter signal-only public output
+        if: >-
+          contains(fromJSON('["claude","deepseek-claude-code","zai-glm-5p2","deepseek-pi","fireworks-pi"]'), steps.backend.outputs.name)
+          && !(steps.backend.outputs.name == 'claude' && github.event_name == 'workflow_dispatch' && inputs.dry_run == true)
+        env:
+          BACKEND: ${{ steps.backend.outputs.name }}
+          DATE: ${{ steps.datetime.outputs.date }}
+          HOUR: ${{ steps.datetime.outputs.hour }}
+          TIMESTAMP: ${{ steps.datetime.outputs.timestamp }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          DIGEST_FILE: ${{ steps.const.outputs.digest_file }}
+          STATUS_FILE: ${{ steps.const.outputs.status_file }}
+          SUMMARY_FILE: ${{ steps.const.outputs.summary_file }}
+          HEADLINES_FILE: ${{ steps.const.outputs.headlines_file }}
+        run: |
+          set -euo pipefail
+          uv run python scripts/validate_twitter_public_output.py \
+            --backend "$BACKEND" \
+            --status-file "$STATUS_FILE" \
+            --digest-file "$DIGEST_FILE" \
+            --summary-file "$SUMMARY_FILE" \
+            --headlines-file "$HEADLINES_FILE" \
+            --date "$DATE" \
+            --hour "$HOUR" \
+            --generated-at "$TIMESTAMP" \
+            --run-id "$RUN_ID" \
+            --run-attempt "$RUN_ATTEMPT"
 
       - name: Summarize Birdy follow-up telemetry
         if: always() && steps.backend.outputs.skip != 'true'
@@ -1267,6 +1358,7 @@ jobs:
           success()
           && steps.push.outputs.pushed == 'true'
           && steps.backend.outputs.name == 'deepseek-claude-code'
+          && steps.summary.outputs.content != ''
         continue-on-error: true
         env:
           HOOKER_URL: ${{ secrets.HOOKER_URL }}
@@ -1311,6 +1403,7 @@ jobs:
           success()
           && steps.push.outputs.pushed == 'true'
           && steps.backend.outputs.name == 'zai-glm-5p2'
+          && steps.summary.outputs.content != ''
         continue-on-error: true
         env:
           HOOKER_URL: ${{ secrets.HOOKER_URL }}
@@ -1357,6 +1450,7 @@ jobs:
           success()
           && steps.push.outputs.pushed == 'true'
           && steps.backend.outputs.name == 'deepseek-pi'
+          && steps.summary.outputs.content != ''
         continue-on-error: true
         env:
           HOOKER_URL: ${{ secrets.HOOKER_URL }}
@@ -1402,6 +1496,7 @@ jobs:
           success()
           && steps.push.outputs.pushed == 'true'
           && steps.backend.outputs.name == 'fireworks-pi'
+          && steps.summary.outputs.content != ''
         continue-on-error: true
         env:
           HOOKER_URL: ${{ secrets.HOOKER_URL }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,8 @@ and opens a PR with methodology fixes.
 | `fetch_ai_blogs.py` | Per-feed AI-blog fetcher used by `daily-ai-blogs.yml`; boundary-handles bad feeds so one failure doesn't crash the run. |
 | `deterministic_rss_digest.py` | Model-free fallback for `hourly-rss.yml`; parses fetched RSS/Atom files and appends a timestamped `research/rss/YYYY-MM-DD.md` section when the agent path fails. |
 | `deterministic_community_digest.py` | Model-free fallback for `4h-community.yml`; parses pre-fetched HN JSON and Reddit RSS into `research/community/*-hn.md` and `*-reddit.md` when the agent path fails. |
-| `deterministic_twitter_digest.py` | Model-free fallback for `hourly-twitter.yml` Twitter tiers; composes the report + Telegram summary from the pre-fetched bird data when the agent path fails, including the primary Claude lane's last-resort recovery from `.twitter-input/bird/all.json`. |
+| `deterministic_twitter_digest.py` | Model-free fallback for `hourly-twitter.yml` Twitter tiers; publishes a report only when fresh stories or concrete Quick hits survive filtering, otherwise records a run-ID/attempt-scoped machine heartbeat under `research/<twitter-lane>/status/`. It also writes the per-run summary/headline artifacts from pre-fetched Birdy data, including primary-lane recovery from `.twitter-input/bird/all.json`. |
+| `validate_twitter_public_output.py` | Enforces the Twitter signal-only contract after every backend: this run's heartbeat identity, exact public-item count, concrete story/Quick-hit presence, normalized same-hour headings, empty no-update reader artifacts, and no operational/no-news filler. |
 | `deterministic_arxiv_digest.py` | Model-free fallback for `daily-arxiv.yml`; queries the arXiv Atom API directly and writes an uncurated per-category `research/arxiv/<date>-papers.md` when the agent path fails (zero-paper windows still write an honest empty note). |
 | `deterministic_daily_digest.py` | Model-free fallback for `daily-digest.yml`; composes `research/digest/<date>-digest.md` (+ Telegram summary) verbatim from the day's committed lane artifacts when the agent fails or its output falls below the content floor. Never invents content; missing lanes are noted explicitly. |
 | `deterministic_bluesky_digest.py` | Model-free fallback for `2h-bluesky.yml`; composes the per-run `.tmp/bluesky-section.md` (engagement-ranked, ≤8 bullets / ≤3 per author, 48h window) from the staged `data/bluesky/*.json` when the agent writes no section. |
@@ -310,7 +311,7 @@ research/
 ├── rss/                       # hourly-rss.yml
 ├── blogs/                     # daily-ai-blogs.yml
 ├── summaries/                 # hourly-twitter.yml (Telegram digest + headline-alert state)
-├── twitter/                   # hourly-twitter.yml
+├── twitter/                   # hourly-twitter.yml (signal-only daily Markdown + status/ run heartbeats)
 ├── youtube/                   # daily-youtube.yml (tuber read-only signal lane)
 ├── twitter-deepseek/          # hourly-twitter.yml backend=deepseek-claude-code
 ├── twitter-deepseek-pi/       # hourly-twitter.yml backend=deepseek-pi

--- a/prompts/twitter-analyst.md
+++ b/prompts/twitter-analyst.md
@@ -14,8 +14,8 @@ PRIOR CONTEXT (read these BEFORE writing — multi-day arcs are first-class):
 - Today's file so far: {{output_dir}}/{{date}}.md
   (may already contain earlier cycles from today. If a section for
   `## {{hour}}:00 UTC` already exists because this is a rerun, replace that
-  same-hour section instead of appending a duplicate. Otherwise append a new
-  section at the end.)
+  same-hour section when publishing, or remove it when the final run status is
+  `no_update`. Otherwise append a new public section only when signal exists.)
 - Yesterday's full digest: {{output_dir}}/{{yesterday}}.md
   (may not exist on the first day; if Read fails, skip)
 {{cross_harness_note}}
@@ -25,7 +25,7 @@ PRIOR CONTEXT (read these BEFORE writing — multi-day arcs are first-class):
 TOOLS YOU CAN USE:
 {{tools_section}}
 HARD CAPS: {{bird_budget}} {{follow_up_tools}} follow-up calls + {{curl_budget}} curl fetches per run.
-Use them when verification matters; quiet cycles should use fewer.
+Use them when verification matters; thin snapshots should use fewer.
 
 INSTRUCTIONS:
 0. Reason from first principles. Stress-test the premise that each candidate
@@ -61,24 +61,35 @@ INSTRUCTIONS:
    bury it in Quick hits with an "if confirmed" hedge.
 7. Put every other notable item into Quick hits, one line each.
 8. Flag loud-but-shaky claims in Skeptic's corner.
-9. End with a concrete Watch list and Research notes.
+9. End with a concrete Watch list when there is a specific next signal to track.
 10. Public-output hygiene: never make internal collection failures,
    auth/cookie problems, {{follow_up_tools}} errors, HTTP 403s, Cloudflare
    challenge pages, stack traces, or raw tool stderr/stdout into a Top Story,
-   Quick hit, Skeptic's corner item, Watch item, or public Research note.
+   Quick hit, Skeptic's corner item, or Watch item.
    Treat those as private pipeline diagnostics. If a source cannot be
    re-verified, simply downgrade or omit the affected claim; do not expose
    the tooling failure or command output to readers.
+11. PUBLICATION IS SIGNAL-ONLY. Pipeline/editorial status is not reader copy.
+   - When at least one Top Story or concrete Quick hit is publishable, write
+     the same-hour section and make `Cycle summary` name the actual
+     developments. A Quick-hit-only cycle is valid and must lead with those
+     items rather than with their rank or the absence of a larger story.
+   - When nothing concrete is publishable, do not create a public same-hour
+     section. On a rerun, remove any existing same-hour filler section and
+     leave the rest of the daily Markdown unchanged. Record the successful
+     scan only in the mandatory status JSON below.
+   - Never use the public brief to announce that a scan was uneventful, that
+     items failed an editorial threshold, or that earlier items were not
+     republished.
 
-FORMAT: Append to the daily file (create if doesn't exist).
-If the file already exists and already has a section for `## {{hour}}:00 UTC`,
-replace that same-hour section. Otherwise append the new section at the end.
-If it doesn't exist, start with:
+FORMAT WHEN PUBLISHING: Append to the daily file (create if it doesn't exist).
+If a section for `## {{hour}}:00 UTC` already exists, replace that same-hour
+section. Otherwise append the new section at the end. Start a new file with:
 `# Twitter/X AI Pulse{{title_suffix}} — {{date}}`
 
 ## {{hour}}:00 UTC
 
-**Cycle summary**: [1-2 sentences naming the dominant theme. If quiet, say so.]
+**Cycle summary**: [1-2 sentences naming the concrete developments in this cycle.]
 
 ### Top stories
 
@@ -119,27 +130,28 @@ shape for the next story.
 
 ### 🚩 Skeptic's corner
 - [Loud claim that did not corroborate, with reason and URL.]
-- [Or "None this cycle"]
+- Omit this heading entirely when there is no concrete claim to challenge.
 
 ### Watch list (next 24h)
 - [Dated, concrete signal]
 
-### Research notes
-- Source checks issued this cycle: [list source names / URLs briefly; do not
-  include raw tool names, auth failures, HTTP errors, stderr, or command output]
-- [If none: "No follow-ups needed — pre-fetched snapshot was sufficient"]
-
-If no main stories exist, write:
+When the cycle has concrete Quick hits but no Top Story, write:
 ## {{hour}}:00 UTC
-**Cycle summary**: Quiet period — no main stories this window.
+**Cycle summary**: [Name the 1-2 most useful Quick-hit developments directly.]
 ### Quick hits
-- No AI-specific quick hits cleared the publication bar this cycle.
+- [Concrete AI item with @handle + URL.]
 
 CONSTRAINTS:
 - Be specific. "Big funding round" → "$200M Series C, $2B post-money, led by X."
+- A Quick hit must describe a concrete event: a release, pricing or funding
+  change, research result, benchmark, security incident, policy action, or
+  similarly checkable development. Generic claims such as "AI agents are the
+  future" or "our AI changes everything" are not news and must be dropped.
 - Do not recycle hype phrasing. Synthesize.
 - High engagement is not proof.
 - Link primary sources when cited.
+- Do not publish monitoring status, source-check logs, a `Research notes`
+  section, or any wording whose only message is that nothing new was found.
 - A short honest brief beats a padded one.
 
 STEP 2 — WRITE TELEGRAM SUMMARY:
@@ -162,12 +174,27 @@ WATCH: [1 concrete signal for next 24h]
 Full update on GitHub.
 ```
 
-If no significant updates were found, write:
-```
-Twitter/X AI Pulse{{title_suffix}} - {{timestamp}}
+If nothing concrete is publishable, create the summary file as an empty file so
+no reader notification is emitted.
 
-Quiet period — no major AI updates on Twitter/X.
+RUN STATUS — ALWAYS WRITE `{{status_file}}` as JSON:
+```json
+{
+  "schema_version": 1,
+  "date": "{{date}}",
+  "hour": "{{hour}}:00 UTC",
+  "generated_at": "{{timestamp}}",
+  "run_id": "{{run_id}}",
+  "run_attempt": {{run_attempt}},
+  "status": "published",
+  "public_items": 3
+}
 ```
+Use `status: "published"` only when the same-hour public digest section exists;
+set `status: "no_update"` and `public_items: 0` when it does not. The status
+file is the machine heartbeat and must be written in every run. Count
+`public_items` as Top Story `<article class="twitter-story">` cards plus linked
+bullets under `### Quick hits`; the count must equal what is actually rendered.
 
 {{headlines_section}}
 

--- a/research/summaries/2026-07-10-twitter-00h-summary.txt
+++ b/research/summaries/2026-07-10-twitter-00h-summary.txt
@@ -1,6 +1,6 @@
 Twitter/X AI Pulse - 2026-07-10 00:30 UTC
 
-CYCLE: Fresh primary-source AI product movement cleared the publication bar.
+CYCLE: OpenAI began rolling out GPT-Live in ChatGPT; Elon Musk said Grok 4.5 has more than 2× inference-speed headroom.
 
 TOP STORIES:
 - OpenAI rolls out GPT-Live voice models in ChatGPT: OpenAI introduced GPT-Live as a new generation of voice models for natural human-AI interaction, rolling out in ChatGPT starting today. Sam Altman framed it as the first voice experience that could shift him from typing to talking with AI.

--- a/research/summaries/2026-07-10-twitter-05h-summary.txt
+++ b/research/summaries/2026-07-10-twitter-05h-summary.txt
@@ -1,6 +1,6 @@
 Twitter/X AI Pulse - 2026-07-10 05:00 UTC
 
-CYCLE: Fresh primary-source AI product movement cleared the publication bar.
+CYCLE: OpenAI gave GPT-5.6 Sol, Terra, and Luna a public Thursday launch window.
 
 TOP STORIES:
 - OpenAI gives GPT-5.6 Sol/Terra/Luna a public launch window: OpenAI says GPT-5.6 Sol, Terra, and Luna will launch publicly this Thursday, with preview access already expanding globally. Sam Altman amplified the Sol launch separately, turning the prior July 7-9 watch item into a primary-source launch item.

--- a/research/summaries/2026-07-10-twitter-07h-summary.txt
+++ b/research/summaries/2026-07-10-twitter-07h-summary.txt
@@ -1,7 +1,11 @@
 Twitter/X AI Pulse - 2026-07-10 07:41 UTC
 
-CYCLE: Quiet follow-up period; no new main stories beyond earlier same-day Twitter/X items.
+CYCLE: Meta introduced Muse Spark 1.1 and previewed the Meta Model API; Sam Altman highlighted GPT-5.6 Sol's lower cost per task.
 
-WATCH: carry forward public rollout details, independent evals, pricing/rate limits, and real-user voice latency.
+QUICK HITS:
+- @AIatMeta: Muse Spark 1.1 and the Meta Model API public preview.
+- @sama: GPT-5.6 Sol cost-per-task gains.
+
+WATCH: Meta API access/pricing and independent Muse Spark 1.1 and GPT-5.6 results.
 
 Full update on GitHub.

--- a/research/twitter/2026-07-10.md
+++ b/research/twitter/2026-07-10.md
@@ -2,7 +2,7 @@
 
 ## 00:00 UTC
 
-**Cycle summary**: Fresh primary-source AI product movement cleared the bar this window: OpenAI rolls out GPT-Live voice models in ChatGPT; Musk says Grok 4.5 still has major inference-speed headroom. The digest treats high-signal launch posts as stories, while keeping benchmark and rollout claims provisional until independent evidence lands.
+**Cycle summary**: OpenAI began rolling out GPT-Live voice models in ChatGPT; Elon Musk said Grok 4.5 could more than double inference speed after xAI's GB300-tuned stack lands.
 
 ### Top stories
 
@@ -50,11 +50,7 @@
 </article>
 
 ### Quick hits
-- @elonmusk: Grok 4.5 on OpenClaw [6,149 likes, 1,042 reposts, 939 replies](https://x.com/elonmusk/status/2075136517144535171)
-- @OpenAI: Listen up. Livestream at 10am. https://t.co/tfqMb74Ri6 [6,874 likes, 516 reposts, 480 replies](https://x.com/OpenAI/status/2074871151302774869)
 - @OpenAI: We audited SWE-Bench Pro, one of the most widely used AI coding benchmarks, and found it no longer reliably measures frontier coding capability. We find 30% of SWE-Bench Pro tasks to be broken, and are retracting our pr... [7,001 likes, 499 reposts, 279 replies](https://x.com/OpenAI/status/2074972179385720836)
-- @ClaudeDevs: Model and effort in Claude Code: knowing more vs. trying harder [4,666 likes, 401 reposts, 180 replies](https://x.com/ClaudeDevs/status/2074900291062034618)
-- @elonmusk: Try out Grok 4.5! [3,270 likes, 707 reposts, 750 replies](https://x.com/elonmusk/status/2075125320521310589)
 
 ### Skeptic's corner
 - GPT-Live's product launch is confirmed; quality claims around naturalness, latency, and safety remain user-verified, not benchmarked.
@@ -63,14 +59,10 @@
 ### Watch list (next 24h)
 - Whether GPT-Live shows low-latency, interruptible, reliable voice behavior in real ChatGPT user reports.
 - Whether xAI publishes Grok 4.5 availability and inference-stack release details.
-- Next scheduled Twitter/X AI monitor run.
-
-### Research notes
-- Source checks issued this cycle: fresh pre-fetched account, search, and news snapshots; stale rows outside the configured freshness window were excluded before ranking.
 
 ## 05:00 UTC
 
-**Cycle summary**: Fresh primary-source AI product movement cleared the bar this window: OpenAI gives GPT-5.6 Sol/Terra/Luna a public launch window. The digest treats high-signal launch posts as stories, while keeping benchmark and rollout claims provisional until independent evidence lands.
+**Cycle summary**: OpenAI gave GPT-5.6 Sol, Terra, and Luna a public Thursday launch window, with pricing, rate limits, and independent performance still open questions.
 
 ### Top stories
 
@@ -96,36 +88,26 @@
 
 ### Quick hits
 - @ClaudeDevs: We've reset 5-hour and weekly rate limits for all users. [23,294 likes, 1,455 reposts, 2,364 replies](https://x.com/ClaudeDevs/status/2075279141352706215)
-- @OpenAI: Today. 10am PT. https://t.co/MVveXg12VD [8,195 likes, 768 reposts, 792 replies](https://x.com/OpenAI/status/2075254288956440848)
 - @OpenAI: Sol, Terra, and Luna, our GPT‑5.6 family of models, are starting to roll out now in ChatGPT, Codex, and the API. https://t.co/Qri7GdtYs3 [7,170 likes, 739 reposts, 377 replies](https://x.com/OpenAI/status/2075271421149020426)
 - @sama: 5.6 livestream going now. in addition to the model, 3 major product things. 1. ChatGPT Work--really big deal! 2. new ChatGPT desktop app 3. hosted sites [7,731 likes, 371 reposts, 551 replies](https://x.com/sama/status/2075264378962907597)
-- @sama: obviously the best model we have ever produced, but also one of the best blog posts we have ever produced: https://t.co/LtgWH41x6g [5,622 likes, 472 reposts, 454 replies](https://x.com/sama/status/2075266471316615436)
 
 ### Skeptic's corner
 - GPT-5.6's public launch date is now primary-source, but capability, price, and eval claims still need independent confirmation.
 
 ### Watch list (next 24h)
 - Whether GPT-5.6 Sol/Terra/Luna become broadly accessible on Thursday, and under what plan/API limits.
-- Next scheduled Twitter/X AI monitor run.
-
-### Research notes
-- Source checks issued this cycle: fresh pre-fetched account, search, and news snapshots; stale rows outside the configured freshness window were excluded before ranking.
 
 ## 07:00 UTC
 
-**Cycle summary**: Quiet follow-up period - no new main stories beyond earlier same-day Twitter/X items.
+**Cycle summary**: Meta introduced Muse Spark 1.1 and opened a public preview of the Meta Model API; Sam Altman highlighted GPT-5.6 Sol's lower cost per task.
 
 ### Quick hits
-- @sama: we have heard enterprises on their concerns about AI costs, and 5.6 sol is a huge step forward for dollars-per-task, as are terra and luna [7,148 likes, 251 reposts, 486 replies](https://x.com/sama/status/2075267201058426944)
-- @sama: it surely doesnt [5,096 likes, 110 reposts, 321 replies](https://x.com/sama/status/2075048072837734448)
 - @AIatMeta: We’re excited to introduce Muse Spark 1.1, a significant upgrade from the first Muse Spark model we released earlier this year. Along with this release, we are launching a public preview of the new Meta Model API where... [3,907 likes, 459 reposts, 212 replies](https://x.com/AIatMeta/status/2075221088821518394)
+- @sama: we have heard enterprises on their concerns about AI costs, and 5.6 sol is a huge step forward for dollars-per-task, as are terra and luna [7,148 likes, 251 reposts, 486 replies](https://x.com/sama/status/2075267201058426944)
 
 ### Skeptic's corner
-- Earlier same-day story claims remain in watch mode; this cycle only saw repeat or follow-up signals.
+- Meta's announcement confirms the release and API preview; benchmark gains, access terms, and independent results still need documentation and user testing.
 
 ### Watch list (next 24h)
-- Next scheduled Twitter/X AI monitor run.
-
-### Research notes
-- Source checks issued this cycle: fresh pre-fetched account, search, and news snapshots; stale rows outside the configured freshness window were excluded before ranking.
-- Earlier same-day story URLs and story families were excluded before ranking to avoid duplicate publication.
+- Meta Model API access, pricing, and model documentation; independent Muse Spark 1.1 results.
+- GPT-5.6 pricing and measured cost-per-task results after broader availability.

--- a/research/twitter/status/2026-07-10-07h.json
+++ b/research/twitter/status/2026-07-10-07h.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "date": "2026-07-10",
+  "hour": "07:00 UTC",
+  "generated_at": "2026-07-10 07:41 UTC",
+  "run_id": "backfill-2026-07-10",
+  "run_attempt": 1,
+  "status": "published",
+  "public_items": 2
+}

--- a/scripts/deterministic_daily_digest.py
+++ b/scripts/deterministic_daily_digest.py
@@ -58,7 +58,7 @@ class LaneSource:
 LANES: tuple[LaneSource, ...] = (
     # The twitter lane's .md is an HTML-article render; the plain-text
     # Telegram summaries are the extractable artifact. Several exist per day
-    # (one per 3h cycle) — the lexically-last (latest hour) wins. The
+    # (one per 3h cycle) — the latest non-empty cycle wins. The
     # [0-9][0-9]h class pins the PRIMARY lane's `<date>-twitter-<HH>h-` files
     # and excludes the comparison lanes (`-twitter-deepseek-<HH>h-` etc.).
     LaneSource(
@@ -174,23 +174,27 @@ def extract_lane(research_dir: Path, lane: LaneSource, dates: list[str], cap: in
         matches = sorted(p for p in glob.glob(pattern) if os.path.isfile(p))
         if not matches:
             continue
-        artifact = Path(matches[-1])  # lexically last = latest cycle of that date
-        relative = artifact.relative_to(research_dir).as_posix()
-        try:
-            text = artifact.read_text(encoding="utf-8")
-        except OSError as exc:
-            empty_artifacts.append(f"{relative} (unreadable: {exc})")
-            continue
-        lines: list[str] = []
-        for mode in lane.modes:
-            if len(lines) >= cap:
-                break
-            for line in EXTRACTORS[mode](text, cap - len(lines)):
-                if line not in lines:
-                    lines.append(line)
-        if lines:
-            return LaneExtract(lane, relative, tuple(lines), "")
-        empty_artifacts.append(relative)
+        # Several sub-daily artifacts can exist for one date. Walk newest to
+        # oldest so a machine-only/empty no_update summary does not shadow an
+        # earlier same-day cycle that contains the actual public signal.
+        for match in reversed(matches):
+            artifact = Path(match)
+            relative = artifact.relative_to(research_dir).as_posix()
+            try:
+                text = artifact.read_text(encoding="utf-8")
+            except OSError as exc:
+                empty_artifacts.append(f"{relative} (unreadable: {exc})")
+                continue
+            lines: list[str] = []
+            for mode in lane.modes:
+                if len(lines) >= cap:
+                    break
+                for line in EXTRACTORS[mode](text, cap - len(lines)):
+                    if line not in lines:
+                        lines.append(line)
+            if lines:
+                return LaneExtract(lane, relative, tuple(lines), "")
+            empty_artifacts.append(relative)
     if empty_artifacts:
         return LaneExtract(
             lane, None, (),

--- a/scripts/deterministic_twitter_digest.py
+++ b/scripts/deterministic_twitter_digest.py
@@ -25,7 +25,9 @@ MAX_TEXT = 220
 DEFAULT_MAX_AGE_HOURS = 36
 FUTURE_SKEW = dt.timedelta(minutes=15)
 STATUS_URL_RE = re.compile(r"https?://(?:www\.)?(?:x|twitter)\.com/[^\s)\"<>]+/status/(\d+)")
-SECTION_RE = re.compile(r"(?ms)^## (?P<hour>\d{2}:00 UTC)\n.*?(?=^## \d{2}:00 UTC\n|\Z)")
+SECTION_RE = re.compile(
+    r"(?ms)^##[ \t]+(?P<hour>\d{2}:00 UTC)[ \t]*\r?\n.*?(?=^##[ \t]+.*(?:\r?\n|\Z)|\Z)"
+)
 STORY_MARKERS = {
     "gpt56": (
         "OpenAI gives GPT-5.6 Sol/Terra/Luna",
@@ -347,14 +349,79 @@ STRONG_AI_TERMS = (
     "mistral",
     "glm",
     "xai",
-    "model",
     "inference",
+    "artificial intelligence",
     "ai ",
     "ai-",
-    "agent",
+    "llm",
+    "language model",
+    "ai model",
+    "model api",
+    "ai agent",
+    "agentic",
+    "coding agent",
     "benchmark",
     "eval",
     "voice model",
+)
+
+EVENT_TERMS = (
+    "acquir",
+    "announce",
+    "available now",
+    "became available",
+    "disclos",
+    "discover",
+    "found that",
+    "we find",
+    "introduc",
+    "launch",
+    "open sourced",
+    "open source",
+    "open-source",
+    "patch",
+    "public preview",
+    "pricing is now",
+    "publish",
+    "rais",
+    "release",
+    "reset",
+    "retract",
+    "roll out",
+    "rolling out",
+    "ship",
+    "unveil",
+)
+
+NAMED_AI_PRODUCT_TERMS = (
+    "chatgpt",
+    "claude",
+    "deepseek",
+    "gemini",
+    "gpt-",
+    "gpt ",
+    "grok",
+    "llama",
+    "muse spark",
+    "mistral",
+    "qwen",
+)
+
+CHECKABLE_OBJECT_TERMS = (
+    "api pricing",
+    "benchmark score",
+    "funding round",
+    "price cut",
+    "pricing is now",
+    "rate limit",
+    "research paper",
+    "system card",
+    "vulnerability",
+)
+
+SPECIFIC_DETAIL_RE = re.compile(
+    r"(?:\b\d+(?:\.\d+)+\b|\b\d+(?:\.\d+)?\s?(?:%|x|ms|seconds?|tokens?|parameters?|million|billion|trillion)\b|\$\s?\d)",
+    re.IGNORECASE,
 )
 
 OFF_TOPIC_TERMS = (
@@ -366,19 +433,52 @@ OFF_TOPIC_TERMS = (
     "post you interacted",
 )
 
+PROMO_SPAM_TERMS = (
+    "airdrop",
+    "crypto presale",
+    "buy now",
+    "coming soon",
+    "follow us",
+    "get yours",
+    "hoodie",
+    "join our community",
+    "join the community",
+    "join the movement",
+    "limited offer",
+    "limited time",
+    "memecoin",
+    "pre-sale",
+    "presale",
+    "sign up now",
+    "token sale",
+    "web3 presale",
+    "whitelist now",
+)
+
 
 def is_ai_relevant(tweet: Tweet) -> bool:
-    text = f"{tweet.author} {tweet.source} {tweet.text}"
-    if has_any(text, ("gpt-live", "gpt live", "gpt-5.6", "chatgpt", "openai", "sama", "grok")):
-        return True
-    return has_any(text, STRONG_AI_TERMS)
+    # Search bucket names and account handles are routing metadata, not proof
+    # that an individual post is news. Require AI-product substance, an event
+    # verb/result, and a named product, checkable object, or numeric detail.
+    text = tweet.text
+    named_ai_product = has_any(text, NAMED_AI_PRODUCT_TERMS)
+    topical = named_ai_product or has_any(text, STRONG_AI_TERMS)
+    event = has_any(text, EVENT_TERMS)
+    specific = (
+        named_ai_product
+        or has_any(text, CHECKABLE_OBJECT_TERMS)
+        or SPECIFIC_DETAIL_RE.search(clean_text(text)) is not None
+    )
+    return topical and event and specific
 
 
 def is_offtopic(tweet: Tweet) -> bool:
-    text = f"{tweet.author} {tweet.text}"
+    text = tweet.text
+    if has_any(text, PROMO_SPAM_TERMS):
+        return True
     if not has_any(text, OFF_TOPIC_TERMS):
         return False
-    if has_any(text, ("openai", "chatgpt", "gpt-", "claude", "grok", "gemini", "deepseek")):
+    if has_any(text, NAMED_AI_PRODUCT_TERMS):
         return False
     return True
 
@@ -387,7 +487,9 @@ def filtered_tweets(tweets: list[Tweet]) -> list[Tweet]:
     return [
         tweet
         for tweet in tweets
-        if is_ai_relevant(tweet) and not is_offtopic(tweet) and not (is_retweet(tweet) and tweet.score == 0)
+        if is_ai_relevant(tweet)
+        and not is_offtopic(tweet)
+        and not (is_retweet(tweet) and tweet.score == 0)
     ]
 
 
@@ -403,19 +505,39 @@ def upsert_section(path: Path, header: str, section: str) -> bool:
     section_start = section.find(header)
     section_only = section[section_start:] if section_start >= 0 else section
     section_text = section_only.rstrip() + "\n"
-    if header in existing:
-        pattern = re.compile(rf"(?ms)^## {re.escape(header.removeprefix('## '))}\n.*?(?=^## \d{{2}}:00 UTC\n|\Z)")
-        next_text, count = pattern.subn(section_text.rstrip() + "\n", existing.rstrip() + "\n", count=1)
-        if count:
-            path.parent.mkdir(parents=True, exist_ok=True)
-            if next_text != existing:
-                atomic_write(path, next_text)
-                return True
-            return False
+    current = header.removeprefix("## ")
+    replaced = False
+
+    def replace_current(match: re.Match[str]) -> str:
+        nonlocal replaced
+        if not replaced and match.group("hour") == current:
+            replaced = True
+            return section_text
+        return match.group(0)
+
+    next_text = SECTION_RE.sub(replace_current, existing)
+    if replaced:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if next_text != existing:
+            atomic_write(path, next_text)
+            return True
+        return False
     body = existing.rstrip()
     next_text = f"{body}\n\n{section_only}" if body else section
     path.parent.mkdir(parents=True, exist_ok=True)
     atomic_write(path, next_text.rstrip() + "\n")
+    return True
+
+
+def remove_section(path: Path, header: str) -> bool:
+    """Remove a same-hour public section while preserving the rest of the day."""
+    if not path.exists():
+        return False
+    existing = path.read_text(encoding="utf-8")
+    next_text = without_current_section(existing, header).rstrip() + "\n"
+    if next_text == existing:
+        return False
+    atomic_write(path, next_text)
     return True
 
 
@@ -565,11 +687,6 @@ def build_stories(
     return stories
 
 
-def has_carried_forward_candidates(tweets: list[Tweet], seen_story_keys: set[str]) -> bool:
-    usable = filtered_tweets(tweets)
-    return any(find_group(usable, key) for key in seen_story_keys)
-
-
 def render_story(story: Story, rank: int) -> list[str]:
     sources = "\n      ".join(primary_link(tweet) for tweet in story.tweets)
     first = story.tweets[0]
@@ -603,27 +720,26 @@ def render_digest(
     tweets: list[Tweet],
     seen_url_keys: set[str] | None = None,
     seen_story_keys: set[str] | None = None,
-) -> tuple[str, str, list[Story], bool]:
+) -> tuple[str, str | None, list[Story], list[Tweet]]:
     seen_url_keys = seen_url_keys or set()
     seen_story_keys = seen_story_keys or set()
     h1 = f"# Twitter/X AI Pulse{title_suffix} - {date}"
     header = f"## {hour}:00 UTC"
     stories = build_stories(tweets, seen_url_keys, seen_story_keys)
     story_urls = {tweet.url for story in stories for tweet in story.tweets}
-    carried_forward = not stories and has_carried_forward_candidates(tweets, seen_story_keys)
-    carried_story_url_keys = {
-        canonical_tweet_url_key(tweet.url)
-        for key in seen_story_keys
-        for tweet in find_group(filtered_tweets(tweets), key)
-    }
     quick_hits = [
         tweet
         for tweet in filtered_tweets(tweets)
         if tweet.url not in story_urls
         and not is_retweet(tweet)
         and canonical_tweet_url_key(tweet.url) not in seen_url_keys
-        and canonical_tweet_url_key(tweet.url) not in carried_story_url_keys
-    ]
+    ][:5]
+
+    # A scheduled scan is operational state, not reader content. If every
+    # candidate was already published (or nothing survived filtering), leave
+    # the public daily digest alone and let the status heartbeat record success.
+    if not stories and not quick_hits:
+        return header, None, stories, quick_hits
 
     lines = [
         h1,
@@ -636,7 +752,7 @@ def render_digest(
         labels = "; ".join(story.title for story in stories[:2])
         lines.extend(
             [
-                f"**Cycle summary**: Fresh primary-source AI product movement cleared the bar this window: {labels}. The digest treats high-signal launch posts as stories, while keeping benchmark and rollout claims provisional until independent evidence lands.",
+                f"**Cycle summary**: {labels}. Performance, pricing, and rollout claims remain provisional until independent evidence lands.",
                 "",
                 "### Top stories",
                 "",
@@ -646,28 +762,21 @@ def render_digest(
             lines.extend(render_story(story, index))
             lines.append("")
     else:
-        summary = (
-            "**Cycle summary**: Quiet follow-up period - no new main stories beyond earlier same-day Twitter/X items."
-            if carried_forward
-            else "**Cycle summary**: Quiet period - no main stories cleared the publication bar from the fresh Twitter/X snapshot."
+        concrete = "; ".join(
+            f"@{tweet.author}: {trim_sentence(tweet.text, 120)}"
+            for tweet in quick_hits[:2]
         )
         lines.extend(
             [
-                summary,
+                f"**Cycle summary**: {concrete}",
                 "",
             ]
         )
 
-    lines.append("### Quick hits")
     if quick_hits:
+        lines.append("### Quick hits")
         for tweet in quick_hits[:5]:
             lines.append(f"- @{tweet.author}: {trim_sentence(tweet.text)} [{engagement(tweet)}]({tweet.url})")
-    elif stories:
-        lines.append("- No additional AI-specific quick hits cleared the publication bar.")
-    elif carried_forward:
-        lines.append("- No new AI-specific quick hits cleared the publication bar beyond earlier same-day items.")
-    else:
-        lines.append("- No notable fresh AI tweets survived parsing.")
 
     skeptic = []
     if any(story.key == "gpt56" for story in stories):
@@ -682,12 +791,6 @@ def render_digest(
         skeptic.append(
             "Grok 4.5 speedup is an executive roadmap claim until xAI ships the GB300-tuned inference stack and users can measure it."
         )
-    if not skeptic:
-        if carried_forward:
-            skeptic.append("Earlier same-day story claims remain in watch mode; this cycle only saw repeat or follow-up signals.")
-        else:
-            skeptic.append("None this cycle.")
-
     watch = []
     if any(story.key == "gpt56" for story in stories):
         watch.append("Whether GPT-5.6 Sol/Terra/Luna become broadly accessible on Thursday, and under what plan/API limits.")
@@ -695,63 +798,67 @@ def render_digest(
         watch.append("Whether GPT-Live shows low-latency, interruptible, reliable voice behavior in real ChatGPT user reports.")
     if any(story.key == "grok" for story in stories):
         watch.append("Whether xAI publishes Grok 4.5 availability and inference-stack release details.")
-    watch.append("Next scheduled Twitter/X AI monitor run.")
-
-    lines.extend(
-        [
-            "",
-            "### Skeptic's corner",
-            *(f"- {item}" for item in skeptic),
-            "",
-            "### Watch list (next 24h)",
-            *(f"- {item}" for item in watch),
-            "",
-            "### Research notes",
-            "- Source checks issued this cycle: fresh pre-fetched account, search, and news snapshots; stale rows outside the configured freshness window were excluded before ranking.",
-        ]
-    )
-    if carried_forward:
-        lines.append("- Earlier same-day story URLs and story families were excluded before ranking to avoid duplicate publication.")
-    return header, "\n".join(lines), stories, carried_forward
+    if skeptic:
+        lines.extend(["", "### Skeptic's corner", *(f"- {item}" for item in skeptic)])
+    if watch:
+        lines.extend(["", "### Watch list (next 24h)", *(f"- {item}" for item in watch)])
+    return header, "\n".join(lines), stories, quick_hits
 
 
 def render_summary(
     timestamp: str,
     title_suffix: str,
-    tweets: list[Tweet],
     stories: list[Story],
-    carried_forward: bool = False,
+    quick_hits: list[Tweet],
 ) -> str:
     if stories:
         bullets = "\n".join(f"- {story.title}: {story.lead}" for story in stories[:3])
+        concrete = "; ".join(story.title for story in stories[:2])
         return (
             f"Twitter/X AI Pulse{title_suffix} - {timestamp}\n\n"
-            "CYCLE: Fresh primary-source AI product movement cleared the publication bar.\n\n"
+            f"CYCLE: {concrete}\n\n"
             f"TOP STORIES:\n{bullets}\n\n"
             "WATCH: public rollout details, independent evals, pricing/rate limits, and real-user voice latency.\n\n"
             "Full update on GitHub.\n"
         )
-    if carried_forward:
-        return (
-            f"Twitter/X AI Pulse{title_suffix} - {timestamp}\n\n"
-            "CYCLE: Quiet follow-up period; no new main stories beyond earlier same-day Twitter/X items.\n\n"
-            "WATCH: carry forward public rollout details, independent evals, pricing/rate limits, and real-user voice latency.\n\n"
-            "Full update on GitHub.\n"
+    if quick_hits:
+        bullets = "\n".join(f"- @{tweet.author}: {trim_sentence(tweet.text, 110)}" for tweet in quick_hits[:3])
+        concrete = "; ".join(
+            f"@{tweet.author}: {trim_sentence(tweet.text, 90)}"
+            for tweet in quick_hits[:2]
         )
-    usable = filtered_tweets(tweets)
-    if usable:
-        bullets = "\n".join(f"- @{tweet.author}: {trim_sentence(tweet.text, 110)}" for tweet in usable[:3])
         return (
             f"Twitter/X AI Pulse{title_suffix} - {timestamp}\n\n"
-            "CYCLE: Quiet period; no story cleared the main-story bar.\n\n"
+            f"CYCLE: {concrete}\n\n"
             f"QUICK HITS:\n{bullets}\n\n"
-            "WATCH: Next scheduled Twitter/X AI monitor run.\n\n"
             "Full update on GitHub.\n"
         )
-    return (
-        f"Twitter/X AI Pulse{title_suffix} - {timestamp}\n\n"
-        "Quiet period - no major AI updates on Twitter/X.\n"
-    )
+    return ""
+
+
+def render_status(
+    date: str,
+    hour: str,
+    timestamp: str,
+    run_id: str,
+    run_attempt: int,
+    published: bool,
+    public_items: int,
+) -> str:
+    return json.dumps(
+        {
+            "schema_version": 1,
+            "date": date,
+            "hour": f"{hour}:00 UTC",
+            "generated_at": timestamp,
+            "run_id": run_id,
+            "run_attempt": run_attempt,
+            "status": "published" if published else "no_update",
+            "public_items": public_items,
+        },
+        indent=2,
+        ensure_ascii=False,
+    ) + "\n"
 
 
 def render_headlines(stories: list[Story]) -> str:
@@ -775,9 +882,12 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--date", required=True)
     parser.add_argument("--hour", required=True)
     parser.add_argument("--timestamp", required=True)
+    parser.add_argument("--run-id", default="local")
+    parser.add_argument("--run-attempt", type=int, default=1)
     parser.add_argument("--title-suffix", default="")
     parser.add_argument("--summary-slug", required=True)
     parser.add_argument("--headlines-file", type=Path)
+    parser.add_argument("--status-file", type=Path)
     parser.add_argument("--limit", type=int, default=20)
     parser.add_argument("--max-age-hours", type=int, default=DEFAULT_MAX_AGE_HOURS)
     args = parser.parse_args(argv)
@@ -789,6 +899,7 @@ def main(argv: list[str] | None = None) -> int:
     tweets = collect_tweets(args.input_dir, args.limit, end_time, args.max_age_hours)
     digest_path = args.out_dir / f"{args.date}.md"
     summary_path = args.summaries_dir / f"{args.date}-{args.summary_slug}-{args.hour}h-summary.txt"
+    status_path = args.status_file or args.out_dir / "status" / f"{args.date}-{args.hour}h.json"
 
     existing_digest = digest_path.read_text(encoding="utf-8") if digest_path.exists() else ""
     current_header = f"## {args.hour}:00 UTC"
@@ -796,7 +907,7 @@ def main(argv: list[str] | None = None) -> int:
     seen_url_keys = published_tweet_url_keys(prior_digest)
     seen_story_keys = published_story_keys(prior_digest)
 
-    header, digest, stories, carried_forward = render_digest(
+    header, digest, stories, quick_hits = render_digest(
         args.date,
         args.hour,
         args.title_suffix,
@@ -804,13 +915,31 @@ def main(argv: list[str] | None = None) -> int:
         seen_url_keys,
         seen_story_keys,
     )
-    changed = upsert_section(digest_path, header, digest)
-    atomic_write(summary_path, render_summary(args.timestamp, args.title_suffix, tweets, stories, carried_forward))
+    if digest is None:
+        changed = remove_section(digest_path, header)
+    else:
+        changed = upsert_section(digest_path, header, digest)
+    published = digest is not None
+    atomic_write(summary_path, render_summary(args.timestamp, args.title_suffix, stories, quick_hits))
+    atomic_write(
+        status_path,
+        render_status(
+            args.date,
+            args.hour,
+            args.timestamp,
+            args.run_id,
+            args.run_attempt,
+            published,
+            len(stories) + len(quick_hits),
+        ),
+    )
     if args.headlines_file is not None:
         atomic_write(args.headlines_file, render_headlines(stories))
 
-    print(f"wrote {digest_path} ({'changed' if changed else 'already had section'})")
+    digest_result = "changed" if changed else ("published" if published else "no public update")
+    print(f"processed {digest_path} ({digest_result})")
     print(f"wrote {summary_path}")
+    print(f"wrote {status_path}")
     if args.headlines_file is not None:
         print(f"wrote {args.headlines_file}")
     return 0

--- a/scripts/test_deterministic_daily_digest.py
+++ b/scripts/test_deterministic_daily_digest.py
@@ -180,6 +180,29 @@ class ComposeTest(unittest.TestCase):
             self.assertEqual(extract.artifact, "blogs/2026-07-01.md")
             self.assertEqual(extract.lines, ("- [Yesterday's post](https://blog/x)",))
 
+    def test_empty_latest_twitter_summary_uses_earlier_same_day_signal(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            research = Path(tmp) / "research"
+            summaries = research / "summaries"
+            summaries.mkdir(parents=True)
+            (summaries / "2026-07-02-twitter-05h-summary.txt").write_text(
+                "QUICK HITS:\n- @AIatMeta: Muse Spark 1.1 and Meta Model API preview.\n",
+                encoding="utf-8",
+            )
+            (summaries / "2026-07-02-twitter-07h-summary.txt").write_text(
+                "",
+                encoding="utf-8",
+            )
+
+            lane = next(l for l in digest.LANES if l.key == "twitter")
+            extract = digest.extract_lane(research, lane, ["2026-07-02", "2026-07-01"], cap=8)
+
+            self.assertEqual(extract.artifact, "summaries/2026-07-02-twitter-05h-summary.txt")
+            self.assertEqual(
+                extract.lines,
+                ("- @AIatMeta: Muse Spark 1.1 and Meta Model API preview.",),
+            )
+
     def test_strip_markdown_flattens_links_and_bold(self):
         self.assertEqual(
             digest.strip_markdown("- **[Venice AI](https://tc)** raised money"),

--- a/scripts/test_deterministic_twitter_digest.py
+++ b/scripts/test_deterministic_twitter_digest.py
@@ -24,7 +24,7 @@ class DeterministicTwitterDigestTest(unittest.TestCase):
                         {
                             "id": "123",
                             "author": {"username": "openai"},
-                            "text": "OpenAI ships a small but relevant AI systems update.",
+                            "text": "OpenAI ships GPT-5.7 Mini with a new AI systems card.",
                             "createdAt": "Mon Jun 29 10:01:00 +0000 2026",
                             "likeCount": 42,
                             "retweetCount": 5,
@@ -83,7 +83,7 @@ class DeterministicTwitterDigestTest(unittest.TestCase):
                                 {
                                     "id": "456",
                                     "author": {"username": "openai"},
-                                    "text": "OpenAI publishes a new AI safety systems note.",
+                                    "text": "OpenAI publishes the GPT-5.7 Mini AI safety system card.",
                                     "createdAt": "Thu Jul 09 07:02:00 +0000 2026",
                                     "likeCount": 10,
                                     "retweetCount": 2,
@@ -125,8 +125,10 @@ class DeterministicTwitterDigestTest(unittest.TestCase):
             self.assertIn("## 07:00 UTC", digest)
             self.assertIn("@openai", digest)
             self.assertIn("https://x.com/openai/status/456", digest)
-            self.assertIn("Next scheduled Twitter/X AI monitor run", digest)
+            self.assertNotIn("Quiet period", digest)
             self.assertIn("Twitter/X AI Pulse - 2026-07-09 07:14 UTC", summary)
+            status = json.loads((out_dir / "status" / "2026-07-09-07h.json").read_text(encoding="utf-8"))
+            self.assertEqual(status["status"], "published")
             self.assertEqual(json.loads(headlines_file.read_text(encoding="utf-8")), [])
 
     def test_excludes_stale_high_engagement_rows_from_fallback(self) -> None:
@@ -156,7 +158,7 @@ class DeterministicTwitterDigestTest(unittest.TestCase):
                                 {
                                     "id": "999",
                                     "author": {"username": "openai"},
-                                    "text": "Fresh AI systems note for the current monitoring window.",
+                                    "text": "OpenAI publishes GPT-5.7 Mini API safety guidance.",
                                     "createdAt": "Thu Jul 09 11:05:00 +0000 2026",
                                     "likeCount": 7,
                                     "retweetCount": 1,
@@ -485,13 +487,551 @@ class DeterministicTwitterDigestTest(unittest.TestCase):
             self.assertEqual(rc, 0)
             digest = (out_dir / "2026-07-09.md").read_text(encoding="utf-8")
             summary = (summaries_dir / "2026-07-09-twitter-13h-summary.txt").read_text(encoding="utf-8")
-            thirteen = digest.split("## 13:00 UTC", 1)[1]
-            self.assertIn("Quiet follow-up period", thirteen)
-            self.assertNotIn("### Top stories", thirteen)
-            self.assertNotIn("OpenAI gives GPT-5.6", thirteen)
-            self.assertNotIn("OpenAI rolls out GPT-Live", thirteen)
-            self.assertIn("no new main stories beyond earlier same-day", summary)
+            self.assertNotIn("## 13:00 UTC", digest)
+            self.assertEqual(summary, "")
+            status = json.loads((out_dir / "status" / "2026-07-09-13h.json").read_text(encoding="utf-8"))
+            self.assertEqual(status["status"], "no_update")
+            self.assertEqual(status["public_items"], 0)
             self.assertEqual(json.loads(headlines_file.read_text(encoding="utf-8")), [])
+
+    def test_unseen_official_launch_drives_quick_hit_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            input_dir = root / "bird"
+            out_dir = root / "research" / "twitter"
+            summaries_dir = root / "research" / "summaries"
+            headlines_file = summaries_dir / "2026-07-10-twitter-07h-headlines.json"
+            input_dir.mkdir()
+            out_dir.mkdir(parents=True)
+            (out_dir / "2026-07-10.md").write_text(
+                "# Twitter/X AI Pulse - 2026-07-10\n\n"
+                "## 05:00 UTC\n\n"
+                "**Cycle summary**: OpenAI gives GPT-5.6 Sol/Terra/Luna a public launch window.\n\n"
+                "### Top stories\n\n"
+                '<a class="twitter-source-chip" href="https://x.com/OpenAI/status/2074704958419792299">@OpenAI</a>\n',
+                encoding="utf-8",
+            )
+            (input_dir / "all.json").write_text(
+                json.dumps(
+                    {
+                        "accounts": {
+                            "OpenAI": [
+                                {
+                                    "id": "2074704958419792299",
+                                    "author": {"username": "OpenAI"},
+                                    "text": "GPT-5.6 Sol, Terra and Luna will launch publicly this Thursday.",
+                                    "createdAt": "Fri Jul 10 06:30:00 +0000 2026",
+                                    "likeCount": 45000,
+                                    "retweetCount": 6500,
+                                    "replyCount": 2300,
+                                }
+                            ],
+                            "AIatMeta": [
+                                {
+                                    "id": "2075221088821518394",
+                                    "author": {"username": "AIatMeta"},
+                                    "text": "We are introducing Muse Spark 1.1 and launching a public preview of the new Meta Model API.",
+                                    "createdAt": "Fri Jul 10 06:45:00 +0000 2026",
+                                    "likeCount": 3907,
+                                    "retweetCount": 459,
+                                    "replyCount": 212,
+                                }
+                            ],
+                            "sama": [
+                                {
+                                    "id": "2075048072837734448",
+                                    "author": {"username": "sama"},
+                                    "text": "it surely doesnt",
+                                    "createdAt": "Fri Jul 10 06:50:00 +0000 2026",
+                                    "likeCount": 5096,
+                                    "retweetCount": 110,
+                                    "replyCount": 321,
+                                },
+                                {
+                                    "id": "2075048072837734449",
+                                    "author": {"username": "sama"},
+                                    "text": "this is a surprisingly beautiful place and I hope everyone gets to visit someday",
+                                    "createdAt": "Fri Jul 10 06:51:00 +0000 2026",
+                                    "likeCount": 7000,
+                                    "retweetCount": 300,
+                                    "replyCount": 400,
+                                }
+                            ],
+                        },
+                        "searches": {
+                            "ai": [
+                                {
+                                    "id": "spam-1",
+                                    "author": {"username": "TokenPump"},
+                                    "text": "Join the hottest AI crypto presale and whitelist now before the token sale closes.",
+                                    "createdAt": "Fri Jul 10 06:52:00 +0000 2026",
+                                    "likeCount": 9000,
+                                    "retweetCount": 800,
+                                    "replyCount": 50,
+                                },
+                                {
+                                    "id": "travel-1",
+                                    "author": {"username": "SummerTrips"},
+                                    "text": "Plan your summer holiday with our experienced travel agent and save on flights.",
+                                    "createdAt": "Fri Jul 10 06:53:00 +0000 2026",
+                                    "likeCount": 8000,
+                                    "retweetCount": 700,
+                                    "replyCount": 40,
+                                },
+                            ]
+                        },
+                        "news": [],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            rc = main(
+                [
+                    "--input-dir",
+                    str(input_dir),
+                    "--out-dir",
+                    str(out_dir),
+                    "--summaries-dir",
+                    str(summaries_dir),
+                    "--date",
+                    "2026-07-10",
+                    "--hour",
+                    "07",
+                    "--timestamp",
+                    "2026-07-10 07:00 UTC",
+                    "--summary-slug",
+                    "twitter",
+                    "--headlines-file",
+                    str(headlines_file),
+                ]
+            )
+
+            self.assertEqual(rc, 0)
+            digest = (out_dir / "2026-07-10.md").read_text(encoding="utf-8")
+            summary = (summaries_dir / "2026-07-10-twitter-07h-summary.txt").read_text(encoding="utf-8")
+            seven = digest.split("## 07:00 UTC", 1)[1]
+            self.assertIn("Muse Spark 1.1", seven)
+            self.assertIn("Meta Model API", seven)
+            self.assertNotIn("Quiet", seven)
+            self.assertNotIn("no new main", seven)
+            self.assertNotIn("it surely doesnt", seven)
+            self.assertNotIn("beautiful place", seven)
+            self.assertNotIn("crypto presale", seven)
+            self.assertNotIn("travel agent", seven)
+            self.assertIn("Muse Spark 1.1", summary)
+            self.assertNotIn("it surely doesnt", summary)
+            status = json.loads((out_dir / "status" / "2026-07-10-07h.json").read_text(encoding="utf-8"))
+            self.assertEqual(status["status"], "published")
+
+    def test_empty_snapshot_writes_heartbeat_without_public_digest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            input_dir = root / "bird"
+            out_dir = root / "research" / "twitter"
+            summaries_dir = root / "research" / "summaries"
+            headlines_file = summaries_dir / "2026-07-10-twitter-10h-headlines.json"
+            input_dir.mkdir()
+            (input_dir / "all.json").write_text(
+                json.dumps({"accounts": {}, "searches": {}, "news": []}),
+                encoding="utf-8",
+            )
+
+            rc = main(
+                [
+                    "--input-dir",
+                    str(input_dir),
+                    "--out-dir",
+                    str(out_dir),
+                    "--summaries-dir",
+                    str(summaries_dir),
+                    "--date",
+                    "2026-07-10",
+                    "--hour",
+                    "10",
+                    "--timestamp",
+                    "2026-07-10 10:00 UTC",
+                    "--summary-slug",
+                    "twitter",
+                    "--headlines-file",
+                    str(headlines_file),
+                ]
+            )
+
+            self.assertEqual(rc, 0)
+            self.assertFalse((out_dir / "2026-07-10.md").exists())
+            self.assertEqual(
+                (summaries_dir / "2026-07-10-twitter-10h-summary.txt").read_text(encoding="utf-8"),
+                "",
+            )
+            status = json.loads((out_dir / "status" / "2026-07-10-10h.json").read_text(encoding="utf-8"))
+            self.assertEqual(status["status"], "no_update")
+            self.assertEqual(json.loads(headlines_file.read_text(encoding="utf-8")), [])
+
+            rc = main(
+                [
+                    "--input-dir",
+                    str(input_dir),
+                    "--out-dir",
+                    str(out_dir),
+                    "--summaries-dir",
+                    str(summaries_dir),
+                    "--date",
+                    "2026-07-10",
+                    "--hour",
+                    "10",
+                    "--timestamp",
+                    "2026-07-10 10:05 UTC",
+                    "--summary-slug",
+                    "twitter",
+                    "--headlines-file",
+                    str(headlines_file),
+                ]
+            )
+            self.assertEqual(rc, 0)
+            rerun_status = json.loads(
+                (out_dir / "status" / "2026-07-10-10h.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(rerun_status["generated_at"], "2026-07-10 10:05 UTC")
+            self.assertFalse((out_dir / "2026-07-10.md").exists())
+
+    def test_generic_ai_hype_is_not_publishable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            input_dir = root / "bird"
+            out_dir = root / "research" / "twitter"
+            summaries_dir = root / "research" / "summaries"
+            headlines_file = summaries_dir / "2026-07-10-twitter-11h-headlines.json"
+            input_dir.mkdir()
+            (input_dir / "all.json").write_text(
+                json.dumps(
+                    {
+                        "accounts": {},
+                        "searches": {
+                            "ai": [
+                                {
+                                    "id": "hype-1",
+                                    "author": {"username": "HypeLab"},
+                                    "text": "Our AI agent is changing everything. Follow us and join the community today!",
+                                    "createdAt": "Fri Jul 10 10:30:00 +0000 2026",
+                                    "likeCount": 5000,
+                                    "retweetCount": 500,
+                                    "replyCount": 100,
+                                },
+                                {
+                                    "id": "hype-2",
+                                    "author": {"username": "FutureAI"},
+                                    "text": "AI agents are the future and everyone will use them soon.",
+                                    "createdAt": "Fri Jul 10 10:31:00 +0000 2026",
+                                    "likeCount": 4000,
+                                    "retweetCount": 400,
+                                    "replyCount": 90,
+                                },
+                                {
+                                    "id": "hype-3",
+                                    "author": {"username": "UpdateAI"},
+                                    "text": "Quick AI update: AI agents are the future and everyone will use them soon.",
+                                    "createdAt": "Fri Jul 10 10:32:00 +0000 2026",
+                                    "likeCount": 3900,
+                                    "retweetCount": 390,
+                                    "replyCount": 80,
+                                },
+                                {
+                                    "id": "hype-4",
+                                    "author": {"username": "BigSoon"},
+                                    "text": "Big update coming soon: our AI agent will change everything.",
+                                    "createdAt": "Fri Jul 10 10:33:00 +0000 2026",
+                                    "likeCount": 3800,
+                                    "retweetCount": 380,
+                                    "replyCount": 70,
+                                },
+                                {
+                                    "id": "hype-5",
+                                    "author": {"username": "SafeThoughts"},
+                                    "text": "AI safety is important and everyone should care.",
+                                    "createdAt": "Fri Jul 10 10:34:00 +0000 2026",
+                                    "likeCount": 3700,
+                                    "retweetCount": 370,
+                                    "replyCount": 60,
+                                },
+                                {
+                                    "id": "hype-6",
+                                    "author": {"username": "ResearchVision"},
+                                    "text": "Our AI research will change everything.",
+                                    "createdAt": "Fri Jul 10 10:35:00 +0000 2026",
+                                    "likeCount": 3600,
+                                    "retweetCount": 360,
+                                    "replyCount": 50,
+                                },
+                                {
+                                    "id": "hype-7",
+                                    "author": {"username": "MovementAI"},
+                                    "text": "We are launching an AI agent that changes everything. Join the movement.",
+                                    "createdAt": "Fri Jul 10 10:36:00 +0000 2026",
+                                    "likeCount": 3500,
+                                    "retweetCount": 350,
+                                    "replyCount": 40,
+                                },
+                                {
+                                    "id": "promo-1",
+                                    "author": {"username": "TradeAI"},
+                                    "text": "Launching our AI trading agent today. Limited offer: sign up now.",
+                                    "createdAt": "Fri Jul 10 10:37:00 +0000 2026",
+                                    "likeCount": 3400,
+                                    "retweetCount": 340,
+                                    "replyCount": 30,
+                                },
+                                {
+                                    "id": "promo-2",
+                                    "author": {"username": "OpenAI"},
+                                    "text": "We are launching a limited edition hoodie today.",
+                                    "createdAt": "Fri Jul 10 10:38:00 +0000 2026",
+                                    "likeCount": 3300,
+                                    "retweetCount": 330,
+                                    "replyCount": 20,
+                                },
+                                {
+                                    "id": "offtopic-2",
+                                    "author": {"username": "AIatMeta"},
+                                    "text": "We are launching a new office in Seoul today.",
+                                    "createdAt": "Fri Jul 10 10:39:00 +0000 2026",
+                                    "likeCount": 3200,
+                                    "retweetCount": 320,
+                                    "replyCount": 20,
+                                },
+                                {
+                                    "id": "rumor-1",
+                                    "author": {"username": "RumorFeed"},
+                                    "text": "OpenAI announces that the future starts now.",
+                                    "createdAt": "Fri Jul 10 10:40:00 +0000 2026",
+                                    "likeCount": 3100,
+                                    "retweetCount": 310,
+                                    "replyCount": 20,
+                                },
+                                {
+                                    "id": "promo-3",
+                                    "author": {"username": "AgentShop"},
+                                    "text": "Launching our OpenAI-powered AI agent today. Get yours today!",
+                                    "createdAt": "Fri Jul 10 10:41:00 +0000 2026",
+                                    "likeCount": 3000,
+                                    "retweetCount": 300,
+                                    "replyCount": 20,
+                                },
+                            ]
+                        },
+                        "news": [],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            rc = main(
+                [
+                    "--input-dir",
+                    str(input_dir),
+                    "--out-dir",
+                    str(out_dir),
+                    "--summaries-dir",
+                    str(summaries_dir),
+                    "--date",
+                    "2026-07-10",
+                    "--hour",
+                    "11",
+                    "--timestamp",
+                    "2026-07-10 11:00:00 UTC",
+                    "--run-id",
+                    "1234",
+                    "--run-attempt",
+                    "1",
+                    "--summary-slug",
+                    "twitter",
+                    "--headlines-file",
+                    str(headlines_file),
+                ]
+            )
+
+            self.assertEqual(rc, 0)
+            self.assertFalse((out_dir / "2026-07-10.md").exists())
+            self.assertEqual(
+                (summaries_dir / "2026-07-10-twitter-11h-summary.txt").read_text(encoding="utf-8"),
+                "",
+            )
+            status = json.loads((out_dir / "status" / "2026-07-10-11h.json").read_text(encoding="utf-8"))
+            self.assertEqual(status["status"], "no_update")
+            self.assertEqual(status["run_id"], "1234")
+            self.assertEqual(status["run_attempt"], 1)
+
+    def test_trusted_primary_release_can_supply_product_context(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            input_dir = root / "bird"
+            out_dir = root / "research" / "twitter"
+            summaries_dir = root / "research" / "summaries"
+            headlines_file = summaries_dir / "2026-07-10-twitter-12h-headlines.json"
+            input_dir.mkdir()
+            (input_dir / "all.json").write_text(
+                json.dumps(
+                    {
+                        "accounts": {
+                            "AIatMeta": [
+                                {
+                                    "id": "1200",
+                                    "author": {"username": "AIatMeta"},
+                                    "text": "Introducing Muse Spark 1.2, available today.",
+                                    "createdAt": "Fri Jul 10 11:30:00 +0000 2026",
+                                    "likeCount": 900,
+                                    "retweetCount": 100,
+                                    "replyCount": 50,
+                                }
+                            ]
+                        },
+                        "searches": {},
+                        "news": [],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            rc = main(
+                [
+                    "--input-dir",
+                    str(input_dir),
+                    "--out-dir",
+                    str(out_dir),
+                    "--summaries-dir",
+                    str(summaries_dir),
+                    "--date",
+                    "2026-07-10",
+                    "--hour",
+                    "12",
+                    "--timestamp",
+                    "2026-07-10 12:00:00 UTC",
+                    "--summary-slug",
+                    "twitter",
+                    "--headlines-file",
+                    str(headlines_file),
+                ]
+            )
+
+            self.assertEqual(rc, 0)
+            digest = (out_dir / "2026-07-10.md").read_text(encoding="utf-8")
+            self.assertIn("Muse Spark 1.2", digest)
+            self.assertIn("https://x.com/AIatMeta/status/1200", digest)
+
+    def test_no_update_removes_same_hour_heading_with_trailing_space(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            input_dir = root / "bird"
+            out_dir = root / "research" / "twitter"
+            summaries_dir = root / "research" / "summaries"
+            headlines_file = summaries_dir / "2026-07-10-twitter-14h-headlines.json"
+            input_dir.mkdir()
+            out_dir.mkdir(parents=True)
+            (input_dir / "all.json").write_text(
+                json.dumps({"accounts": {}, "searches": {}, "news": []}),
+                encoding="utf-8",
+            )
+            (out_dir / "2026-07-10.md").write_text(
+                "# Twitter/X AI Pulse - 2026-07-10\r\n\r\n"
+                "## 14:00 UTC \r\n\r\n"
+                "**Cycle summary**: Quiet follow-up period.\r\n",
+                encoding="utf-8",
+            )
+
+            rc = main(
+                [
+                    "--input-dir",
+                    str(input_dir),
+                    "--out-dir",
+                    str(out_dir),
+                    "--summaries-dir",
+                    str(summaries_dir),
+                    "--date",
+                    "2026-07-10",
+                    "--hour",
+                    "14",
+                    "--timestamp",
+                    "2026-07-10 14:00:00 UTC",
+                    "--summary-slug",
+                    "twitter",
+                    "--headlines-file",
+                    str(headlines_file),
+                ]
+            )
+
+            self.assertEqual(rc, 0)
+            digest = (out_dir / "2026-07-10.md").read_text(encoding="utf-8")
+            self.assertNotIn("## 14:00 UTC", digest)
+            self.assertNotIn("Quiet follow-up", digest)
+
+    def test_new_url_in_seen_story_family_remains_publishable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            input_dir = root / "bird"
+            out_dir = root / "research" / "twitter"
+            summaries_dir = root / "research" / "summaries"
+            headlines_file = summaries_dir / "2026-07-10-twitter-13h-headlines.json"
+            input_dir.mkdir()
+            out_dir.mkdir(parents=True)
+            (out_dir / "2026-07-10.md").write_text(
+                "# Twitter/X AI Pulse - 2026-07-10\n\n"
+                "## 12:00 UTC\n\n"
+                "**Cycle summary**: OpenAI gives GPT-5.6 Sol/Terra/Luna a public launch window.\n\n"
+                '<a href="https://x.com/OpenAI/status/1">@OpenAI</a>\n',
+                encoding="utf-8",
+            )
+            (input_dir / "all.json").write_text(
+                json.dumps(
+                    {
+                        "accounts": {
+                            "OpenAI": [
+                                {
+                                    "id": "2",
+                                    "author": {"username": "OpenAI"},
+                                    "text": "GPT-5.6 API pricing is now public, with lower cached-input pricing for Sol.",
+                                    "createdAt": "Fri Jul 10 12:30:00 +0000 2026",
+                                    "likeCount": 1200,
+                                    "retweetCount": 180,
+                                    "replyCount": 90,
+                                }
+                            ]
+                        },
+                        "searches": {},
+                        "news": [],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            rc = main(
+                [
+                    "--input-dir",
+                    str(input_dir),
+                    "--out-dir",
+                    str(out_dir),
+                    "--summaries-dir",
+                    str(summaries_dir),
+                    "--date",
+                    "2026-07-10",
+                    "--hour",
+                    "13",
+                    "--timestamp",
+                    "2026-07-10 13:00 UTC",
+                    "--summary-slug",
+                    "twitter",
+                    "--headlines-file",
+                    str(headlines_file),
+                ]
+            )
+
+            self.assertEqual(rc, 0)
+            digest = (out_dir / "2026-07-10.md").read_text(encoding="utf-8")
+            thirteen = digest.split("## 13:00 UTC", 1)[1]
+            self.assertIn("API pricing is now public", thirteen)
+            self.assertIn("https://x.com/OpenAI/status/2", thirteen)
+            self.assertNotIn("Quiet", thirteen)
+            status = json.loads((out_dir / "status" / "2026-07-10-13h.json").read_text(encoding="utf-8"))
+            self.assertEqual(status["status"], "published")
 
 
 if __name__ == "__main__":

--- a/scripts/test_validate_twitter_public_output.py
+++ b/scripts/test_validate_twitter_public_output.py
@@ -1,0 +1,187 @@
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from validate_twitter_public_output import ContractError, validate
+
+
+class ValidateTwitterPublicOutputTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.status = self.root / "status.json"
+        self.digest = self.root / "digest.md"
+        self.summary = self.root / "summary.txt"
+        self.headlines = self.root / "headlines.json"
+        self.headlines.write_text("[]\n", encoding="utf-8")
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def write_status(self, state: str, public_items: int, generated_at: str = "2026-07-10 10:07:09 UTC") -> None:
+        self.status.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "date": "2026-07-10",
+                    "hour": "10:00 UTC",
+                    "generated_at": generated_at,
+                    "run_id": "1234",
+                    "run_attempt": 2,
+                    "status": state,
+                    "public_items": public_items,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def validate(self) -> None:
+        validate(
+            backend="claude",
+            status_file=self.status,
+            digest_file=self.digest,
+            summary_file=self.summary,
+            headlines_file=self.headlines,
+            date="2026-07-10",
+            hour="10",
+            generated_at="2026-07-10 10:07:09 UTC",
+            run_id="1234",
+            run_attempt=2,
+        )
+
+    def test_accepts_concrete_published_section(self) -> None:
+        self.write_status("published", 2)
+        self.summary.write_text("Concrete Meta API and safety update.\n", encoding="utf-8")
+        self.digest.write_text(
+            "# Twitter/X AI Pulse\n\n"
+            "## 10:00 UTC\n\n"
+            "**Cycle summary**: Meta released Muse Spark 1.1 and a public Model API preview.\n\n"
+            "<article class=\"twitter-story\">"
+            "<h3 class=\"twitter-story-title\">Muse Spark 1.1</h3>"
+            "<p class=\"twitter-story-lead\">Meta released the model and API preview.</p>"
+            "<a class=\"twitter-source-chip\" href=\"https://x.com/AIatMeta/status/122\">@AIatMeta</a>"
+            "</article>\n\n"
+            "### Quick hits\n"
+            "- @AIatMeta: Model API preview [source](https://x.com/AIatMeta/status/123)\n",
+            encoding="utf-8",
+        )
+        self.validate()
+
+    def test_rejects_summary_only_fake_publication(self) -> None:
+        self.write_status("published", 1)
+        self.summary.write_text("AI agents are the future.\n", encoding="utf-8")
+        self.digest.write_text(
+            "## 10:00 UTC\n\n**Cycle summary**: AI agents are the future.\n",
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(ContractError, "no story card"):
+            self.validate()
+
+    def test_rejects_empty_story_shell(self) -> None:
+        self.write_status("published", 1)
+        self.summary.write_text("Meta released Muse Spark 1.1.\n", encoding="utf-8")
+        self.digest.write_text(
+            "## 10:00 UTC\n\n"
+            "**Cycle summary**: Meta released Muse Spark 1.1.\n\n"
+            "<article class=\"twitter-story\"></article>\n",
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(ContractError, "no story card"):
+            self.validate()
+
+    def test_rejects_story_with_source_only_in_html_comment(self) -> None:
+        self.write_status("published", 1)
+        self.summary.write_text("Meta released Muse Spark 1.1.\n", encoding="utf-8")
+        self.digest.write_text(
+            "## 10:00 UTC\n\n"
+            "**Cycle summary**: Meta released Muse Spark 1.1.\n\n"
+            "<article class=\"twitter-story\">"
+            "<h3 class=\"twitter-story-title\">Muse Spark 1.1</h3>"
+            "<p class=\"twitter-story-lead\">Meta released a model.</p>"
+            "<!-- <a class=\"twitter-source-chip\" "
+            "href=\"https://x.com/AIatMeta/status/122\">source</a> -->"
+            "</article>\n",
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(ContractError, "no story card"):
+            self.validate()
+
+    def test_rejects_html_entity_only_story_text(self) -> None:
+        self.write_status("published", 1)
+        self.summary.write_text("Meta released Muse Spark 1.1.\n", encoding="utf-8")
+        self.digest.write_text(
+            "## 10:00 UTC\n\n"
+            "**Cycle summary**: Meta released Muse Spark 1.1.\n\n"
+            "<article class=\"twitter-story\">"
+            "<h3 class=\"twitter-story-title\">&nbsp;</h3>"
+            "<p class=\"twitter-story-lead\">&#160;</p>"
+            "<a class=\"twitter-source-chip\" "
+            "href=\"https://x.com/AIatMeta/status/122\">source</a>"
+            "</article>\n",
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(ContractError, "no story card"):
+            self.validate()
+
+    def test_trailing_space_heading_counts_as_public_section(self) -> None:
+        self.write_status("no_update", 0)
+        self.summary.write_text("", encoding="utf-8")
+        self.digest.write_text(
+            "# Twitter/X AI Pulse\r\n\r\n## 10:00 UTC \r\n\r\n"
+            "**Cycle summary**: Hidden card.\r\n",
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(ContractError, "must not leave"):
+            self.validate()
+
+    def test_rejects_stale_run_identity(self) -> None:
+        self.write_status("no_update", 0, generated_at="2026-07-10 10:07:00 UTC")
+        self.summary.write_text("", encoding="utf-8")
+        with self.assertRaisesRegex(ContractError, "generated_at"):
+            self.validate()
+
+    def test_rejects_operational_filler_anywhere_in_section(self) -> None:
+        self.write_status("published", 1)
+        self.summary.write_text("Concrete launch.\n", encoding="utf-8")
+        self.digest.write_text(
+            "## 10:00 UTC\n\n"
+            "**Cycle summary**: Meta released Muse Spark 1.1.\n\n"
+            "<article class=\"twitter-story\"></article>\n\n"
+            "### Watch list (next 24h)\n- Next scheduled Twitter/X AI monitor run.\n",
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(ContractError, "operational/no-news filler"):
+            self.validate()
+
+    def test_rejects_equivalent_no_news_narration(self) -> None:
+        phrases = (
+            "No noteworthy AI updates this cycle.",
+            "No significant AI developments in this window.",
+            "None this cycle.",
+            "Monitoring found no material AI changes.",
+            "Only earlier AI items repeated.",
+            "No follow-ups needed — pre-fetched snapshot was sufficient.",
+        )
+        for phrase in phrases:
+            with self.subTest(phrase=phrase):
+                self.write_status("published", 1)
+                self.summary.write_text("Meta released Muse Spark 1.1.\n", encoding="utf-8")
+                self.digest.write_text(
+                    "## 10:00 UTC\n\n"
+                    "**Cycle summary**: Meta released Muse Spark 1.1.\n\n"
+                    "### Quick hits\n"
+                    "- @AIatMeta: Muse Spark 1.1 released "
+                    "[source](https://x.com/AIatMeta/status/123)\n\n"
+                    f"### Watch list (next 24h)\n- {phrase}\n",
+                    encoding="utf-8",
+                )
+                with self.assertRaisesRegex(ContractError, "operational/no-news filler"):
+                    self.validate()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate_twitter_public_output.py
+++ b/scripts/validate_twitter_public_output.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Validate the signal-only contract for one Twitter/X monitoring cycle."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+H2_RE = re.compile(r"^##[ \t]+(?P<title>.*?)[ \t]*\r?$", re.MULTILINE)
+STORY_BLOCK_RE = re.compile(r"<article\b(?P<attrs>[^>]*)>(?P<body>.*?)</article>", re.IGNORECASE | re.DOTALL)
+CLASS_RE = re.compile(r"\bclass=(?P<quote>['\"])(?P<classes>.*?)(?P=quote)", re.IGNORECASE)
+TITLE_RE = re.compile(
+    r"<h[1-6]\b[^>]*\bclass=(?P<quote>['\"])[^'\"]*\btwitter-story-title\b[^'\"]*(?P=quote)[^>]*>(?P<body>.*?)</h[1-6]>",
+    re.IGNORECASE | re.DOTALL,
+)
+LEAD_RE = re.compile(
+    r"<p\b[^>]*\bclass=(?P<quote>['\"])[^'\"]*\btwitter-story-lead\b[^'\"]*(?P=quote)[^>]*>(?P<body>.*?)</p>",
+    re.IGNORECASE | re.DOTALL,
+)
+HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+SOURCE_ANCHOR_RE = re.compile(
+    r"<a\b(?=[^>]*\bclass=(?P<class_quote>['\"])[^'\"]*\btwitter-source-chip\b[^'\"]*(?P=class_quote))"
+    r"(?=[^>]*\bhref=(?P<href_quote>['\"])https?://(?:www\.)?(?:x|twitter)\.com/[^'\"\s<>]+/status/\d+(?P=href_quote))[^>]*>",
+    re.IGNORECASE,
+)
+X_STATUS_RE = re.compile(
+    r"https?://(?:www\.)?(?:x|twitter)\.com/[^\s)\]<>]+/status/\d+",
+    re.IGNORECASE,
+)
+FILLER_RE = re.compile(
+    r"(?:"
+    r"\bquiet\b|"
+    r"\bno\s+(?:(?:new|noteworthy|significant|material|major|fresh|concrete|publishable|main)\s+)*(?:ai\s+)?(?:stor(?:y|ies)|updates?|developments?|changes?|items?)\b|"
+    r"\bpublication bar\b|"
+    r"\bsame-day (?:twitter/x )?items\b|"
+    r"\bfollow-up period\b|"
+    r"\bnext scheduled (?:twitter/x )?(?:ai )?monitor run\b|"
+    r"\bnothing (?:new|concrete|publishable)\b|"
+    r"\bnone this cycle\b|"
+    r"\bmonitor(?:ing)? (?:found|saw|surfaced|returned) no\b|"
+    r"\bonly earlier .*? (?:items?|stories?) (?:repeated|remain(?:ed)?)\b|"
+    r"\bno follow-ups? needed\b|"
+    r"\bpre-fetched snapshot\b|"
+    r"\bsource checks? (?:issued|performed|completed) this cycle\b|"
+    r"^###[ \t]+Research notes[ \t]*$|"
+    r"\bno_update\b"
+    r")",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+class ContractError(ValueError):
+    """Raised when a cycle violates the public-output contract."""
+
+
+def load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ContractError(f"missing JSON artifact: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ContractError(f"invalid JSON artifact {path}: {exc}") from exc
+
+
+def cycle_sections(text: str, hour: str) -> list[str]:
+    """Return matching sections using the dashboard's any-H2 boundary."""
+    matches = list(H2_RE.finditer(text))
+    sections: list[str] = []
+    expected = f"{hour}:00 UTC"
+    for index, match in enumerate(matches):
+        if match.group("title").strip() != expected:
+            continue
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+        sections.append(text[match.start() : end])
+    return sections
+
+
+def public_item_count(section: str) -> int:
+    section = HTML_COMMENT_RE.sub("", section)
+
+    def visible_text(fragment: str) -> str:
+        without_tags = re.sub(r"<[^>]+>", "", fragment)
+        return html.unescape(without_tags).replace("\xa0", " ").strip()
+
+    stories = 0
+    for block in STORY_BLOCK_RE.finditer(section):
+        class_match = CLASS_RE.search(block.group("attrs"))
+        if class_match is None or "twitter-story" not in class_match.group("classes").split():
+            continue
+        body = block.group("body")
+        title = TITLE_RE.search(body)
+        lead = LEAD_RE.search(body)
+        if title is None or not visible_text(title.group("body")):
+            continue
+        if lead is None or not visible_text(lead.group("body")):
+            continue
+        if SOURCE_ANCHOR_RE.search(body) is None:
+            continue
+        stories += 1
+    quick_hits = 0
+    in_quick_hits = False
+    for line in section.splitlines():
+        stripped = line.strip()
+        if re.fullmatch(r"###[ \t]+Quick hits[ \t]*", stripped, re.IGNORECASE):
+            in_quick_hits = True
+            continue
+        if in_quick_hits and stripped.startswith("#"):
+            in_quick_hits = False
+        if in_quick_hits and re.match(r"^[-*][ \t]+\S", stripped) and X_STATUS_RE.search(stripped):
+            quick_hits += 1
+    return stories + quick_hits
+
+
+def validate(
+    *,
+    backend: str,
+    status_file: Path,
+    digest_file: Path,
+    summary_file: Path,
+    date: str,
+    hour: str,
+    generated_at: str,
+    run_id: str,
+    run_attempt: int,
+    headlines_file: Path | None = None,
+) -> None:
+    status = load_json(status_file)
+    if not isinstance(status, dict):
+        raise ContractError("status must be a JSON object")
+
+    expected = {
+        "schema_version": 1,
+        "date": date,
+        "hour": f"{hour}:00 UTC",
+        "generated_at": generated_at,
+        "run_id": run_id,
+        "run_attempt": run_attempt,
+    }
+    for key, value in expected.items():
+        if status.get(key) != value:
+            raise ContractError(
+                f"status {key} must equal this run's {value!r}; got {status.get(key)!r}"
+            )
+
+    state = status.get("status")
+    public_items = status.get("public_items")
+    if state not in {"published", "no_update"}:
+        raise ContractError("status must be 'published' or 'no_update'")
+    if isinstance(public_items, bool) or not isinstance(public_items, int) or public_items < 0:
+        raise ContractError("public_items must be a non-negative integer")
+    if not summary_file.exists():
+        raise ContractError(f"missing summary artifact: {summary_file}")
+
+    digest = digest_file.read_text(encoding="utf-8") if digest_file.exists() else ""
+    sections = cycle_sections(digest, hour)
+    if len(sections) > 1:
+        raise ContractError(f"digest contains {len(sections)} same-hour sections")
+
+    if backend == "claude":
+        if headlines_file is None:
+            raise ContractError("Claude validation requires --headlines-file")
+        headlines = load_json(headlines_file)
+        if not isinstance(headlines, list):
+            raise ContractError("headline artifact must be a JSON array")
+    else:
+        headlines = None
+
+    if state == "published":
+        if public_items < 1:
+            raise ContractError("published status requires public_items > 0")
+        if len(sections) != 1:
+            raise ContractError("published status requires exactly one same-hour public section")
+        section = sections[0]
+        summary_match = re.search(
+            r"^\*\*Cycle summary\*\*:[ \t]*(?P<summary>\S.*)$",
+            section,
+            re.MULTILINE,
+        )
+        if summary_match is None:
+            raise ContractError("published section requires a non-empty Cycle summary")
+        filler = FILLER_RE.search(section)
+        if filler is not None:
+            raise ContractError(f"public section contains operational/no-news filler: {filler.group(0)!r}")
+        actual_items = public_item_count(section)
+        if actual_items < 1:
+            raise ContractError("published section has no story card or linked Quick-hit bullet")
+        if actual_items != public_items:
+            raise ContractError(
+                f"public_items says {public_items}, but the section contains {actual_items} public items"
+            )
+        if summary_file.stat().st_size == 0:
+            raise ContractError("published status requires a non-empty notification summary")
+        return
+
+    if public_items != 0:
+        raise ContractError("no_update status requires public_items == 0")
+    if sections:
+        raise ContractError("no_update status must not leave a same-hour public section")
+    if summary_file.stat().st_size != 0:
+        raise ContractError("no_update status requires an empty notification summary")
+    if backend == "claude" and headlines != []:
+        raise ContractError("no_update status requires an empty Claude headline array")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--backend", required=True)
+    parser.add_argument("--status-file", type=Path, required=True)
+    parser.add_argument("--digest-file", type=Path, required=True)
+    parser.add_argument("--summary-file", type=Path, required=True)
+    parser.add_argument("--headlines-file", type=Path)
+    parser.add_argument("--date", required=True)
+    parser.add_argument("--hour", required=True)
+    parser.add_argument("--generated-at", required=True)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--run-attempt", type=int, required=True)
+    args = parser.parse_args(argv)
+
+    try:
+        validate(
+            backend=args.backend,
+            status_file=args.status_file,
+            digest_file=args.digest_file,
+            summary_file=args.summary_file,
+            headlines_file=args.headlines_file,
+            date=args.date,
+            hour=args.hour,
+            generated_at=args.generated_at,
+            run_id=args.run_id,
+            run_attempt=args.run_attempt,
+        )
+    except ContractError as exc:
+        parser.error(str(exc))
+    print(f"validated Twitter public-output contract: {args.status_file}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Outcome

Removes no-news/editorial filler from the public Twitter timeline and backfills the July 10 page with concrete developments only.

## What changed

- empty cycles now write a run-specific machine heartbeat, an empty notification summary, and no public Markdown section
- Quick-hit-only cycles lead with the actual developments; generic hype, promos, off-topic posts, and repeated URLs are filtered
- all five Twitter backends share one public-output validator and exact diff-scope guard
- validator requires real story cards or linked Quick hits, exact item counts, current run identity, and rejects operational/no-news narration
- daily digest falls back to the latest non-empty same-day Twitter summary
- July 10 public copy removes the reported filler and other monitoring-only notes

## Verification

- `uv run python -m unittest discover -s scripts -p 'test_*.py'` — 483 tests passed, 6 skipped
- model tickets: 116 valid
- wiki: 56 pages valid
- backend matrix check, `actionlint`, and `git diff --check` passed
- dashboard production build passed
- desktop and 390px mobile browser QA: no filler text, no Research notes, no horizontal overflow; Meta Muse Spark/API update renders