### PR TITLE
opencode-kimi: survive Cloudflare bot-filtered Go probes (UA + 401/402-only)

### DIFF
--- a/.github/workflows/generative-research.yml
+++ b/.github/workflows/generative-research.yml
@@ -1939,14 +1939,19 @@ jobs:
             # "kimi-k3" — verified against GET /zen/go/v1/models) but
             # otherwise an undocumented surface (models.dev provider.toml
             # caveat). Probe with one tiny billable completion and be
-            # AUTH-FATAL ONLY: 401/402/403 are definitive (bad key, no
-            # active Go subscription, or exhausted usage) and fail the run;
-            # any other status is a warning and the opencode harness itself
-            # stays the authoritative check — it speaks the exact SDK
-            # dialect production uses and fails fast on a truly dead route.
+            # AUTH-FATAL ONLY: 401/402 are definitive (bad key / billing)
+            # and fail the run. 403 is deliberately NON-fatal here:
+            # opencode.ai sits behind Cloudflare, whose bot filter answers
+            # 403 "error code: 1010" to client signatures it dislikes
+            # (observed live from this runner), so a 403 is ambiguous and
+            # only warns. The custom UA clears the python/curl signature
+            # ban in the common case, and the opencode harness itself stays
+            # the authoritative check — it is the exact SDK client this
+            # gateway expects and fails fast on a truly dead route.
             body_file="${RUNNER_TEMP:-/tmp}/opencode-go-preflight-body.txt"
             status=$(curl -sS --max-time 60 --retry 2 --retry-delay 5 \
               -o "$body_file" -w '%{http_code}' \
+              -A "ai-research-arm-preflight/1.0 (+https://github.com/guzus/ai-research-arm)" \
               -H "Authorization: Bearer $OPENCODE_API_KEY" \
               -H "Content-Type: application/json" \
               --data '{"model":"kimi-k3","max_tokens":128,"messages":[{"role":"user","content":"Reply with exactly: ok"}]}' \
@@ -1955,12 +1960,12 @@ jobs:
               2*)
                 echo "OpenCode Go preflight OK (HTTP $status)."
                 ;;
-              401|402|403)
-                echo "::error::OpenCode Go preflight failed with HTTP $status — the key is invalid, the account has no active Go subscription, or Go usage limits are exhausted. Check the plan + limits at https://opencode.ai/auth (or unset OPENCODE_API_KEY to route via MOONSHOT_API_KEY). Response: $(head -c 500 "$body_file" 2>/dev/null || true)"
+              401|402)
+                echo "::error::OpenCode Go preflight failed with HTTP $status — the key is invalid or cannot bill Go usage. Check the plan + limits at https://opencode.ai/auth (or unset OPENCODE_API_KEY to route via MOONSHOT_API_KEY). Response: $(head -c 500 "$body_file" 2>/dev/null || true)"
                 exit 1
                 ;;
               *)
-                echo "::warning::OpenCode Go raw preflight returned HTTP $status (undocumented raw surface — not blocking; the opencode harness is the authoritative check). Response: $(head -c 500 "$body_file" 2>/dev/null || true)"
+                echo "::warning::OpenCode Go raw preflight returned HTTP $status (undocumented raw surface — not blocking; a Cloudflare 'error code: 10xx' body means the probe was bot-filtered, not an auth verdict; the opencode harness is the authoritative check). Response: $(head -c 500 "$body_file" 2>/dev/null || true)"
                 ;;
             esac
           elif [ -n "${MOONSHOT_API_KEY:-}" ]; then

--- a/.github/workflows/opencode-kimi-canary.yml
+++ b/.github/workflows/opencode-kimi-canary.yml
@@ -85,6 +85,11 @@ jobs:
           headers = {
               "Authorization": f"Bearer {key}",
               "Content-Type": "application/json",
+              # opencode.ai sits behind Cloudflare, whose bot filter bans
+              # the default python-urllib signature with 403 "error code:
+              # 1010" (observed live, run 29699747370). An honest custom
+              # UA clears the UA-signature ban.
+              "User-Agent": "ai-research-arm-canary/1.0 (+https://github.com/guzus/ai-research-arm)",
           }
 
           # Failure policy differs by route. Moonshot's API is a documented
@@ -92,10 +97,11 @@ jobs:
           # Go raw endpoint is undocumented (models.dev provider.toml
           # caveat) — verified facts: GET /zen/go/v1/models is live and
           # lists bare ids like "kimi-k3" — so on the Go route only
-          # 401/402/403 (bad key / no active Go subscription / exhausted
-          # usage) are fatal; anything else prints a warning and defers to
-          # the harness stage below, which speaks the exact SDK dialect
-          # production uses and is the authoritative gate.
+          # 401/402 (bad key / billing) are fatal. 403 is deliberately
+          # NON-fatal there: Cloudflare's bot filter answers 403 "error
+          # code: 1010" to clients it dislikes (observed live), so a Go
+          # 403 is ambiguous and the harness stage below — the exact SDK
+          # client production uses — is the authoritative gate.
           go_route = route == "opencode-go"
 
           # Informational listing probe (free; the Go listing is public).
