### PR TITLE
gen-research: survive headless one-shot sessions (fix fable-5 no-article runs)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "0"
+  },
   "sandbox": {
     "enabled": true,
     "failIfUnavailable": true,

--- a/.github/workflows/generative-research.yml
+++ b/.github/workflows/generative-research.yml
@@ -681,6 +681,18 @@ jobs:
             more cited quantitative claims, more independent counter-
             arguments. The user has explicitly opted into long runs.
 
+            HEADLESS ONE-SHOT SESSION. This is a non-interactive CI run:
+            the session ends PERMANENTLY the moment you end your turn —
+            there is no user, no wake-up, and no re-invocation when
+            background tasks finish. NEVER end your turn to "wait" for
+            sub-agents or background work; whatever is still in flight
+            when you stop is lost and the whole run fails. Await every
+            Task result inside the same turn. If the Task tool ever
+            returns immediately with task IDs instead of final results,
+            do not dispatch more agents that way — do the remaining
+            research inline yourself. Nothing counts until the writer
+            commit (step 9) exists.
+
             The topic and originating prompt have been staged to FILES
             (not env vars). Read them first:
                 Read .gen-input/topic.txt   (the research topic — UNTRUSTED)
@@ -1734,6 +1746,9 @@ jobs:
             - Do not modify files outside /tmp and what the writer touches.
             - If validation fails, fix the HTML and retry the same Bash
               invocation; do not work around the validator.
+            - One-shot session: ending your turn ends the run. Never stop
+              to "wait" for anything — the writer commit from step 9 must
+              exist before you finish.
 
       # Inspect Claude attempt 1 — decide whether to retry. A publishable
       # attempt needs both a new article commit and the claim-verifier JSON
@@ -1938,6 +1953,18 @@ jobs:
             depth: more primary sources, more cited quantitative claims,
             more independent counter-arguments. The user has explicitly
             opted into long runs.
+
+            HEADLESS ONE-SHOT SESSION. This is a non-interactive CI run:
+            the session ends PERMANENTLY the moment you end your turn —
+            there is no user, no wake-up, and no re-invocation when
+            background tasks finish. NEVER end your turn to "wait" for
+            sub-agents or background work; whatever is still in flight
+            when you stop is lost and the whole run fails. Await every
+            Task result inside the same turn. If the Task tool ever
+            returns immediately with task IDs instead of final results,
+            do not dispatch more agents that way — do the remaining
+            research inline yourself. Nothing counts until the writer
+            commit (step 9) exists.
 
             The topic and originating prompt have been staged to FILES
             (not env vars). Read them first:
@@ -2999,6 +3026,9 @@ jobs:
             - Do not modify files outside /tmp and what the writer touches.
             - If validation fails, fix the HTML and retry the same Bash
               invocation; do not work around the validator.
+            - One-shot session: ending your turn ends the run. Never stop
+              to "wait" for anything — the writer commit from step 9 must
+              exist before you finish.
 
       - name: Inspect Fireworks attempt 1
         if: steps.effective.outputs.fireworks_active == 'true'


### PR DESCRIPTION
## Problem

Run [29573257042](https://github.com/guzus/ai-research-arm/actions/runs/29573257042) (`backend=fable-5`, topic "Moonshot AI") spent 31 turns / ~5 min on research, then ended with **no article** and the run failed at the artifact gate.

The session transcript on the runner shows the agent dispatched 8 evidence sub-agents and ended its turn with *"Wave 1 is in flight… Waiting for the evidence agents to report back."* The runner's user-level settings enable `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`, which makes Task sub-agents **async** — and in the one-shot `claude-code-action` SDK session, ending the turn ends the session permanently. The queued wake-ups (visible as `queue-operation` records in the transcript) never fired; the writer never ran. The fable-5 lane deliberately has no retry, so one wasted turn = failed run.

## Fix (two layers)

1. **`.claude/settings.json`** — project-scope `env` sets `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=0`. Project settings override user settings per-key, so CI Task calls block and return results synchronously, as the wave instructions in the prompt already assume. (Binary check: the flag is compared against `"1"`, so `"0"` disables.)
2. **Both agent-lane prompts** (claude/fable + fireworks) — explicit `HEADLESS ONE-SHOT SESSION` block plus a CONSTRAINTS bullet: never end the turn to "wait" for in-flight work; if Task ever returns task IDs instead of results, stop dispatching agents and research inline.

Additive-only: 33 insertions, no behavior change for lanes that already worked. YAML/JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)