### PR TITLE
Stabilize dashboard navigation and archive UX

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -47,6 +47,8 @@
             </a>
           </div>
         </div>
+      </header>
+      <div class="nav-shell">
         <nav class="tabs" id="tabs">
           <div class="calendar" id="calendar"></div>
           <a class="tab" data-tab="twitter" href="/twitter">Twitter</a>
@@ -69,7 +71,8 @@
           </div>
           <div class="search-results" id="searchResults" role="listbox" hidden></div>
         </div>
-        <div class="controls">
+      </div>
+      <div class="controls">
           <a
             class="request-btn"
             href="https://github.com/guzus/ai-research-arm/issues/new?labels=gen-research&title=%5BResearch%5D%20&body=%23%23%20Research%20request%0A%0ATopic%3A%20%0A%0AContext%3A%20%0A%0ATags%3A%20%0A%0Abackend%3A%20claude"
@@ -84,8 +87,7 @@
           <button class="icon-btn refresh-btn" id="refreshBtn" title="Refresh (R)" aria-label="Refresh">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M23 4v6h-6M1 20v-6h6"/><path d="M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15"/></svg>
           </button>
-        </div>
-      </header>
+      </div>
       <div id="content"></div>
       <footer class="site-footer">
         <a class="footer-link" href="https://x.com/uncanny_guzus" target="_blank" rel="noopener noreferrer">

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -246,6 +246,8 @@ let currentDate = new Date();
 let searchTerm = '';
 let activeTab: Tab = 'today';
 let selectedSlug: string | null = null;
+let researchIndexPage = 1;
+let wikiIndexPage = 1;
 let activeLanguage: ResearchLanguage = loadStoredLanguage();
 let calendarMonth = new Date(currentDate.getFullYear(), currentDate.getMonth(), 1);
 const availabilityCache = new Map<string, Set<string>>();
@@ -340,16 +342,35 @@ function routeFromState(): string {
     return '/agents';
   }
   if (activeTab === 'research') {
-    return selectedSlug ? '/research/' + selectedSlug : '/research';
+    return selectedSlug ? '/research/' + selectedSlug : paginationRoute('/research', researchIndexPage);
   }
   if (activeTab === 'wiki') {
-    return selectedSlug ? '/wiki/' + selectedSlug : '/wiki';
+    return selectedSlug ? '/wiki/' + selectedSlug : paginationRoute('/wiki', wikiIndexPage);
   }
   if (activeTab === 'models' && selectedSlug) {
     return '/models/forecast/' + selectedSlug;
   }
   if (activeTab === 'models') return '/models';
   return '/' + activeTab + '/' + fmtDate(currentDate);
+}
+
+function paginationRoute(path: string, page: number): string {
+  return page > 1 ? path + '?page=' + page : path;
+}
+
+function pageFromSearch(): number {
+  const raw = new URLSearchParams(location.search).get('page');
+  if (!raw || !/^\d+$/.test(raw)) return 1;
+  const page = Number(raw);
+  return Number.isSafeInteger(page) && page > 0 ? page : 1;
+}
+
+function canonicalizeIndexPage(): void {
+  const target = routeFromState();
+  if (location.pathname + location.search === target) return;
+  history.replaceState(history.state, '', target);
+  lastAppliedPathname = target;
+  applyRuntimeSeo(target);
 }
 
 // Tracks whether the SPA has rendered at least once. The first call
