### PR TITLE
Fail daily-youtube loudly on total tuber-api fetch failure instead of committing empty signal

### DIFF
--- a/scripts/fetch_youtube_signal.py
+++ b/scripts/fetch_youtube_signal.py
@@ -32,6 +32,10 @@ DEFAULT_TUBER_API_BASE = "https://tuber-api.guzus.xyz"
 USER_AGENT = "ai-research-arm/1.0 (https://github.com/guzus/ai-research-arm)"
 TIMEOUT_SECONDS = 25
 FORBIDDEN_GENERATION_PATH_PARTS = ("/summarize", "/acp/jobs")
+# Exit code for "every checked source failed and nothing was collected".
+# Distinct from 2 (argument validation) so the workflow/telemetry can tell
+# a total tuber-api outage apart from a bad invocation.
+EXIT_TOTAL_FETCH_FAILURE = 3
 
 PRIORITY_WEIGHT = {"P0": 100, "P1": 70, "P2": 40}
 KIND_WEIGHT = {"channel": 24, "search": 10, "trending": 0}
@@ -700,7 +704,30 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     sources = load_sources(args.registry)
+    out_path = args.out_dir / f"{target_date.isoformat()}.md"
     candidates, fetch_errors = collect_candidates(sources, base_url=args.tuber_api_base)
+
+    # Total signal loss must fail loudly instead of committing a fresh-dated
+    # empty artifact. The freshness watchdog (scripts/check_lane_freshness.py)
+    # is git-recency based, so an empty file dated today looks healthy and
+    # hides a tuber-api outage (2026-07-12: all 10 sources returned HTTP 502
+    # and the lane still went green). collect_candidates checks EVERY registry
+    # source regardless of include_in_digest, and each checked source yields
+    # at most one fetch error, so "all checked sources failed" is exactly
+    # len(fetch_errors) == len(sources). Partial failure (any source
+    # succeeded, or any candidate collected) keeps the current write path.
+    if sources and not candidates and len(fetch_errors) == len(sources):
+        print(
+            f"ERROR: total tuber-api fetch failure: all {len(sources)} checked source(s) "
+            f"failed against {args.tuber_api_base} and 0 candidates were collected; "
+            f"refusing to write {out_path} so the outage stays visible to the "
+            "freshness watchdog instead of resetting its git-recency clock",
+            file=sys.stderr,
+        )
+        for source, error in fetch_errors:
+            print(f"ERROR:   {source.name}: {error}", file=sys.stderr)
+        return EXIT_TOTAL_FETCH_FAILURE
+
     enrich_errors = enrich_candidates(
         candidates,
         base_url=args.tuber_api_base,
@@ -718,7 +745,6 @@ def main(argv: list[str] | None = None) -> int:
         enrich_errors=enrich_errors,
         base_url=args.tuber_api_base,
     )
