### PR TITLE
Add explicit Fable 5 generative research backend

### DIFF
--- a/.github/workflows/generative-research.yml
+++ b/.github/workflows/generative-research.yml
@@ -12,6 +12,7 @@ name: Generative Research
 # Backends, mutually exclusive at runtime:
 #   * glm-5p2  — preferred default: GLM 5.2 through Fireworks' Anthropic-compatible endpoint.
 #   * claude   — anthropics/claude-code-action@v1 with OAuth (model claude-sonnet-5).
+#   * fable-5  — explicit, premium native Anthropic path (model claude-fable-5).
 #   * codex    — Codex CLI signed in with ChatGPT-managed auth.json.
 #   * deepseek — comparison/fallback route through Fireworks'
 #                Anthropic-compatible endpoint via ANTHROPIC_BASE_URL /
@@ -62,6 +63,7 @@ on:
           - deepseek-v4-flash
           - codex
           - claude
+          - fable-5
           - deepseek
       fireworks_fallback:
         description: 'If a Fireworks backend fails preflight: claude = fall back to native Claude (default), none = fail the run (strict backend comparison)'
@@ -249,12 +251,13 @@ jobs:
               case "$CANDIDATE" in
                 default) CANDIDATE="$DEFAULT_BACKEND" ;;
                 claude-opus-4-8|claude-sonnet-5) CANDIDATE="claude" ;;
+                claude-fable-5|fable-5) CANDIDATE="fable-5" ;;
                 codex|openai-codex) CANDIDATE="codex" ;;
                 deepseek) CANDIDATE="deepseek-v4-flash" ;;
                 glm-5.2|glm5.2|glm52|glm-5p2) CANDIDATE="glm-5p2" ;;
               esac
               if [ -n "${CANDIDATE:-}" ]; then
-                if [ "$CANDIDATE" != "claude" ] && [ "$CANDIDATE" != "codex" ] && [ "$CANDIDATE" != "deepseek-v4-flash" ] && [ "$CANDIDATE" != "glm-5p2" ]; then
+                if [ "$CANDIDATE" != "claude" ] && [ "$CANDIDATE" != "fable-5" ] && [ "$CANDIDATE" != "codex" ] && [ "$CANDIDATE" != "deepseek-v4-flash" ] && [ "$CANDIDATE" != "glm-5p2" ]; then
                   echo "unsupported backend/model: $CANDIDATE" >&2
                   exit 1
                 fi
@@ -290,8 +293,9 @@ jobs:
             deepseek) BACKEND="deepseek-v4-flash" ;;
             glm-5.2|glm5.2|glm52|glm-5p2) BACKEND="glm-5p2" ;;
             claude-opus-4-8|claude-sonnet-5) BACKEND="claude" ;;
+            claude-fable-5|fable-5) BACKEND="fable-5" ;;
           esac
-          if [ "$BACKEND" != "claude" ] && [ "$BACKEND" != "codex" ] && [ "$BACKEND" != "deepseek-v4-flash" ] && [ "$BACKEND" != "glm-5p2" ]; then
+          if [ "$BACKEND" != "claude" ] && [ "$BACKEND" != "fable-5" ] && [ "$BACKEND" != "codex" ] && [ "$BACKEND" != "deepseek-v4-flash" ] && [ "$BACKEND" != "glm-5p2" ]; then
             echo "unsupported backend/model: $BACKEND" >&2
             exit 1
           fi
@@ -420,6 +424,25 @@ jobs:
           echo "Effective backend:  $backend (used_fallback=$used_fallback, fireworks_active=$fireworks_active)"
           if [ "$failed" = "true" ]; then
             exit 1
+          fi
+
+      # Keep native Claude model routing explicit and fail closed. Both the
+      # Claude Code alias pin and writer metadata consume this single output,
+      # so an opt-in Fable run cannot silently execute or publish as Sonnet.
+      - name: Resolve native Claude model
+        id: native-model
+        env:
+          EFFECTIVE_BACKEND: ${{ steps.effective.outputs.backend }}
+        run: |
+          set -euo pipefail
+          case "$EFFECTIVE_BACKEND" in
+            claude) model="claude-sonnet-5" ;;
+            fable-5) model="claude-fable-5" ;;
+            *) model="" ;;
+          esac
+          echo "model=$model" >> "$GITHUB_OUTPUT"
+          if [ -n "$model" ]; then
+            echo "Resolved native Claude model: $model"
           fi
 
       # Verify the writer's required output directory exists. The writer