@@ -143,11 +149,17 @@ jobs:
                   body = json.loads(resp.read().decode())
           except urllib.error.HTTPError as exc:
               safe_body = exc.read().decode(errors="replace")[:500]
-              if exc.code in (401, 402, 403):
+              cf_hint = (
+                  " — body looks like a Cloudflare bot-filter block, NOT an auth verdict"
+                  if "error code: 10" in safe_body
+                  else ""
+              )
+              fatal_codes = (401, 402) if go_route else (401, 402, 403)
+              if exc.code in fatal_codes:
                   print(f"::error::kimi-k3 completion probe on {route} failed with HTTP {exc.code} — dead key, or {billing_hint}: {safe_body}")
                   sys.exit(1)
               if go_route:
-                  print(f"::warning::kimi-k3 completion probe on {route} returned HTTP {exc.code} (undocumented raw surface — not blocking; the harness stage below is authoritative): {safe_body}")
+                  print(f"::warning::kimi-k3 completion probe on {route} returned HTTP {exc.code}{cf_hint} (undocumented raw surface — not blocking; the harness stage below is authoritative): {safe_body}")
                   body = {}
               else:
                   print(f"::error::kimi-k3 completion probe on {route} failed with HTTP {exc.code} — dead key, or {billing_hint}: {safe_body}")

--- a/docs/generative-research-backends.md
+++ b/docs/generative-research-backends.md
@@ -251,11 +251,15 @@ The canary resolves the same Go-first route as the production lane, then
 runs two probes: a stdlib-only raw API check (a models listing plus one
 tiny `kimi-k3` completion against the resolved endpoint), followed by a
 tool-denied headless `opencode run` using the exact production argv. On
-the Go route the raw probe is **auth-fatal only** — 401/402/403 (bad
-key, no active Go subscription, exhausted caps) fail the run, while any
-other status merely warns, because the raw `/zen/go/v1` surface is
-undocumented and the opencode harness stage is the authoritative check.
-The documented Moonshot route stays strict on every probe failure.
+the Go route the raw probe is **auth-fatal only** — 401/402 (bad key /
+billing) fail the run, while any other status merely warns: the raw
+`/zen/go/v1` surface is undocumented, and Cloudflare's bot filter in
+front of opencode.ai answers 403 `error code: 1010` to client
+signatures it dislikes (observed live), so a Go 403 is ambiguous. The
+probes send an honest custom User-Agent to clear the common
+python/curl signature ban, and the opencode harness stage — the exact
+SDK client the gateway expects — is the authoritative check. The
+documented Moonshot route stays strict on every probe failure.
 
 Dispatch a research run:
 
@@ -284,13 +288,14 @@ Lane mechanics, mirroring the Codex path:
   same data boundary (untrusted inputs in `.gen-input/*.txt`), same
   methodology artifacts, same validation gates, and the writer owns the
   commit with `--model kimi-k3` metadata.
-- The workflow preflights the resolved route's API (missing secrets, a
-  dead key, no active Go subscription, or an exhausted Go cap fails in
-  seconds, before install/agent) and fails closed — an explicit
-  `opencode-kimi-k3` request never falls back to Claude, matching the
-  comparison-lane strictness of `fireworks_fallback=none`. Non-auth
-  statuses from the undocumented Go raw endpoint only warn; the opencode
-  run itself is the authoritative check on that route.
+- The workflow preflights the resolved route's API (missing secrets or a
+  definitively dead key — HTTP 401/402 — fails in seconds, before
+  install/agent) and fails closed — an explicit `opencode-kimi-k3`
+  request never falls back to Claude, matching the comparison-lane
+  strictness of `fireworks_fallback=none`. Other statuses from the
+  undocumented Go raw endpoint (including Cloudflare bot-filter 403s)
+  only warn; the opencode run itself is the authoritative check on that
+  route.
 - opencode has no Claude-style server WebSearch; the prompt steers research
   through `scripts/research_search.py`, `scripts/source_cache.py`,
   `curl`/`pdftotext`, `bird`, and opencode's webfetch tool.


### PR DESCRIPTION
Follow-up to #791. Verified directly on the gunux runner that the OpenCode Go account drives Kimi K3 end-to-end (`opencode run -m opencode-go/kimi-k3` returns the canary token, exit 0).

**Root cause of the canary failure in #791:** the raw `/zen/go/v1` probes are bot-filtered by Cloudflare, which returns HTTP 403 with body `error code: 1010` to default python-urllib/curl client signatures — not an auth verdict. The old probe treated that 403 as fatal.

**Fix (evidence-backed):**
- Both probes send an honest `User-Agent`. Verified on gunux this clears the filter: `GET /zen/go/v1/models` → 200, `POST /chat/completions` → real 401 (bad key) / 200 (valid key).
- On the Go route only 401/402 are auth-fatal; any other status (incl. a Cloudflare 403) warns and defers to the opencode harness stage, which is the authoritative check. The documented Moonshot route stays strict.

Local checks: `build_backend_matrix.py --check`, `test_backend_matrix.py` (37), actionlint all green.