### PR TITLE
Show wiki page history as a sticky right rail on wide viewports

### DIFF
--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -2929,16 +2929,25 @@ function renderWikiPage(page: WikiPage, body: string, signal?: AbortSignal): voi
       wikiKvHtml(page),
       wikiTagsHtml(page.tags),
       '  </div>',
+      // Body + backlinks/related on the left; History in an <aside> rail that
+      // the CSS floats right on wide viewports and stacks after the main
+      // column otherwise. History is this file's git history, read live from
+      // the GitHub API — never stored in the page. Filled by
+      // hydrateWikiHistory below; if that fails (offline, rate-limited) the
+      // slot degrades to a GitHub link.
+      '<div class="wiki-page-columns">',
+      '<div class="wiki-page-main">',
       '  <div class="wiki-page-body md-content"></div>',
       backlinksHtml,
       relatedHtml,
-      // History is this file's git history, read live from the GitHub API —
-      // never stored in the page. Filled by hydrateWikiHistory below; if that
-      // fails (offline, rate-limited) the slot degrades to a GitHub link.
+      '</div>',
+      '<aside class="wiki-page-rail">',
       '<section class="wiki-history">',
       '  <h2 class="wiki-section-title">History</h2>',
       '  <div class="wiki-history-body"><p class="wiki-history-empty">Loading history…</p></div>',
       '</section>',
+      '</aside>',
+      '</div>',
       '</div>',
     ].join('\n'),
   );

--- a/dashboard/src/style.css
+++ b/dashboard/src/style.css
@@ -4138,6 +4138,45 @@ a.wiki-history-summary:hover { text-decoration: underline; }
   .wiki-history-summary { grid-column: 1 / -1; }
 }
 
+/* ── History right rail (wide viewports) ─────────────────
+ * With enough width the page splits into two columns: body +
+ * backlinks/related left, History as a sticky right rail with
+ * its own scroll (same sticky pattern as the front-page pane).
+ * Below the breakpoint the rail stacks after the main column,
+ * which is the pre-rail layout unchanged. */
+@media (min-width: 1200px) {
+  .wiki-page-card {
+    max-width: min(var(--page-max), 1160px);
+    /* .content-card clips (overflow: hidden), which kills position: sticky
+     * for the rail — opt out like .wiki-index-card does. */
+    overflow: visible;
+  }
+  .wiki-page-columns {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 300px;
+    gap: 0 44px;
+    align-items: start;
+  }
+  .wiki-page-rail {
+    position: sticky;
+    top: calc(var(--sticky-nav-height) + 16px);
+    max-height: calc(100vh - var(--sticky-nav-height) - 32px);
+    overflow-y: auto;
+  }
+  .wiki-page-rail .wiki-history {
+    margin-top: 0;
+    padding-top: 0;
+    border-top: none;
+  }
+  /* The ~300px rail gets the same stacked rows as narrow screens. */
+  .wiki-page-rail .wiki-history-item {
+    grid-template-columns: 5.75rem 1fr;
+    row-gap: 2px;
+  }
+  .wiki-page-rail .wiki-history-op { grid-column: 2; }
+  .wiki-page-rail .wiki-history-summary { grid-column: 1 / -1; }
+}
+
 /* ── Wikilinks (in-body and in lists) ─────────────────── */
 .wikilink {
   color: var(--accent-warm);


### PR DESCRIPTION
## Summary
- At ≥1200px viewport width, wiki pages become two columns: page body + backlinks/related left (~750px measure), **History as a 300px sticky right rail** with its own scroll (reuses the `--sticky-nav-height` sticky pattern from the front-page pane).
- The rail uses the same stacked row layout as narrow screens; below 1200px everything stacks exactly as before (no mobile/tablet change).
- `.wiki-page-card` opts out of the `.content-card` `overflow: hidden` clip at the breakpoint (same precedent as `.wiki-index-card`) — the clip defeats `position: sticky`.

## Verification
Browser-verified on the built bundle: side-by-side geometry and sticky pin (rail top 62px after 1200px scroll) at 1440×900 on the 31-row anthropic page; stacked fallback asserted at 1000×800 and 390×844.

🤖 Generated with [Claude Code](https://claude.com/claude-code)