@@ -591,9 +614,12 @@ jobs:
 
       # ---- Claude backend ---------------------------------------------------
       # OAuth-authenticated against native Anthropic. The writer records
-      # --model claude-sonnet-5 (the actual served model). Pinning
-      # ANTHROPIC_DEFAULT_OPUS_MODEL keeps the CLI's --model opus alias from
-      # drifting under this workflow. This lane is gated on the EFFECTIVE
+      # --model from the native-model resolver (the actual served model).
+      # Normal Claude runs remain claude-sonnet-5; explicit fable-5 runs use
+      # claude-fable-5. Pinning
+      # The resolved model is passed literally to Claude Code and also pins
+      # every alias/subagent slot so no nested agent can drift. This lane is
+      # gated on the EFFECTIVE
       # backend, so it also serves runs that requested a Fireworks profile
       # but fell back here when preflight found Fireworks unavailable.
       # Hard wall-clock cap on the model step. The runner already lost
@@ -604,7 +630,7 @@ jobs:
         uses: ./.github/actions/setup-claude-sandbox
 
       - name: Run Generative Research (Claude, attempt 1)
-        if: steps.effective.outputs.backend == 'claude'
+        if: contains(fromJSON('["claude","fable-5"]'), steps.effective.outputs.backend)
         id: gen-claude
         continue-on-error: true
         timeout-minutes: 90
@@ -620,12 +646,19 @@ jobs:
           GEN_SLUG: ${{ steps.params.outputs.slug }}
           GEN_SOURCE: ${{ steps.params.outputs.source }}
           GEN_DRAFT: ${{ steps.draft.outputs.path }}
+          GEN_MODEL: ${{ steps.native-model.outputs.model }}
           # birdy auth — bird and bird-fast read these cookies to call
           # X/Twitter as a primary source. Same secrets used by the
           # hourly-twitter workflow.
           AUTH_TOKEN: ${{ secrets.BIRD_AUTH_TOKEN }}
           CT0: ${{ secrets.BIRD_CT0 }}
-          ANTHROPIC_DEFAULT_OPUS_MODEL: claude-sonnet-5
+          # BACKEND_MATRIX_DEFAULT_MODEL documents the unchanged default for
+          # the static routing checker; the runtime pin is resolved above.
+          BACKEND_MATRIX_DEFAULT_MODEL: claude-sonnet-5
+          ANTHROPIC_DEFAULT_OPUS_MODEL: ${{ steps.native-model.outputs.model }}
+          ANTHROPIC_DEFAULT_SONNET_MODEL: ${{ steps.native-model.outputs.model }}
+          ANTHROPIC_DEFAULT_HAIKU_MODEL: ${{ steps.native-model.outputs.model }}
+          CLAUDE_CODE_SUBAGENT_MODEL: ${{ steps.native-model.outputs.model }}
         with: &claude_with
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # The hourly Twitter lane auto-dispatches this workflow with
@@ -638,7 +671,7 @@ jobs:
           # The agent reads topic/prompt/tags from .gen-input/*.txt files
           # instead — same defense as research-issue.yml after PR #42.
           claude_args: |
-            --model opus --max-turns 120 --allowedTools "Read,Write,Edit,Bash(git:*),Bash(uv:*),Bash(cat:*),Bash(ls:*),Bash(curl:*),Bash(pdftotext:*),Bash(bird:*),Bash(bird-fast:*),Bash(jq:*),WebSearch,WebFetch,Task,TodoWrite"
+            --model ${{ steps.native-model.outputs.model }} --max-turns 120 --allowedTools "Read,Write,Edit,Bash(git:*),Bash(uv:*),Bash(cat:*),Bash(ls:*),Bash(curl:*),Bash(pdftotext:*),Bash(bird:*),Bash(bird-fast:*),Bash(jq:*),WebSearch,WebFetch,Task,TodoWrite"
           prompt: |
             You are a deep-research analyst writing a COMPREHENSIVE,
             analyst-grade HTML article on the topic supplied by the user.