@@ -542,7 +563,7 @@ function applyRuntimeSeo(target: string): void {
 // real route change from a hash-only navigation (anchor click between
 // sections in the same article). Maintained from both updateRoute and
 // the popstate handler.
-let lastAppliedPathname = location.pathname;
+let lastAppliedPathname = location.pathname + location.search;
 
 // gtag is loaded by the <script> in index.html. Type as optional so the
 // dashboard still works when GA is blocked (adblockers, privacy modes).
@@ -581,7 +602,7 @@ function updateRoute(): void {
   pendingRouteState = null;
   if (shouldSyncSeo) applyRuntimeSeo(target);
   routeInitialized = true;
-  lastAppliedPathname = location.pathname;
+  lastAppliedPathname = location.pathname + location.search;
   homeRouteRequested = false;
 }
 
@@ -648,6 +669,7 @@ function parseRoute(path: string): boolean {
   if (researchMatch) {
     activeTab = 'research';
     selectedSlug = researchMatch[1] || null;
+    researchIndexPage = selectedSlug ? 1 : pageFromSearch();
     syncTabUi();
     return true;
   }
@@ -658,6 +680,7 @@ function parseRoute(path: string): boolean {
   if (wikiMatch) {
     activeTab = 'wiki';
     selectedSlug = wikiMatch[1] || null;
+    wikiIndexPage = selectedSlug ? 1 : pageFromSearch();
     syncTabUi();
     return true;
   }
@@ -973,7 +996,7 @@ function buildCalendarHtml(): string {
     : ' aria-label="Open ' + selectedLabel + ' day view"';
   const headerIndicator = isDayView ? (open ? '&#9650;' : '&#9660;') : '&rsaquo;';
   let html = '<button class="cal-header" type="button" data-cal-toggle' + headerAttrs + '>';
-  html += '<span class="cal-header-label">' + selectedLabel + '<span class="cal-chevron">' + headerIndicator + '</span></span>';
+  html += '<span class="cal-header-label"><span class="cal-selected-date">' + selectedLabel + '</span><span class="cal-chevron">' + headerIndicator + '</span></span>';
   html += '</button>';
 
   // Month nav + day grid live in a popover so the pill keeps a fixed size.
@@ -2466,6 +2489,7 @@ function setSafeWikiContent(el: HTMLElement, rawHtml: string): void {
 }
 
 const WIKI_TYPE_ORDER: WikiType[] = ['entity', 'concept', 'theme'];
+const WIKI_PAGE_SIZE = 12;
 const WIKI_TYPE_LABEL: Record<string, string> = {
   entity: 'Entities',
   concept: 'Concepts',
@@ -2547,6 +2571,32 @@ function wikiInternalLink(slug: string, text?: string): string {
   );
 }
 
+function paginationHtml(page: number, totalItems: number, pageSize: number, label: string): string {
+  const pageCount = Math.max(1, Math.ceil(totalItems / pageSize));
+  if (pageCount <= 1) return '';
+  const safePage = Math.min(Math.max(1, page), pageCount);
+  const first = (safePage - 1) * pageSize + 1;
+  const last = Math.min(safePage * pageSize, totalItems);
+  const pageLink = (target: number, text: string, className: string): string => {
+    const disabled = target < 1 || target > pageCount;
+    if (disabled) {
+      return '<span class="index-pagination-link ' + className + ' is-disabled" aria-disabled="true">' + text + '</span>';
+    }
+    const href = paginationRoute(activeTab === 'wiki' ? '/wiki' : '/research', target);
+    return '<a class="index-pagination-link ' + className + '" href="' + href + '" data-index-page="' + target + '">' + text + '</a>';
+  };
+  return [
+    '<nav class="index-pagination" aria-label="' + escapeHtml(label) + ' pagination">',
+    '  <div class="index-pagination-summary">' + first + '\u2013' + last + ' of ' + totalItems + '</div>',
+    '  <div class="index-pagination-controls">',
+    pageLink(safePage - 1, '&larr;<span> Previous</span>', 'index-pagination-prev'),
+    '    <span class="index-pagination-status" aria-current="page">' + safePage + ' / ' + pageCount + '</span>',
+    pageLink(safePage + 1, '<span>Next </span>&rarr;', 'index-pagination-next'),
+    '  </div>',
+    '</nav>',
+  ].join('\n');
+}
+
 // LIST view: catalog grouped by type + a recent-changes panel + a count.
 function renderWikiIndex(index: WikiIndex): void {
   setDocTitle(null);
@@ -2578,9 +2628,27 @@ function renderWikiIndex(index: WikiIndex): void {
       })
     : pages;
 
-  // Group by type, with the known types first then any unknown types.
+  // Sort before slicing so pagination stays deterministic when the committed
+  // index order changes. Known types retain the catalog's semantic order.
+  const typeRank = (type: string): number => {
+    const rank = WIKI_TYPE_ORDER.indexOf(type as WikiType);
+    return rank === -1 ? WIKI_TYPE_ORDER.length : rank;
+  };
+  visible.sort((a, b) =>
+    typeRank(String(a.type)) - typeRank(String(b.type)) ||
+    String(a.type).localeCompare(String(b.type)) ||
+    a.title.localeCompare(b.title) ||
+    a.slug.localeCompare(b.slug),
+  );
+  const pageCount = Math.max(1, Math.ceil(visible.length / WIKI_PAGE_SIZE));
+  const requestedPage = wikiIndexPage;
+  wikiIndexPage = Math.min(wikiIndexPage, pageCount);
+  if (wikiIndexPage !== requestedPage) canonicalizeIndexPage();
+  const pageRows = visible.slice((wikiIndexPage - 1) * WIKI_PAGE_SIZE, wikiIndexPage * WIKI_PAGE_SIZE);
+
+  // Group the current page by type, with the known types first then any unknown types.
   const groups = new Map<string, WikiPage[]>();
-  for (const p of visible) {
+  for (const p of pageRows) {
     const key = String(p.type || 'other');
     if (!groups.has(key)) groups.set(key, []);
     groups.get(key)!.push(p);
@@ -2634,6 +2702,7 @@ function renderWikiIndex(index: WikiIndex): void {
       '  <div class="wiki-index-main">',
       emptyNote,
       sections.join('\n'),
+      paginationHtml(wikiIndexPage, visible.length, WIKI_PAGE_SIZE, 'Wiki pages'),
       '  </div>',
       '</div>',
     ].join('\n'),
@@ -3653,7 +3722,7 @@ function closeTicketModal(): void {
       return;
     }
     history.replaceState(null, '', routeFromState());
-    lastAppliedPathname = location.pathname;
+    lastAppliedPathname = location.pathname + location.search;
     trackPageView();
   }
   restoreTicketModalFocus();
@@ -3888,6 +3957,8 @@ function isResearchDisplayTag(tag: string): boolean {
   return tag !== 'fireworks-fallback' && !tag.startsWith('requested-');
 }
 
+const RESEARCH_PAGE_SIZE = 12;
+
 function renderResearchIndex(rows: GenResearchRow[]): void {
   setDocTitle(null);
   if (rows.length === 0) {
@@ -3895,8 +3966,10 @@ function renderResearchIndex(rows: GenResearchRow[]): void {
     return;
   }
   const term = searchTerm.toLowerCase();
-  // Newest first. The writer appends ascending, so reverse.
-  const reversed = rows.slice().reverse();
+  // Newest first with a slug tie-breaker, independent of manifest insertion order.
+  const reversed = rows.slice().sort((a, b) =>
+    b.created_at.localeCompare(a.created_at) || a.slug.localeCompare(b.slug),
+  );
   const visible = term
     ? reversed.filter((r) => {
         const hay = (r.title + ' ' + r.prompt + ' ' + (r.tags || []).join(' ')).toLowerCase();
@@ -3904,8 +3977,16 @@ function renderResearchIndex(rows: GenResearchRow[]): void {
       })
     : reversed;
 
+  const pageCount = Math.max(1, Math.ceil(visible.length / RESEARCH_PAGE_SIZE));
+  const requestedPage = researchIndexPage;
+  researchIndexPage = Math.min(researchIndexPage, pageCount);
+  if (researchIndexPage !== requestedPage) canonicalizeIndexPage();
+  const pageRows = visible.slice(
+    (researchIndexPage - 1) * RESEARCH_PAGE_SIZE,
+    researchIndexPage * RESEARCH_PAGE_SIZE,
+  );
   const items: string[] = [];
-  for (const row of visible) {
+  for (const row of pageRows) {
     let title = escapeHtml(row.title);
     if (searchTerm) {
       const escaped = searchTerm.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -3957,6 +4038,7 @@ function renderResearchIndex(rows: GenResearchRow[]): void {
       items.join('\n'),
       '    </ul>',
       empty,
+      paginationHtml(researchIndexPage, visible.length, RESEARCH_PAGE_SIZE, 'Research articles'),
       '  </div>',
       '</div>',
     ].join('\n'),
@@ -4991,6 +5073,18 @@ languageSwitch?.addEventListener('click', (e) => {
 // Retry button + research index navigation (event delegation on content)
 content.addEventListener('click', (e) => {
   const target = e.target as HTMLElement;
+  const paginationLink = target.closest('[data-index-page]') as HTMLAnchorElement | null;
+  if (paginationLink && !selectedSlug && (activeTab === 'research' || activeTab === 'wiki')) {
+    const page = Number(paginationLink.dataset.indexPage);
+    if (Number.isSafeInteger(page) && page > 0) {
+      e.preventDefault();
+      if (activeTab === 'research') researchIndexPage = page;
+      else wikiIndexPage = page;
+      load();
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+    return;
+  }
   if (target.closest('[data-ara-figure-close]')) {
     closeAraFigureModal();
     return;
@@ -5264,6 +5358,8 @@ document.querySelectorAll<HTMLAnchorElement>('.tab').forEach((btn) => {
     const tab = btn.dataset.tab as Tab;
     if (tab === activeTab) return;
     activeTab = tab;
+    if (tab === 'research') researchIndexPage = 1;
+    if (tab === 'wiki') wikiIndexPage = 1;
     latestAliasRequested = tab === 'twitter' ? 'twitter' : null;
     selectedSlug = null;
     syncTabUi();
@@ -5305,7 +5401,7 @@ load();
 // Hash-only changes (anchor click within an article) just scroll; route
 // changes re-fetch via load() and fire a SPA page_view to GA.
 window.addEventListener('popstate', () => {
-  const newPathname = location.pathname;
+  const newPathname = location.pathname + location.search;
   if (newPathname === lastAppliedPathname) {
     // Same article, different anchor — just scroll to the new fragment.
     scrollToHashIfPresent();

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -683,19 +683,6 @@ function syncTabUi(): void {
     const isActive = tabButton.dataset.tab === activeTab;
     tabButton.classList.toggle('active', isActive);
   });
-  const activeTabButton = document.querySelector<HTMLElement>('.tab.active');
-  if (activeTabButton) {
-    const activeButton = activeTabButton;
-    const revealActiveTab = () => {
-      const tabs = document.getElementById('tabs');
-      if (!tabs) return;
-      const target =
-        activeButton.offsetLeft - (tabs.clientWidth - activeButton.offsetWidth) / 2;
-      tabs.scrollLeft = Math.max(0, target);
-    };
-    requestAnimationFrame(revealActiveTab);
-    window.setTimeout(revealActiveTab, 120);
-  }
   document.body.classList.toggle('tab-today', activeTab === 'today');
   document.body.classList.toggle('tab-research', activeTab === 'research');
   document.body.classList.toggle('tab-frontpage', activeTab === 'frontpage');
@@ -1042,8 +1029,8 @@ function renderCalendar(): void {
   if (calendarEl.classList.contains('open')) positionCalPop();
 }
 
-// Close the picker on scroll — the pill isn't sticky, so a fixed popover would
-// otherwise detach from it.
+// Close the picker on scroll so a fixed popover never lags behind its anchor
+// while the sticky navigation changes position.
 window.addEventListener('scroll', () => {
   if (calendarEl.classList.contains('open')) {
     calendarEl.classList.remove('open');

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -883,26 +883,20 @@ function findResearchRow(slug: string): GenResearchRow | null {
 
 // ── Calendar ──────────────────────────────────────────
 function dataUrlForDate(dateStr: string): string {
-  if (activeTab === 'today') {
-    return `${DATA_BASE}/digest/${dateStr}-digest.md`;
-  }
-  if (activeTab === 'models') {
-    return `${DATA_BASE}/models/${dateStr}-timeline.md`;
-  }
-  if (activeTab === 'frontpage') {
-    return `${DATA_BASE}/front-page/${dateStr}-front-page.png`;
-  }
-  return `${DATA_BASE}/twitter/${dateStr}.md`;
+  // Picking a date always opens the day view, regardless of the current tab.
+  // Availability therefore describes the destination (digest), not whichever
+  // route happened to be active when the calendar opened.
+  return `${DATA_BASE}/digest/${dateStr}-digest.md`;
 }
 
 function cacheKey(year: number, month: number): string {
-  return `${activeTab}-${year}-${String(month + 1).padStart(2, '0')}`;
+  return `today-${year}-${String(month + 1).padStart(2, '0')}`;
 }
 
-function probeAvailability(year: number, month: number): void {
+function probeAvailability(year: number, month: number, focusSelector?: string): void {
   const key = cacheKey(year, month);
   if (availabilityCache.has(key)) {
-    renderCalendar();
+    renderCalendar(focusSelector);
     return;
   }
 
@@ -911,20 +905,20 @@ function probeAvailability(year: number, month: number): void {
     if (!availabilityCache.has(key)) {
       availabilityCache.set(key, new Set<string>());
     }
-    renderCalendar();
+    renderCalendar(focusSelector);
     return;
   }
 
   // No manifest yet — wait for it, then render. Avoids the 404 storm entirely.
   const available = new Set<string>();
   availabilityCache.set(key, available);
-  renderCalendar();
+  renderCalendar(focusSelector);
 
   loadManifest().then((m) => {
     if (m) {
       // Hydrate already filled the cache; just re-render if still relevant.
       if (calendarMonth.getFullYear() === year && calendarMonth.getMonth() === month) {
-        renderCalendar();
+        renderCalendar(focusSelector);
       }
       return;
     }
@@ -942,7 +936,7 @@ function probeAvailability(year: number, month: number): void {
     }
     Promise.all(promises).then(() => {
       if (calendarMonth.getFullYear() === year && calendarMonth.getMonth() === month) {
-        renderCalendar();
+        renderCalendar(focusSelector);
       }
     });
   });
@@ -965,16 +959,16 @@ function buildCalendarHtml(): string {
 
   const dows = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
   const open = calendarEl.classList.contains('open');
-  let html = '<div class="cal-header" data-cal-toggle>';
+  let html = '<button class="cal-header" type="button" data-cal-toggle aria-expanded="' + open + '" aria-controls="calendar-popover" aria-label="Choose a date">';
   html += '<span class="cal-header-label">' + monthLabel + '<span class="cal-chevron">' + (open ? '&#9650;' : '&#9660;') + '</span></span>';
-  html += '</div>';
+  html += '</button>';
 
   // Month nav + day grid live in a popover so the pill keeps a fixed size.
-  html += '<div class="cal-pop">';
+  html += '<div class="cal-pop" id="calendar-popover" role="group" aria-label="' + monthLabel + ' calendar">';
   html += '<div class="cal-header-nav">';
-  html += '<button class="cal-nav-btn" data-cal-nav="-1">&lsaquo;</button>';
-  html += '<button class="cal-today-btn" data-cal-today>Today</button>';
-  html += '<button class="cal-nav-btn" data-cal-nav="1">&rsaquo;</button>';
+  html += '<button class="cal-nav-btn" type="button" data-cal-nav="-1" aria-label="Previous month">&lsaquo;</button>';
+  html += '<span class="cal-pop-title" aria-live="polite">' + monthLabel + '</span>';
+  html += '<button class="cal-nav-btn" type="button" data-cal-nav="1" aria-label="Next month">&rsaquo;</button>';
   html += '</div>';
 
   html += '<div class="cal-grid">';
@@ -987,7 +981,8 @@ function buildCalendarHtml(): string {
     const pm = month === 0 ? 11 : month - 1;
     const py = month === 0 ? year - 1 : year;
     const dateStr = `${py}-${String(pm + 1).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
-    html += '<div class="cal-day other-month" data-date="' + dateStr + '">' + d + '</div>';
+    const dateLabel = new Date(py, pm, d).toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' });
+    html += '<button class="cal-day other-month" type="button" data-date="' + dateStr + '" aria-label="' + dateLabel + '">' + d + '</button>';
   }
 
   for (let d = 1; d <= daysInMonth; d++) {
@@ -996,7 +991,10 @@ function buildCalendarHtml(): string {
     if (dateStr === todayStr) cls += ' today';
     if (dateStr === selectedStr) cls += ' selected';
     if (available.has(dateStr)) cls += ' has-data';
-    html += '<div class="' + cls + '" data-date="' + dateStr + '">' + d + '</div>';
+    const dateLabel = new Date(year, month, d).toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' });
+    const ariaCurrent = dateStr === todayStr ? ' aria-current="date"' : '';
+    const ariaSelected = dateStr === selectedStr ? ' aria-pressed="true"' : '';
+    html += '<button class="' + cls + '" type="button" data-date="' + dateStr + '" aria-label="' + dateLabel + '"' + ariaCurrent + ariaSelected + '>' + d + '</button>';
   }
 
   const totalCells = firstDay + daysInMonth;
@@ -1005,10 +1003,12 @@ function buildCalendarHtml(): string {
     const nm = month === 11 ? 0 : month + 1;
     const ny = month === 11 ? year + 1 : year;
     const dateStr = `${ny}-${String(nm + 1).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
-    html += '<div class="cal-day other-month" data-date="' + dateStr + '">' + d + '</div>';
+    const dateLabel = new Date(ny, nm, d).toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' });
+    html += '<button class="cal-day other-month" type="button" data-date="' + dateStr + '" aria-label="' + dateLabel + '">' + d + '</button>';
   }
 
   html += '</div>';
+  html += '<button class="cal-today-btn" type="button" data-cal-today>Go to today</button>';
   html += '</div>';
   return html;
 }
@@ -1021,12 +1021,15 @@ function positionCalPop(): void {
   if (!pop || !header) return;
   const r = header.getBoundingClientRect();
   pop.style.top = (r.bottom + 8) + 'px';
-  pop.style.left = Math.max(8, Math.min(r.left, window.innerWidth - 296)) + 'px';
+  pop.style.left = Math.max(8, Math.min(r.left, window.innerWidth - pop.offsetWidth - 8)) + 'px';
 }
 
-function renderCalendar(): void {
+function renderCalendar(focusSelector?: string): void {
   setSafeCalendar(calendarEl, buildCalendarHtml());
   if (calendarEl.classList.contains('open')) positionCalPop();
+  if (focusSelector) {
+    calendarEl.querySelector<HTMLElement>(focusSelector)?.focus();
+  }
 }
 
 // Close the picker on scroll so a fixed popover never lags behind its anchor
@@ -1043,7 +1046,11 @@ function setSafeCalendar(el: HTMLElement, rawHtml: string): void {
   while (el.firstChild) el.removeChild(el.firstChild);
   const clean = DOMPurify.sanitize(rawHtml, {
     USE_PROFILES: { html: true },
-    ADD_ATTR: ['data-date', 'data-cal-nav', 'data-cal-today', 'data-cal-toggle'],
+    ADD_ATTR: [
+      'data-date', 'data-cal-nav', 'data-cal-today', 'data-cal-toggle',
+      'aria-controls', 'aria-current', 'aria-expanded', 'aria-label',
+      'aria-live', 'aria-pressed',
+    ],
   });
   el.insertAdjacentHTML('beforeend', clean);
 }
@@ -1056,8 +1063,8 @@ function handleCalendarClick(e: Event): void {
   if (toggleEl && !target.closest('[data-cal-nav]') && !target.closest('[data-cal-today]')) {
     // The pill is a date picker: clicking it opens the calendar from any tab;
     // picking a day (cal-day handler) then opens that day's digest/newspaper.
-    calendarEl.classList.toggle('open');
-    renderCalendar();
+    const opened = calendarEl.classList.toggle('open');
+    renderCalendar(opened ? '.cal-day.selected, [data-cal-today]' : undefined);
     return;
   }
 
@@ -1065,7 +1072,11 @@ function handleCalendarClick(e: Event): void {
   if (navBtn) {
     const dir = parseInt(navBtn.dataset.calNav!, 10);
     calendarMonth.setMonth(calendarMonth.getMonth() + dir);
-    probeAvailability(calendarMonth.getFullYear(), calendarMonth.getMonth());
+    probeAvailability(
+      calendarMonth.getFullYear(),
+      calendarMonth.getMonth(),
+      `[data-cal-nav="${dir}"]`,
+    );
     return;
   }
 
@@ -1074,6 +1085,7 @@ function handleCalendarClick(e: Event): void {
     const now = new Date();
     currentDate = now;
     activeTab = 'today';
+    calendarEl.classList.remove('open');
     syncTabUi();
     calendarMonth = new Date(now.getFullYear(), now.getMonth(), 1);
     probeAvailability(calendarMonth.getFullYear(), calendarMonth.getMonth());
@@ -5171,6 +5183,11 @@ document.getElementById('refreshBtn')!.addEventListener('click', () => {
 // Keyboard shortcuts
 document.addEventListener('keydown', (e: KeyboardEvent) => {
   if (e.key === 'Escape') {
+    if (calendarEl.classList.contains('open')) {
+      calendarEl.classList.remove('open');
+      renderCalendar();
+      calendarEl.querySelector<HTMLButtonElement>('[data-cal-toggle]')?.focus();
+    }
     closeTicketOddsModal();
     closeAraFigureModal();
     return;

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -678,6 +678,9 @@ function applyRoute(): boolean {
 }
 
 function syncTabUi(): void {
+  // The picker itself belongs to the day view. Other tabs keep the date pill
+  // as a shortcut back to that date, so never leave its popover hanging open.
+  if (activeTab !== 'today') calendarEl.classList.remove('open');
   document.querySelectorAll('.tab').forEach((b) => {
     const tabButton = b as HTMLElement;
     const isActive = tabButton.dataset.tab === activeTab;
@@ -952,6 +955,11 @@ function buildCalendarHtml(): string {
   const selectedStr = fmtDate(currentDate);
 
   const monthLabel = calendarMonth.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+  const selectedLabel = currentDate.toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
 
   const firstDay = new Date(year, month, 1).getDay();
   const daysInMonth = new Date(year, month + 1, 0).getDate();
@@ -959,8 +967,13 @@ function buildCalendarHtml(): string {
 
   const dows = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
   const open = calendarEl.classList.contains('open');
-  let html = '<button class="cal-header" type="button" data-cal-toggle aria-expanded="' + open + '" aria-controls="calendar-popover" aria-label="Choose a date">';
-  html += '<span class="cal-header-label">' + monthLabel + '<span class="cal-chevron">' + (open ? '&#9650;' : '&#9660;') + '</span></span>';
+  const isDayView = activeTab === 'today';
+  const headerAttrs = isDayView
+    ? ' aria-expanded="' + open + '" aria-controls="calendar-popover" aria-label="Choose a date"'
+    : ' aria-label="Open ' + selectedLabel + ' day view"';
+  const headerIndicator = isDayView ? (open ? '&#9650;' : '&#9660;') : '&rsaquo;';
+  let html = '<button class="cal-header" type="button" data-cal-toggle' + headerAttrs + '>';
+  html += '<span class="cal-header-label">' + selectedLabel + '<span class="cal-chevron">' + headerIndicator + '</span></span>';
   html += '</button>';
 
   // Month nav + day grid live in a popover so the pill keeps a fixed size.
@@ -1061,8 +1074,20 @@ function handleCalendarClick(e: Event): void {
   // Toggle fold/unfold when clicking the header (but not nav buttons)
   const toggleEl = target.closest('[data-cal-toggle]') as HTMLElement | null;
   if (toggleEl && !target.closest('[data-cal-nav]') && !target.closest('[data-cal-today]')) {
-    // The pill is a date picker: clicking it opens the calendar from any tab;
-    // picking a day (cal-day handler) then opens that day's digest/newspaper.
+    // Outside the day view, the date pill is a shortcut back to the same date.
+    // Once there, clicking it opens the picker for choosing another day.
+    if (activeTab !== 'today') {
+      latestAliasRequested = null;
+      activeTab = 'today';
+      selectedSlug = null;
+      calendarEl.classList.remove('open');
+      syncTabUi();
+      calendarMonth = new Date(currentDate.getFullYear(), currentDate.getMonth(), 1);
+      probeAvailability(calendarMonth.getFullYear(), calendarMonth.getMonth());
+      load();
+      return;
+    }
+
     const opened = calendarEl.classList.toggle('open');
     renderCalendar(opened ? '.cal-day.selected, [data-cal-today]' : undefined);
     return;

--- a/dashboard/src/render/twitter.ts
+++ b/dashboard/src/render/twitter.ts
@@ -464,7 +464,6 @@ function renderTwitterDateNav(options: TwitterReportRenderOptions): string {
     '  <div class="twitter-date-current">',
     '    <div class="twitter-date-current-label">Twitter summaries</div>',
     '    <div class="twitter-date-current-date">' + escapeHtml(options.shownDateTitle) + '</div>',
-    options.fallbackDate ? '    <div class="twitter-date-current-note">Showing fallback for ' + escapeHtml(options.currentDateStr) + '</div>' : '',
     '  </div>',
     '  ' + link(options.nextDate, 'Next day', 'twitter-date-link--next'),
     '</nav>',
@@ -476,16 +475,6 @@ export function renderTwitterReportHtml(md: string, options: TwitterReportRender
   const cards: string[] = [renderTwitterDateNav(options)];
   const timelineItems: InfoTimelineItem[] = [];
   const mindshareCycles: TwitterMindshareCycle[] = [];
-  if (options.fallbackDate) {
-    cards.push(
-      '<div class="frontpage-fallback-note">No Twitter report for ' +
-        escapeHtml(options.currentDateStr) +
-        '. Showing ' +
-        escapeHtml(options.fallbackDate) +
-        ' instead.</div>',
-    );
-  }
-
   for (const section of sections) {
     if (!section.title && (!section.body || /^#\s+.+$/.test(section.body.trim()))) continue;
 

--- a/dashboard/src/style.css
+++ b/dashboard/src/style.css
@@ -1300,10 +1300,23 @@ body.tab-agents .section-nav {
 }
 
 .cal-header-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+  width: 100%;
   font-size: var(--nav-font-size);
   font-weight: 600;
   color: var(--text);
   user-select: none;
+}
+
+.cal-selected-date {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .cal-header-nav {
@@ -1452,6 +1465,20 @@ body.tab-agents .section-nav {
 @media (prefers-color-scheme: dark) {
   .calendar.open .cal-pop {
     box-shadow: 0 18px 48px rgba(0, 0, 0, 0.55), var(--shadow-sm);
+  }
+}
+
+/* These rules intentionally follow the base calendar declarations. The mobile
+ * navbar's dark date masthead must win the cascade on every active tab, not
+ * only Today (whose body selector happened to be more specific). */
+@media (max-width: 640px) {
+  .calendar .cal-header,
+  .calendar .cal-header-label,
+  .calendar .cal-selected-date,
+  .calendar .cal-chevron {
+    color: #ffffff;
+    opacity: 1;
+    -webkit-text-fill-color: #ffffff;
   }
 }
 
@@ -3315,6 +3342,82 @@ body.tab-frontpage .section-nav {
 .gen-research-empty {
   padding: 24px 0 8px;
   text-align: center;
+}
+
+/* Shared archive pagination for Research and Wiki. Anchors preserve browser
+ * history and remain useful without JavaScript; the SPA intercepts them only
+ * to avoid a full reload. */
+.index-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 22px;
+  padding-top: 18px;
+  border-top: 1px solid var(--border-light);
+  color: var(--text-tertiary);
+  font-size: 0.78rem;
+}
+
+.index-pagination-controls {
+  display: grid;
+  grid-template-columns: minmax(86px, 1fr) auto minmax(86px, 1fr);
+  align-items: center;
+  gap: 8px;
+}
+
+.index-pagination-link,
+.index-pagination-status {
+  min-height: 38px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 7px 12px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.index-pagination-link:hover {
+  color: var(--text);
+  border-color: var(--text-tertiary);
+  background: var(--bg-hover);
+}
+
+.index-pagination-link:focus-visible {
+  outline: 2px solid var(--accent-warm);
+  outline-offset: 2px;
+}
+
+.index-pagination-link.is-disabled {
+  opacity: 0.38;
+}
+
+.index-pagination-status {
+  border-color: transparent;
+  padding-inline: 6px;
+  font-variant-numeric: tabular-nums;
+}
+
+@media (max-width: 640px) {
+  .index-pagination {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .index-pagination-summary {
+    text-align: center;
+  }
+
+  .index-pagination-controls {
+    grid-template-columns: 1fr auto 1fr;
+  }
+
+  .index-pagination-link {
+    min-height: 44px;
+  }
 }
 
 /* Single doc view */

--- a/dashboard/src/style.css
+++ b/dashboard/src/style.css
@@ -536,7 +536,7 @@ body.has-digest-player .app {
   border-radius: 999px;
   box-shadow: var(--shadow-sm);
   padding: 7px 14px;
-  inline-size: 154px;
+  inline-size: 184px;
 }
 body.tab-today .calendar {
   background: var(--accent);

--- a/dashboard/src/style.css
+++ b/dashboard/src/style.css
@@ -1263,6 +1263,10 @@ body.tab-agents .section-nav {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  width: 100%;
+  border: 0;
+  background: transparent;
+  color: inherit;
   cursor: pointer;
 }
 
@@ -1281,12 +1285,12 @@ body.tab-agents .section-nav {
   display: block;
   position: fixed;          /* fixed so it escapes the .tabs overflow-x clip */
   z-index: 1100;
-  width: 280px;
-  padding: 12px;
+  width: min(320px, calc(100vw - 24px));
+  padding: 14px;
   background: var(--bg);
   border: 1px solid var(--border);
-  border-radius: 12px;
-  box-shadow: var(--shadow-lg);
+  border-radius: 16px;
+  box-shadow: 0 18px 48px rgba(14, 22, 36, 0.16), var(--shadow-sm);
 }
 
 .cal-chevron {
@@ -1303,25 +1307,34 @@ body.tab-agents .section-nav {
 }
 
 .cal-header-nav {
-  display: flex;
+  display: grid;
+  grid-template-columns: 36px 1fr 36px;
   align-items: center;
-  justify-content: space-between;
-  gap: 4px;
-  margin-bottom: 8px;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.cal-pop-title {
+  min-width: 0;
+  color: var(--text);
+  font-size: 0.86rem;
+  font-weight: 700;
+  line-height: 1.2;
+  text-align: center;
 }
 
 .cal-nav-btn {
-  width: 28px;
-  height: 28px;
+  width: 36px;
+  height: 36px;
   display: flex;
   align-items: center;
   justify-content: center;
   background: none;
   border: 1px solid var(--border);
-  border-radius: 7px;
+  border-radius: 10px;
   cursor: pointer;
   color: var(--text-secondary);
-  font-size: 0.78rem;
+  font-size: 1.1rem;
   font-weight: 600;
   transition: all 0.12s;
 }
@@ -1333,16 +1346,18 @@ body.tab-agents .section-nav {
 }
 
 .cal-today-btn {
-  height: 28px;
-  padding: 0 10px;
-  background: none;
+  width: 100%;
+  height: 36px;
+  margin-top: 10px;
+  padding: 0 14px;
+  background: var(--bg-secondary);
   border: 1px solid var(--border);
-  border-radius: 7px;
+  border-radius: 10px;
   cursor: pointer;
   color: var(--text-secondary);
   font-family: var(--font);
-  font-size: 0.72rem;
-  font-weight: 500;
+  font-size: 0.76rem;
+  font-weight: 650;
   transition: all 0.12s;
 }
 
@@ -1357,18 +1372,29 @@ body.tab-agents .section-nav {
   font-size: 0.68rem;
   font-weight: 600;
   color: var(--text-tertiary);
-  padding: 4px 0;
+  min-height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   user-select: none;
 }
 
 .cal-day {
   position: relative;
-  text-align: center;
-  padding: 6px 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-width: 0;
+  aspect-ratio: 1;
+  padding: 0;
+  border: 0;
+  background: transparent;
   font-size: 0.78rem;
-  font-weight: 500;
+  font-weight: 550;
+  line-height: 1;
   color: var(--text);
-  border-radius: 8px;
+  border-radius: 10px;
   cursor: pointer;
   transition: all 0.1s;
   user-select: none;
@@ -1383,33 +1409,50 @@ body.tab-agents .section-nav {
   opacity: 0.45;
 }
 
+.cal-header:focus-visible,
+.cal-nav-btn:focus-visible,
+.cal-today-btn:focus-visible,
+.cal-day:focus-visible {
+  outline: 2px solid var(--accent-warm);
+  outline-offset: 2px;
+}
+
 .cal-day.today {
-  box-shadow: inset 0 0 0 1.5px var(--accent);
+  box-shadow: inset 0 0 0 1.5px var(--accent-warm);
+  font-weight: 700;
 }
 
 .cal-day.selected {
   background: var(--accent);
   color: var(--on-accent);
+  font-weight: 700;
+  box-shadow: 0 3px 10px var(--accent-warm-shadow);
 }
 
 .cal-day.selected.today {
-  box-shadow: none;
+  box-shadow: 0 3px 10px var(--accent-warm-shadow);
 }
 
 .cal-day.has-data::after {
   content: '';
   position: absolute;
-  bottom: 2px;
+  bottom: 4px;
   left: 50%;
   transform: translateX(-50%);
-  width: 4px;
-  height: 4px;
+  width: 3px;
+  height: 3px;
   border-radius: 50%;
   background: var(--accent-warm);
 }
 
 .cal-day.selected.has-data::after {
   background: rgba(255, 255, 255, 0.7);
+}
+
+@media (prefers-color-scheme: dark) {
+  .calendar.open .cal-pop {
+    box-shadow: 0 18px 48px rgba(0, 0, 0, 0.55), var(--shadow-sm);
+  }
 }
 
 /* ── Main Content Card ─────────────────────────────── */

--- a/dashboard/src/style.css
+++ b/dashboard/src/style.css
@@ -36,6 +36,7 @@
   --font: var(--font-serif);
   --font-mono: var(--font-serif);
   --nav-font-size: 0.82rem;
+  --sticky-nav-height: 46px;
   --reading-font-family: var(--font-serif);
   --reading-font-size: 1rem;
   --reading-line-height: 1.85;
@@ -113,7 +114,7 @@ body.has-digest-player .app {
  * GitHub link should sit close enough to feel like one block. */
 .header {
   max-width: var(--page-max);
-  margin: 0 auto 32px;
+  margin: 0 auto 24px;
 }
 
 /* Card chrome doesn't follow the viewport on ultra-wide displays.
@@ -175,11 +176,11 @@ body.has-digest-player .app {
   }
 }
 
-/* When the floating TOC is visible (set by JS in renderResearchTOC),
- * push the app contents right so they don't sit under the TOC. */
+/* When the floating TOC is visible (set by JS in renderResearchTOC), shift
+ * only article content so route changes never move the masthead or nav. */
 @media (min-width: 1280px) {
-  body.has-toc .app {
-    padding-left: max(280px, var(--page-gutter));
+  body.has-toc #content {
+    margin-left: max(0px, calc(280px - var(--page-gutter)));
   }
 }
 
@@ -200,14 +201,14 @@ body.has-digest-player .app {
 
 /* ── Header ────────────────────────────────────────── */
 .header {
-  margin-bottom: 32px;
+  margin-bottom: 24px;
 }
 
 .header-top {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 24px;
+  margin-bottom: 0;
   gap: 16px;
 }
 
@@ -312,6 +313,28 @@ body.has-digest-player .app {
 .header-link-label { display: inline; }
 
 /* ── Tabs ─────────────────────────────────────────── */
+.nav-shell {
+  position: sticky;
+  z-index: 1200;
+  top: 0;
+  max-width: var(--page-max);
+  margin: 0 auto 32px;
+  padding-top: 8px;
+  background: var(--bg-secondary);
+}
+
+/* Search belongs to the shared nav, but must not make that sticky rail taller
+ * when it opens. Float it directly below the rail instead. */
+.nav-shell .search-overlay {
+  position: absolute;
+  z-index: 1400;
+  top: 100%;
+  left: 0;
+  width: min(560px, 100%);
+  max-width: none;
+  margin-bottom: 0;
+}
+
 .tabs {
   display: flex;
   align-items: center;
@@ -355,7 +378,7 @@ body.has-digest-player .app {
   font-size: var(--nav-font-size);
   font-weight: 500;
   cursor: pointer;
-  transition: all 0.15s;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
 }
 
 .tab:hover {
@@ -375,6 +398,8 @@ body.has-digest-player .app {
   align-items: center;
   gap: 10px;
   flex-wrap: wrap;
+  max-width: var(--page-max);
+  margin: -32px auto 32px;
 }
 
 .icon-btn {
@@ -511,6 +536,7 @@ body.has-digest-player .app {
   border-radius: 999px;
   box-shadow: var(--shadow-sm);
   padding: 7px 14px;
+  inline-size: 154px;
 }
 body.tab-today .calendar {
   background: var(--accent);
@@ -522,6 +548,10 @@ body.tab-today .cal-chevron { color: var(--on-accent); opacity: 0.75; }
 /* On phones, the nav becomes a newspaper-style control grid: date masthead,
  * two rows of section buttons, then a full-width search row. */
 @media (max-width: 640px) {
+  .nav-shell {
+    position: static;
+  }
+
   .tabs {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -548,6 +578,7 @@ body.tab-today .cal-chevron { color: var(--on-accent); opacity: 0.75; }
     grid-column: 1 / -1;
     justify-content: stretch;
     width: 100%;
+    inline-size: 100%;
     padding: 10px 14px;
     background: #171717;
     border-bottom: 1px solid var(--border);
@@ -624,7 +655,6 @@ body:not(.tab-research) .request-btn { display: none; }
 /* The controls row now holds only Request research → hide it off /research. */
 body:not(.tab-research) .controls { display: none; }
 
-body.tab-agents .calendar,
 body.tab-agents .section-nav {
   display: none;
 }
@@ -2559,7 +2589,7 @@ body.has-toc .section-nav { display: none; }
   .header-link-label { display: none; }
   .controls { gap: 6px; }
   .search-box { flex-basis: 100%; }
-  .search-overlay {
+  .nav-shell .search-overlay {
     position: fixed;
     z-index: 1400;
     top: 58px;
@@ -3082,11 +3112,11 @@ body.has-toc .section-nav { display: none; }
 
 .today-layout-frontpage {
   position: sticky;
-  top: 16px;
+  top: calc(var(--sticky-nav-height) + 16px);
   /* Bound the newspaper to the viewport and give it its own scroll, so a
    * tall edition scrolls independently of the digest (which scrolls with
    * the page on the right). */
-  max-height: calc(100vh - 32px);
+  max-height: calc(100vh - var(--sticky-nav-height) - 32px);
   overflow-y: auto;
 }
 
@@ -3950,6 +3980,7 @@ body.tab-frontpage .section-nav {
 
   /* Hide all app chrome */
   .header,
+  .nav-shell,
   .tabs,
   .calendar,
   .controls,
@@ -4818,6 +4849,7 @@ body.ticket-odds-modal-open { overflow: hidden; }
 
 .tab-focus-reader .app { padding: 0; }
 .tab-focus-reader .header,
+.tab-focus-reader .nav-shell,
 .tab-focus-reader .site-footer,
 .tab-focus-reader .section-nav,
 .tab-focus-reader .shortcut-guide,


### PR DESCRIPTION
## What changed

- makes the dashboard date/navigation rail route-stable and sticky on desktop
- redesigns the calendar picker with clearer date states and keyboard support
- shows the active date in the nav and routes non-day tabs back to that date
- fixes the hidden mobile date label caused by CSS cascade order
- adds URL-backed, 12-item pagination to Research and Wiki archives
- removes Twitter fallback warning copy while retaining fallback content and the actual report date

## Why

Route changes were shifting or resizing the top navigation, the mobile date label could render dark-on-dark, and the full Research/Wiki archives were too long on phones. Twitter fallback warnings also added noise even though the fallback report date was already visible.

## Validation

- `npm run typecheck`
- `bun test` (7/7)
- production Vite/build pipeline
- desktop/mobile/dark-mode calendar and navigation QA
- pagination routing, canonicalization, refresh, and browser-history review

## Release

Head: `feat/article-bridge`
Base: `main`