### PR TITLE
Clarify GitHub Actions timeline header

### DIFF
--- a/dashboard/src/render/agents.ts
+++ b/dashboard/src/render/agents.ts
@@ -139,13 +139,8 @@ export function renderAgentsStudioHtml(): string {
     '  <div class="content-card agents-lite-card">',
     '    <div class="content-card-header agents-lite-header">',
     '      <div>',
-    '        <div class="content-card-title">Agent workers</div>',
-    '        <p>Real completed and scheduled pipeline work, shown by UTC start and end time.</p>',
-    '      </div>',
-    '      <div class="agents-lite-metrics" id="armMetrics">',
-    '        <div class="agents-lite-metric"><span>completed</span><strong>--</strong></div>',
-    '        <div class="agents-lite-metric"><span>scheduled</span><strong>--</strong></div>',
-    '        <div class="agents-lite-metric"><span>window</span><strong>--</strong></div>',
+    '        <div class="content-card-title">ai-research-arm runs on automated GitHub Actions.</div>',
+    '        <p>Below is the recent and upcoming run schedule. Read how it works in this <a href="https://guzus.substack.com/p/open-sourcing-ai-research-arm-ara" target="_blank" rel="noopener noreferrer">blog post</a>.</p>',
     '      </div>',
     '    </div>',
     '    <div class="content-card-body agents-lite-body" id="armTimeline">',
@@ -158,7 +153,6 @@ export function renderAgentsStudioHtml(): string {
 
 export function hydrateAgentsTimeline(root: ParentNode, timeline: ArmTimeline | null): void {
   const mount = root.querySelector<HTMLElement>('#armTimeline');
-  const metrics = root.querySelector<HTMLElement>('#armMetrics');
   if (!mount) return;
   mount.replaceChildren();
 
@@ -190,26 +184,9 @@ export function hydrateAgentsTimeline(root: ParentNode, timeline: ArmTimeline | 
     return;
   }
 
-  const completed = items.filter((item) => item.kind === 'completed').length;
-  const scheduled = items.filter((item) => item.kind === 'scheduled').length;
-  if (metrics) {
-    metrics.replaceChildren();
-    for (const [label, value] of [
-      ['completed', String(completed)],
-      ['scheduled', String(scheduled)],
-      ['window', formatDuration(windowStartMs, windowEndMs)],
-    ]) {
-      const card = document.createElement('div');
-      card.className = 'agents-lite-metric';
-      card.appendChild(makeText('span', '', label));
-      card.appendChild(makeText('strong', '', value));
-      metrics.appendChild(card);
-    }
-  }
-
   const header = document.createElement('div');
   header.className = 'agents-work-summary';
-  header.appendChild(makeText('div', 'agents-work-summary-title', 'UTC work ledger'));
+  header.appendChild(makeText('div', 'agents-work-summary-title', 'GitHub Actions'));
   header.appendChild(makeText('div', 'agents-work-summary-meta', formatUtcDateTime(windowStartMs) + ' - ' + formatUtcDateTime(windowEndMs)));
   mount.appendChild(header);
 

--- a/dashboard/src/style.css
+++ b/dashboard/src/style.css
@@ -659,11 +659,7 @@ body.tab-agents .section-nav {
 }
 
 .content-card-header.agents-lite-header {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(280px, 340px);
-  align-items: start;
-  justify-content: space-between;
-  gap: 18px;
+  display: block;
 }
 
 .agents-lite-header > div {
@@ -678,38 +674,9 @@ body.tab-agents .section-nav {
   letter-spacing: 0;
 }
 
-.agents-lite-metrics {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(88px, 1fr));
-  gap: 8px;
-  min-width: min(100%, 340px);
-}
-
-.agents-lite-metric {
-  min-height: 58px;
-  display: grid;
-  gap: 3px;
-  align-content: center;
-  padding: 9px 10px;
-  border: 1px solid var(--border-light);
-  border-radius: 8px;
-  background: var(--bg-secondary);
-}
-
-.agents-lite-metric span {
-  color: var(--text-tertiary);
-  font-size: 0.72rem;
-  font-style: normal;
-  font-weight: 650;
-  letter-spacing: 0;
-  line-height: 1.2;
-  text-transform: uppercase;
-}
-
-.agents-lite-metric strong {
-  color: var(--text);
-  font-size: 1.3rem;
-  line-height: 1;
+.agents-lite-header a {
+  color: var(--accent-warm);
+  text-underline-offset: 2px;
 }
 
 .agents-lite-body {
@@ -941,15 +908,6 @@ body.tab-agents .section-nav {
 }
 
 @media (max-width: 760px) {
-  .content-card-header.agents-lite-header {
-    grid-template-columns: 1fr;
-  }
-
-  .agents-lite-metrics {
-    width: 100%;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-
   .agents-work-summary {
     display: grid;
   }


### PR DESCRIPTION
## Summary
- replace the Agent workers copy with an explanation of the automated GitHub Actions schedule and a link to the ARA blog post
- rename UTC work ledger to GitHub Actions
- remove the completed, scheduled, and window metric cards and their unused styling/hydration logic

## Verification
- bun run build
- browser QA at 1280x720 and 375x812
- confirmed zero metric cards, correct blog URL, no page overflow, and no console errors

## Release path
This repository has no staging branch, so this PR targets main.