@@ -1678,7 +1711,7 @@ jobs:
                     --tags "$(cat .gen-input/tags.txt)" \
                     --source "$GEN_SOURCE" \
                     --prompt "$(cat .gen-input/prompt.txt)" \
-                    --model claude-sonnet-5 \
+                    --model "$GEN_MODEL" \
                     --cite-density-min 10 --refs-min 20 \
                     --qsanity \
                     --html-body "$GEN_DRAFT"
@@ -1690,7 +1723,7 @@ jobs:
                     --tags "$(cat .gen-input/tags.txt)" \
                     --source "$GEN_SOURCE" \
                     --prompt "$(cat .gen-input/prompt.txt)" \
-                    --model claude-sonnet-5 \
+                    --model "$GEN_MODEL" \
                     --cite-density-min 10 --refs-min 20 \
                     --qsanity \
                     --html-body "$GEN_DRAFT"
@@ -1708,7 +1741,10 @@ jobs:
       # one more attempt under RECOVERY MODE. The second attempt sees the
       # partial $GEN_DRAFT on disk (the runner's _work/_temp survives across
       # steps within the same job) and finishes the draft instead of
-      # restarting research from scratch.
+      # restarting research from scratch. This recovery retry is deliberately
+      # limited to normal Claude: premium fable-5 dispatches get exactly one
+      # model-action attempt and fail the artifact gate instead of spending on
+      # a second session.
       - name: Inspect Claude attempt 1
         if: steps.effective.outputs.backend == 'claude'
         id: claude-attempt-1
@@ -3156,6 +3192,32 @@ jobs:
           echo "has_file=true" >> "$GITHUB_OUTPUT"
           echo "Generated: research/generative/$FILENAME"
 
+      # Fable is a premium, explicit selector, so provenance must be exact.
+      # Do not rely only on the agent following its writer command: verify the
+      # committed index row against the same resolver output that pinned the
+      # served model, and roll back before any push if they differ.
+      - name: Verify Fable model provenance
+        if: steps.effective.outputs.backend == 'fable-5' && steps.outfile.outputs.has_file == 'true'
+        env:
+          FILE: ${{ steps.outfile.outputs.file }}
+          EXPECTED_MODEL: ${{ steps.native-model.outputs.model }}
+          PRE_SHA: ${{ steps.pre.outputs.sha }}
+        run: |
+          set -euo pipefail
+          actual_model=$(jq -r --arg file "$FILE" \
+            '[.[] | select(.file == $file) | .model] | last // ""' \
+            research/generative/index.json)
+          if [ "$actual_model" != "$EXPECTED_MODEL" ]; then
+            echo "::error::Fable provenance mismatch: expected model '$EXPECTED_MODEL', index records '${actual_model:-missing}'."
+            git reset --hard "$PRE_SHA"
+            git clean -fd -- research/generative || true
+            rm -f "$GITHUB_WORKSPACE/.gen-verifier-findings.json"
+            rm -f "$GITHUB_WORKSPACE/.gen-redteam-findings.json"
+            rm -f "$GITHUB_WORKSPACE/.gen-claims-ledger.json"
+            exit 1
+          fi
+          echo "Verified Fable model provenance: $actual_model"
+
       # Deterministic post-write quality gate. The agent runs the same
       # gate during its compile-check loop, and the writer re-runs it
       # at commit time — this third pass is the workflow-level seatbelt
@@ -3647,7 +3709,7 @@ jobs:
       # even if every tool call failed and the writer produced no commit. Keep
       # the workflow contract tied to the article artifact, not session exit.
       - name: Fail Claude run without article