-    out_path = args.out_dir / f"{target_date.isoformat()}.md"
     write_atomic(out_path, markdown)
     print(
         f"Wrote {out_path} with {len(selected)} selected video(s), "

--- a/scripts/test_fetch_youtube_signal.py
+++ b/scripts/test_fetch_youtube_signal.py
@@ -4,11 +4,16 @@
 from __future__ import annotations
 
 import datetime as dt
+import json
 import os
 import sys
 import tempfile
 import unittest
+import urllib.error
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
 from pathlib import Path
+from unittest import mock
 
 sys.path.insert(0, os.path.dirname(__file__))
 
@@ -307,6 +312,131 @@ class RenderAndMainTest(unittest.TestCase):
 
         self.assertEqual(rc, 0)
         self.assertIn("Example model release", text)
+
+
+GUARD_REGISTRY = [
+    {
+        "id": "down-channel",
+        "name": "Down Channel",
+        "kind": "channel",
+        "channel": "@downchannel",
+        "priority": "P0",
+        "count": 5,
+        "tags": ["official"],
+        "include_in_digest": True,
+    },
+    {
+        "id": "up-search",
+        "name": "Up Search",
+        "kind": "search",
+        "query": "ai news",
+        "priority": "P1",
+        "count": 5,
+        "tags": ["research"],
+        "include_in_digest": True,
+    },
+]
+
+
+class TotalFetchFailureGuardTest(unittest.TestCase):
+    """Total signal loss must fail loudly, not commit an empty artifact.
+
+    2026-07-12 incident: tuber-api returned HTTP 502 for all 10 sources and
+    the lane still committed a fresh-dated file ("Unique videos collected: 0
+    / Fetch errors: 10") with exit 0. The git-recency freshness watchdog
+    (scripts/check_lane_freshness.py) can never catch that shape because the
+    file exists and is dated today. main() must instead exit
+    EXIT_TOTAL_FETCH_FAILURE (3) and write nothing when EVERY checked source
+    produced a fetch error and zero candidates were collected, while partial
+    failures keep the current always-write behavior.
+    """
+
+    API_BASE = "https://tuber-api.test.invalid"
+
+    def run_main(self, td, fake_fetch, registry_rows=None):
+        """Run main() with the per-source network boundary stubbed out.
+
+        fetch_source_candidates is resolved as a module global inside
+        collect_candidates, so patching it exercises the real per-source
+        error accumulation. Enrichment budgets are zeroed so
+        enrich_candidates makes no network calls of its own.
+        """
+        registry = Path(td) / "sources.json"
+        registry.write_text(
+            json.dumps(GUARD_REGISTRY if registry_rows is None else registry_rows),
+            encoding="utf-8",
+        )
+        out_dir = Path(td) / "out"
+        stdout, stderr = StringIO(), StringIO()
+        with mock.patch.object(youtube, "fetch_source_candidates", fake_fetch):
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                rc = youtube.main(
+                    [
+                        "--registry", str(registry),
+                        "--out-dir", str(out_dir),
+                        "--date", "2026-07-12",
+                        "--tuber-api-base", self.API_BASE,
+                        "--max-preview-checks", "0",
+                        "--max-transcript-checks", "0",
+                    ]
+                )
+        return rc, stdout.getvalue(), stderr.getvalue(), out_dir / "2026-07-12.md"
+
+    @staticmethod
+    def all_sources_down(source, *, base_url, fetch_json_fn=None):
+        raise urllib.error.URLError("tuber-api unreachable (HTTP 502)")
+
+    def test_total_failure_exits_3_and_writes_nothing(self):
+        with tempfile.TemporaryDirectory() as td:
+            rc, out, err, out_path = self.run_main(td, self.all_sources_down)
+
+            self.assertEqual(rc, youtube.EXIT_TOTAL_FETCH_FAILURE)
+            self.assertEqual(rc, 3)  # distinct from 2 (argument validation)
+            self.assertFalse(out_path.exists())
+            self.assertFalse(out_path.parent.exists())  # no partial output either
+            self.assertNotIn("Wrote", out)
+            self.assertIn("ERROR:", err)
+            self.assertIn(self.API_BASE, err)
+            # Per-source error summary names every failed source.
+            self.assertIn("Down Channel", err)
+            self.assertIn("Up Search", err)
+            self.assertIn("URLError", err)
+
+    def test_partial_failure_still_writes_daily_file(self):
+        def one_source_up(source, *, base_url, fetch_json_fn=None):
+            if source.id == "down-channel":
+                raise urllib.error.URLError("tuber-api unreachable (HTTP 502)")
+            candidate = youtube.normalize_video(
+                source,
+                {
+                    "id": "gH4FTjDm9FQ",
+                    "title": "OpenAI announces a new reasoning model",
+                    "publishedAt": "2 days ago",
+                    "channel": "Up Search Channel",
+                },
+            )
+            assert candidate is not None
+            return [candidate]
+
+        with tempfile.TemporaryDirectory() as td:
+            rc, out, err, out_path = self.run_main(td, one_source_up)
+
+            self.assertEqual(rc, 0)
+            self.assertTrue(out_path.exists())
+            text = out_path.read_text(encoding="utf-8")
+            self.assertIn("Unique videos collected: 1", text)
+            self.assertIn("Fetch errors: 1", text)
+            self.assertIn("Wrote", out)
+
+    def test_empty_registry_keeps_current_write_behavior(self):
+        # The guard requires at least one checked source: an empty registry
+        # is a configuration state, not a fetch outage, and keeps writing.
+        with tempfile.TemporaryDirectory() as td:
+            rc, _out, _err, out_path = self.run_main(td, self.all_sources_down, registry_rows=[])
+
+            self.assertEqual(rc, 0)
+            self.assertTrue(out_path.exists())
+            self.assertIn("Sources checked: 0", out_path.read_text(encoding="utf-8"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem: a green run that blinds the watchdog

`scripts/fetch_youtube_signal.py` unconditionally wrote `research/youtube/<date>.md` and returned 0, even when it collected nothing at all. That turns **total signal loss into a healthy-looking commit**:

- The freshness watchdog (`scripts/check_lane_freshness.py`) is **git-recency based** — the youtube lane alerts only after 30h without a commit. A fresh-dated empty artifact resets that clock, so the one failure shape it exists to catch (lane produced nothing) is exactly the shape it can never see.
- `daily-youtube.yml` runs the script under `set -euo pipefail` with no `continue-on-error`, and hooker telemetry posts the job status — but exit 0 means the job stays green, so nothing fires there either.

### Incident evidence (2026-07-12)

tuber-api.guzus.xyz was down; all 10 registry sources returned HTTP 502. The lane still committed [`research/youtube/2026-07-12.md`](https://github.com/guzus/ai-research-arm/blob/main/research/youtube/2026-07-12.md) (generated 00:16 UTC) reporting:

```
- Sources checked: 10 (10 enabled for digest inclusion)
- Unique videos collected: 0
- Fetch errors: 10
```

…and the run went green. No alert on any channel.

## Fix

In `main()`, when there was **at least one checked source**, **every checked source produced a fetch error**, and **zero candidates were collected** → print an `ERROR:` summary to stderr (API base + one line per failed source), write **nothing**, and return **exit 3** (`EXIT_TOTAL_FETCH_FAILURE`, distinct from 2 = argument validation).

Count precision: `collect_candidates` fetches **every** registry source regardless of `include_in_digest` (that flag only affects scoring/selection), and each checked source contributes at most one fetch error — so total failure is exactly `len(fetch_errors) == len(sources)`.

Behavior preserved:
- **Partial failure** (≥1 source succeeded, or any candidate collected) → writes the file, exit 0, errors still listed in the `## Fetch Errors` section as before.
- **Quiet-but-healthy day** (sources respond with zero videos) → not a total failure; writes as before.
- **Empty registry** → config state, not an outage; keeps writing (guard requires ≥1 checked source).

Failure now surfaces twice: the run goes red immediately (job-status telemetry), and because no file is committed, the freshness watchdog's 30h staleness alert also fires if the outage persists.

## Tests

Extended the existing `scripts/test_fetch_youtube_signal.py` (it already existed from the lane's initial commit) with a `TotalFetchFailureGuardTest` suite that stubs the per-source fetch boundary (`fetch_source_candidates`, resolved as a module global inside `collect_candidates`, so real error accumulation is exercised; enrichment budgets zeroed so no network):

- total failure → exit 3, no file, out-dir never created, stderr names API base + every source
- partial failure → exit 0, file written, `Unique videos collected: 1` / `Fetch errors: 1`
- empty-registry boundary → keeps current write behavior

## Verification (observed)

- `uv run python -m unittest scripts.test_fetch_youtube_signal -v` → `Ran 19 tests ... OK` (16 pre-existing + 3 new)
- Full suite, exact CI invocation `uv run python -m unittest discover -s scripts -p 'test_*.py'` → `Ran 487 tests ... OK (skipped=6)`, exit 0
- `uv run --with pytest pytest scripts/test_fetch_youtube_signal.py -q` → `19 passed`
- Real end-to-end total-failure run: `python3 scripts/fetch_youtube_signal.py --tuber-api-base http://127.0.0.1:9 --out-dir <tmp> --date 2026-07-12` → **exit 3**, stderr header + 10 per-source `URLError: Connection refused` lines, out-dir never created

No workflow changes needed: CI test discovery picks the file up automatically, and `daily-youtube.yml` already propagates a non-zero exit as a failed run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)