### PR TITLE
Improve forecast sharing and sitewide SEO

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -3,7 +3,7 @@
 	encode zstd gzip
 
 	@html {
-		path / /index.html /today /today/ /twitter /models /frontpage /research /research/* /wiki /wiki/*
+		path / /index.html /today /today/* /twitter /twitter/* /models /models/* /frontpage /frontpage/* /research /research/* /wiki /wiki/* /agents /agents/ /design/*
 		not path *.js *.css *.json *.xml *.txt *.png *.jpg *.jpeg *.webp *.gif *.svg *.ico *.avif *.woff *.woff2
 	}
 	header @html Cache-Control "public, max-age=0, must-revalidate"
@@ -15,6 +15,15 @@
 
 	@data path /research/manifest.json /research/*.json /research/*/*.json /research/*/*/*.json
 	header @data Cache-Control "public, max-age=0, must-revalidate"
+
+	# Raw research/data artifacts feed the canonical HTML routes. Keep them
+	# fetchable by the app while preventing duplicate Markdown/HTML/JSON URLs
+	# from competing with /today, /twitter, /models, /research, and /wiki pages.
+	@rawResearchArtifacts {
+		path /research/*
+		path_regexp rawResearchFile \.(?:html|json|jsonl|m4a|md|mp3|tmp|txt|wav)$
+	}
+	header @rawResearchArtifacts X-Robots-Tag "noindex, nofollow"
 
 	@seo path /sitemap.xml /robots.txt /feed.xml /llms.txt
 	header @seo Cache-Control "public, max-age=300, stale-while-revalidate=3600"
@@ -29,6 +38,8 @@
 		Referrer-Policy "strict-origin-when-cross-origin"
 	}
 
-	try_files {path} {path}/index.html /index.html
+	# Every legitimate public SPA route has a generated HTML entry point. Return
+	# a real 404 for unknown/missing routes instead of a homepage soft-404.
+	try_files {path} {path}/index.html =404
 	file_server
 }

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -38,7 +38,7 @@
       <header class="header">
         <div class="header-top">
           <div class="brand">
-            <h1 class="brand-title" id="brandHome" role="button" tabindex="0" title="Home">ai-research-arm</h1>
+            <a class="brand-title" id="brandHome" href="/" title="Home">ai-research-arm</a>
           </div>
           <div class="header-actions">
             <a class="header-link" href="https://github.com/guzus/ai-research-arm" target="_blank" rel="noopener">
@@ -49,11 +49,11 @@
         </div>
         <nav class="tabs" id="tabs">
           <div class="calendar" id="calendar"></div>
-          <button class="tab" data-tab="twitter">Twitter</button>
-          <button class="tab" data-tab="models">Jira</button>
-          <button class="tab" data-tab="research">Research</button>
-          <button class="tab" data-tab="wiki">Wiki</button>
-          <button class="tab" data-tab="agents">Arm</button>
+          <a class="tab" data-tab="twitter" href="/twitter">Twitter</a>
+          <a class="tab" data-tab="models" href="/models">Jira</a>
+          <a class="tab" data-tab="research" href="/research">Research</a>
+          <a class="tab" data-tab="wiki" href="/wiki">Wiki</a>
+          <a class="tab" data-tab="agents" href="/agents">Arm</a>
           <button class="brand-search" id="searchToggle" type="button" aria-label="Search" title="Search (⌘F or /)">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>
           </button>

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -10,6 +10,7 @@
     "predev": "node scripts/prebuild.mjs",
     "prebuild": "node scripts/prebuild.mjs",
     "dev": "vite",
+    "test": "node --test scripts/*.test.mjs",
     "typecheck": "tsc --noEmit",
     "build": "tsc --noEmit && vite build",
     "postbuild": "node scripts/postbuild-seo.mjs",

--- a/dashboard/scripts/forecast-seo.mjs
+++ b/dashboard/scripts/forecast-seo.mjs
@@ -1,0 +1,57 @@
+// Pure helpers shared by the SEO postbuild and its tests. Forecast pages are
+// deliberately limited to tickets with a valid prediction-market mapping:
+// ordinary model tickets stay on the board and do not become thin indexable
+// pages merely because they exist.
+
+const SLUG_RE = /^[a-z0-9]+(?:[a-z0-9._-]*[a-z0-9])?$/;
+
+function compact(value) {
+  return String(value || '').replace(/\s+/g, ' ').trim();
+}
+
+function validMapping(mapping) {
+  return !!mapping && typeof mapping === 'object' &&
+    ['event_slug', 'market_id', 'token_id', 'question']
+      .every(key => compact(mapping[key]).length > 0);
+}
+
+export function mappedForecastTickets(index) {
+  const tickets = Array.isArray(index?.tickets) ? index.tickets : [];
+  return tickets
+    .filter(ticket =>
+      ticket && typeof ticket === 'object' &&
+      SLUG_RE.test(compact(ticket.slug)) &&
+      compact(ticket.title) &&
+      ticket.verification === 'confirmed' &&
+      Array.isArray(ticket.polymarket) &&
+      ticket.polymarket.length > 0 &&
+      ticket.polymarket.slice(0, 3).every(validMapping))
+    .map(ticket => ({ ...ticket, polymarket: ticket.polymarket.slice(0, 3) }))
+    .sort((a, b) => compact(a.slug).localeCompare(compact(b.slug)));
+}
+
+export function forecastRoute(slug) {
+  if (!SLUG_RE.test(compact(slug))) throw new TypeError('invalid forecast slug');
+  return `/models/forecast/${compact(slug)}`;
+}
+
+export function forecastSeoRecord(ticket, siteOrigin) {
+  const route = forecastRoute(ticket.slug);
+  const questions = ticket.polymarket.map(mapping => compact(mapping.question));
+  const title = `${compact(ticket.title)} forecast`;
+  const company = compact(ticket.company) || 'AI model';
+  const status = compact(ticket.status).replace(/-/g, ' ') || 'tracked';
+  const updated = compact(ticket.updated_at);
+  const marketSummary = questions.length === 1
+    ? `Linked prediction market: ${questions[0]}`
+    : `${questions.length} linked prediction markets, including: ${questions[0]}`;
+  const marketSentence = /[.!?]$/.test(marketSummary) ? marketSummary : `${marketSummary}.`;
+  const dateSummary = updated ? ` Updated ${updated}.` : '';
+  return {
+    route,
+    url: `${String(siteOrigin).replace(/\/+$/, '')}${route}`,
+    title,
+    description: `${company} model-release forecast (${status}). ${marketSentence}${dateSummary}`,
+    questions,
+  };
+}

--- a/dashboard/scripts/forecast-seo.test.mjs
+++ b/dashboard/scripts/forecast-seo.test.mjs
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { forecastRoute, forecastSeoRecord, mappedForecastTickets } from './forecast-seo.mjs';
+
+const mapped = {
+  slug: 'openai-ipo-2026-06',
+  title: 'OpenAI IPO',
+  company: 'OpenAI',
+  status: 'confirmed',
+  verification: 'confirmed',
+  updated_at: '2026-07-11',
+  polymarket: [{
+    event_slug: 'openai-ipo-by',
+    market_id: '123',
+    token_id: '456',
+    question: 'OpenAI IPO by December 31, 2026?',
+  }],
+};
+
+test('only well-shaped mapped tickets receive forecast pages', () => {
+  const rows = mappedForecastTickets({ tickets: [
+    { ...mapped, slug: 'z-ticket' },
+    { ...mapped, slug: 'a-ticket' },
+    { ...mapped, slug: 'ordinary-ticket', polymarket: null },
+    { ...mapped, slug: 'unverified-ticket', verification: 'partial' },
+    { ...mapped, slug: 'broken-ticket', polymarket: [{ question: 'Missing IDs' }] },
+    { ...mapped, slug: '../unsafe' },
+  ] });
+  assert.deepEqual(rows.map(row => row.slug), ['a-ticket', 'z-ticket']);
+});
+
+test('forecast metadata is deterministic and does not claim a live price', () => {
+  const record = forecastSeoRecord(mapped, 'https://ara.guzus.xyz/');
+  assert.equal(record.route, '/models/forecast/openai-ipo-2026-06');
+  assert.equal(record.url, 'https://ara.guzus.xyz/models/forecast/openai-ipo-2026-06');
+  assert.equal(record.title, 'OpenAI IPO forecast');
+  assert.match(record.description, /Linked prediction market: OpenAI IPO by December 31, 2026\?/);
+  assert.match(record.description, /Updated 2026-07-11/);
+  assert.doesNotMatch(record.description, /\b\d+%|live odds/i);
+  assert.doesNotMatch(record.description, /\?\./);
+});
+
+test('forecast routes reject unsafe slugs', () => {
+  assert.throws(() => forecastRoute('../openai'), /invalid forecast slug/);
+});

--- a/dashboard/scripts/postbuild-seo.mjs
+++ b/dashboard/scripts/postbuild-seo.mjs
@@ -5,14 +5,19 @@
 // Coverage:
 //   - Homepage (dist/index.html): rewrites the SEO:DEFAULT block with a
 //     homepage-specific title/description/OG + the default social share image.
-//   - "today" route (dist/today/index.html): latest daily digest -- per-page
-//     title/description/OG + the digest body inlined into #content.
+//   - Dated daily digest, Twitter/X report, and newspaper routes: unique
+//     metadata/content; undated latest aliases canonicalize to the dated page.
+//   - Research and wiki archive hubs: crawlable collections with real links.
 //   - Generative articles (dist/research/<slug>/index.html): per-article
 //     title/description/OG + JSON-LD Article + article body inlined.
 //   - Wiki pages (dist/wiki/<slug>/index.html): per-page title/description/OG
 //     from research/wiki/index.json + page body inlined.
+//   - Verified mapped model forecasts (dist/models/forecast/<slug>/index.html):
+//     stable metadata + committed evidence and prediction-market links.
+//   - Internal/duplicate routes (agents, focus-reader, dated model aliases):
+//     explicit noindex pages with an appropriate canonical.
 //
-// Also emits dist/sitemap.xml (article + tab + wiki URLs with lastmod),
+// Also emits dist/sitemap.xml (canonical indexable URLs only, with lastmod),
 // dist/robots.txt (allow all + sitemap pointer), dist/feed.xml, and
 // dist/llms.txt for AI-answer engines.
 //
@@ -32,6 +37,13 @@ import { join, dirname, resolve, extname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { marked } from 'marked';
 import { chromium } from 'playwright-core';
+import { forecastSeoRecord, mappedForecastTickets } from './forecast-seo.mjs';
+import {
+  datedPagePolicy,
+  isIndexableResearchEntry,
+  latestAliasPolicy,
+  sortDatedRecords,
+} from './site-seo.mjs';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const dashboardDir = dirname(here);
@@ -43,9 +55,13 @@ const articlesDir = join(researchRoot, 'generative');
 const indexJsonPath = join(articlesDir, 'index.json');
 const frontPageDir = join(researchRoot, 'front-page');
 const digestDir = join(researchRoot, 'digest');
+const twitterDir = join(researchRoot, 'twitter');
+const modelTimelineDir = join(researchRoot, 'models');
 const wikiDir = join(researchRoot, 'wiki');
 const wikiIndexPath = join(wikiDir, 'index.json');
 const distGenerativeDir = join(dist, 'research', 'generative');
+const distTicketIndexPath = join(dist, 'research', 'models', 'tickets', 'index.json');
+const armTimelinePath = join(researchRoot, 'arm', 'timeline.json');
 
 // Override via env (POSTBUILD_SITE_ORIGIN) for preview deploys.
 const SITE_ORIGIN = process.env.POSTBUILD_SITE_ORIGIN || 'https://ara.guzus.xyz';
@@ -78,6 +94,7 @@ const SOCIAL_PREVIEW_PREFIX = (process.env.SOCIAL_PREVIEW_PREFIX || 'social-prev
 // the whole block (markers included) per page; if the markers are absent we
 // fall back to replacing just <title>...</title> so older shells still work.
 const SEO_BLOCK_RE = /<!-- SEO:DEFAULT:START[\s\S]*?SEO:DEFAULT:END -->/;
+const STATIC_CONTENT_RE = /<!-- SEO:STATIC:START -->[\s\S]*?<!-- SEO:STATIC:END -->/;
 
 function stripTags(html) {
   return html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
@@ -109,7 +126,10 @@ function htmlEscapeAttr(s) {
 }
 
 function jsonLdTag(data) {
-  return `<script type="application/ld+json">${JSON.stringify(data)}</script>`;
+  // JSON.stringify does not escape HTML-significant characters. Keep model-
+  // authored ticket/article text from terminating the JSON-LD script early.
+  const json = JSON.stringify(data).replace(/</g, '\\u003c').replace(/>/g, '\\u003e');
+  return `<script type="application/ld+json">${json}</script>`;
 }
 
 function sharedMetaTags(title, desc) {
@@ -601,16 +621,79 @@ async function renderArticleSocialScreenshots(rows) {
 function applySeoBlock(template, metaBlockLines) {
   const metaBlock = metaBlockLines.join('\n    ');
   if (SEO_BLOCK_RE.test(template)) {
-    return template.replace(SEO_BLOCK_RE, metaBlock);
+    // Preserve the markers so a diagnostic/manual second postbuild remains
+    // idempotent instead of appending a second canonical/OG block.
+    const wrapped = [
+      '<!-- SEO:DEFAULT:START -->',
+      metaBlock,
+      '<!-- SEO:DEFAULT:END -->',
+    ].join('\n    ');
+    return template.replace(SEO_BLOCK_RE, wrapped);
   }
   return template.replace(/<title>[\s\S]*?<\/title>/, metaBlock);
 }
 
 function inlineContent(template, innerHtml) {
+  const block = `<!-- SEO:STATIC:START -->${innerHtml}<!-- SEO:STATIC:END -->`;
+  if (STATIC_CONTENT_RE.test(template)) {
+    return template.replace(STATIC_CONTENT_RE, block);
+  }
   return template.replace(
     '<div id="content"></div>',
-    `<div id="content">${innerHtml}</div>`,
+    `<div id="content">${block}</div>`,
   );
+}
+
+function demoteHeadings(html) {
+  return String(html || '')
+    .replace(/<h1(\s[^>]*)?>/gi, '<h2$1>')
+    .replace(/<\/h1>/gi, '</h2>');
+}
+
+function singleH1Snapshot(title, bodyHtml, classes = 'content-card') {
+  return [
+    `<article class="${htmlEscapeAttr(classes)}">`,
+    '<div class="content-card-body">',
+    `<h1>${htmlEscapeAttr(title)}</h1>`,
+    demoteHeadings(bodyHtml),
+    '</div>',
+    '</article>',
+  ].join('');
+}
+
+function standardMetaBlock({
+  title,
+  description,
+  canonicalUrl,
+  shareImage,
+  type = 'website',
+  indexable = true,
+  jsonLd,
+  published,
+  modified,
+}) {
+  const desc = truncateDescription(compactText(description));
+  return [
+    `<title>${htmlEscapeAttr(title)} -- ara</title>`,
+    `<meta name="description" content="${htmlEscapeAttr(desc)}" />`,
+    ...sharedMetaTags(title, desc),
+    `<link rel="canonical" href="${htmlEscapeAttr(canonicalUrl)}" />`,
+    `<meta name="robots" content="${indexable ? 'index,follow,max-image-preview:large,max-snippet:-1' : 'noindex,follow'}" />`,
+    `<meta property="og:type" content="${htmlEscapeAttr(type)}" />`,
+    `<meta property="og:title" content="${htmlEscapeAttr(title)}" />`,
+    `<meta property="og:description" content="${htmlEscapeAttr(desc)}" />`,
+    `<meta property="og:url" content="${htmlEscapeAttr(canonicalUrl)}" />`,
+    `<meta property="og:site_name" content="ara -- AI research arm" />`,
+    published ? `<meta property="article:published_time" content="${htmlEscapeAttr(published)}" />` : '',
+    modified ? `<meta property="article:modified_time" content="${htmlEscapeAttr(modified)}" />` : '',
+    ...imageMetaTags(shareImage, title),
+    `<meta name="twitter:card" content="${shareImage ? 'summary_large_image' : 'summary'}" />`,
+    `<meta name="twitter:title" content="${htmlEscapeAttr(title)}" />`,
+    `<meta name="twitter:description" content="${htmlEscapeAttr(desc)}" />`,
+    `<link rel="alternate" type="application/rss+xml" title="ara -- AI research arm" href="${SITE_ORIGIN}/feed.xml" />`,
+    `<link rel="alternate" type="text/plain" title="llms.txt" href="${SITE_ORIGIN}/llms.txt" />`,
+    jsonLd ? jsonLdTag(jsonLd) : '',
+  ].filter(Boolean);
 }
 
 function extractMeta(articleHtml) {
@@ -627,7 +710,7 @@ function extractMeta(articleHtml) {
   return { title, desc };
 }
 
-function buildArticlePage(template, row, articleHtml, shareImageUrl, generatedImages = new Map()) {
+function buildArticlePage(template, row, articleHtml, shareImageUrl, generatedImages = new Map(), indexable = true) {
   const url = `${SITE_ORIGIN}/research/${row.slug}`;
   const { title: extracted, desc } = extractMeta(articleHtml);
   const title = extracted || row.title || row.slug;
@@ -659,7 +742,7 @@ function buildArticlePage(template, row, articleHtml, shareImageUrl, generatedIm
     ...sharedMetaTags(title, desc),
     keywords.length ? `<meta name="news_keywords" content="${htmlEscapeAttr(keywords.join(', '))}" />` : '',
     `<link rel="canonical" href="${url}" />`,
-    `<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1" />`,
+    `<meta name="robots" content="${indexable ? 'index,follow,max-image-preview:large,max-snippet:-1' : 'noindex,follow'}" />`,
     `<meta property="og:type" content="article" />`,
     `<meta property="og:title" content="${htmlEscapeAttr(title)}" />`,
     `<meta property="og:description" content="${htmlEscapeAttr(desc)}" />`,
@@ -676,9 +759,14 @@ function buildArticlePage(template, row, articleHtml, shareImageUrl, generatedIm
   ].filter(Boolean);
 
   let html = applySeoBlock(template, metaBlock);
+  const displayHeadingRe = /<h2(\s+class="ara-display"[^>]*)>([\s\S]*?)<\/h2>/i;
+  const demotedArticleHtml = demoteHeadings(articleHtml);
+  const crawlerArticleHtml = displayHeadingRe.test(demotedArticleHtml)
+    ? demotedArticleHtml.replace(displayHeadingRe, '<h1$1>$2</h1>')
+    : `<h1>${htmlEscapeAttr(title)}</h1>${demotedArticleHtml}`;
   html = inlineContent(
     html,
-    `<div class="content-card gen-research-doc"><div class="content-card-body">${articleHtml}</div></div>`,
+    `<div class="content-card gen-research-doc"><div class="content-card-body">${crawlerArticleHtml}</div></div>`,
   );
   return html;
 }
@@ -722,7 +810,26 @@ function buildHomePage(template, shareImageUrl) {
     `<link rel="alternate" type="text/plain" title="llms.txt" href="${SITE_ORIGIN}/llms.txt" />`,
     jsonLdTag(jsonLd),
   ];
-  return applySeoBlock(template, metaBlock);
+  const snapshot = [
+    '<section class="content-card forecast-static-page">',
+    '<div class="content-card-body">',
+    '<p class="ara-eyebrow">Independent AI intelligence</p>',
+    '<h1>AI news, model forecasts, and research</h1>',
+    `<p>${htmlEscapeAttr(desc)}</p>`,
+    '<nav aria-label="Explore ara">',
+    '<ul>',
+    '<li><a href="/today">Daily AI digest</a></li>',
+    '<li><a href="/twitter">Twitter/X AI signal reports</a></li>',
+    '<li><a href="/models">AI model forecasts and prediction markets</a></li>',
+    '<li><a href="/research">Long-form generative research</a></li>',
+    '<li><a href="/wiki">LLM wiki</a></li>',
+    '<li><a href="/frontpage">Daily AI newspaper</a></li>',
+    '</ul>',
+    '</nav>',
+    '</div>',
+    '</section>',
+  ].join('');
+  return inlineContent(applySeoBlock(template, metaBlock), snapshot);
 }
 
 function latestDigest() {
@@ -751,11 +858,11 @@ function digestDescription(md) {
   return 'The day in AI: releases, funding, research, and community signal, synthesized into a single daily digest.';
 }
 
-function buildDigestPage(template, digest, shareImageUrl) {
+function buildDigestPage(template, digest, shareImageUrl, policy = datedPagePolicy('today', digest.date, SITE_ORIGIN)) {
   const md = readFileSync(digest.path, 'utf8');
   const title = `AI Daily Digest -- ${digest.date}`;
   const desc = digestDescription(md);
-  const url = `${SITE_ORIGIN}/today`;
+  const url = policy.canonicalUrl;
   const bodyHtml = sanitizeFragment(marked.parse(md));
 
   const jsonLd = {
@@ -783,7 +890,7 @@ function buildDigestPage(template, digest, shareImageUrl) {
     `<meta name="description" content="${htmlEscapeAttr(desc)}" />`,
     ...sharedMetaTags(title, desc),
     `<link rel="canonical" href="${url}" />`,
-    `<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1" />`,
+    `<meta name="robots" content="${policy.indexable ? 'index,follow,max-image-preview:large,max-snippet:-1' : 'noindex,follow'}" />`,
     `<meta property="og:type" content="article" />`,
     `<meta property="og:title" content="${htmlEscapeAttr(title)}" />`,
     `<meta property="og:description" content="${htmlEscapeAttr(desc)}" />`,
@@ -802,9 +909,370 @@ function buildDigestPage(template, digest, shareImageUrl) {
   let html = applySeoBlock(template, metaBlock);
   html = inlineContent(
     html,
-    `<div class="content-card"><div class="content-card-body">${bodyHtml}</div></div>`,
+    singleH1Snapshot(title, bodyHtml),
   );
   return html;
+}
+
+function datedMarkdownRecords(dir, pattern) {
+  if (!existsSync(dir)) return [];
+  return sortDatedRecords(readdirSync(dir).map(name => {
+    const match = pattern.exec(name);
+    return match ? { date: match[1], path: join(dir, name), name } : null;
+  }).filter(Boolean));
+}
+
+function digestRecords() {
+  return datedMarkdownRecords(digestDir, /^(\d{4}-\d{2}-\d{2})-digest\.md$/);
+}
+
+function twitterRecords() {
+  return datedMarkdownRecords(twitterDir, /^(\d{4}-\d{2}-\d{2})\.md$/);
+}
+
+function renderedWordCount(markdown) {
+  const text = decodeEntities(stripTags(sanitizeFragment(marked.parse(markdown))));
+  return compactText(text).split(/\s+/).filter(Boolean).length;
+}
+
+function frontPageRecords() {
+  if (!existsSync(frontPageDir)) return [];
+  return sortDatedRecords(readdirSync(frontPageDir).map(name => {
+    const match = /^(\d{4}-\d{2}-\d{2})-front-page\.png$/.exec(name);
+    if (!match) return null;
+    const notesPath = join(frontPageDir, `${match[1]}-front-page.ara.md`);
+    return {
+      date: match[1],
+      path: join(frontPageDir, name),
+      notesPath: existsSync(notesPath) ? notesPath : null,
+      imageUrl: `${SITE_ORIGIN}/research/front-page/${name}`,
+    };
+  }).filter(Boolean));
+}
+
+function buildTwitterPage(template, report, shareImageUrl, policy = datedPagePolicy('twitter', report.date, SITE_ORIGIN)) {
+  const markdown = readFileSync(report.path, 'utf8');
+  const title = `Twitter/X AI signal report -- ${report.date}`;
+  const description = digestDescription(markdown);
+  const bodyHtml = sanitizeFragment(marked.parse(markdown));
+  const reportNode = {
+    '@type': 'Report',
+    headline: title,
+    description,
+    datePublished: report.date,
+    dateModified: report.date,
+    inLanguage: 'en',
+    isAccessibleForFree: true,
+    author: publisherNode(),
+    publisher: publisherNode(),
+    mainEntityOfPage: { '@type': 'WebPage', '@id': policy.canonicalUrl },
+    about: [{ '@type': 'Thing', name: 'AI news from Twitter and X' }],
+    url: policy.canonicalUrl,
+  };
+  if (shareImageUrl) reportNode.image = shareImageUrl;
+  const metaBlock = standardMetaBlock({
+    title,
+    description,
+    canonicalUrl: policy.canonicalUrl,
+    shareImage: shareImageUrl,
+    type: 'article',
+    indexable: policy.indexable,
+    published: report.date,
+    modified: report.date,
+    jsonLd: { '@context': 'https://schema.org', '@graph': [organizationNode(), reportNode] },
+  });
+  return inlineContent(
+    applySeoBlock(template, metaBlock),
+    singleH1Snapshot(title, bodyHtml),
+  );
+}
+
+function frontPageDescription(record) {
+  const digestPath = join(digestDir, `${record.date}-digest.md`);
+  if (existsSync(digestPath)) return digestDescription(readFileSync(digestPath, 'utf8'));
+  if (record.notesPath) {
+    const notes = readFileSync(record.notesPath, 'utf8');
+    const deck = notes.match(/^deck:\s*["']?(.+?)["']?\s*$/m)?.[1];
+    if (deck) return truncateDescription(deck);
+  }
+  return `The ara daily AI newspaper front page for ${record.date}, generated from the verified daily digest.`;
+}
+
+function buildFrontPagePage(template, record, policy = datedPagePolicy('frontpage', record.date, SITE_ORIGIN)) {
+  const title = `Daily AI newspaper -- ${record.date}`;
+  const description = frontPageDescription(record);
+  const image = {
+    url: record.imageUrl,
+    alt: `ara daily AI newspaper front page for ${record.date}`,
+  };
+  const workNode = {
+    '@type': 'CreativeWork',
+    headline: title,
+    description,
+    datePublished: record.date,
+    dateModified: record.date,
+    inLanguage: 'en',
+    isAccessibleForFree: true,
+    author: publisherNode(),
+    publisher: publisherNode(),
+    mainEntityOfPage: { '@type': 'WebPage', '@id': policy.canonicalUrl },
+    image: record.imageUrl,
+    url: policy.canonicalUrl,
+  };
+  const metaBlock = standardMetaBlock({
+    title,
+    description,
+    canonicalUrl: policy.canonicalUrl,
+    shareImage: image,
+    type: 'article',
+    indexable: policy.indexable,
+    published: record.date,
+    modified: record.date,
+    jsonLd: { '@context': 'https://schema.org', '@graph': [organizationNode(), workNode] },
+  });
+  const body = [
+    `<p>${htmlEscapeAttr(description)}</p>`,
+    `<figure><img src="${htmlEscapeAttr(record.imageUrl)}" alt="${htmlEscapeAttr(image.alt)}" loading="eager" decoding="async"><figcaption>${htmlEscapeAttr(title)}</figcaption></figure>`,
+    `<p><a href="/today/${htmlEscapeAttr(record.date)}">Read the source daily digest</a></p>`,
+  ].join('');
+  return inlineContent(
+    applySeoBlock(template, metaBlock),
+    singleH1Snapshot(title, body),
+  );
+}
+
+function buildArchivePage(template, {
+  route,
+  title,
+  description,
+  eyebrow,
+  items,
+  shareImageUrl,
+}) {
+  const url = `${SITE_ORIGIN}${route}`;
+  const normalized = items.map((item, index) => ({ ...item, position: index + 1 }));
+  const collectionNode = {
+    '@type': 'CollectionPage',
+    name: title,
+    description,
+    url,
+    isPartOf: { '@id': `${SITE_ORIGIN}/#website` },
+    mainEntity: {
+      '@type': 'ItemList',
+      numberOfItems: normalized.length,
+      itemListElement: normalized.map(item => ({
+        '@type': 'ListItem',
+        position: item.position,
+        name: item.title,
+        url: `${SITE_ORIGIN}${item.route}`,
+      })),
+    },
+  };
+  const metaBlock = standardMetaBlock({
+    title,
+    description,
+    canonicalUrl: url,
+    shareImage: shareImageUrl,
+    jsonLd: { '@context': 'https://schema.org', '@graph': [organizationNode(), collectionNode] },
+  });
+  const list = normalized.map(item => [
+    '<li>',
+    `<a href="${htmlEscapeAttr(item.route)}"><strong>${htmlEscapeAttr(item.title)}</strong></a>`,
+    item.meta ? `<p>${htmlEscapeAttr(item.meta)}</p>` : '',
+    item.description ? `<p>${htmlEscapeAttr(truncateDescription(compactText(item.description), 240))}</p>` : '',
+    '</li>',
+  ].filter(Boolean).join('')).join('');
+  const snapshot = [
+    '<section class="content-card forecast-static-page">',
+    '<div class="content-card-body">',
+    `<p class="ara-eyebrow">${htmlEscapeAttr(eyebrow)}</p>`,
+    `<h1>${htmlEscapeAttr(title)}</h1>`,
+    `<p>${htmlEscapeAttr(description)}</p>`,
+    `<ol>${list}</ol>`,
+    '</div>',
+    '</section>',
+  ].join('');
+  return inlineContent(applySeoBlock(template, metaBlock), snapshot);
+}
+
+function buildNoindexPage(template, { route, canonicalRoute, title, description, body, shareImageUrl }) {
+  const canonicalUrl = `${SITE_ORIGIN}${canonicalRoute}`;
+  const metaBlock = standardMetaBlock({
+    title,
+    description,
+    canonicalUrl,
+    shareImage: shareImageUrl,
+    indexable: false,
+  });
+  return inlineContent(
+    applySeoBlock(template, metaBlock),
+    singleH1Snapshot(title, `<p>${htmlEscapeAttr(body || description)}</p>`),
+  );
+}
+
+function polymarketEventUrl(mapping) {
+  return `https://polymarket.com/event/${encodeURIComponent(String(mapping.event_slug))}`;
+}
+
+// A crawler-facing forecast page intentionally contains only committed
+// evidence and mapping metadata. Live odds remain a fail-soft browser concern;
+// baking a build-time price into OG copy would make shared cards stale or false.
+function buildForecastPage(template, ticket, shareImageUrl) {
+  const record = forecastSeoRecord(ticket, SITE_ORIGIN);
+  const desc = truncateDescription(record.description);
+  const published = ticket.created_at || ticket.updated_at;
+  const modified = ticket.updated_at || ticket.created_at;
+  const keywords = [
+    'AI forecast',
+    'prediction markets',
+    'Polymarket',
+    ticket.company,
+    ticket.model,
+    ...(Array.isArray(ticket.labels) ? ticket.labels : []),
+  ].filter(Boolean);
+  const marketUrls = ticket.polymarket.map(polymarketEventUrl);
+  const sourceUrls = (Array.isArray(ticket.sources) ? ticket.sources : [])
+    .filter(source => /^https?:\/\/\S+$/i.test(String(source)));
+  const jsonLd = {
+    '@type': 'Report',
+    headline: record.title,
+    description: desc,
+    datePublished: published,
+    dateModified: modified,
+    inLanguage: 'en',
+    isAccessibleForFree: true,
+    author: publisherNode(),
+    publisher: publisherNode(),
+    mainEntityOfPage: { '@type': 'WebPage', '@id': record.url },
+    about: record.questions.map(name => ({ '@type': 'Thing', name })),
+    keywords,
+    citation: sourceUrls,
+    sameAs: marketUrls,
+    url: record.url,
+  };
+  if (shareImageUrl) jsonLd.image = shareImageUrl;
+
+  const metaBlock = [
+    `<title>${htmlEscapeAttr(record.title)} -- ara</title>`,
+    `<meta name="description" content="${htmlEscapeAttr(desc)}" />`,
+    ...sharedMetaTags(record.title, desc),
+    `<meta name="news_keywords" content="${htmlEscapeAttr(keywords.join(', '))}" />`,
+    `<link rel="canonical" href="${record.url}" />`,
+    `<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1" />`,
+    `<meta property="og:type" content="article" />`,
+    `<meta property="og:title" content="${htmlEscapeAttr(record.title)}" />`,
+    `<meta property="og:description" content="${htmlEscapeAttr(desc)}" />`,
+    `<meta property="og:url" content="${record.url}" />`,
+    `<meta property="og:site_name" content="ara -- AI research arm" />`,
+    published ? `<meta property="article:published_time" content="${htmlEscapeAttr(published)}" />` : '',
+    modified ? `<meta property="article:modified_time" content="${htmlEscapeAttr(modified)}" />` : '',
+    ...imageMetaTags(shareImageUrl, record.title),
+    `<meta name="twitter:card" content="${shareImageUrl ? 'summary_large_image' : 'summary'}" />`,
+    `<meta name="twitter:title" content="${htmlEscapeAttr(record.title)}" />`,
+    `<meta name="twitter:description" content="${htmlEscapeAttr(desc)}" />`,
+    `<link rel="alternate" type="application/rss+xml" title="ara -- AI research arm" href="${SITE_ORIGIN}/feed.xml" />`,
+    `<link rel="alternate" type="text/plain" title="llms.txt" href="${SITE_ORIGIN}/llms.txt" />`,
+    jsonLdTag({ '@context': 'https://schema.org', '@graph': [organizationNode(), jsonLd] }),
+  ].filter(Boolean);
+
+  const marketItems = ticket.polymarket.map(mapping => {
+    const outcome = String(mapping.outcome || '').trim();
+    return [
+      '<li>',
+      `<a href="${htmlEscapeAttr(polymarketEventUrl(mapping))}" rel="noopener noreferrer">${htmlEscapeAttr(mapping.question)}</a>`,
+      outcome ? ` <span>(${htmlEscapeAttr(outcome)} outcome)</span>` : '',
+      '</li>',
+    ].join('');
+  }).join('');
+  const sources = sourceUrls.map(source =>
+    `<li><a href="${htmlEscapeAttr(source)}" rel="noopener noreferrer">${htmlEscapeAttr(source)}</a></li>`,
+  ).join('');
+  const bodyHtml = sanitizeFragment(marked.parse(String(ticket.body || '')));
+  const status = String(ticket.status || 'tracked').replace(/-/g, ' ');
+  const snapshot = [
+    '<article class="content-card forecast-static-page">',
+    '<div class="content-card-body">',
+    '<p class="ara-eyebrow">AI forecast · prediction-market linked</p>',
+    `<h1>${htmlEscapeAttr(ticket.title)}</h1>`,
+    `<p>${htmlEscapeAttr(ticket.company)} · ${htmlEscapeAttr(status)} · verified · updated ${htmlEscapeAttr(ticket.updated_at || 'unknown')}</p>`,
+    '<section><h2>Linked prediction markets</h2>',
+    `<ul>${marketItems}</ul>`,
+    '<p>Live probabilities load in the interactive view and may be unavailable. Market links and questions are committed mappings; no price is asserted in this static snapshot.</p>',
+    '</section>',
+    bodyHtml ? `<section><h2>Forecast evidence</h2>${bodyHtml}</section>` : '',
+    sources ? `<section><h2>Sources</h2><ul>${sources}</ul></section>` : '',
+    '</div>',
+    '</article>',
+  ].filter(Boolean).join('');
+
+  return inlineContent(applySeoBlock(template, metaBlock), snapshot);
+}
+
+function buildModelsPage(template, forecastTickets, shareImageUrl) {
+  const url = `${SITE_ORIGIN}/models`;
+  const title = 'AI model forecasts and prediction markets';
+  const desc = truncateDescription(
+    'Verified AI model-release forecasts with evidence timelines and linked prediction-market questions. Live probabilities load in the interactive model board.',
+  );
+  const forecastRecords = forecastTickets.map(ticket => ({
+    ticket,
+    record: forecastSeoRecord(ticket, SITE_ORIGIN),
+  }));
+  const jsonLd = {
+    '@type': 'CollectionPage',
+    name: title,
+    description: desc,
+    url,
+    isPartOf: { '@id': `${SITE_ORIGIN}/#website` },
+    mainEntity: {
+      '@type': 'ItemList',
+      numberOfItems: forecastRecords.length,
+      itemListElement: forecastRecords.map(({ record }, index) => ({
+        '@type': 'ListItem',
+        position: index + 1,
+        name: record.title,
+        url: record.url,
+      })),
+    },
+  };
+  const metaBlock = [
+    `<title>${htmlEscapeAttr(title)} -- ara</title>`,
+    `<meta name="description" content="${htmlEscapeAttr(desc)}" />`,
+    ...sharedMetaTags(title, desc),
+    `<link rel="canonical" href="${url}" />`,
+    `<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1" />`,
+    `<meta property="og:type" content="website" />`,
+    `<meta property="og:title" content="${htmlEscapeAttr(title)}" />`,
+    `<meta property="og:description" content="${htmlEscapeAttr(desc)}" />`,
+    `<meta property="og:url" content="${url}" />`,
+    `<meta property="og:site_name" content="ara -- AI research arm" />`,
+    ...imageMetaTags(shareImageUrl, title),
+    `<meta name="twitter:card" content="${shareImageUrl ? 'summary_large_image' : 'summary'}" />`,
+    `<meta name="twitter:title" content="${htmlEscapeAttr(title)}" />`,
+    `<meta name="twitter:description" content="${htmlEscapeAttr(desc)}" />`,
+    `<link rel="alternate" type="application/rss+xml" title="ara -- AI research arm" href="${SITE_ORIGIN}/feed.xml" />`,
+    `<link rel="alternate" type="text/plain" title="llms.txt" href="${SITE_ORIGIN}/llms.txt" />`,
+    jsonLdTag({ '@context': 'https://schema.org', '@graph': [organizationNode(), jsonLd] }),
+  ];
+  const rows = forecastRecords.map(({ ticket, record }) => [
+    '<li>',
+    `<a href="${htmlEscapeAttr(record.route)}"><strong>${htmlEscapeAttr(ticket.title)}</strong></a>`,
+    `<p>${htmlEscapeAttr(ticket.company)} · ${htmlEscapeAttr(String(ticket.status).replace(/-/g, ' '))} · updated ${htmlEscapeAttr(ticket.updated_at)}</p>`,
+    `<p>${htmlEscapeAttr(record.questions.join(' · '))}</p>`,
+    '</li>',
+  ].join('')).join('');
+  const snapshot = [
+    '<section class="content-card forecast-static-page">',
+    '<div class="content-card-body">',
+    '<p class="ara-eyebrow">AI forecast radar</p>',
+    `<h1>${htmlEscapeAttr(title)}</h1>`,
+    `<p>${htmlEscapeAttr(desc)}</p>`,
+    rows ? `<ol>${rows}</ol>` : '<p>No verified market-linked forecasts are currently published.</p>',
+    '<p>Probabilities are informational only and may be unavailable. Each forecast page identifies its committed market mapping and source evidence.</p>',
+    '</div>',
+    '</section>',
+  ].join('');
+  return inlineContent(applySeoBlock(template, metaBlock), snapshot);
 }
 
 function wikiPageImages(page, fallbackAlt) {
@@ -919,19 +1387,16 @@ function buildWikiPage(template, page, shareImageUrl) {
   let html = applySeoBlock(template, metaBlock);
   html = inlineContent(
     html,
-    `<div class="content-card"><div class="content-card-body"><h2>${htmlEscapeAttr(title)}</h2>${wikiImageGalleryHtml(page, title)}${bodyHtml}</div></div>`,
+    singleH1Snapshot(title, `${wikiImageGalleryHtml(page, title)}${bodyHtml}`),
   );
   return html;
 }
 
-function buildSitemap(entries, wikiPages) {
+function buildSitemap(entries, wikiPages, forecastTickets, datedPages) {
   const today = new Date().toISOString().slice(0, 10);
   const rootEntries = [
     { loc: SITE_ORIGIN + '/', priority: '1.0' },
-    { loc: SITE_ORIGIN + '/today', priority: '0.9' },
-    { loc: SITE_ORIGIN + '/twitter', priority: '0.7' },
     { loc: SITE_ORIGIN + '/models', priority: '0.7' },
-    { loc: SITE_ORIGIN + '/frontpage', priority: '0.6' },
     { loc: SITE_ORIGIN + '/research', priority: '0.9' },
     { loc: SITE_ORIGIN + '/wiki', priority: '0.7' },
   ].map(e => ({ ...e, lastmod: today }));
@@ -948,7 +1413,20 @@ function buildSitemap(entries, wikiPages) {
     priority: '0.6',
   }));
 
-  const all = [...rootEntries, ...articleEntries, ...wikiEntries];
+  const forecastEntries = (forecastTickets || []).map(ticket => ({
+    loc: forecastSeoRecord(ticket, SITE_ORIGIN).url,
+    lastmod: (ticket.updated_at || ticket.created_at || today).slice(0, 10),
+    priority: '0.7',
+  }));
+
+  const reportEntries = (datedPages || []).map(page => ({
+    loc: `${SITE_ORIGIN}${page.route}`,
+    lastmod: page.date,
+    priority: page.section === 'today' ? '0.8' : page.section === 'twitter' ? '0.6' : '0.5',
+  }));
+
+  const all = [...rootEntries, ...reportEntries, ...articleEntries, ...wikiEntries, ...forecastEntries]
+    .sort((a, b) => a.loc.localeCompare(b.loc));
   const lines = [
     '<?xml version="1.0" encoding="UTF-8"?>',
     '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
@@ -1002,14 +1480,16 @@ function recentDigestEntries(limit = 10) {
       return {
         date,
         title: `AI Daily Digest -- ${date}`,
-        url: `${SITE_ORIGIN}/today#${date}`,
+        url: `${SITE_ORIGIN}/today/${date}`,
         description: digestDescription(md),
       };
     });
 }
 
-function buildLlmsTxt(entries, wikiPages) {
+function buildLlmsTxt(entries, wikiPages, forecastTickets) {
   const today = new Date().toISOString().slice(0, 10);
+  const digests = recentDigestEntries(10);
+  const latestTwitter = twitterRecords().at(-1);
   const recentArticles = entries
     .filter(e => e.kind !== 'standalone')
     .slice()
@@ -1030,7 +1510,8 @@ function buildLlmsTxt(entries, wikiPages) {
     '## Canonical entry points',
     '',
     `- [Homepage](${SITE_ORIGIN}/): Live AI-news dashboard and archive navigation.`,
-    `- [Today](${SITE_ORIGIN}/today): Latest daily AI digest.`,
+    `- [Latest daily digest](${digests[0]?.url || `${SITE_ORIGIN}/today`}): Daily AI news synthesis.`,
+    latestTwitter ? `- [Latest Twitter/X report](${SITE_ORIGIN}/twitter/${latestTwitter.date}): Source-attributed AI signals from Twitter/X.` : '',
     `- [Research archive](${SITE_ORIGIN}/research): Long-form generative research articles.`,
     `- [LLM Wiki](${SITE_ORIGIN}/wiki): Entity, concept, and theme pages built from curated AI-news synthesis.`,
     `- [Model timeline](${SITE_ORIGIN}/models): Model-release timeline and tickets.`,
@@ -1045,7 +1526,6 @@ function buildLlmsTxt(entries, wikiPages) {
     '',
   ];
 
-  const digests = recentDigestEntries(10);
   if (digests.length) {
     lines.push('## Recent daily digests', '');
     for (const digest of digests) {
@@ -1073,6 +1553,15 @@ function buildLlmsTxt(entries, wikiPages) {
       const title = markdownLine(page.title || page.slug);
       const desc = markdownLine(page.summary || title);
       lines.push(`- [${title}](${SITE_ORIGIN}/wiki/${page.slug}): ${desc}`);
+    }
+    lines.push('');
+  }
+
+  if (forecastTickets?.length) {
+    lines.push('## Verified prediction-market forecasts', '');
+    for (const ticket of forecastTickets) {
+      const record = forecastSeoRecord(ticket, SITE_ORIGIN);
+      lines.push(`- [${markdownLine(record.title)}](${record.url}): ${markdownLine(record.description)}`);
     }
     lines.push('');
   }
@@ -1112,8 +1601,8 @@ function buildFeed(entries, shareImageUrl) {
       const md = readFileSync(join(digestDir, `${date}-digest.md`), 'utf8');
       items.push({
         title: `AI Daily Digest -- ${date}`,
-        link: `${SITE_ORIGIN}/today`,
-        guid: `${SITE_ORIGIN}/today#${date}`,
+        link: `${SITE_ORIGIN}/today/${date}`,
+        guid: `${SITE_ORIGIN}/today/${date}`,
         date,
         description: digestDescription(md),
       });
@@ -1206,28 +1695,107 @@ for (const row of entries) {
     continue;
   }
   const articleHtml = readFileSync(articlePath, 'utf8');
-  const page = buildArticlePage(template, row, articleHtml, shareImageUrl);
+  const indexable = isIndexableResearchEntry(row);
+  const page = buildArticlePage(template, row, articleHtml, shareImageUrl, new Map(), indexable);
   const outDir = join(dist, 'research', row.slug);
   mkdirSync(outDir, { recursive: true });
   writeFileSync(join(outDir, 'index.html'), page);
-  articleRows.push({ row, articleHtml, outDir });
+  articleRows.push({ row, articleHtml, outDir, indexable });
   written++;
 }
 
 const generatedArticleImages = await renderArticleSocialScreenshots(entries);
 if (generatedArticleImages.size) {
-  for (const { row, articleHtml, outDir } of articleRows) {
-    const page = buildArticlePage(template, row, articleHtml, shareImageUrl, generatedArticleImages);
+  for (const { row, articleHtml, outDir, indexable } of articleRows) {
+    const page = buildArticlePage(template, row, articleHtml, shareImageUrl, generatedArticleImages, indexable);
     writeFileSync(join(outDir, 'index.html'), page);
   }
 }
 
-// 2) "today" digest page.
-const digest = latestDigest();
-if (digest) {
+// 2) Dated editorial reports. Each real artifact receives one self-canonical
+// route. Undated convenience routes are noindex aliases to the latest dated
+// artifact, so they remain useful to humans without duplicating the index.
+const digests = digestRecords();
+const twitterReports = twitterRecords();
+const frontPages = frontPageRecords();
+const datedPages = [];
+for (const digest of digests) {
+  const policy = datedPagePolicy('today', digest.date, SITE_ORIGIN);
+  const outDir = join(dist, 'today', digest.date);
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(join(outDir, 'index.html'), buildDigestPage(template, digest, shareImageUrl, policy));
+  datedPages.push({ section: 'today', date: digest.date, route: policy.route });
+}
+const latestDigestRecord = digests.at(-1) || null;
+if (latestDigestRecord) {
   const outDir = join(dist, 'today');
   mkdirSync(outDir, { recursive: true });
-  writeFileSync(join(outDir, 'index.html'), buildDigestPage(template, digest, shareImageUrl));
+  writeFileSync(
+    join(outDir, 'index.html'),
+    buildDigestPage(
+      template,
+      latestDigestRecord,
+      shareImageUrl,
+      latestAliasPolicy('today', latestDigestRecord.date, SITE_ORIGIN),
+    ),
+  );
+}
+
+for (const report of twitterReports) {
+  const markdown = readFileSync(report.path, 'utf8');
+  report.wordCount = renderedWordCount(markdown);
+  const basePolicy = datedPagePolicy('twitter', report.date, SITE_ORIGIN);
+  const policy = report.wordCount >= 300
+    ? basePolicy
+    : { ...basePolicy, indexable: false };
+  const outDir = join(dist, 'twitter', report.date);
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(join(outDir, 'index.html'), buildTwitterPage(template, report, shareImageUrl, policy));
+  if (policy.indexable) datedPages.push({ section: 'twitter', date: report.date, route: policy.route });
+}
+const latestTwitterRecord = twitterReports.at(-1) || null;
+if (latestTwitterRecord) {
+  const outDir = join(dist, 'twitter');
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(
+    join(outDir, 'index.html'),
+    buildTwitterPage(
+      template,
+      latestTwitterRecord,
+      shareImageUrl,
+      latestAliasPolicy('twitter', latestTwitterRecord.date, SITE_ORIGIN),
+    ),
+  );
+}
+
+for (const frontPage of frontPages) {
+  const policy = {
+    route: `/frontpage/${frontPage.date}`,
+    canonicalRoute: `/today/${frontPage.date}`,
+    canonicalUrl: `${SITE_ORIGIN}/today/${frontPage.date}`,
+    indexable: false,
+  };
+  const outDir = join(dist, 'frontpage', frontPage.date);
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(join(outDir, 'index.html'), buildFrontPagePage(template, frontPage, policy));
+}
+const latestFrontPageRecord = frontPages.at(-1) || null;
+if (latestFrontPageRecord) {
+  const outDir = join(dist, 'frontpage');
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(
+    join(outDir, 'index.html'),
+    buildFrontPagePage(
+      template,
+      latestFrontPageRecord,
+      {
+        route: '/frontpage',
+        canonicalRoute: `/today/${latestFrontPageRecord.date}`,
+        canonicalUrl: `${SITE_ORIGIN}/today/${latestFrontPageRecord.date}`,
+        indexable: false,
+      },
+    ),
+  );
 }
 
 // 3) Wiki pages.
@@ -1249,19 +1817,133 @@ if (existsSync(wikiIndexPath)) {
   }
 }
 
-// 4) Homepage -- rewrite dist/index.html LAST (it was the template above, so
+
+// Archive hubs are indexable collections, not generic SPA shells. Their
+// direct links also keep valuable articles and wiki pages within a short crawl
+// path from the homepage.
+const publishedEntries = articleRows.filter(item => item.indexable).map(item => item.row);
+const researchItems = publishedEntries
+  .slice()
+  .sort((a, b) => String(b.created_at || '').localeCompare(String(a.created_at || '')))
+  .map(row => ({
+    route: `/research/${row.slug}`,
+    title: row.title || row.slug,
+    meta: row.created_at ? String(row.created_at).slice(0, 10) : '',
+    description: row.prompt || row.title || row.slug,
+  }));
+const researchHubDir = join(dist, 'research');
+mkdirSync(researchHubDir, { recursive: true });
+writeFileSync(join(researchHubDir, 'index.html'), buildArchivePage(template, {
+  route: '/research',
+  title: 'AI research archive',
+  description: 'Source-cited, long-form research on AI models, companies, infrastructure, policy, and emerging technical claims.',
+  eyebrow: 'Generative research',
+  items: researchItems,
+  shareImageUrl,
+}));
+
+const wikiItems = wikiPages
+  .slice()
+  .sort((a, b) => String(a.title || a.slug).localeCompare(String(b.title || b.slug)))
+  .map(page => ({
+    route: `/wiki/${page.slug}`,
+    title: page.title || page.slug,
+    meta: [page.type, page.updated_at || page.created_at].filter(Boolean).join(' · '),
+    description: decodeEntities(stripTags(page.summary || page.title || page.slug)),
+  }));
+const wikiHubDir = join(dist, 'wiki');
+mkdirSync(wikiHubDir, { recursive: true });
+writeFileSync(join(wikiHubDir, 'index.html'), buildArchivePage(template, {
+  route: '/wiki',
+  title: 'LLM and AI wiki',
+  description: 'A maintained knowledge base of AI labs, models, infrastructure concepts, policy themes, and market participants.',
+  eyebrow: 'Compounding knowledge base',
+  items: wikiItems,
+  shareImageUrl,
+}));
+
+// 4) Verified model forecasts with committed Polymarket mappings. Read the
+// sanitized index emitted by prebuild so crawler and runtime contracts cannot
+// drift. Ordinary/unverified tickets intentionally receive no static page.
+let forecastTickets = [];
+let forecastWritten = 0;
+if (existsSync(distTicketIndexPath)) {
+  try {
+    const ticketIndex = JSON.parse(readFileSync(distTicketIndexPath, 'utf8'));
+    forecastTickets = mappedForecastTickets(ticketIndex);
+    for (const ticket of forecastTickets) {
+      const outDir = join(dist, 'models', 'forecast', ticket.slug);
+      mkdirSync(outDir, { recursive: true });
+      writeFileSync(join(outDir, 'index.html'), buildForecastPage(template, ticket, shareImageUrl));
+      forecastWritten++;
+    }
+  } catch (e) {
+    console.warn(`postbuild-seo: ticket index parse failed (${e.message}); skipping forecast pages`);
+  }
+}
+const distModelsDir = join(dist, 'models');
+mkdirSync(distModelsDir, { recursive: true });
+writeFileSync(join(distModelsDir, 'index.html'), buildModelsPage(template, forecastTickets, shareImageUrl));
+
+// Historical /models/YYYY-MM-DD URLs all render the same live ticket board.
+// Preserve those legacy links, but canonicalize and noindex them instead of
+// presenting 100+ duplicate pages to crawlers.
+const modelTimelineRecords = datedMarkdownRecords(modelTimelineDir, /^(\d{4}-\d{2}-\d{2})-timeline\.md$/);
+for (const record of modelTimelineRecords) {
+  const outDir = join(distModelsDir, record.date);
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(join(outDir, 'index.html'), buildNoindexPage(template, {
+    route: `/models/${record.date}`,
+    canonicalRoute: '/models',
+    title: `AI model timeline -- ${record.date}`,
+    description: 'This historical URL resolves to the live AI model forecast board.',
+    body: 'The model board is maintained as a live ticket collection. Continue to the canonical model forecasts page.',
+    shareImageUrl,
+  }));
+}
+
+// Operational and design-preview surfaces are public for transparency and QA,
+// but they are not search landing pages.
+const agentsDescription = existsSync(armTimelinePath)
+  ? 'Live operational timeline for the autonomous agents and scheduled workflows that maintain ara.'
+  : 'Operational surface for the autonomous agents that maintain ara.';
+const agentsDir = join(dist, 'agents');
+mkdirSync(agentsDir, { recursive: true });
+writeFileSync(join(agentsDir, 'index.html'), buildNoindexPage(template, {
+  route: '/agents',
+  canonicalRoute: '/agents',
+  title: 'ara agent operations',
+  description: agentsDescription,
+  body: agentsDescription,
+  shareImageUrl,
+}));
+const focusReaderDir = join(dist, 'design', 'focus-reader');
+mkdirSync(focusReaderDir, { recursive: true });
+writeFileSync(join(focusReaderDir, 'index.html'), buildNoindexPage(template, {
+  route: '/design/focus-reader',
+  canonicalRoute: '/design/focus-reader',
+  title: 'Focus reader design preview',
+  description: 'An internal design preview for ara reading experiences.',
+  body: 'This route is a design and quality-assurance surface, not a published research page.',
+  shareImageUrl,
+}));
+
+// 5) Homepage -- rewrite dist/index.html LAST (it was the template above, so
 //    article/today/wiki pages inherit the default block, not the homepage one).
 writeFileSync(indexHtmlPath, buildHomePage(template, shareImageUrl));
 
-// 5) sitemap.xml, robots.txt, feed.xml, llms.txt.
-writeFileSync(join(dist, 'sitemap.xml'), buildSitemap(entries, wikiPages));
+// 6) sitemap.xml, robots.txt, feed.xml, llms.txt.
+writeFileSync(join(dist, 'sitemap.xml'), buildSitemap(publishedEntries, wikiPages, forecastTickets, datedPages));
 writeFileSync(join(dist, 'robots.txt'), buildRobots());
-writeFileSync(join(dist, 'feed.xml'), buildFeed(entries, shareImageUrl));
-writeFileSync(join(dist, 'llms.txt'), buildLlmsTxt(entries, wikiPages));
+writeFileSync(join(dist, 'feed.xml'), buildFeed(publishedEntries, shareImageUrl));
+writeFileSync(join(dist, 'llms.txt'), buildLlmsTxt(publishedEntries, wikiPages, forecastTickets));
 
 console.log(
   `postbuild-seo: ${written} article pages (${skipped} skipped), ` +
-  `${digest ? 1 : 0} digest page, ${wikiWritten} wiki pages`,
+  `${digests.length} digests, ${twitterReports.length} Twitter reports ` +
+  `(${twitterReports.filter(report => report.wordCount >= 300).length} indexable), ` +
+  `${frontPages.length} newspaper pages, ${wikiWritten} wiki pages, ` +
+  `${forecastWritten} verified forecast pages, ${modelTimelineRecords.length} noindex model aliases`,
 );
 console.log(`postbuild-seo: share image: ${shareImageUrl || '(none found)'}`);
 console.log('postbuild-seo: sitemap.xml + robots.txt + feed.xml + llms.txt written to dist/');

--- a/dashboard/scripts/site-seo.mjs
+++ b/dashboard/scripts/site-seo.mjs
@@ -1,0 +1,63 @@
+// Pure route-policy helpers used by the SEO postbuild and tests. Keeping the
+// canonical/indexability decisions here makes it harder for the sitemap and
+// emitted HTML to silently disagree.
+
+const DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
+const DATED_SECTIONS = new Set(['today', 'twitter', 'frontpage']);
+
+export function datedRoute(section, date) {
+  if (!DATED_SECTIONS.has(section)) throw new TypeError('invalid dated section');
+  if (!isIsoCalendarDate(date)) throw new TypeError('invalid route date');
+  return `/${section}/${date}`;
+}
+
+export function latestAliasPolicy(section, date, siteOrigin) {
+  const route = datedRoute(section, date);
+  return {
+    route: `/${section}`,
+    canonicalRoute: route,
+    canonicalUrl: `${String(siteOrigin).replace(/\/+$/, '')}${route}`,
+    indexable: false,
+  };
+}
+
+export function datedPagePolicy(section, date, siteOrigin) {
+  const route = datedRoute(section, date);
+  return {
+    route,
+    canonicalRoute: route,
+    canonicalUrl: `${String(siteOrigin).replace(/\/+$/, '')}${route}`,
+    indexable: true,
+  };
+}
+
+export function sortDatedRecords(records) {
+  return [...records]
+    .filter(record => isIsoCalendarDate(record?.date))
+    .sort((a, b) => String(a.date).localeCompare(String(b.date)));
+}
+
+export function isIsoCalendarDate(value) {
+  const match = DATE_RE.exec(String(value || ''));
+  if (!match) return false;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day;
+}
+
+export function isIndexableResearchEntry(entry) {
+  if (!entry || typeof entry !== 'object') return false;
+  const tags = new Set(
+    (Array.isArray(entry.tags) ? entry.tags : [])
+      .map(tag => String(tag).trim().toLowerCase())
+      .filter(Boolean),
+  );
+  if (tags.has('fixture') || tags.has('test')) return false;
+  if (String(entry.slug || '') === 'components') return false;
+  if (tags.has('system') && tags.has('reference')) return false;
+  return true;
+}

--- a/dashboard/scripts/site-seo.test.mjs
+++ b/dashboard/scripts/site-seo.test.mjs
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  datedPagePolicy,
+  datedRoute,
+  isIsoCalendarDate,
+  isIndexableResearchEntry,
+  latestAliasPolicy,
+  sortDatedRecords,
+} from './site-seo.mjs';
+
+test('dated public reports use stable self-canonical routes', () => {
+  assert.deepEqual(
+    datedPagePolicy('twitter', '2026-07-14', 'https://ara.guzus.xyz/'),
+    {
+      route: '/twitter/2026-07-14',
+      canonicalRoute: '/twitter/2026-07-14',
+      canonicalUrl: 'https://ara.guzus.xyz/twitter/2026-07-14',
+      indexable: true,
+    },
+  );
+});
+
+test('research fixtures remain available without entering the search index', () => {
+  assert.equal(isIndexableResearchEntry({ slug: 'useful', tags: ['ai'] }), true);
+  assert.equal(isIndexableResearchEntry({ slug: 'seed', tags: ['fixture'] }), false);
+  assert.equal(isIndexableResearchEntry({ slug: 'test-run', tags: ['test'] }), false);
+  assert.equal(isIndexableResearchEntry({ slug: 'components', tags: ['reference'] }), false);
+});
+
+test('undated latest aliases canonicalize to the dated report and stay out of the index', () => {
+  assert.deepEqual(
+    latestAliasPolicy('today', '2026-07-15', 'https://ara.guzus.xyz'),
+    {
+      route: '/today',
+      canonicalRoute: '/today/2026-07-15',
+      canonicalUrl: 'https://ara.guzus.xyz/today/2026-07-15',
+      indexable: false,
+    },
+  );
+});
+
+test('route inputs and dated ordering are deterministic', () => {
+  assert.equal(datedRoute('frontpage', '2026-07-15'), '/frontpage/2026-07-15');
+  assert.throws(() => datedRoute('agents', '2026-07-15'), /invalid dated section/);
+  assert.throws(() => datedRoute('today', '../latest'), /invalid route date/);
+  assert.equal(isIsoCalendarDate('2026-02-28'), true);
+  assert.equal(isIsoCalendarDate('2026-02-29'), false);
+  assert.equal(isIsoCalendarDate('2026-02-31'), false);
+  assert.equal(isIsoCalendarDate('2026-99-99'), false);
+  assert.deepEqual(
+    sortDatedRecords([{ date: '2026-07-15' }, { date: 'bad' }, { date: '2026-07-13' }])
+      .map(record => record.date),
+    ['2026-07-13', '2026-07-15'],
+  );
+});

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -327,6 +327,12 @@ const languageSwitch = document.getElementById('languageSwitch');
 // are disambiguated from routes by the file extension; Vercel rewrites only
 // extensionless paths to /index.html.
 function routeFromState(): string {
+  if (homeRouteRequested && activeTab === 'today') {
+    return '/';
+  }
+  if (latestAliasRequested === activeTab) {
+    return `/${activeTab}`;
+  }
   if (activeTab === 'focusReader') {
     return '/design/focus-reader';
   }
@@ -339,6 +345,10 @@ function routeFromState(): string {
   if (activeTab === 'wiki') {
     return selectedSlug ? '/wiki/' + selectedSlug : '/wiki';
   }
+  if (activeTab === 'models' && selectedSlug) {
+    return '/models/forecast/' + selectedSlug;
+  }
+  if (activeTab === 'models') return '/models';
   return '/' + activeTab + '/' + fmtDate(currentDate);
 }
 
@@ -348,6 +358,185 @@ function routeFromState(): string {
 // of the stack). Every subsequent call is a user navigation and gets
 // pushState so browser back/forward walks through the visited views.
 let routeInitialized = false;
+// Set by parsing `/` so initial hydration and Back/Forward can render the
+// latest Today view without rewriting the self-canonical homepage URL. It is
+// consumed by the next updateRoute call; subsequent user navigation gets the
+// normal dated route.
+let homeRouteRequested = false;
+type LatestAliasTab = 'today' | 'twitter' | 'frontpage';
+let latestAliasRequested: LatestAliasTab | null = null;
+
+// The public canonical must remain stable across local previews, alternate
+// hostnames, and future CDN aliases. Share actions use this origin rather than
+// location.origin so a QA session never leaks a localhost/preview URL.
+const PUBLIC_SITE_ORIGIN = 'https://ara.guzus.xyz';
+let pendingRouteState: Record<string, unknown> | null = null;
+
+type RuntimeSeoState = {
+  canonicalPath: string;
+  description: string;
+  documentTitle: string;
+  heading: string;
+  indexable: boolean;
+  type: 'article' | 'website';
+};
+
+const runtimePageHeading = document.createElement('h1');
+runtimePageHeading.className = 'runtime-page-heading';
+
+function latestAliasDate(tab: LatestAliasTab, fallback: string): string {
+  const dates = manifest?.[tab];
+  if (!Array.isArray(dates) || dates.length === 0) return fallback;
+  const sorted = dates.filter(isIsoCalendarDate).slice().sort();
+  return sorted[sorted.length - 1] || fallback;
+}
+
+function runtimeSeoState(target: string): RuntimeSeoState {
+  const fallbackDate = fmtDate(currentDate);
+  const isLatestAlias = latestAliasRequested === activeTab;
+  const date = isLatestAlias
+    ? latestAliasDate(latestAliasRequested as LatestAliasTab, fallbackDate)
+    : fallbackDate;
+  if (target === '/') {
+    return {
+      canonicalPath: '/',
+      description: 'Independent AI intelligence: daily news synthesis, model forecasts, prediction-market context, long-form research, and a maintained LLM wiki.',
+      documentTitle: 'ara -- AI research arm',
+      heading: 'AI news, model forecasts, and research',
+      indexable: true,
+      type: 'website',
+    };
+  }
+  if (activeTab === 'today') {
+    return {
+      canonicalPath: `/today/${date}`,
+      description: `The ara daily AI digest for ${date}, covering model releases, research, funding, policy, and community signal.`,
+      documentTitle: `AI Daily Digest -- ${date} -- ara`,
+      heading: `AI Daily Digest -- ${date}`,
+      indexable: !isLatestAlias,
+      type: 'article',
+    };
+  }
+  if (activeTab === 'twitter') {
+    return {
+      canonicalPath: `/twitter/${date}`,
+      description: `Source-attributed AI signals from Twitter/X for ${date}.`,
+      documentTitle: `Twitter/X AI signal report -- ${date} -- ara`,
+      heading: `Twitter/X AI signal report -- ${date}`,
+      indexable: !isLatestAlias,
+      type: 'article',
+    };
+  }
+  if (activeTab === 'frontpage') {
+    return {
+      canonicalPath: `/today/${date}`,
+      description: `The ara daily AI newspaper front page for ${date}, generated from the canonical daily digest.`,
+      documentTitle: `Daily AI newspaper -- ${date} -- ara`,
+      heading: `Daily AI newspaper -- ${date}`,
+      indexable: false,
+      type: 'article',
+    };
+  }
+  if (activeTab === 'models') {
+    const detail = Boolean(selectedSlug);
+    return {
+      canonicalPath: target,
+      description: detail
+        ? 'A verified AI model forecast with committed prediction-market context and supporting evidence.'
+        : 'Verified AI model forecasts, release timelines, and prediction-market context.',
+      documentTitle: detail ? 'AI model forecast -- ara' : 'AI model forecasts and prediction markets -- ara',
+      heading: detail ? 'AI model forecast' : 'AI model forecasts and prediction markets',
+      indexable: true,
+      type: detail ? 'article' : 'website',
+    };
+  }
+  if (activeTab === 'research') {
+    const detail = Boolean(selectedSlug);
+    return {
+      canonicalPath: target,
+      description: detail
+        ? 'Source-cited, long-form AI research from ara.'
+        : 'Source-cited, long-form research on AI models, companies, infrastructure, policy, and emerging technical claims.',
+      documentTitle: detail ? 'AI research -- ara' : 'AI research archive -- ara',
+      heading: detail ? 'AI research' : 'AI research archive',
+      indexable: true,
+      type: detail ? 'article' : 'website',
+    };
+  }
+  if (activeTab === 'wiki') {
+    const detail = Boolean(selectedSlug);
+    return {
+      canonicalPath: target,
+      description: detail
+        ? 'A maintained ara knowledge-base entry about AI models, labs, infrastructure, policy, or markets.'
+        : 'A maintained knowledge base of AI labs, models, infrastructure concepts, policy themes, and market participants.',
+      documentTitle: 'LLM and AI wiki -- ara',
+      heading: detail ? 'LLM and AI wiki entry' : 'LLM and AI wiki',
+      indexable: true,
+      type: detail ? 'article' : 'website',
+    };
+  }
+  if (activeTab === 'agents') {
+    return {
+      canonicalPath: '/agents',
+      description: 'Live operational timeline for the autonomous agents and scheduled workflows that maintain ara.',
+      documentTitle: 'ara agent operations -- ara',
+      heading: 'ara agent operations',
+      indexable: false,
+      type: 'website',
+    };
+  }
+  return {
+    canonicalPath: '/design/focus-reader',
+    description: 'An internal design preview for ara reading experiences.',
+    documentTitle: 'Focus reader design preview -- ara',
+    heading: 'Focus reader design preview',
+    indexable: false,
+    type: 'website',
+  };
+}
+
+function setMetaContent(selector: string, value: string): void {
+  document.head.querySelector<HTMLMetaElement>(selector)?.setAttribute('content', value);
+}
+
+function setRuntimeIndexable(indexable: boolean): void {
+  setMetaContent(
+    'meta[name="robots"]',
+    indexable ? 'index,follow,max-image-preview:large,max-snippet:-1' : 'noindex,follow',
+  );
+}
+
+function syncRuntimePageHeading(): void {
+  if (content.querySelector('h1')) {
+    runtimePageHeading.remove();
+    return;
+  }
+  if (!runtimePageHeading.isConnected) content.before(runtimePageHeading);
+}
+
+function setRuntimePageHeading(value: string): void {
+  runtimePageHeading.textContent = value;
+  syncRuntimePageHeading();
+}
+
+new MutationObserver(syncRuntimePageHeading).observe(content, { childList: true, subtree: true });
+
+function applyRuntimeSeo(target: string): void {
+  const seo = runtimeSeoState(target);
+  const canonicalUrl = new URL(seo.canonicalPath, PUBLIC_SITE_ORIGIN).href;
+  document.title = seo.documentTitle;
+  document.head.querySelector<HTMLLinkElement>('link[rel="canonical"]')?.setAttribute('href', canonicalUrl);
+  setMetaContent('meta[name="description"]', seo.description);
+  setRuntimeIndexable(seo.indexable);
+  setMetaContent('meta[property="og:type"]', seo.type);
+  setMetaContent('meta[property="og:title"]', seo.heading);
+  setMetaContent('meta[property="og:description"]', seo.description);
+  setMetaContent('meta[property="og:url"]', canonicalUrl);
+  setMetaContent('meta[name="twitter:title"]', seo.heading);
+  setMetaContent('meta[name="twitter:description"]', seo.description);
+  setRuntimePageHeading(seo.heading);
+}
 
 // Tracks the last pathname we routed to. Lets popstate distinguish a
 // real route change from a hash-only navigation (anchor click between
@@ -380,22 +569,45 @@ function trackPageView(): void {
 function updateRoute(): void {
   const target = routeFromState();
   const current = location.pathname + location.search;
+  const shouldSyncSeo = routeInitialized || current !== target;
   if (current !== target) {
     if (routeInitialized) {
-      history.pushState(null, '', target);
+      history.pushState(pendingRouteState, '', target);
       trackPageView();
     } else {
       history.replaceState(null, '', target);
     }
   }
+  pendingRouteState = null;
+  if (shouldSyncSeo) applyRuntimeSeo(target);
   routeInitialized = true;
   lastAppliedPathname = location.pathname;
+  homeRouteRequested = false;
+}
+
+function isIsoCalendarDate(value: string): boolean {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) return false;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day;
 }
 
 function parseRoute(path: string): boolean {
   // Strip the trailing slash but keep the leading one
   const clean = path.replace(/\/+$/, '') || '/';
-  if (clean === '/') return false;
+  latestAliasRequested = null;
+  if (clean === '/') {
+    activeTab = 'today';
+    selectedSlug = null;
+    homeRouteRequested = true;
+    syncTabUi();
+    return true;
+  }
   const trimmed = clean.replace(/^\/+/, '');
   if (trimmed === 'design/focus-reader') {
     activeTab = 'focusReader';
@@ -409,10 +621,21 @@ function parseRoute(path: string): boolean {
     syncTabUi();
     return true;
   }
+  const forecastMatch = trimmed.match(/^models\/forecast\/([a-z0-9][a-z0-9._-]*[a-z0-9]|[a-z0-9])$/);
+  if (forecastMatch) {
+    activeTab = 'models';
+    selectedSlug = forecastMatch[1];
+    syncTabUi();
+    return true;
+  }
   const dateMatch = trimmed.match(/^(today|twitter|models|frontpage)(?:\/(\d{4}-\d{2}-\d{2}))?$/);
   if (dateMatch) {
+    if (dateMatch[2] && !isIsoCalendarDate(dateMatch[2])) return false;
     activeTab = dateMatch[1] as Tab;
     selectedSlug = null;
+    if (!dateMatch[2] && activeTab !== 'models') {
+      latestAliasRequested = activeTab as LatestAliasTab;
+    }
     if (dateMatch[2]) {
       const parts = dateMatch[2].split('-');
       currentDate = new Date(+parts[0], +parts[1] - 1, +parts[2]);
@@ -579,6 +802,7 @@ function displayDate(d: Date): string {
 }
 
 function shiftDate(days: number): void {
+  latestAliasRequested = null;
   currentDate.setDate(currentDate.getDate() + days);
   const newMonth = new Date(currentDate.getFullYear(), currentDate.getMonth(), 1);
   if (newMonth.getTime() !== calendarMonth.getTime()) {
@@ -859,6 +1083,7 @@ function handleCalendarClick(e: Event): void {
   }
 
   if (target.closest('[data-cal-today]')) {
+    latestAliasRequested = null;
     const now = new Date();
     currentDate = now;
     activeTab = 'today';
@@ -871,6 +1096,7 @@ function handleCalendarClick(e: Event): void {
 
   const dayEl = target.closest('.cal-day') as HTMLElement | null;
   if (dayEl && dayEl.dataset.date) {
+    latestAliasRequested = null;
     const parts = dayEl.dataset.date.split('-');
     currentDate = new Date(+parts[0], +parts[1] - 1, +parts[2]);
     activeTab = 'today';                 // picking a date opens that day's view
@@ -915,7 +1141,7 @@ function setSafeContent(
   // `target` is NOT in DOMPurify's default allowlist; every external link
   // this app emits pairs target="_blank" with rel="noopener", so allowing
   // it restores the intended new-tab behavior (ticket sources, tweet links).
-  const addAttr = ['id', 'href', 'type', 'target', 'data-slug', 'data-focus-index', 'data-pct', 'data-paper-date', 'data-columns', 'data-filter-status', 'data-filter-company', 'data-has-audio-file', 'data-digest-audio-play', 'data-digest-audio-label', 'data-audio-date', 'data-odds-event', 'data-odds-market', 'data-odds-token', 'data-odds-question', 'data-odds-outcome', 'aria-label', 'aria-current', 'aria-expanded', 'aria-controls', 'aria-pressed', 'aria-haspopup', 'loading', 'decoding', 'controls', 'preload', 'src', 'max', 'value'];
+  const addAttr = ['id', 'href', 'type', 'target', 'data-slug', 'data-ticket-share', 'data-focus-index', 'data-pct', 'data-paper-date', 'data-columns', 'data-filter-status', 'data-filter-company', 'data-has-audio-file', 'data-digest-audio-play', 'data-digest-audio-label', 'data-audio-date', 'data-odds-event', 'data-odds-market', 'data-odds-token', 'data-odds-question', 'data-odds-outcome', 'aria-label', 'aria-describedby', 'aria-current', 'aria-expanded', 'aria-controls', 'aria-pressed', 'aria-haspopup', 'aria-live', 'loading', 'decoding', 'controls', 'preload', 'src', 'max', 'value'];
   if (opts.allowIframe) {
     // iframe + its iframe-only attributes are re-enabled exclusively for the
     // trusted, self-constructed sandboxed standalone-doc iframe.
@@ -1169,6 +1395,7 @@ function navigateToDigestAudioDate(): void {
   if (!digestAudioState.date) return;
   const date = dateFromString(digestAudioState.date);
   if (!date) return;
+  latestAliasRequested = null;
   currentDate = date;
   activeTab = 'today';
   selectedSlug = null;
@@ -1677,6 +1904,7 @@ function showLoading(): void {
       '</div>',
     ].join('\n'),
   );
+  setRuntimePageHeading(runtimeSeoState(routeFromState()).heading);
 }
 
 function showEmpty(dateStr: string): void {
@@ -2297,7 +2525,7 @@ function wikiInternalLink(slug: string, text?: string): string {
 
 // LIST view: catalog grouped by type + a recent-changes panel + a count.
 function renderWikiIndex(index: WikiIndex): void {
-  setDocTitle('Wiki');
+  setDocTitle(null);
   const pages = index.pages.slice();
   if (pages.length === 0) {
     setSafeWikiContent(
@@ -2463,7 +2691,7 @@ function renderWikiPage(page: WikiPage, body: string): void {
 }
 
 function renderWikiNotFound(slug: string): void {
-  setDocTitle('Wiki');
+  setDocTitle(null);
   // All trusted dashboard chrome (including the back <button>) — use the
   // standard sanitizer so the button + data-wiki-back survive. No LLM body here.
   setSafeContent(
@@ -2497,6 +2725,9 @@ function renderTwitterReport(md: string, fallbackDate: string | null = null): vo
     renderSourceChips,
     renderHandleChips,
   }));
+  if (latestAliasRequested !== 'twitter') {
+    setRuntimeIndexable(stripMarkdown(md).split(/\s+/).filter(Boolean).length >= 300);
+  }
   void hydrateTweetCards(content);
   void wikifyContent(content);
 }
@@ -2668,6 +2899,103 @@ function ticketPolymarketMappings(ticket: Ticket): TicketPolymarketMapping[] {
       typeof m.token_id === 'string' && m.token_id.trim() !== '' &&
       typeof m.question === 'string' && m.question.trim() !== '')
     .slice(0, 3);
+}
+
+function isShareableForecastTicket(ticket: Ticket): boolean {
+  // SEO postbuild uses the same threshold: a market mapping plus the ticket's
+  // strongest evidence state. Partial/unverified tickets remain board-only.
+  return ticket.verification === 'confirmed' && ticketPolymarketMappings(ticket).length > 0;
+}
+
+function forecastPath(ticket: Ticket): string {
+  return `/models/forecast/${encodeURIComponent(ticket.slug)}`;
+}
+
+function forecastUrl(ticket: Ticket): string {
+  return new URL(forecastPath(ticket), PUBLIC_SITE_ORIGIN).href;
+}
+
+function ticketForecastActionsHtml(ticket: Ticket): string {
+  if (!isShareableForecastTicket(ticket)) return '';
+  const statusId = `ticket-share-status-${ticket.slug}`;
+  const markets = ticketPolymarketMappings(ticket).map(mapping => {
+    const href = `https://polymarket.com/event/${encodeURIComponent(mapping.event_slug)}`;
+    const outcome = mapping.outcome?.trim() ? ` · ${escapeHtml(mapping.outcome.trim())}` : '';
+    return `<li><a href="${href}" target="_blank" rel="noopener noreferrer">${escapeHtml(mapping.question)}${outcome} ↗</a></li>`;
+  }).join('');
+  return `<div class="ticket-forecast-actions">
+    <div class="ticket-forecast-heading">
+      <h4 class="ticket-history-title">Linked forecasts</h4>
+      <button class="ticket-share-button" type="button" data-ticket-share="${escapeHtml(ticket.slug)}" aria-describedby="${escapeHtml(statusId)}">Share forecast</button>
+    </div>
+    <ul class="ticket-forecast-links">${markets}</ul>
+    <span class="ticket-share-status" id="${escapeHtml(statusId)}" role="status" aria-live="polite"></span>
+  </div>`;
+}
+
+function copyTextFallback(text: string): boolean {
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'fixed';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+  textarea.select();
+  let copied = false;
+  try {
+    copied = document.execCommand('copy');
+  } catch {
+    copied = false;
+  }
+  textarea.remove();
+  return copied;
+}
+
+function trackForecastShare(ticket: Ticket, method: 'native' | 'clipboard'): void {
+  if (typeof window.gtag !== 'function') return;
+  window.gtag('event', 'share', {
+    method,
+    content_type: 'model_forecast',
+    item_id: ticket.slug,
+    content_id: forecastUrl(ticket),
+  });
+}
+
+async function shareTicketForecast(ticket: Ticket, button: HTMLButtonElement): Promise<void> {
+  const status = button.closest('.ticket-forecast-actions')?.querySelector<HTMLElement>('.ticket-share-status');
+  const shareData = {
+    title: `${ticket.title} forecast — ara`,
+    text: `Verified model forecast with linked prediction-market context: ${ticket.title}`,
+    url: forecastUrl(ticket),
+  };
+  if (typeof navigator.share === 'function') {
+    try {
+      await navigator.share(shareData);
+      if (status) status.textContent = 'Shared.';
+      trackForecastShare(ticket, 'native');
+      return;
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        if (status) status.textContent = '';
+        return;
+      }
+      // A platform can expose navigator.share but reject a payload. Fall
+      // through to copy so the control still works in partial implementations.
+    }
+  }
+  let copied = false;
+  try {
+    await navigator.clipboard.writeText(shareData.url);
+    copied = true;
+  } catch {
+    copied = copyTextFallback(shareData.url);
+  }
+  if (copied) {
+    if (status) status.textContent = 'Forecast link copied.';
+    trackForecastShare(ticket, 'clipboard');
+  } else if (status) {
+    status.textContent = `Copy this link: ${shareData.url}`;
+  }
 }
 
 function fmtOddsPct(price: number): string {
@@ -3181,9 +3509,10 @@ function ticketExpandedPanel(ticket: Ticket | null): string {
   return `<section class="ticket-detail-panel" aria-label="${escapeHtml(ticket.title)} details">
     <div class="ticket-detail-header">
       ${ticketStatusPill(ticket.status)}
-      <h3>${escapeHtml(ticket.title)}</h3>
+      <h3 id="ticket-dialog-title-${escapeHtml(ticket.slug)}">${escapeHtml(ticket.title)}</h3>
     </div>
     <div class="ticket-expanded">
+      ${ticketForecastActionsHtml(ticket)}
       <dl class="ara-kv">${kvRows}</dl>
       <div class="ticket-body md-content">${DOMPurify.sanitize(renderReportMarkdown(ticket.body))}</div>
       <div class="ticket-history">
@@ -3245,12 +3574,37 @@ function companyKey(company: string): string {
 // Ticket detail modal — clicking a card opens a larger overlay with the full
 // ticket (metadata grid, body, history timeline, sources).
 let ticketModalEl: HTMLElement | null = null;
+let ticketModalReturnFocusSlug: string | null = null;
+
+function rememberTicketModalOrigin(ticket: Ticket): void {
+  ticketModalReturnFocusSlug = ticket.slug;
+}
+
+function restoreTicketModalFocus(): void {
+  if (!ticketModalReturnFocusSlug || selectedSlug) return;
+  const slug = ticketModalReturnFocusSlug;
+  const card = Array.from(content.querySelectorAll<HTMLElement>('.ticket-card'))
+    .find(candidate => candidate.dataset.slug === slug);
+  if (!card) return;
+  ticketModalReturnFocusSlug = null;
+  card.focus();
+}
+
 function openTicketModal(ticket: Ticket): void {
   if (!ticketModalEl) {
     ticketModalEl = document.createElement('div');
     ticketModalEl.className = 'ticket-modal';
+    ticketModalEl.setAttribute('role', 'dialog');
+    ticketModalEl.setAttribute('aria-modal', 'true');
     ticketModalEl.addEventListener('click', (e) => {
       const tgt = e.target as HTMLElement;
+      const shareButton = tgt.closest('[data-ticket-share]') as HTMLButtonElement | null;
+      if (shareButton) {
+        const slug = shareButton.dataset.ticketShare;
+        const shareTicket = slug && ticketsCache ? ticketsCache.find((candidate) => candidate.slug === slug) : null;
+        if (shareTicket && isShareableForecastTicket(shareTicket)) void shareTicketForecast(shareTicket, shareButton);
+        return;
+      }
       if (tgt === ticketModalEl || tgt.closest('.ticket-modal-close')) closeTicketModal();
     });
     document.body.appendChild(ticketModalEl);
@@ -3260,16 +3614,48 @@ function openTicketModal(ticket: Ticket): void {
     '<div class="ticket-modal-card"><button class="ticket-modal-close" type="button" aria-label="Close">✕</button>' +
       ticketExpandedPanel(ticket) + '</div>',
   );
+  ticketModalEl.setAttribute('aria-labelledby', `ticket-dialog-title-${ticket.slug}`);
   ticketModalEl.style.display = 'flex';
   document.body.classList.add('modal-open');
+  ticketModalEl.querySelector<HTMLButtonElement>('.ticket-modal-close')?.focus();
 }
 function closeTicketModal(): void {
   if (ticketModalEl) ticketModalEl.style.display = 'none';
   document.body.classList.remove('modal-open');
+  if (activeTab === 'models' && selectedSlug) {
+    selectedSlug = null;
+    if (history.state?.araForecastFromBoard === true) {
+      history.back();
+      return;
+    }
+    history.replaceState(null, '', routeFromState());
+    lastAppliedPathname = location.pathname;
+    trackPageView();
+  }
+  restoreTicketModalFocus();
 }
 document.addEventListener('keydown', (e) => {
-  if (!ticketModalEl) return;
-  if (e.key === 'Escape' && ticketModalEl.style.display === 'flex') {
+  if (e.key === 'Tab' && ticketModalEl?.style.display === 'flex') {
+    const focusable = Array.from(ticketModalEl.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    )).filter(element => !element.hasAttribute('hidden'));
+    if (focusable.length === 0) {
+      e.preventDefault();
+      return;
+    }
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const active = document.activeElement;
+    if (e.shiftKey && (active === first || !ticketModalEl.contains(active))) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && active === last) {
+      e.preventDefault();
+      first.focus();
+    }
+    return;
+  }
+  if (e.key === 'Escape' && ticketModalEl?.style.display === 'flex') {
     closeTicketModal();
     return;
   }
@@ -3281,7 +3667,17 @@ document.addEventListener('keydown', (e) => {
     const card = active?.closest?.('.ticket-card') as HTMLElement | null;
     const slug = card?.dataset.slug;
     const ticket = slug && ticketsCache ? ticketsCache.find((t) => t.slug === slug) : null;
-    if (ticket) { e.preventDefault(); openTicketModal(ticket); }
+    if (ticket) {
+      e.preventDefault();
+      rememberTicketModalOrigin(ticket);
+      if (isShareableForecastTicket(ticket)) {
+        pendingRouteState = { araForecastFromBoard: true };
+        selectedSlug = ticket.slug;
+        load();
+      } else {
+        openTicketModal(ticket);
+      }
+    }
   }
 });
 
@@ -3364,6 +3760,9 @@ function renderTickets(tickets: Ticket[] | null): void {
   // Hydrate odds lazily so the grid paints first; failures leave em-dash
   // chips and never block or break the tab.
   window.setTimeout(() => { void hydrateTicketOdds(); }, 0);
+  if (!selectedSlug && ticketModalReturnFocusSlug) {
+    window.requestAnimationFrame(restoreTicketModalFocus);
+  }
 }
 
  function frontPageBodyHtml(frontPage: FrontPageAsset): string {
@@ -3442,15 +3841,22 @@ function renderToday(md: string, frontPage: FrontPageAsset | null = null): void 
 
 // ── Generative research ───────────────────────────────
 
-// Default <title> from index.html, used to reset when leaving an article.
-const DEFAULT_DOC_TITLE = document.title;
-
 /** Update the browser title so the print dialog suggests a useful PDF
  * filename (browsers default to <title>). Reset on back-to-index. */
 function setDocTitle(articleTitle: string | null): void {
-  document.title = articleTitle
-    ? `${articleTitle} — ara`
-    : DEFAULT_DOC_TITLE;
+  const seo = runtimeSeoState(routeFromState());
+  const pageTitle = articleTitle || seo.heading;
+  document.title = articleTitle ? `${articleTitle} — ara` : seo.documentTitle;
+  setMetaContent('meta[property="og:title"]', pageTitle);
+  setMetaContent('meta[name="twitter:title"]', pageTitle);
+  setRuntimePageHeading(pageTitle);
+}
+
+function isIndexableResearchRow(row: GenResearchRow): boolean {
+  const tags = new Set((row.tags || []).map(tag => String(tag).trim().toLowerCase()));
+  if (tags.has('fixture') || tags.has('test')) return false;
+  if (row.slug === 'components') return false;
+  return !(tags.has('system') && tags.has('reference'));
 }
 
 /** Operational backend-routing metadata is searchable, but not article subject matter. */
@@ -3565,6 +3971,7 @@ function renderResearchDoc(row: GenResearchRow, body: string): void {
   );
 
   setDocTitle(row.title);
+  setRuntimeIndexable(isIndexableResearchRow(row));
   updateResearchAudioUi();
 
   // After DOM is in place, apply data-pct viz fills, wrap tables in a
@@ -3980,6 +4387,12 @@ async function load(): Promise<void> {
   const controller = new AbortController();
   activeLoadController = controller;
   stopResearchAudio();
+  // A direct forecast route owns the ticket modal. Navigating away via
+  // back/forward must dismiss it without rewriting the destination route.
+  if (ticketModalEl && (activeTab !== 'models' || !selectedSlug)) {
+    ticketModalEl.style.display = 'none';
+    document.body.classList.remove('modal-open');
+  }
   // Polymarket midpoint polling only runs while the models tab is shown.
   if (activeTab !== 'models') stopTicketOddsPolling();
 
@@ -4007,6 +4420,7 @@ async function load(): Promise<void> {
       await loadManifest();
       if (requestId !== loadRequestId) return;
     }
+    if (latestAliasRequested) applyRuntimeSeo(routeFromState());
     if (activeTab === 'focusReader') {
       const result = await withTimeout(loadFocusReaderData(controller.signal), LOAD_TIMEOUT_MS, controller);
       if (requestId !== loadRequestId) return;
@@ -4122,6 +4536,13 @@ async function load(): Promise<void> {
         showError('Loading timed out', 'Network may be slow. Click to retry.');
       } else {
         renderTickets(ticketsResult);
+        const routedTicket = selectedSlug && Array.isArray(ticketsResult)
+          ? ticketsResult.find(ticket => ticket.slug === selectedSlug)
+          : null;
+        if (routedTicket && isShareableForecastTicket(routedTicket)) {
+          setDocTitle(`${routedTicket.title} forecast`);
+          openTicketModal(routedTicket);
+        }
       }
     } else if (activeTab === 'today') {
       // Fetch digest + front page in parallel — the front page goes
@@ -4295,13 +4716,15 @@ document.getElementById('shortcutToggle')!.addEventListener('click', () => {
 function goHome(): void {
   activeTab = 'today';
   selectedSlug = null;
+  latestAliasRequested = null;
+  homeRouteRequested = true;
   syncTabUi();
   load();
 }
 const brandHome = document.getElementById('brandHome');
-brandHome?.addEventListener('click', goHome);
-brandHome?.addEventListener('keydown', (e) => {
-  if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); goHome(); }
+brandHome?.addEventListener('click', (event) => {
+  event.preventDefault();
+  goHome();
 });
 
 const searchToggle = document.getElementById('searchToggle');
@@ -4433,13 +4856,14 @@ function moveSearchSel(d: number): void {
 
 function activateSearchHit(h: SearchHit): void {
   closeSearch();
+  latestAliasRequested = null;
   if (h.type === 'model') {
     activeTab = 'models';
-    selectedSlug = null;
+    const t = ticketsCache ? ticketsCache.find((x) => x.slug === h.slug) : null;
+    selectedSlug = t && isShareableForecastTicket(t) ? t.slug : null;
     syncTabUi();
     load();
-    const t = ticketsCache ? ticketsCache.find((x) => x.slug === h.slug) : null;
-    if (t) window.setTimeout(() => openTicketModal(t), 60);
+    if (t && !isShareableForecastTicket(t)) window.setTimeout(() => openTicketModal(t), 60);
     return;
   }
   if (h.type === 'digest') {
@@ -4614,6 +5038,7 @@ content.addEventListener('click', (e) => {
     const match = href.match(/^\/twitter\/(\d{4}-\d{2}-\d{2})$/);
     if (match) {
       e.preventDefault();
+      latestAliasRequested = null;
       currentDate = ymdToDate(match[1]);
       calendarMonth = new Date(currentDate.getFullYear(), currentDate.getMonth(), 1);
       load();
@@ -4686,7 +5111,16 @@ content.addEventListener('click', (e) => {
     if (target.closest('a, button')) return;
     const slug = row.dataset.slug;
     const ticket = slug && ticketsCache ? ticketsCache.find((t) => t.slug === slug) : null;
-    if (ticket) openTicketModal(ticket);
+    if (ticket) {
+      rememberTicketModalOrigin(ticket);
+      if (isShareableForecastTicket(ticket)) {
+        pendingRouteState = { araForecastFromBoard: true };
+        selectedSlug = ticket.slug;
+        load();
+      } else {
+        openTicketModal(ticket);
+      }
+    }
   }
 });
 
@@ -4772,6 +5206,7 @@ document.addEventListener('keydown', (e: KeyboardEvent) => {
       break;
     case 't':
     case 'T': {
+      latestAliasRequested = null;
       const now = new Date();
       currentDate = now;
       calendarMonth = new Date(now.getFullYear(), now.getMonth(), 1);
@@ -4794,11 +5229,13 @@ document.addEventListener('keydown', (e: KeyboardEvent) => {
 });
 
 // ── Tab navigation ────────────────────────────────────
-document.querySelectorAll<HTMLButtonElement>('.tab').forEach((btn) => {
-  btn.addEventListener('click', () => {
+document.querySelectorAll<HTMLAnchorElement>('.tab').forEach((btn) => {
+  btn.addEventListener('click', (event) => {
+    event.preventDefault();
     const tab = btn.dataset.tab as Tab;
     if (tab === activeTab) return;
     activeTab = tab;
+    latestAliasRequested = tab === 'twitter' ? 'twitter' : null;
     selectedSlug = null;
     syncTabUi();
     document.body.classList.toggle('tab-research', activeTab === 'research');

--- a/dashboard/src/style.css
+++ b/dashboard/src/style.css
@@ -4682,6 +4682,58 @@ body.ticket-odds-modal-open { overflow: hidden; }
 .ticket-detail-panel .ticket-body {
   max-width: 760px;
 }
+.ticket-forecast-actions {
+  padding: 12px 14px;
+  border: 1px solid var(--border-light);
+  border-radius: 10px;
+  background: var(--bg-secondary);
+}
+.ticket-forecast-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+.ticket-forecast-heading .ticket-history-title { margin: 0; }
+.ticket-share-button {
+  flex: 0 0 auto;
+  min-height: 34px;
+  padding: 7px 11px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+  color: var(--text);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 650;
+  cursor: pointer;
+}
+.ticket-share-button:hover { background: var(--bg-hover); }
+.ticket-share-button:focus-visible {
+  outline: 2px solid var(--accent-warm);
+  outline-offset: 2px;
+}
+.ticket-forecast-links {
+  display: grid;
+  gap: 7px;
+  margin: 0;
+  padding-left: 18px;
+  font-size: 12.5px;
+  line-height: 1.45;
+}
+.ticket-forecast-links a { color: var(--accent-warm); }
+.ticket-share-status {
+  display: block;
+  min-height: 1.3em;
+  margin-top: 7px;
+  color: var(--text-tertiary);
+  font-size: 11px;
+  overflow-wrap: anywhere;
+}
+@media (max-width: 480px) {
+  .ticket-forecast-heading { align-items: flex-start; }
+}
 .ticket-body {
   font-size: 14px;
   line-height: 1.55;
@@ -5372,4 +5424,15 @@ body.ticket-odds-modal-open { overflow: hidden; }
   .focus-surface-tabs {
     justify-content: flex-start;
   }
+}
+.runtime-page-heading {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }


### PR DESCRIPTION
## Summary

- add stable, shareable `/models/forecast/<slug>` routes for confirmed model tickets with committed Polymarket mappings
- add native sharing with clipboard fallback, share analytics, accessible forecast dialogs, focus restoration, and correct browser history behavior
- generate dedicated SEO pages for the homepage, dated Today and Twitter reports, Models, Research, Wiki, and eligible detail pages
- add crawlable Research and Wiki collection hubs, canonical feeds, `llms.txt`, structured data, and deterministic sitemap generation
- classify latest aliases, thin reports, Frontpage duplicates, fixtures, operational views, and raw research artifacts as noindex instead of indexing everything
- return real 404s for unknown or impossible routes and synchronize canonical, robots, descriptions, Open Graph metadata, and H1s during SPA navigation

## Why

The dashboard previously served most routes through one generic SPA shell. Valuable pages lacked dedicated crawler and social metadata, model forecasts had no stable share URL, unknown routes produced soft 404s, and convenience aliases could compete with canonical dated content.

This change gives every public route an explicit search contract: unique durable content is indexable and self-canonical, while aliases, duplicates, thin/internal surfaces, and raw artifacts remain accessible without entering the search index.

## Impact

- 378 sitemap URLs now resolve to dedicated, indexable, self-canonical HTML
- 118 dated daily digests and 131 substantive Twitter reports are indexable
- 75 Frontpage wrappers, two thin Twitter reports, legacy model dates, and internal/experimental routes are intentionally noindex
- three confirmed model forecasts receive stable share pages without baking stale live prices into social metadata
- Caddy serves valid routes directly, returns 404 for missing routes, and applies `X-Robots-Tag: noindex, nofollow` to extension-based raw research artifacts

## Validation

- `npm test` — 7/7 passed
- `npm run typecheck` — passed
- `SKIP_LFS_POINTERS=1 npm run build` — passed
- Caddy v2.10 configuration validation — passed
- live Caddy response checks — valid routes 200, missing/impossible routes 404, raw artifacts noindex
- desktop and mobile browser checks — direct routes, aliases, SPA metadata, forecast sharing/modal flow, and Back/Forward behavior passed with no page errors or horizontal overflow
- static crawl assertions — all 378 sitemap entries exist, are indexable/self-canonical, and have one H1
- repeated postbuild HTML/XML/TXT hash — byte-identical

## Note

S3 credentials were not present locally, so generated social-preview screenshots were verified as local build artifacts only.