-        if: always() && steps.effective.outputs.backend == 'claude' && steps.outfile.outputs.has_file != 'true'
+        if: always() && contains(fromJSON('["claude","fable-5"]'), steps.effective.outputs.backend) && steps.outfile.outputs.has_file != 'true'
         env:
           EXECUTION_FILE_1: ${{ steps.gen-claude.outputs.execution_file }}
           EXECUTION_FILE_2: ${{ steps.gen-claude-retry.outputs.execution_file }}

--- a/docs/backend-matrix.md
+++ b/docs/backend-matrix.md
@@ -105,6 +105,7 @@ Reading notes:
 | zai-canary · PINNED | `zai-claude-code-canary.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Z.ai | `glm-5.2` | `ZAI_API_KEY` | hard fail (strict — never walks the chain) |
 | (dispatch path) backend=fireworks (+2 retry steps) | `generative-research.yml` | Claude Code · claude-code-action (env-rerouted) | Fireworks (Anthropic-compatible endpoint) | dynamic: per fireworks profile step | `FIREWORKS_API_KEY` | workflow-level `fireworks_fallback` input (default `claude`) |
 | (dispatch path) backend=codex | `generative-research.yml` | Codex CLI | OpenAI (ChatGPT subscription auth) | codex CLI default | `CODEX_AUTH_JSON` | — |
+| (dispatch path) backend=fable-5 | `generative-research.yml` | Claude Code · claude-code-action (explicit premium selector) | Anthropic (native) | `claude-fable-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (no model-action retry) |
 
 ### Workflows with no model lane (deterministic / infra)
 
@@ -116,7 +117,7 @@ Reading notes:
 - `daily-youtube.yml`
 - `liveness-check.yml`
 
-_Global ordered fallback chain (SSOT `fallback.chain`): `claude`; native path serves `claude-sonnet-5`. 30 SSOT lanes (+2 dispatch execution paths) across 24 workflows; 7 workflows run no model._
+_Global ordered fallback chain (SSOT `fallback.chain`): `claude`; native path serves `claude-sonnet-5`. 30 SSOT lanes (+3 dispatch execution paths) across 24 workflows; 7 workflows run no model._
 
 <!-- END GENERATED BACKEND MATRIX -->
 

--- a/docs/generative-research-backends.md
+++ b/docs/generative-research-backends.md
@@ -10,6 +10,7 @@ research pipeline:
 |---|---|---|---|
 | `glm-5p2` | `GLM 5.2` via Fireworks | `FIREWORKS_API_KEY` via Fireworks' Anthropic-compatible endpoint | Preferred default for manual and issue-triggered generative research. Routes through `accounts/fireworks/models/glm-5p2` and records `glm-5p2` in article metadata. Uses the same retry, quality-gate, verifier, methodology-artifact, and safe-push path as `deepseek-v4-flash`. |
 | `claude` | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | Explicit native Anthropic Claude Code path and default fallback when a Fireworks backend is unavailable. The workflow pins `ANTHROPIC_DEFAULT_OPUS_MODEL=claude-sonnet-5`, so the Claude Code `opus` alias resolves to Sonnet 5 for this lane. |
+| `fable-5` | `claude-fable-5` | `CLAUDE_CODE_OAUTH_TOKEN` | Explicit premium native Anthropic path for deliberate one-off runs. It is never the default or a fallback target, and it gets one model-action attempt rather than Claude's automatic recovery retry. The workflow passes the literal model ID to Claude Code and resolves every alias/subagent pin plus article metadata from `claude-fable-5`, preventing a Fable-labeled article from silently running on Sonnet. |
 | `codex` | Codex CLI default model for ChatGPT auth | `CODEX_AUTH_JSON` seeded into file-backed `auth.json` | Optional Codex backend using ChatGPT-managed Codex auth rather than OpenAI API billing. Codex reads the same staged input files, writes the same methodology artifacts, and publishes through the same writer contract; article metadata records `codex`. |
 | `deepseek-v4-flash` | `deepseek-v4-flash` via Fireworks | `FIREWORKS_API_KEY` via Fireworks' Anthropic-compatible endpoint | Optional comparison backend. Routes through Fireworks (`accounts/fireworks/models/deepseek-v4-flash`); the direct DeepSeek API is retired (billing/credits). The `--model opus` passed to Claude Code is ignored — `ANTHROPIC_MODEL` env governs the served model. All model slots (incl. subagents) use the Fireworks model id. Retries up to two times if the Anthropic-compatible socket drops before an article commit is produced. |
 
