### PR TITLE
Bind Polymarket odds to model tickets: live probabilities + sparklines on the /models board

### DIFF
--- a/.github/workflows/24h-model-timeline.yml
+++ b/.github/workflows/24h-model-timeline.yml
@@ -269,6 +269,11 @@ jobs:
               - The body is markdown narrative; keep it concise (the
                 history field is the audit trail). 3–10 short paragraphs
                 is typical.
+              - Optional `polymarket:` frontmatter: maintain mappings per
+                the "Polymarket market mappings" section of
+                docs/model-tickets.md — add one only when a clearly-matching
+                ACTIVE market exists, keep mappings after markets resolve,
+                and NEVER invent IDs (only IDs read from the Polymarket API).
               - Do not write outside research/models/tickets/ and the
                 single daily-diff file in research/models/.
 

--- a/dashboard/scripts/prebuild.mjs
+++ b/dashboard/scripts/prebuild.mjs
@@ -175,6 +175,49 @@ function collectDates(dir, re) {
   return Array.from(dates).sort();
 }
 
+// Lenient shape-check for the optional `polymarket:` frontmatter (see
+// docs/model-tickets.md). scripts/check_model_tickets.py is the strict
+// gate; here a malformed mapping is dropped with a warning so one bad
+// autonomous-agent write can never fail the deploy. Returns a clean
+// array of mappings, or null when nothing usable remains.
+function sanitizeTicketPolymarket(raw, ticketName) {
+  if (raw == null) return null;
+  if (!Array.isArray(raw)) {
+    console.warn(`prebuild: WARNING — tickets/${ticketName}: polymarket is not a list; dropping it`);
+    return null;
+  }
+  const clean = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      console.warn(`prebuild: WARNING — tickets/${ticketName}: polymarket mapping is not an object; dropping mapping`);
+      continue;
+    }
+    const str = (v) => (typeof v === 'string' && v.trim() ? v.trim() : null);
+    const event_slug = str(entry.event_slug);
+    const question = str(entry.question);
+    // market_id is small enough to coerce from an accidental YAML number;
+    // token_id is ~78 digits and unrecoverable once parsed as a number.
+    const market_id = str(entry.market_id) ??
+      (typeof entry.market_id === 'number' && Number.isSafeInteger(entry.market_id)
+        ? String(entry.market_id)
+        : null);
+    const token_id = str(entry.token_id);
+    if (!event_slug || !market_id || !token_id || !question) {
+      console.warn(`prebuild: WARNING — tickets/${ticketName}: polymarket mapping missing/invalid required field; dropping mapping`);
+      continue;
+    }
+    const mapping = { event_slug, market_id, token_id, question };
+    const outcome = str(entry.outcome);
+    if (outcome) mapping.outcome = outcome;
+    clean.push(mapping);
+  }
+  if (clean.length > 3) {
+    console.warn(`prebuild: WARNING — tickets/${ticketName}: polymarket has ${clean.length} mappings; keeping the first 3`);
+    clean.length = 3;
+  }
+  return clean.length ? clean : null;
+}
+
 function buildTicketsIndex() {
   // Parse every research/models/tickets/<slug>.md, split frontmatter
   // and body, and emit a single tickets/index.json that the dashboard
@@ -228,6 +271,11 @@ function buildTicketsIndex() {
     if (Array.isArray(fm.history)) {
       fm.history = fm.history.map((h) => ({ ...h, ts: isoDate(h.ts) }));
     }
+    // Optional Polymarket odds mappings — pass through only well-shaped
+    // entries so the dashboard never sees a malformed mapping.
+    const polymarket = sanitizeTicketPolymarket(fm.polymarket, name);
+    if (polymarket) fm.polymarket = polymarket;
+    else delete fm.polymarket;
     tickets.push({ ...fm, body });
   }
 

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -183,6 +183,17 @@ type FocusReaderData = {
 type TicketStatus = 'rumored' | 'in-testing' | 'confirmed' | 'released' | 'closed';
 type TicketVerification = 'confirmed' | 'partial' | 'unverified';
 type TicketHistoryEntry = { ts: string; change: string };
+// Optional Polymarket market binding — the ticket tracks a real-world
+// event; the market is the crowd's live probability for it. Contract in
+// docs/model-tickets.md ("Polymarket market mappings"); prebuild.mjs
+// shape-checks entries before they reach index.json.
+type TicketPolymarketMapping = {
+  event_slug: string;
+  market_id: string;
+  token_id: string;
+  question: string;
+  outcome?: string | null;
+};
 type Ticket = {
   slug: string;
   title: string;
@@ -199,6 +210,7 @@ type Ticket = {
   closed_at: string | null;
   closed_reason: string | null;
   history: TicketHistoryEntry[];
+  polymarket?: TicketPolymarketMapping[] | null;
   body: string;
 };
 type TicketIndex = { tickets: Ticket[] };
@@ -883,7 +895,10 @@ function setSafeContent(
   // audio players), so they stay in the default allowlist; they are NOT
   // iframe-only.
   const addTags = ['mark', 'article', 'figure', 'figcaption', 'audio', 'nav', 'section', 'details', 'summary'];
-  const addAttr = ['id', 'href', 'type', 'data-slug', 'data-focus-index', 'data-pct', 'data-paper-date', 'data-columns', 'data-filter-status', 'data-filter-company', 'data-has-audio-file', 'data-digest-audio-play', 'data-digest-audio-label', 'data-audio-date', 'aria-label', 'aria-current', 'aria-expanded', 'aria-controls', 'aria-pressed', 'loading', 'decoding', 'controls', 'preload', 'src', 'max', 'value'];
+  // `target` is NOT in DOMPurify's default allowlist; every external link
+  // this app emits pairs target="_blank" with rel="noopener", so allowing
+  // it restores the intended new-tab behavior (ticket odds chips, sources).
+  const addAttr = ['id', 'href', 'type', 'target', 'data-slug', 'data-focus-index', 'data-pct', 'data-paper-date', 'data-columns', 'data-filter-status', 'data-filter-company', 'data-has-audio-file', 'data-digest-audio-play', 'data-digest-audio-label', 'data-audio-date', 'data-odds-event', 'data-odds-market', 'data-odds-token', 'data-odds-spark', 'aria-label', 'aria-current', 'aria-expanded', 'aria-controls', 'aria-pressed', 'loading', 'decoding', 'controls', 'preload', 'src', 'max', 'value'];
   if (opts.allowIframe) {
     // iframe + its iframe-only attributes are re-enabled exclusively for the
     // trusted, self-constructed sandboxed standalone-doc iframe.
@@ -2487,6 +2502,354 @@ function loadTickets(): Promise<Ticket[] | null> {
   return ticketsPromise;
 }
 
+// ── Polymarket odds (models tab) ─────────────────────
+// Ticket cards with `polymarket` mappings show live market odds: one chip
+// per mapping (probability from the gamma event snapshot, then a 60s CLOB
+// midpoint poll while the tab is visible) plus a price-history sparkline
+// for the primary (first) mapping. Everything degrades gracefully: any
+// fetch failure leaves an em-dash chip titled "odds unavailable" and the
+// tab renders fully with Polymarket unreachable.
+//
+// API notes (verified against the live services):
+// - GET gamma-api.polymarket.com/events?slug=<event_slug> → [event]; each
+//   markets[] item carries stringified-JSON `outcomes`/`outcomePrices`/
+//   `clobTokenIds` arrays (index-aligned; prices are "0".."1" strings).
+// - GET clob.polymarket.com/midpoint?token_id=<t> → {"mid":"0.455"}. On
+//   closed markets it 200s with an error body — never poll closed markets;
+//   render their final price from the gamma outcomePrices instead.
+// - GET clob.polymarket.com/prices-history?market=<TOKEN_ID>&interval=max
+//   &fidelity=180 → {"history":[{t,p},...]} (param is named `market` but
+//   takes the CLOB token id; works on resolved tokens too).
+// - Both hosts send ACAO:* — use plain fetch with NO credentials option
+//   (credentials would make the browser reject the CORS response).
+// - Trust market-level active/closed, not event-level (observed drift).
+const POLYMARKET_GAMMA_BASE = 'https://gamma-api.polymarket.com';
+const POLYMARKET_CLOB_BASE = 'https://clob.polymarket.com';
+const ODDS_POLL_INTERVAL_MS = 60_000;
+const ODDS_FETCH_TIMEOUT_MS = 10_000;
+
+type PolymarketMarketState = {
+  closed: boolean;
+  // token id → last gamma price (0..1). Index-aligned parse of
+  // clobTokenIds ↔ outcomePrices, so it works for Yes or No tokens.
+  prices: Map<string, number>;
+};
+type PolymarketEventSnapshot = { markets: Map<string, PolymarketMarketState> };
+type OddsHistoryPoint = { t: number; p: number };
+
+// Session caches: one gamma snapshot per event slug, one history series per
+// token. A resolved-null (failed) fetch is evicted so a later models-tab
+// render may retry once — never more than one in-flight request per key.
+const polymarketEventPromises = new Map<string, Promise<PolymarketEventSnapshot | null>>();
+const polymarketHistoryPromises = new Map<string, Promise<OddsHistoryPoint[] | null>>();
+// Latest CLOB midpoint per token — overrides the (session-old) gamma price
+// on re-renders so filter/tab churn doesn't flash stale numbers.
+const polymarketMidpointPrices = new Map<string, number>();
+let oddsPollTimer: number | null = null;
+let oddsPollTokens = new Set<string>();
+
+async function fetchPolymarketJson(url: string): Promise<unknown | null> {
+  // Plain fetch, no credentials option (see API notes above).
+  const controller = new AbortController();
+  const timer = window.setTimeout(() => controller.abort(), ODDS_FETCH_TIMEOUT_MS);
+  try {
+    const resp = await fetch(url, { signal: controller.signal });
+    if (!resp.ok) return null;
+    return (await resp.json()) as unknown;
+  } catch {
+    return null;
+  } finally {
+    window.clearTimeout(timer);
+  }
+}
+
+// gamma stringifies nested arrays ("[\"Yes\",\"No\"]") — parse defensively.
+function parseStringifiedArray(raw: unknown): unknown[] | null {
+  if (Array.isArray(raw)) return raw;
+  if (typeof raw !== 'string') return null;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function loadPolymarketEvent(eventSlug: string): Promise<PolymarketEventSnapshot | null> {
+  const cached = polymarketEventPromises.get(eventSlug);
+  if (cached) return cached;
+  const promise = (async (): Promise<PolymarketEventSnapshot | null> => {
+    const data = await fetchPolymarketJson(
+      `${POLYMARKET_GAMMA_BASE}/events?slug=${encodeURIComponent(eventSlug)}`,
+    );
+    if (!Array.isArray(data) || !data.length) return null;
+    const event = data[0] as { markets?: unknown };
+    if (!event || !Array.isArray(event.markets)) return null;
+    const markets = new Map<string, PolymarketMarketState>();
+    for (const raw of event.markets as Array<Record<string, unknown>>) {
+      if (!raw || typeof raw !== 'object') continue;
+      const id = raw.id == null ? '' : String(raw.id);
+      if (!id) continue;
+      const tokens = parseStringifiedArray(raw.clobTokenIds);
+      const priceStrs = parseStringifiedArray(raw.outcomePrices);
+      const prices = new Map<string, number>();
+      if (tokens && priceStrs) {
+        for (let i = 0; i < tokens.length && i < priceStrs.length; i++) {
+          const token = typeof tokens[i] === 'string' ? (tokens[i] as string) : '';
+          const price = Number(priceStrs[i]);
+          if (token && Number.isFinite(price) && price >= 0 && price <= 1) prices.set(token, price);
+        }
+      }
+      markets.set(id, { closed: raw.closed === true, prices });
+    }
+    return markets.size ? { markets } : null;
+  })().then((snapshot) => {
+    // Evict failures so a later visit can retry; keep successes for the session.
+    if (snapshot === null) polymarketEventPromises.delete(eventSlug);
+    return snapshot;
+  });
+  polymarketEventPromises.set(eventSlug, promise);
+  return promise;
+}
+
+function loadPolymarketHistory(tokenId: string): Promise<OddsHistoryPoint[] | null> {
+  const cached = polymarketHistoryPromises.get(tokenId);
+  if (cached) return cached;
+  const promise = (async (): Promise<OddsHistoryPoint[] | null> => {
+    const data = await fetchPolymarketJson(
+      `${POLYMARKET_CLOB_BASE}/prices-history?market=${encodeURIComponent(tokenId)}&interval=max&fidelity=180`,
+    );
+    const history = (data as { history?: unknown } | null)?.history;
+    if (!Array.isArray(history)) return null;
+    const points: OddsHistoryPoint[] = [];
+    for (const entry of history as Array<Record<string, unknown>>) {
+      const t = Number(entry?.t);
+      const p = Number(entry?.p);
+      if (Number.isFinite(t) && Number.isFinite(p) && p >= 0 && p <= 1) points.push({ t, p });
+    }
+    return points.length >= 2 ? points : null;
+  })().then((points) => {
+    if (points === null) polymarketHistoryPromises.delete(tokenId);
+    return points;
+  });
+  polymarketHistoryPromises.set(tokenId, promise);
+  return promise;
+}
+
+// Belt-and-braces over prebuild's sanitizer: only well-shaped mappings, max 3.
+function ticketPolymarketMappings(ticket: Ticket): TicketPolymarketMapping[] {
+  if (!Array.isArray(ticket.polymarket)) return [];
+  return ticket.polymarket
+    .filter((m): m is TicketPolymarketMapping =>
+      !!m && typeof m === 'object' &&
+      typeof m.event_slug === 'string' && m.event_slug.trim() !== '' &&
+      typeof m.market_id === 'string' && m.market_id.trim() !== '' &&
+      typeof m.token_id === 'string' && m.token_id.trim() !== '' &&
+      typeof m.question === 'string' && m.question.trim() !== '')
+    .slice(0, 3);
+}
+
+function fmtOddsPct(price: number): string {
+  const pct = price * 100;
+  if (pct > 0 && pct < 1) return '<1%';
+  if (pct > 99 && pct < 100) return '>99%';
+  return `${Math.round(pct)}%`;
+}
+
+// Static chip skeleton (em-dash placeholder); hydrateTicketOdds fills prices
+// in after the grid paints. Chips are links to the Polymarket event page.
+function ticketOddsSectionHtml(ticket: Ticket): string {
+  const mappings = ticketPolymarketMappings(ticket);
+  if (!mappings.length) return '';
+  const chips = mappings.map((m, i) => {
+    const label = (m.outcome && m.outcome.trim()) || m.question;
+    const spark = i === 0
+      ? `<span class="ticket-odds-spark-slot" data-odds-spark="${escapeHtml(m.token_id)}" aria-hidden="true"></span>`
+      : '';
+    return `<a class="ticket-odds-chip" href="https://polymarket.com/event/${encodeURIComponent(m.event_slug)}"
+      target="_blank" rel="noopener noreferrer"
+      data-odds-event="${escapeHtml(m.event_slug)}" data-odds-market="${escapeHtml(m.market_id)}" data-odds-token="${escapeHtml(m.token_id)}"
+      title="Polymarket: ${escapeHtml(m.question)}"
+      aria-label="Polymarket odds: ${escapeHtml(m.question)}">
+      <span class="ticket-odds-pct">—</span>
+      <span class="ticket-odds-label">${escapeHtml(label)}</span>
+    </a>${spark}`;
+  }).join('');
+  return `<div class="ticket-odds">${chips}</div>`;
+}
+
+function applyOddsToChip(chip: HTMLElement, price: number, closed: boolean): void {
+  const pctEl = chip.querySelector<HTMLElement>('.ticket-odds-pct');
+  if (!pctEl) return;
+  chip.classList.remove('is-unavailable');
+  if (closed) {
+    const yes = price >= 0.5;
+    chip.classList.add('is-resolved', yes ? 'is-resolved-yes' : 'is-resolved-no');
+    pctEl.textContent = `${yes ? '✓' : '✗'} ${Math.round(price * 100)}%`;
+    chip.title = `${chip.title.replace(/ — .*$/, '')} — resolved ${yes ? 'Yes' : 'No'}`;
+  } else {
+    pctEl.textContent = fmtOddsPct(price);
+  }
+}
+
+function markChipUnavailable(chip: HTMLElement): void {
+  const pctEl = chip.querySelector<HTMLElement>('.ticket-odds-pct');
+  if (pctEl) pctEl.textContent = '—';
+  chip.classList.add('is-unavailable');
+  chip.title = 'odds unavailable';
+}
+
+// Tiny inline SVG sparkline (~120x28) of the primary market's price history.
+// Built via DOM APIs (no sanitizer round-trip, no libraries); stroke uses
+// currentColor so the CSS theme decides the color in light and dark mode.
+function buildOddsSparkline(points: OddsHistoryPoint[]): SVGSVGElement {
+  const W = 120;
+  const H = 28;
+  const PAD = 2.5;
+  // Downsample long series but always keep the final point.
+  let series = points;
+  if (series.length > 80) {
+    const stride = Math.ceil(series.length / 80);
+    const sampled = series.filter((_, i) => i % stride === 0);
+    if (sampled[sampled.length - 1] !== series[series.length - 1]) sampled.push(series[series.length - 1]);
+    series = sampled;
+  }
+  const t0 = series[0].t;
+  const t1 = series[series.length - 1].t;
+  const tSpan = Math.max(1, t1 - t0);
+  let pMin = Math.min(...series.map((pt) => pt.p));
+  let pMax = Math.max(...series.map((pt) => pt.p));
+  if (pMax - pMin < 0.05) {
+    // Flat series: pad the band so the line doesn't hug an edge.
+    const mid = (pMax + pMin) / 2;
+    pMin = Math.max(0, mid - 0.025);
+    pMax = Math.min(1, mid + 0.025);
+  }
+  const pSpan = Math.max(1e-6, pMax - pMin);
+  const x = (t: number) => PAD + ((t - t0) / tSpan) * (W - 2 * PAD);
+  const y = (p: number) => H - PAD - ((p - pMin) / pSpan) * (H - 2 * PAD);
+  const d = series
+    .map((pt, i) => `${i === 0 ? 'M' : 'L'}${x(pt.t).toFixed(1)} ${y(pt.p).toFixed(1)}`)
+    .join(' ');
+  const SVG_NS = 'http://www.w3.org/2000/svg';
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  svg.setAttribute('class', 'ticket-odds-spark');
+  svg.setAttribute('viewBox', `0 0 ${W} ${H}`);
+  svg.setAttribute('preserveAspectRatio', 'none');
+  svg.setAttribute('role', 'img');
+  svg.setAttribute('aria-label', 'Odds history');
+  const path = document.createElementNS(SVG_NS, 'path');
+  path.setAttribute('d', d);
+  path.setAttribute('fill', 'none');
+  path.setAttribute('stroke', 'currentColor');
+  path.setAttribute('stroke-width', '1.5');
+  path.setAttribute('stroke-linejoin', 'round');
+  path.setAttribute('stroke-linecap', 'round');
+  svg.appendChild(path);
+  const last = series[series.length - 1];
+  const dot = document.createElementNS(SVG_NS, 'circle');
+  dot.setAttribute('cx', x(last.t).toFixed(1));
+  dot.setAttribute('cy', y(last.p).toFixed(1));
+  dot.setAttribute('r', '1.8');
+  dot.setAttribute('fill', 'currentColor');
+  svg.appendChild(dot);
+  return svg;
+}
+
+function stopTicketOddsPolling(): void {
+  if (oddsPollTimer !== null) {
+    window.clearInterval(oddsPollTimer);
+    oddsPollTimer = null;
+  }
+  oddsPollTokens = new Set();
+}
+
+async function pollOddsMidpoints(): Promise<void> {
+  if (activeTab !== 'models') {
+    stopTicketOddsPolling();
+    return;
+  }
+  if (document.hidden || oddsPollTokens.size === 0) return;
+  await Promise.all(Array.from(oddsPollTokens).map(async (tokenId) => {
+    const data = await fetchPolymarketJson(
+      `${POLYMARKET_CLOB_BASE}/midpoint?token_id=${encodeURIComponent(tokenId)}`,
+    );
+    const mid = Number((data as { mid?: unknown } | null)?.mid);
+    if (!Number.isFinite(mid) || mid < 0 || mid > 1) return; // closed/error bodies land here
+    polymarketMidpointPrices.set(tokenId, mid);
+    for (const chip of content.querySelectorAll<HTMLElement>(
+      `.ticket-odds-chip[data-odds-token="${tokenId}"]`,
+    )) {
+      applyOddsToChip(chip, mid, false);
+    }
+  }));
+}
+
+function startTicketOddsPolling(openTokens: Set<string>): void {
+  oddsPollTokens = openTokens;
+  if (openTokens.size === 0) {
+    stopTicketOddsPolling();
+    return;
+  }
+  if (oddsPollTimer === null) {
+    oddsPollTimer = window.setInterval(() => { void pollOddsMidpoints(); }, ODDS_POLL_INTERVAL_MS);
+  }
+}
+
+// Fill the odds chips (and the primary sparkline) after the grid paints.
+// One gamma snapshot per event slug and one history fetch per token per
+// session; stale/detached elements are skipped via isConnected checks.
+async function hydrateTicketOdds(): Promise<void> {
+  const chips = Array.from(content.querySelectorAll<HTMLElement>('.ticket-odds-chip'));
+  if (!chips.length) {
+    stopTicketOddsPolling();
+    return;
+  }
+  const bySlug = new Map<string, HTMLElement[]>();
+  for (const chip of chips) {
+    const slug = chip.dataset.oddsEvent || '';
+    if (!slug) continue;
+    const group = bySlug.get(slug);
+    if (group) group.push(chip);
+    else bySlug.set(slug, [chip]);
+  }
+  const openTokens = new Set<string>();
+  await Promise.all(Array.from(bySlug.entries()).map(async ([slug, group]) => {
+    const snapshot = await loadPolymarketEvent(slug);
+    for (const chip of group) {
+      if (!chip.isConnected) continue;
+      const marketId = chip.dataset.oddsMarket || '';
+      const tokenId = chip.dataset.oddsToken || '';
+      const market = snapshot?.markets.get(marketId);
+      const gammaPrice = market?.prices.get(tokenId);
+      if (!market || gammaPrice === undefined) {
+        markChipUnavailable(chip);
+        continue;
+      }
+      if (market.closed) {
+        applyOddsToChip(chip, gammaPrice, true);
+      } else {
+        // Prefer a fresher midpoint from a previous poll over the
+        // session-cached gamma snapshot price.
+        applyOddsToChip(chip, polymarketMidpointPrices.get(tokenId) ?? gammaPrice, false);
+        openTokens.add(tokenId);
+      }
+    }
+  }));
+  if (activeTab !== 'models') return; // user navigated away mid-hydration
+  startTicketOddsPolling(openTokens);
+  // Sparklines for primary mappings — lazy, one history fetch per token.
+  await Promise.all(
+    Array.from(content.querySelectorAll<HTMLElement>('.ticket-odds-spark-slot')).map(async (slot) => {
+      const tokenId = slot.dataset.oddsSpark || '';
+      if (!tokenId) return;
+      const points = await loadPolymarketHistory(tokenId);
+      if (!points || !slot.isConnected) return; // no history → keep the slot empty
+      slot.replaceChildren(buildOddsSparkline(points));
+    }),
+  );
+}
+
 function ticketStatusPill(status: TicketStatus): string {
   // Color via class so dark/light mode and contrast stay consistent.
   const labels: Record<TicketStatus, string> = {
@@ -2503,12 +2866,14 @@ function ticketStatusPill(status: TicketStatus): string {
 // (note, expected, model, verification, sources, history) lives in the modal
 // that opens on click, so the board stays short and scannable.
 function ticketCard(ticket: Ticket): string {
-  // Bird's-eye board = company + title only; labels/details live in the modal.
+  // Bird's-eye board = company + title (+ live Polymarket odds chips when
+  // the ticket has market mappings); labels/details live in the modal.
   return `<article class="ticket-card ticket-card-${ticket.status}" data-slug="${escapeHtml(ticket.slug)}" tabindex="0" role="button" aria-label="${escapeHtml(ticket.title)}">
     <div class="ticket-card-top">
       <span class="ticket-company">${escapeHtml(ticket.company)}</span>
     </div>
     <h3 class="ticket-title">${escapeHtml(ticket.title)}</h3>
+    ${ticketOddsSectionHtml(ticket)}
   </article>`;
 }
 
@@ -2646,6 +3011,7 @@ document.addEventListener('keydown', (e) => {
 
 function renderTickets(tickets: Ticket[] | null): void {
   if (!tickets || tickets.length === 0) {
+    stopTicketOddsPolling();
     setSafeContent(
       content,
       `<div class="content-card"><div class="content-card-body">
@@ -2701,6 +3067,10 @@ function renderTickets(tickets: Ticket[] | null): void {
   const emptyNote = filtered.length === 0
     ? `<div class="ticket-board-empty">No tickets match the current filters.</div>`
     : '';
+  // Disclaimer shown whenever any loaded ticket carries market mappings.
+  const oddsNote = tickets.some((t) => ticketPolymarketMappings(t).length > 0)
+    ? `<p class="tickets-odds-note">Odds: Polymarket midpoints, informational only — not investment advice.</p>`
+    : '';
   setSafeContent(
     content,
     `<div class="tickets-view">
@@ -2712,8 +3082,12 @@ function renderTickets(tickets: Ticket[] | null): void {
         ${board}
       </div>
       ${emptyNote}
+      ${oddsNote}
     </div>`,
   );
+  // Hydrate odds lazily so the grid paints first; failures leave em-dash
+  // chips and never block or break the tab.
+  window.setTimeout(() => { void hydrateTicketOdds(); }, 0);
 }
 
  function frontPageBodyHtml(frontPage: FrontPageAsset): string {
@@ -3324,6 +3698,8 @@ async function load(): Promise<void> {
   const controller = new AbortController();
   activeLoadController = controller;
   stopResearchAudio();
+  // Polymarket midpoint polling only runs while the models tab is shown.
+  if (activeTab !== 'models') stopTicketOddsPolling();
 
   // Hide the floating TOC unconditionally; renderResearchDoc shows it
   // again when it has enough sections to be useful.

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -31,6 +31,23 @@ import {
   scrollToHashIfPresent,
 } from './ara-enhance';
 
+// Sanitizer-level guarantee: any sanitized anchor keeping target="_blank"
+// MUST carry rel="noopener noreferrer". Sanitized content is adversarial /
+// model-authored (digest/twitter/wiki/ticket markdown flows raw HTML
+// anchors through marked verbatim), and DOMPurify keeps `target` (it's in
+// setSafeContent's ADD_ATTR) without adding any rel — a bare target="_blank"
+// from model output would be a reverse-tabnabbing vector. App-emitted links
+// already set rel="noopener" by hand; they harmlessly gain noreferrer here.
+// Registered ONCE at module init; keys on `target`, so the sandboxed
+// standalone-doc iframe path (no target attr) is untouched. Covers every
+// sanitize call site: setSafeContent, setSafeWikiContent, and the bare
+// ticket-body sanitize.
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+  if (node instanceof Element && node.getAttribute('target') === '_blank') {
+    node.setAttribute('rel', 'noopener noreferrer');
+  }
+});
+
 const DATA_BASE: string = import.meta.env.BASE_URL + 'research';
 
 // Audio files live in S3 (s3.guzus.xyz), not in research/audio/. The mp3s in
@@ -2777,8 +2794,11 @@ async function pollOddsMidpoints(): Promise<void> {
     const mid = Number((data as { mid?: unknown } | null)?.mid);
     if (!Number.isFinite(mid) || mid < 0 || mid > 1) return; // closed/error bodies land here
     polymarketMidpointPrices.set(tokenId, mid);
+    // CSS.escape: token ids are digit strings in practice, but the validator
+    // only requires a non-empty string — a hostile-but-legal value must not
+    // throw a selector SyntaxError inside the poll loop.
     for (const chip of content.querySelectorAll<HTMLElement>(
-      `.ticket-odds-chip[data-odds-token="${tokenId}"]`,
+      `.ticket-odds-chip[data-odds-token="${CSS.escape(tokenId)}"]`,
     )) {
       applyOddsToChip(chip, mid, false);
     }

--- a/dashboard/src/style.css
+++ b/dashboard/src/style.css
@@ -4356,6 +4356,82 @@ body.modal-open { overflow: hidden; }
   font-weight: 500;
 }
 
+/* ── Polymarket odds on ticket cards ──────────────────
+ * One chip per market mapping (max 3, wraps on narrow cards / mobile) plus
+ * an inline sparkline for the primary mapping. Hydrated lazily after the
+ * grid paints; an unreachable Polymarket leaves em-dash chips only. */
+.ticket-odds {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+.ticket-odds-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  max-width: 100%;
+  padding: 2px 8px;
+  border: 1px solid var(--border-light);
+  border-radius: 999px;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.5;
+  text-decoration: none;
+  white-space: nowrap;
+  transition: border-color 120ms ease, color 120ms ease, background 120ms ease;
+}
+.ticket-odds-chip:hover {
+  border-color: var(--accent-warm);
+  background: var(--bg-hover);
+  color: var(--accent-warm);
+}
+.ticket-odds-pct {
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: var(--text);
+}
+.ticket-odds-chip:hover .ticket-odds-pct { color: var(--accent-warm); }
+.ticket-odds-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 150px;
+  color: var(--text-tertiary);
+}
+/* Resolved markets: final ✓/✗ + 0/100% from the gamma snapshot. */
+.ticket-odds-chip.is-resolved-yes .ticket-odds-pct { color: #166534; }
+.ticket-odds-chip.is-resolved-no  .ticket-odds-pct { color: #b91c1c; }
+.ticket-odds-chip.is-unavailable { opacity: 0.65; }
+.ticket-odds-spark-slot {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+}
+.ticket-odds-spark {
+  width: 120px;
+  height: 28px;
+  display: block;
+  color: var(--accent-warm);
+  opacity: 0.9;
+}
+.tickets-odds-note {
+  margin-top: 10px;
+  font-size: 11px;
+  color: var(--text-tertiary);
+}
+@media (prefers-color-scheme: dark) {
+  .ticket-odds-chip.is-resolved-yes .ticket-odds-pct { color: #86efac; }
+  .ticket-odds-chip.is-resolved-no  .ticket-odds-pct { color: #fca5a5; }
+}
+@media (max-width: 640px) {
+  /* Stacked mobile columns are full-width — let the label breathe but keep
+   * chips wrapping instead of forcing horizontal overflow. */
+  .ticket-odds-label { max-width: 40vw; }
+  .ticket-odds-spark { width: 96px; height: 24px; }
+}
+
 .ticket-verification {
   font-size: 10.5px;
   padding: 2px 6px;

--- a/docs/model-tickets.md
+++ b/docs/model-tickets.md
@@ -54,6 +54,12 @@ sources:                           # required, list of citations (URLs or @handl
   - https://red.anthropic.com/2026/mythos-preview/
   - "@scaling01"
   - "@kimmonismus"
+polymarket:                        # optional, 1-3 Polymarket market mappings (see "Polymarket market mappings")
+  - event_slug: mythos-released-by         # required, gamma event slug (polymarket.com/event/<event_slug>)
+    market_id: "2850825"                   # required, gamma market id — quote it, must be a string
+    token_id: "31380452762865791793..."    # required, CLOB YES-outcome token id — quote it, must be a string
+    question: "Mythos released by Aug 31, 2026?"   # required, human question incl. the outcome
+    outcome: "Aug 31 2026"                 # optional, short outcome label for the dashboard chip
 created_at: 2026-04-15             # required, YYYY-MM-DD
 updated_at: 2026-05-16             # required, YYYY-MM-DD (>= created_at)
 closed_at: null                    # required, YYYY-MM-DD when status=closed, else null
@@ -126,6 +132,58 @@ captures this in `verification`:
 If a ticket sits at `unverified` for more than ~15 daily cycles, the
 CRUD agent may close it with `closed_reason: stale-rumor-unverified`.
 
+## Polymarket market mappings (optional)
+
+A ticket tracks a real-world event; a Polymarket market is the crowd's
+live probability for that event. The optional `polymarket:` frontmatter
+key binds the two so the dashboard's models tab can render live odds
+(and their evolution) on the ticket card.
+
+Shape — a list of 1–3 mappings, **most-relevant first** (the first
+mapping is the primary one and gets the price-history sparkline):
+
+| Field        | Required | Meaning                                                                    |
+|--------------|----------|-----------------------------------------------------------------------------|
+| `event_slug` | yes      | Gamma event slug — the page at `https://polymarket.com/event/<event_slug>`  |
+| `market_id`  | yes      | Gamma market `id` inside that event (string — quote it in YAML)             |
+| `token_id`   | yes      | CLOB token id of the **Yes** outcome (string — quote it; ~78 digits)        |
+| `question`   | yes      | Human-readable market question including the outcome/date                   |
+| `outcome`    | no       | Short outcome label for the chip, e.g. `"Dec 31 2026"`                       |
+
+Validator rules (`scripts/check_model_tickets.py`): the key may be
+omitted or `null`; when present it must be a list of 1–3 mappings; every
+required field must be a non-empty **string** (`market_id` and
+`token_id` must be quoted in YAML — an unquoted 78-digit token id parses
+as a number and loses precision); no keys other than the five above are
+allowed inside a mapping.
+
+Maintenance protocol for the CRUD agent:
+
+1. **Add** a mapping only when a clearly-matching **active** market
+   exists — the market's resolution criteria must resolve on the same
+   real-world event the ticket tracks (e.g. a "GPT-6 released by ..."
+   market does NOT match a GPT-5.6 ticket; a "Grok 5" market that
+   excludes Grok 4.x variants does NOT match a Grok 4.5 ticket). Find
+   candidates via
+   `https://gamma-api.polymarket.com/public-search?q=<terms>&events_status=active`,
+   then read the event via
+   `https://gamma-api.polymarket.com/events?slug=<event_slug>` and check
+   the market's `description` text before mapping.
+2. **Never invent IDs.** Only use `event_slug` / `market_id` /
+   `token_id` values read from the Polymarket API response
+   (`markets[].id` and the first element of the market's
+   `clobTokenIds` JSON array = the Yes token). No recalled,
+   pattern-matched, or guessed IDs.
+3. **Keep mappings when markets resolve.** Final odds and the price
+   history stay valuable on released/closed tickets — do not remove a
+   mapping because the market closed.
+4. **Max 3 mappings per ticket**, most-relevant first. Prefer one
+   near-term date market plus (optionally) a longer-dated one from the
+   same event.
+
+Adding, correcting, or pruning a mapping is a ticket UPDATE: bump
+`updated_at` and append a `history` entry describing the change.
+
 ## Slug conventions
 
 - Lowercase ASCII, hyphen-separated, no underscores
@@ -184,6 +242,11 @@ signal:
      (`closed_reason: superseded-by:<successor-slug>`)
 
 6. **Never delete**. Closing preserves history; deletion does not.
+
+7. **Polymarket mappings** follow the "Polymarket market mappings"
+   section above: add one only when a clearly-matching active market
+   exists, keep mappings after markets resolve, never invent IDs (only
+   IDs read from the Polymarket API), max 3 per ticket.
 
 ## Daily diff
 

--- a/research/models/tickets/anthropic-ipo-2026-06.md
+++ b/research/models/tickets/anthropic-ipo-2026-06.md
@@ -33,13 +33,21 @@ sources:
   - "@KateClarkTweets"
   - "@cdriebusch"
   - "@SpirosMargaris"
+polymarket:
+  - event_slug: anthropic-ipo-by
+    market_id: "2413330"
+    token_id: "48566046548914168443252668519852295704538578584318207505303160546351275413281"
+    question: "Anthropic IPO by Dec 31, 2026?"
+    outcome: "Dec 31 2026"
 created_at: 2026-06-02
-updated_at: 2026-06-02
+updated_at: 2026-07-13
 closed_at: null
 closed_reason: null
 history:
   - ts: 2026-06-02
     change: "Created — Anthropic confidentially filed S-1 with the SEC 2026-06-01, ahead of OpenAI in the public-markets race. Revenue run-rate ~$47B (May 2026) vs ~$10B the prior year; valuation $965B post-Series-H. WSJ broke the story (@KateClarkTweets, @cdriebusch), corroborated by The Register, US News, Fox Business, Spokesman, Ground News in-window. Status: confirmed; verification: confirmed (multiple primary press outlets + Anthropic on-record acknowledgment per US News framing 'the company said on Monday'). Public S-1 follow-on expected ~1 month after the confidential filing; the IPO follows on from there. Distinct from but downstream of [[anthropic-series-h-2026-05]] (the $65B Series H provided the post-money baseline) and [[anthropic-spacex-colossus-2026-05]] (the SpaceX Colossus compute lease that was disclosed in connection with the S-1 prep)"
+  - ts: 2026-07-13
+    change: "Linked Polymarket odds (metadata-only, no status change): 'Will Anthropic IPO by December 31, 2026?' (event anthropic-ipo-by, market 2413330, ~66% Yes at link time) — the market prices this ticket's central open question, the IPO completing in 2026 after the 2026-06-01 confidential S-1. IDs read from the gamma API."
 ---
 
 Anthropic **confidentially filed an S-1 registration statement with

--- a/research/models/tickets/gemini-3-5-pro.md
+++ b/research/models/tickets/gemini-3-5-pro.md
@@ -63,8 +63,14 @@ sources:
   - "@demishassabis"
   - "@yuichisatoeco"
   - "@TeksCreate"
+polymarket:
+  - event_slug: new-gemini-reasoning-flagship-released-by
+    market_id: "2744113"
+    token_id: "25761338113444612714107266818739035748862800597161579847841911944183859450941"
+    question: "New Gemini reasoning flagship released by Jul 31, 2026?"
+    outcome: "Jul 31 2026"
 created_at: 2026-05-20
-updated_at: 2026-07-12
+updated_at: 2026-07-13
 closed_at: null
 closed_reason: null
 history:
@@ -82,6 +88,8 @@ history:
     change: "Date rumor fragments further: contradictory claims now circulate in the same window (July 17 vs. a competing July 22 figure vs. a reply denying the model exists at all), plus a separate zero-engagement claim of a 2M-token context window (vs. Claude's 1M), no Google confirmation. Unconfirmed across twelve consecutive digest cycles now with internal contradiction on both date and spec. Status stays confirmed (I/O commitment only); verification stays confirmed; the retrain/date/context-size cluster stays unverified."
   - ts: 2026-07-12
     change: "Rumor cluster directly rebutted: a Japanese-language post traces the '2M context / July 17' figures to leak-articles citing each other (not Google's blog), and notes Google's own Vertex AI catalog doesn't list a 'Gemini 3.5 Pro' entry (only 3.1 Pro / 3 Pro Image / 2.5 Pro) — while a same-day account still restates the 2M/July-17 claim as fact. Confirms the unverified flag; no primary Google source has surfaced. Status stays confirmed; verification stays confirmed; retrain/date/context cluster stays unverified."
+  - ts: 2026-07-13
+    change: "Linked Polymarket odds (metadata-only, no status change): 'Will a new Gemini flagship be released by July 31, 2026?' (event new-gemini-reasoning-flagship-released-by, market 2744113, ~79% Yes at link time). IDs read from the gamma API; the market's resolution text requires a next-generation reasoning-focused Gemini flagship, which is exactly what this ticket tracks."
 ---
 
 At Google I/O 2026, Google revealed the **Gemini 3.5** family. The first

--- a/research/models/tickets/openai-ipo-2026-06.md
+++ b/research/models/tickets/openai-ipo-2026-06.md
@@ -50,8 +50,19 @@ sources:
   - "@kimmonismus"
   - "@NikkeiAsia"
   - "@AndrewCurran_"
+polymarket:
+  - event_slug: openai-ipo-by
+    market_id: "656312"
+    token_id: "78959017184382580042532738046363918551357602274462396865643365060706535362447"
+    question: "OpenAI IPO by Dec 31, 2026?"
+    outcome: "Dec 31 2026"
+  - event_slug: openai-1t-valuation-in-2026
+    market_id: "1294378"
+    token_id: "64331993849372828574205433970128694273870271382825385630135274078215785897027"
+    question: "OpenAI $1T+ valuation in 2026?"
+    outcome: "In 2026"
 created_at: 2026-06-09
-updated_at: 2026-06-26
+updated_at: 2026-07-13
 closed_at: null
 closed_reason: null
 history:
@@ -59,6 +70,8 @@ history:
     change: "Created — OpenAI's newsroom confirmed on record it 'recently submitted a confidential S-1,' pre-empting an expected leak and stressing timing is undecided. OpenAI primary statement → status confirmed, verification confirmed. Media-only (not in OpenAI's statement): up-to-$1T valuation, ~$2B/month revenue, possible September debut, Goldman Sachs / Morgan Stanley as leads. Lands days after Anthropic's confidential filing ([[anthropic-ipo-2026-06]]) and a week before the SpaceX debut ([[spacex-ipo-2026-06]]) — the AI IPO supercycle now formally on the record"
   - ts: 2026-06-26
     change: "NYT reported OpenAI is leaning toward delaying its IPO to 2027 (from Q3/Q4 2026), with Altman pushing advisers for a $1T valuation and rejecting lower offers; advisers warned retail appetite may not hold after SpaceX's volatile post-IPO trading (ATH $201.80→$154.54, -23%; [[spacex-ipo-2026-06]]). Financials per NYT: ~$13B 2025 revenue, ~$2B/mo now, hoping to ~triple this year; bankers/lawyers hired for Q3/Q4 2026; prior private valuation ~$852B (Mar 2026). Severe market reaction: SoftBank -12–13% (~$65B OpenAI exposure), ¥5.6T erased, Nikkei -4%, KOSPI circuit breaker (-5.81%). Single-sourced to NYT ('people familiar'), no OpenAI confirmation/denial — the delay could be negotiating posture (bridge financing) rather than a fixed decision. The filing stays confirmed; the 2027 lean + $1T ask is NYT-reported → status confirmed, verification confirmed (credible outlet + observable market reaction). Pairs with the GPT-5.6 federal-stagger story ([[openai-gpt-5-6]]) as compounding near-term monetization constraints. Sources: @kimmonismus (NYT relay), @NikkeiAsia, @AndrewCurran_."
+  - ts: 2026-07-13
+    change: "Linked Polymarket odds (metadata-only, no status change): 'Will OpenAI IPO by December 31 2026?' (event openai-ipo-by, market 656312, ~22% Yes at link time) and 'OpenAI $1T+ valuation in 2026?' (event openai-1t-valuation-in-2026, market 1294378, ~58% Yes) — the two markets price exactly this ticket's open questions (IPO timing after the NYT 2027-lean report, and the $1T ask Altman is reportedly holding out for). IDs read from the gamma API."
 ---
 
 OpenAI **confirmed on record, via its own newsroom**, that it has

--- a/scripts/check_model_tickets.py
+++ b/scripts/check_model_tickets.py
@@ -33,6 +33,12 @@ SLUG_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
 HANDLE_RE = re.compile(r"^@[A-Za-z0-9_]{1,30}$")
 URL_RE = re.compile(r"^https?://\S+$")
 
+# Optional `polymarket:` frontmatter — see "Polymarket market mappings"
+# in docs/model-tickets.md. Keep these in lockstep with the doc.
+POLYMARKET_REQUIRED_KEYS = ("event_slug", "market_id", "token_id", "question")
+POLYMARKET_ALLOWED_KEYS = frozenset(POLYMARKET_REQUIRED_KEYS + ("outcome",))
+POLYMARKET_MAX_MAPPINGS = 3
+
 
 @dataclass
 class Failure:
@@ -159,6 +165,48 @@ def _check_history(val: Any, path: Path, report: Report, created_at: date | None
             prev_ts = ts
 
 
+def _check_polymarket(val: Any, path: Path, report: Report) -> None:
+    """Validate the optional `polymarket:` list of market mappings.
+
+    Contract (docs/model-tickets.md, "Polymarket market mappings"):
+    omitted or null is fine; otherwise a list of 1..3 mappings, each with
+    non-empty string event_slug/market_id/token_id/question, an optional
+    non-empty string outcome, and no other keys. market_id/token_id must
+    be YAML strings (quoted) — unquoted 78-digit token ids parse as
+    numbers and lose precision.
+    """
+    if val is None:
+        return
+    if not isinstance(val, list):
+        report.fail(path, "polymarket", f"must be a list of market mappings, got {type(val).__name__}")
+        return
+    if not val:
+        report.fail(path, "polymarket", "must have at least one mapping when present — omit the key instead")
+        return
+    if len(val) > POLYMARKET_MAX_MAPPINGS:
+        report.fail(
+            path, "polymarket",
+            f"at most {POLYMARKET_MAX_MAPPINGS} mappings per ticket (most-relevant first), got {len(val)}",
+        )
+    for i, mapping in enumerate(val):
+        if not isinstance(mapping, dict):
+            report.fail(path, "polymarket", f"mapping {i} must be a mapping with {'/'.join(POLYMARKET_REQUIRED_KEYS)} keys")
+            continue
+        unknown = sorted(set(mapping) - POLYMARKET_ALLOWED_KEYS)
+        if unknown:
+            report.fail(path, "polymarket", f"mapping {i} has unknown key(s): {', '.join(unknown)}")
+        for key in POLYMARKET_REQUIRED_KEYS:
+            v = mapping.get(key)
+            if not isinstance(v, str) or not v.strip():
+                report.fail(
+                    path, "polymarket",
+                    f"mapping {i} {key} must be a non-empty string (quote numeric ids in YAML), got {v!r}",
+                )
+        outcome = mapping.get("outcome")
+        if outcome is not None and (not isinstance(outcome, str) or not outcome.strip()):
+            report.fail(path, "polymarket", f"mapping {i} outcome must be a non-empty string or omitted, got {outcome!r}")
+
+
 def check_ticket(path: Path, report: Report) -> None:
     report.files_checked += 1
     try:
@@ -228,6 +276,9 @@ def check_ticket(path: Path, report: Report) -> None:
     if "labels" in data and data["labels"] is not None:
         if not isinstance(data["labels"], list) or not all(isinstance(l, str) for l in data["labels"]):
             report.fail(path, "labels", "must be a list of strings or null")
+
+    if "polymarket" in data:
+        _check_polymarket(data["polymarket"], path, report)
 
     body_stripped = body.strip()
     if not body_stripped:

--- a/scripts/test_check_model_tickets.py
+++ b/scripts/test_check_model_tickets.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Tests for scripts/check_model_tickets.py — focused on the optional
+`polymarket:` frontmatter contract (docs/model-tickets.md, "Polymarket
+market mappings") plus a base-schema smoke test."""
+
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+import check_model_tickets as cmt
+
+VALID_MAPPING = textwrap.dedent(
+    """\
+    polymarket:
+      - event_slug: anthropic-ipo-by
+        market_id: "2413330"
+        token_id: "48566046548914168443252668519852295704538578584318207505303160546351275413281"
+        question: "Anthropic IPO by Dec 31, 2026?"
+        outcome: "Dec 31 2026"
+    """
+)
+
+
+def make_ticket(polymarket_block: str = "") -> str:
+    return textwrap.dedent(
+        """\
+        ---
+        slug: test-ticket
+        title: Test ticket
+        company: TestCo
+        model: TestModel
+        status: confirmed
+        verification: confirmed
+        sources:
+          - "@testhandle"
+        {polymarket}created_at: 2026-07-01
+        updated_at: 2026-07-13
+        closed_at: null
+        closed_reason: null
+        history:
+          - ts: 2026-07-01
+            change: Created
+        ---
+
+        Body narrative.
+        """
+    ).format(polymarket=polymarket_block)
+
+
+class CheckPolymarketTest(unittest.TestCase):
+    def check(self, text: str) -> cmt.Report:
+        report = cmt.Report()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "test-ticket.md"
+            path.write_text(text, encoding="utf-8")
+            cmt.check_ticket(path, report)
+        return report
+
+    def polymarket_failures(self, report: cmt.Report) -> list[str]:
+        return [f.msg for f in report.failures if f.field == "polymarket"]
+
+    def test_absent_key_passes(self):
+        report = self.check(make_ticket())
+        self.assertTrue(report.ok(), [f"{f.field}: {f.msg}" for f in report.failures])
+
+    def test_valid_mapping_passes(self):
+        report = self.check(make_ticket(VALID_MAPPING))
+        self.assertTrue(report.ok(), [f"{f.field}: {f.msg}" for f in report.failures])
+
+    def test_null_key_passes(self):
+        report = self.check(make_ticket("polymarket: null\n"))
+        self.assertTrue(report.ok(), [f"{f.field}: {f.msg}" for f in report.failures])
+
+    def test_outcome_is_optional(self):
+        block = "\n".join(line for line in VALID_MAPPING.splitlines() if "outcome" not in line) + "\n"
+        report = self.check(make_ticket(block))
+        self.assertTrue(report.ok(), [f"{f.field}: {f.msg}" for f in report.failures])
+
+    def test_missing_token_id_fails(self):
+        block = "\n".join(line for line in VALID_MAPPING.splitlines() if "token_id" not in line) + "\n"
+        report = self.check(make_ticket(block))
+        self.assertFalse(report.ok())
+        self.assertTrue(any("token_id" in msg for msg in self.polymarket_failures(report)))
+
+    def test_unquoted_numeric_market_id_fails(self):
+        block = VALID_MAPPING.replace('market_id: "2413330"', "market_id: 2413330")
+        report = self.check(make_ticket(block))
+        self.assertFalse(report.ok())
+        self.assertTrue(any("market_id" in msg for msg in self.polymarket_failures(report)))
+
+    def test_more_than_three_mappings_fails(self):
+        entry_lines = "\n".join(VALID_MAPPING.splitlines()[1:])  # the "- event_slug: ..." mapping lines
+        block = "polymarket:\n" + (entry_lines + "\n") * 4
+        report = self.check(make_ticket(block))
+        self.assertFalse(report.ok())
+        self.assertTrue(any("at most 3" in msg for msg in self.polymarket_failures(report)))
+
+    def test_empty_list_fails(self):
+        report = self.check(make_ticket("polymarket: []\n"))
+        self.assertFalse(report.ok())
+        self.assertTrue(any("omit the key" in msg for msg in self.polymarket_failures(report)))
+
+    def test_unknown_key_inside_mapping_fails(self):
+        block = VALID_MAPPING.rstrip() + '\n    midpoint: "0.5"\n'
+        report = self.check(make_ticket(block))
+        self.assertFalse(report.ok())
+        self.assertTrue(any("unknown key" in msg for msg in self.polymarket_failures(report)))
+
+    def test_non_list_fails(self):
+        report = self.check(make_ticket('polymarket: "anthropic-ipo-by"\n'))
+        self.assertFalse(report.ok())
+        self.assertTrue(any("must be a list" in msg for msg in self.polymarket_failures(report)))
+
+    def test_base_schema_still_enforced(self):
+        # Sanity: an unrelated schema violation still fails alongside the new key.
+        text = make_ticket(VALID_MAPPING).replace("status: confirmed", "status: imaginary")
+        report = self.check(text)
+        self.assertFalse(report.ok())
+        self.assertTrue(any(f.field == "status" for f in report.failures))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_check_model_tickets.py
+++ b/scripts/test_check_model_tickets.py
@@ -89,6 +89,19 @@ class CheckPolymarketTest(unittest.TestCase):
         self.assertFalse(report.ok())
         self.assertTrue(any("market_id" in msg for msg in self.polymarket_failures(report)))
 
+    def test_unquoted_numeric_token_id_fails(self):
+        # token_id is the load-bearing precision field: unquoted, YAML parses
+        # the ~78-digit id as a number (and JS parsers lose precision), so the
+        # validator must reject non-string values outright.
+        block = VALID_MAPPING.replace(
+            'token_id: "48566046548914168443252668519852295704538578584318207505303160546351275413281"',
+            "token_id: 48566046548914168443252668519852295704538578584318207505303160546351275413281",
+        )
+        self.assertNotEqual(block, VALID_MAPPING)  # guard: replacement matched
+        report = self.check(make_ticket(block))
+        self.assertFalse(report.ok())
+        self.assertTrue(any("token_id" in msg for msg in self.polymarket_failures(report)))
+
     def test_more_than_three_mappings_fails(self):
         entry_lines = "\n".join(VALID_MAPPING.splitlines()[1:])  # the "- event_slug: ..." mapping lines
         block = "polymarket:\n" + (entry_lines + "\n") * 4


### PR DESCRIPTION
## What

Model-timeline tickets are real-world events; Polymarket prices are the market's live probability for those events. This PR binds them: tickets may now carry an optional `polymarket:` frontmatter mapping (schema + validator + CRUD protocol), and the dashboard's models tab renders live odds chips plus a price-history sparkline per mapped ticket.

- **Schema** (`docs/model-tickets.md`): optional `polymarket:` list of 1–3 mappings (`event_slug`, `market_id`, `token_id`, `question`, optional `outcome`), most-relevant first — first mapping is primary and gets the sparkline. New "Polymarket market mappings" section documents the maintenance protocol: add only for a clearly-matching **active** market (checked against the market's resolution text), **never invent IDs** (only IDs read from the gamma API), keep mappings after markets resolve, max 3.
- **Validator** (`scripts/check_model_tickets.py`, in lockstep with the doc): list of 1–3 mappings, non-empty string fields, no unknown keys inside a mapping, quoted-string ids (an unquoted 78-digit token id parses as a YAML number and loses precision). 11 new unit tests in `scripts/test_check_model_tickets.py`.
- **Prebuild** (`dashboard/scripts/prebuild.mjs`): lenient per-mapping shape check into `models/tickets/index.json` — malformed mappings are dropped with a `console.warn`, never failing the deploy (verified with a synthetic malformed ticket).
- **Dashboard** (`dashboard/src/main.ts`, `dashboard/src/style.css`): odds chips on ticket cards (one per mapping, max 3; link to `polymarket.com/event/<slug>` in a new tab), resolved markets render ✓/✗ + final 0/100%, primary mapping gets a ~120×28 inline SVG sparkline (no libraries, `currentColor` stroke, light+dark themes), chips wrap on mobile, and a footer disclaimer: *"Odds: Polymarket midpoints, informational only — not investment advice."*
- **CRUD agent** (`.github/workflows/24h-model-timeline.yml`): one prompt bullet pointing at the new schema section (actionlint clean).

## Seed mappings (IDs verified against the live gamma API at build time)

| Ticket | Market(s) | Odds at link time |
|---|---|---|
| `gemini-3-5-pro` | New Gemini reasoning flagship released by Jul 31, 2026? (`new-gemini-reasoning-flagship-released-by`, market 2744113) | ~79% |
| `openai-ipo-2026-06` | OpenAI IPO by Dec 31, 2026? (`openai-ipo-by`, 656312); OpenAI $1T+ valuation in 2026? (`openai-1t-valuation-in-2026`, 1294378) | ~22% / ~58% |
| `anthropic-ipo-2026-06` | Anthropic IPO by Dec 31, 2026? (`anthropic-ipo-by`, 2413330) | ~66% |

**Deliberately skipped** (per the "map only when the ticket clearly corresponds" rule — each verified against the live market's resolution text):
- `gpt-6-released-by`: requires a model named **GPT-6**; the repo ticket (`openai-gpt-5-6`) tracks GPT-5.6, which already released without resolving this market — different event.
- `next-claude-opus-released-byptptpt-…`: series created 2026-07-01, qualifies **Opus 4.9 / 5.0 / 5** only; `opus-4-8` is closed for a release that predates the market, and no ticket tracks the next Opus yet.
- `grok-5-released-byptptpt-…`: resolution text **excludes Grok 4-generation variants**; the repo ticket (`grok-v9-medium`) is now branded Grok 4.5, whose release would resolve this market *No*.

The CRUD agent can attach these later if matching tickets appear — that is exactly the maintenance protocol this PR documents.

## API contract notes (verified live)

- **CORS**: `gamma-api.polymarket.com` and `clob.polymarket.com` send `access-control-allow-origin: *`, no auth. Fetches use plain `fetch()` with **no credentials option** — CLOB also sends `allow-credentials: true`, and a credentialed request makes browsers reject the `ACAO:*` response.
- **Snapshot**: one `GET /events?slug=<event_slug>` renders every outcome; `outcomes` / `outcomePrices` / `clobTokenIds` are **stringified JSON arrays** (double-parsed, index-aligned, guarded).
- **Resolution fallback**: on closed markets `/midpoint` 200s with an error body — closed markets are **never polled**; their final price renders from the gamma `outcomePrices` (0/1) and the sparkline stays (`prices-history` works on resolved tokens). Market-level `active`/`closed` is trusted, **not** event-level (observed drift on `gpt-6-released-by`: event endDate 2025-12-31 with child markets active into 2026).
- **Politeness**: gamma snapshot once per session per event slug, history once per session per token, midpoint poll every 60s for **open** markets only and only while the models tab is shown (interval cleared on tab switch; ticks skipped while `document.hidden`). A failed fetch is evicted from the session cache so a later visit may retry once — no retry storms.

## Degradation guarantees (tested in a real browser)

- Both Polymarket hosts blackholed → the models tab renders **fully** (124 cards, 5 columns), chips show an em-dash with title `odds unavailable`, zero page errors.
- One malformed mapping in one ticket → prebuild drops that mapping with a warning and ships the rest; the strict validator (CI + CRUD agent) is the hard gate.
- 10s fetch timeout on every Polymarket call; all parsing shape-checked.

Verified with the live API: chips rendered 65% / 79% / 22% / 58% matching the gamma snapshot; 3 sparklines drew; the 60s poll fired exactly once per open token and stopped after switching tabs; a temporarily-mapped resolved market rendered `✗ 0%`; dark mode + 390px mobile checked (no horizontal overflow, chips wrap).

## Note for reviewers

`setSafeContent`'s DOMPurify allowlist now includes `target` (plus the four `data-odds-*` attributes). DOMPurify 3.x strips `target` by default, so every pre-existing `target="_blank"` in the app (ticket sources, research links) was being silently removed; all such anchors here pair it with `rel="noopener"`, so allowing it restores intended behavior safely.

## Verification

- `uv run python scripts/check_model_tickets.py` → `OK — 124 ticket(s) valid`
- `uv run python -m unittest discover -s scripts -p 'test_*.py'` → `Ran 498 tests … OK (skipped=6)`
- `cd dashboard && bun install --frozen-lockfile && bun run build` → prebuild + tsc + vite + postbuild green
- `actionlint .github/workflows/24h-model-timeline.yml` → clean
- Built bundle's external hosts: pre-existing (github, tradingview, s3.guzus.xyz) + exactly `polymarket.com`, `gamma-api.polymarket.com`, `clob.polymarket.com`

## v1 non-goals (follow-ups)

No WebSocket feeds, no stock-ticker tagging, no ticket-history event markers overlaid on sparklines, no new tickets, no server/proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)