### PR TITLE
dashboard: give Request research button breathing room below the nav

### DIFF
--- a/dashboard/src/style.css
+++ b/dashboard/src/style.css
@@ -399,7 +399,9 @@ body.has-digest-player .app {
   gap: 10px;
   flex-wrap: wrap;
   max-width: var(--page-max);
-  margin: -32px auto 32px;
+  /* The nav-shell above leaves 32px; reclaim most of it but keep 12px of
+   * air so the row doesn't sit flush against the tab pills. */
+  margin: -20px auto 32px;
 }
 
 .icon-btn {


### PR DESCRIPTION
The Request research button sat flush against the nav pills: `.controls` pulls up with `margin-top: -32px`, which exactly cancels `.nav-shell`'s 32px bottom margin (the tabs' 16px bottom margin collapses into it), leaving a 0px gap.

Soften the pull to `-20px` so 12px of air remains between the pills and the button.

Verified in the vite dev server at 1280px (desktop) and 375px (mobile) — clear gap, no overlap, print CSS and mobile grid rules unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)