@@ -273,6 +274,12 @@ gh workflow run generative-research.yml \
   -f slug="qa-claude-power-bottlenecks" \
   -f backend=claude \
   -f tags="qa,comparison,claude"
+
+gh workflow run generative-research.yml \
+  -f topic="$TOPIC" \
+  -f slug="qa-fable-5-power-bottlenecks" \
+  -f backend=fable-5 \
+  -f tags="qa,comparison,fable-5"
 ```
 
 Each run executes the same writer contract, ARA DSL validation,
@@ -297,6 +304,10 @@ The expected difference is the model backend:
   reuse stale `/tmp/gen-research*.ara.md` content from another backend or run.
 - Claude: native Anthropic endpoint, `claude-sonnet-5` metadata in
   `research/generative/index.json`.
+- Fable 5: native Anthropic endpoint, `claude-fable-5` metadata in
+  `research/generative/index.json`. This opt-in selector does not change the
+  normal `claude` or default routes, and it does not enter the Claude
+  model-action retry path.
 
 After the runs finish, compare:
 

--- a/scripts/build_backend_matrix.py
+++ b/scripts/build_backend_matrix.py
@@ -62,7 +62,7 @@ STEP_OUTCOME_RE = re.compile(r"steps\.([a-zA-Z0-9_\-]+)\.outcome\s*==\s*'failure
 
 # Backends generative-research.yml can actually execute (its params step
 # validates against this same set at runtime).
-GEN_RESEARCH_BACKENDS = {"claude", "codex", "deepseek-v4-flash", "glm-5p2"}
+GEN_RESEARCH_BACKENDS = {"claude", "fable-5", "codex", "deepseek-v4-flash", "glm-5p2"}
 
 REQUIRED_AGENT_RUN_SECRETS = {
     "claude-code-oauth-token": "CLAUDE_CODE_OAUTH_TOKEN",
@@ -126,6 +126,7 @@ class Observation:
     det_by_tier: dict[str, str] = field(default_factory=dict)
     det_job_wide: list[str] = field(default_factory=list)
     has_dispatch_fireworks_fallback: bool = False
+    has_fable_dispatch: bool = False
 
 
 def fail(msg: str) -> None:
@@ -245,6 +246,8 @@ def observe_workflow(wf_path: Path) -> Observation:
     on_block = wf.get("on") or wf.get(True) or {}
     dispatch_inputs = ((on_block.get("workflow_dispatch") or {}).get("inputs") or {})
     obs.has_dispatch_fireworks_fallback = "fireworks_fallback" in dispatch_inputs
+    backend_options = ((dispatch_inputs.get("backend") or {}).get("options") or [])
+    obs.has_fable_dispatch = "fable-5" in backend_options
     step_id_to_lane: dict[str, str] = {}
 
     for job in (wf.get("jobs") or {}).values():
@@ -319,11 +322,26 @@ def observe_workflow(wf_path: Path) -> Observation:
                     rerouted = "zai"
                 arg_model = native_model_from_args(with_block)
                 env_pin = ""
-                if arg_model in {"opus", "sonnet", "haiku"}:
+                if "${{" in arg_model:
+                    # A workflow may resolve the literal Claude model at
+                    # runtime. Keep the static default contract explicit so
+                    # the generated matrix can still prove the normal lane
+                    # did not change while documenting opt-in selectors
+                    # separately.
+                    env_pin = str(env.get("BACKEND_MATRIX_DEFAULT_MODEL", ""))
+                    arg_model = ""
+                elif arg_model in {"opus", "sonnet", "haiku"}:
                     pin = str(env.get(f"ANTHROPIC_DEFAULT_{arg_model.upper()}_MODEL")
                               or env.get("ANTHROPIC_MODEL") or "")
                     if pin and "${{" not in pin:
                         env_pin = pin
+                    elif pin and "${{" in pin:
+                        # generative-research has an explicit premium Fable
+                        # dispatch path, while its normal native lane remains
+                        # Sonnet. The runtime resolver drives both API pin and
+                        # writer metadata; this literal records the unchanged
+                        # default for the static mirror check.
+                        env_pin = str(env.get("BACKEND_MATRIX_DEFAULT_MODEL", ""))
                 eff = EFFECTIVE_IF_RE.search(cond)
                 lane_hint = eff.group(1) if eff else ("fireworks" if "fireworks_active" in cond else "")
                 obs.native.append(NativeStep(
@@ -583,6 +601,11 @@ def build_rows(lanes: dict[str, dict], observations: dict[str, Observation],
             rows.append(["(dispatch path) backend=codex", f"`{wf_name}`", "Codex CLI",
                          "OpenAI (ChatGPT subscription auth)", "codex CLI default",
                          f"`{obs.codex_token}`", "—"])
+        if obs.has_fable_dispatch:
+            rows.append(["(dispatch path) backend=fable-5", f"`{wf_name}`",
+                         "Claude Code · claude-code-action (explicit premium selector)",
+                         "Anthropic (native)", "`claude-fable-5`",
+                         "`CLAUDE_CODE_OAUTH_TOKEN`", "hard fail (no model-action retry)"])
 
     return rows
 

--- a/scripts/test_backend_matrix.py
+++ b/scripts/test_backend_matrix.py
@@ -105,6 +105,21 @@ class RoutingInvariants(unittest.TestCase):
         self.assertIn("generative-research-default",
                       self.obs["generative-research.yml"].resolver_lanes)
 
+    def test_gen_research_fable_is_explicit_and_fail_closed(self):
+        workflow = (REPO_ROOT / ".github" / "workflows" /
+                    "generative-research.yml").read_text(encoding="utf-8")
+        self.assertIn('- fable-5', workflow)
+        self.assertIn('fable-5) model="claude-fable-5"', workflow)
+        self.assertIn('ANTHROPIC_DEFAULT_OPUS_MODEL: ${{ steps.native-model.outputs.model }}', workflow)
+        self.assertIn('CLAUDE_CODE_SUBAGENT_MODEL: ${{ steps.native-model.outputs.model }}', workflow)
+        self.assertIn('--model ${{ steps.native-model.outputs.model }}', workflow)
+        self.assertIn('--model "$GEN_MODEL"', workflow)
+        self.assertIn("if: steps.effective.outputs.backend == 'claude'\n        id: claude-attempt-1", workflow)
+        self.assertIn("Verify Fable model provenance", workflow)
+        self.assertIn("actual_model=$(jq -r", workflow)
+        self.assertTrue(self.obs["generative-research.yml"].has_fable_dispatch)
+        self.assertEqual(self.lanes["generative-research-default"]["backend"], "claude")
+
     def test_comparison_tiers_are_strict(self):
         # Comparison artifacts must be attributable to their labeled backend:
         # a silent chain re-route would corrupt the comparison (round-3 F1).


### PR DESCRIPTION
## What changed

- add an explicit opt-in `fable-5` generative-research backend
- pass `claude-fable-5` literally to Claude Code and pin every subagent model slot
- record and verify matching article provenance before publishing
- disable automatic model retry for the premium Fable path
- keep the normal default and `claude` routes unchanged
- update backend documentation, generated matrix, and routing tests

## Why

Run one CXMT generative-research article with Fable 5 without changing routine model costs or allowing an automatic premium retry.

## Verification

- `actionlint .github/workflows/generative-research.yml`
- `uv run python scripts/test_backend_matrix.py` (36 tests)
- `uv run python scripts/build_backend_matrix.py --check`
- `uv run python -m unittest discover -s scripts -p 'test_*.py'` (524 tests, 6 skipped)
- `git diff --check`

The CXMT workflow will be dispatched from this feature ref after CI passes; its generated article will be reviewed in this PR before squash-merging to `main`.