### PR TITLE
Fix effective Claude sandbox policy

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,7 +16,8 @@
         "/etc/ssl/private"
       ],
       "allowRead": [
-        "."
+        ".",
+        ".git/config"
       ]
     },
     "credentials": {
@@ -35,6 +36,14 @@
         },
         {
           "path": "~/.ssh",
+          "mode": "deny"
+        },
+        {
+          "path": "~/.claude",
+          "mode": "deny"
+        },
+        {
+          "path": "~/.claude.json",
           "mode": "deny"
         }
       ],
@@ -58,18 +67,31 @@
         {
           "name": "ZAI_API_KEY",
           "mode": "deny"
+        },
+        {
+          "name": "GITHUB_TOKEN",
+          "mode": "deny"
+        },
+        {
+          "name": "GH_TOKEN",
+          "mode": "deny"
         }
       ]
     }
   },
   "permissions": {
     "deny": [
-      "Read(~/**)",
+      "Read(~/.aws/**)",
+      "Read(~/.config/gh/**)",
+      "Read(~/.docker/**)",
+      "Read(~/.ssh/**)",
+      "Read(~/.claude/**)",
+      "Read(~/.claude.json)",
+      "Read(./.git/config)",
       "Read(//root/**)",
       "Read(//proc/**)",
       "Read(//sys/**)",
       "Read(//run/**)",
-      "Read(//var/run/**)",
       "Read(//etc/ssh/**)",
       "Read(//etc/ssl/private/**)"
     ]

--- a/.github/actions/setup-claude-sandbox/action.yml
+++ b/.github/actions/setup-claude-sandbox/action.yml
@@ -51,9 +51,10 @@ runs:
         tmp_path.replace(settings_path)
         PY
 
-        # Exercise the mount shape that failed in production. /var/run is a
-        # symlink to /run on Ubuntu and is not a valid bwrap tmpfs target; the
-        # project policy masks the canonical /run directory instead.
+        # Exercise the canonical mount shape used by the effective policy.
+        # Claude merges Read(...) permission denies into the Bash sandbox, so
+        # scripts/test_claude_sandbox_policy.py also rejects a lexical
+        # /var/run alias before this preflight can give a false-positive pass.
         bwrap \
           --ro-bind / / \
           --dev /dev \

--- a/.github/workflows/generative-research.yml
+++ b/.github/workflows/generative-research.yml
@@ -3643,6 +3643,29 @@ jobs:
           echo "Codex outcome: ${{ steps.gen-codex.outcome }}"
           exit 1
 
+      # claude-code-action reports success when the model session completes,
+      # even if every tool call failed and the writer produced no commit. Keep
+      # the workflow contract tied to the article artifact, not session exit.
+      - name: Fail Claude run without article
+        if: always() && steps.effective.outputs.backend == 'claude' && steps.outfile.outputs.has_file != 'true'
+        env:
+          EXECUTION_FILE_1: ${{ steps.gen-claude.outputs.execution_file }}
+          EXECUTION_FILE_2: ${{ steps.gen-claude-retry.outputs.execution_file }}
+          OUTCOME_1: ${{ steps.gen-claude.outcome }}
+          OUTCOME_2: ${{ steps.gen-claude-retry.outcome }}
+        run: |
+          echo "::error::Claude backend did not produce an article."
+          echo "Attempt 1 outcome: ${OUTCOME_1:-skipped}"
+          echo "Retry 1 outcome: ${OUTCOME_2:-skipped}"
+          for execution_file in "$EXECUTION_FILE_2" "$EXECUTION_FILE_1"; do
+            if [ -n "${execution_file:-}" ] && [ -f "$execution_file" ]; then
+              uv run python scripts/summarize_claude_execution.py "$execution_file" \
+                --github-annotation error
+              break
+            fi
+          done
+          exit 1
+
       # Only fires when the EFFECTIVE backend was a Fireworks profile —
       # i.e. preflight passed but the Fireworks agent produced nothing.
       # A run that already fell back to Claude follows the Claude lane's

--- a/scripts/test_claude_sandbox_policy.py
+++ b/scripts/test_claude_sandbox_policy.py
@@ -1,4 +1,5 @@
 import json
+import re
 import sys
 import unittest
 from pathlib import Path
@@ -37,9 +38,69 @@ class ClaudeSandboxPolicyTests(unittest.TestCase):
         permissions = self.settings["permissions"]["deny"]
 
         self.assertIn("Read(//run/**)", permissions)
-        # Keep the lexical alias denied for the Read tool even though bwrap
-        # must only receive the canonical /run mount destination.
-        self.assertIn("Read(//var/run/**)", permissions)
+        # Claude merges Read(...) denies into the Bash sandbox's denyRead
+        # paths. Keeping the lexical alias here therefore recreates the broken
+        # `bwrap --tmpfs /var/run` mount even when sandbox.filesystem.denyRead
+        # correctly uses /run.
+        aliases = [
+            rule
+            for rule in permissions
+            if rule.startswith(("Read(//var/run", "Edit(//var/run"))
+        ]
+        self.assertEqual([], aliases)
+
+        if sys.platform.startswith("linux"):
+            noncanonical_paths = []
+            for rule in permissions:
+                match = re.fullmatch(r"(?:Read|Edit)\(//(.+?)(?:/\*\*)?\)", rule)
+                if not match:
+                    continue
+                path = Path("/" + match.group(1))
+                if path.exists() and path.absolute() != path.resolve():
+                    noncanonical_paths.append((rule, str(path.resolve())))
+            self.assertEqual(
+                [],
+                noncanonical_paths,
+                "absolute Read/Edit denies merged into bwrap must be canonical",
+            )
+
+    def test_read_tool_can_access_workspace_under_home(self) -> None:
+        permissions = self.settings["permissions"]["deny"]
+
+        # GitHub checks out the repository below /home/guzus. Permission deny
+        # rules take precedence, so Read(~/**) blocks the workspace even though
+        # sandbox.filesystem.allowRead contains "." (that carve-out applies to
+        # sandboxed subprocesses, not to the independent Read tool).
+        self.assertNotIn("Read(~/**)", permissions)
+
+        # Preserve direct-tool protection for the credential directories the
+        # Bash sandbox masks instead of denying the runner's whole home tree.
+        for path in (".aws", ".config/gh", ".docker", ".ssh", ".claude"):
+            self.assertIn(f"Read(~/{path}/**)", permissions)
+        self.assertIn("Read(~/.claude.json)", permissions)
+
+    def test_git_remote_token_is_not_readable_via_file_tool(self) -> None:
+        permissions = self.settings["permissions"]["deny"]
+        allow_read = self.settings["sandbox"]["filesystem"]["allowRead"]
+
+        # claude-code-action temporarily stores its GitHub credential in the
+        # checkout's remote URL. Deny direct Read access, while the exact
+        # sandbox allowRead carve-out keeps permitted Bash(git:*) operations
+        # able to read the repository config.
+        self.assertIn("Read(./.git/config)", permissions)
+        self.assertIn(".git/config", allow_read)
+
+    def test_sandbox_masks_agent_credentials(self) -> None:
+        credentials = self.settings["sandbox"]["credentials"]
+        denied_files = {
+            item["path"] for item in credentials["files"] if item["mode"] == "deny"
+        }
+        denied_env = {
+            item["name"] for item in credentials["envVars"] if item["mode"] == "deny"
+        }
+
+        self.assertTrue({"~/.claude", "~/.claude.json"} <= denied_files)
+        self.assertTrue({"GITHUB_TOKEN", "GH_TOKEN"} <= denied_env)
 
     def test_research_tree_has_no_committed_diagnostic_dotfiles(self) -> None:
         allowed = {".gitignore", ".gitkeep"}


### PR DESCRIPTION
## Root cause

Claude merges `Read(...)` permission denies into its Linux Bash sandbox. The policy retained `Read(//var/run/**)`, recreating the invalid bubblewrap `--tmpfs /var/run` mount even after the explicit sandbox path was changed to `/run`. `Read(~/**)` also denied the checkout itself because gunux stores it below `/home/guzus`.

## Fix

- remove the noncanonical `/var/run` permission alias and broad Read-tool home deny
- retain canonical `/run`, fail-closed strong sandboxing, and workspace-only Bash reads
- protect explicit home credential paths, Claude auth, GitHub token env vars, and direct `.git/config` reads
- make the preflight comment describe the effective merged policy and expand regression tests
- fail Generative Research when a Claude session completes without an article commit

## Verification

- 487 Python tests passed, 6 skipped
- 6 sandbox-policy tests passed
- model-ticket, wiki, wiki-index, and backend-matrix validators passed
- `actionlint -shellcheck=` passed
- changed Claude no-article shell block passed shellcheck
- `git diff --check` passed

## Live verification after merge

Rerun `hourly-rss.yml` on gunux and require the exact dated RSS artifact; action session success alone is not accepted as evidence.