### PR TITLE
Add quiet A/B side-by-side view to the Twitter tab

### DIFF
--- a/dashboard/scripts/prebuild.mjs
+++ b/dashboard/scripts/prebuild.mjs
@@ -30,6 +30,19 @@ const skipLfsPointers = process.env.SKIP_LFS_POINTERS === '1';
 // committed — we only copy it here; we never rebuild it in JS.
 const COPY_DIRS = ['twitter', 'models', 'front-page', 'digest', 'audio', 'generative', 'wiki', 'youtube', 'arm'];
 
+// Twitter comparison-lane dirs (hourly-twitter.yml backend tiers). Copied for
+// the A/B side-by-side view but deliberately NOT in COPY_DIRS/DATE_PATTERNS:
+// manifest keys feed the freshness rows, and these lanes run manually/rarely,
+// so listing them there would report them as permanently stale. The A/B view
+// discovers them through twitter-ab.json (built below) instead.
+const AB_COMPARISON_LANES = [
+  'twitter-opencode-kimi',
+  'twitter-zai',
+  'twitter-deepseek',
+  'twitter-deepseek-pi',
+  'twitter-fireworks-pi',
+];
+
 // Regex patterns for the date-keyed sources. The `generative` key is
 // special-cased below: it reads research/generative/index.json directly.
 const DATE_PATTERNS = {
@@ -163,6 +176,51 @@ function copyData() {
     const dest = join(publicResearch, sub);
     copyResearchDir(src, dest);
   }
+
+  for (const lane of AB_COMPARISON_LANES) {
+    const src = join(researchSrc, lane);
+    if (!existsSync(src)) continue;
+    copyResearchDir(src, join(publicResearch, lane));
+  }
+}
+
+// ── Twitter A/B index ───────────────────────────────────────
+// For each date where the PRIMARY twitter digest and at least one comparison
+// lane both carry the same `## HH:00 UTC` cycle, record {date → hour → lanes}.
+// The SPA loads this tiny JSON to decide where an A/B chip appears — the chip
+// is hour-accurate without the client fetching or parsing any comparison file.
+const CYCLE_HEADING_RE = /^## (\d{2}):00 UTC$/gm;
+
+function cycleHours(file) {
+  if (!existsSync(file)) return [];
+  const hours = [];
+  const text = readFileSync(file, 'utf8');
+  for (const m of text.matchAll(CYCLE_HEADING_RE)) hours.push(m[1]);
+  return hours;
+}
+
+function buildTwitterAbIndex() {
+  const index = {};
+  const primaryDir = join(researchSrc, 'twitter');
+  for (const lane of AB_COMPARISON_LANES) {
+    const laneDir = join(researchSrc, lane);
+    if (!existsSync(laneDir)) continue;
+    for (const name of readdirSync(laneDir)) {
+      const m = /^(\d{4}-\d{2}-\d{2})\.md$/.exec(name);
+      if (!m) continue;
+      const date = m[1];
+      const primaryHours = new Set(cycleHours(join(primaryDir, name)));
+      for (const hour of new Set(cycleHours(join(laneDir, name)))) {
+        if (!primaryHours.has(hour)) continue;
+        index[date] ??= {};
+        index[date][hour] ??= [];
+        if (!index[date][hour].includes(lane)) index[date][hour].push(lane);
+      }
+    }
+  }
+  writeFileSync(join(publicResearch, 'twitter-ab.json'), JSON.stringify(index));
+  const dates = Object.keys(index).length;
+  console.log(`prebuild: twitter-ab.json — ${dates} date(s) with same-hour comparison cycles`);
 }
 
 function collectDates(dir, re) {
@@ -788,6 +846,7 @@ function buildSearchIndex() {
 }
 
 copyData();
+buildTwitterAbIndex();
 buildArmTimeline();
 buildTicketsIndex();
 buildManifest();

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -16,12 +16,14 @@ import { hydrateAgentsTimeline, renderAgentsStudioHtml } from './render/agents';
 import type { ArmTimeline } from './render/agents';
 import { renderTodayHtml } from './render/today';
 import {
+  buildTwitterCycleContent,
+  extractTwitterCycleBody,
   parseTwitterStories,
   renderTwitterReportHtml,
   sanitizePublicReportMarkdown,
   storyCurrentLead,
 } from './render/twitter';
-import type { TwitterStory } from './render/twitter';
+import type { TwitterReportRenderOptions, TwitterStory } from './render/twitter';
 import {
   closeAraFigureModal,
   enhanceAraArticle,
@@ -2970,10 +2972,60 @@ function renderWikiNotFound(slug: string): void {
   );
 }
 
-function renderTwitterReport(md: string, fallbackDate: string | null = null): void {
+// ── Twitter A/B side-by-side (comparison lanes) ─────────────────────────────
+// twitter-ab.json (prebuild-generated) maps date → hour → comparison-lane
+// slugs where a same-hour cycle exists in both the primary digest and the
+// lane. It only gates the quiet A/B chip; everything below is lazy — nothing
+// is fetched until a reader clicks the chip.
+type TwitterAbIndex = Record<string, Record<string, string[]>>;
+let twitterAbIndexCache: TwitterAbIndex | undefined;
+let currentTwitterMd = '';
+let currentTwitterMdDate = '';
+const twitterAbMdCache = new Map<string, string | null>();
+
+const TWITTER_AB_LANE_META: Record<string, { label: string; model: string; harness: string }> = {
+  'twitter-opencode-kimi': { label: 'Kimi K3', model: 'kimi-k3 · OpenCode Go / Moonshot', harness: 'opencode CLI' },
+  'twitter-zai': { label: 'GLM-5.2', model: 'glm-5.2 · Z.ai', harness: 'Claude Code' },
+  'twitter-deepseek': { label: 'DeepSeek V4 Flash', model: 'deepseek-v4-flash · Fireworks', harness: 'Claude Code' },
+  'twitter-deepseek-pi': { label: 'DeepSeek V4 Flash', model: 'deepseek-v4-flash · Fireworks', harness: 'pi (container)' },
+  'twitter-fireworks-pi': { label: 'Kimi K2.7', model: 'kimi-k2p7 · Fireworks', harness: 'pi (container)' },
+};
+// The primary tier's model is resolved at run time by agent-run
+// (Fireworks GLM → Z.ai → native Claude), so label the chain, not one model.
+const TWITTER_AB_PRIMARY_META = {
+  label: 'Primary lane',
+  model: 'agent-run chain: GLM-5.2 → Z.ai → claude-sonnet-5',
+  harness: 'Claude Code',
+};
+
+async function ensureTwitterAbIndex(signal?: AbortSignal): Promise<TwitterAbIndex> {
+  if (twitterAbIndexCache) return twitterAbIndexCache;
+  try {
+    const resp = await fetch(`${DATA_BASE}/twitter-ab.json`, { signal });
+    twitterAbIndexCache = resp.ok ? ((await resp.json()) as TwitterAbIndex) : {};
+  } catch {
+    twitterAbIndexCache = {}; // no chips; the news view is unaffected
+  }
+  return twitterAbIndexCache;
+}
+
+async function fetchTwitterAbLaneMd(lane: string, dateStr: string, signal?: AbortSignal): Promise<string | null> {
+  const key = `${lane}:${dateStr}`;
+  if (twitterAbMdCache.has(key)) return twitterAbMdCache.get(key) ?? null;
+  let md: string | null = null;
+  try {
+    const resp = await fetch(`${DATA_BASE}/${lane}/${dateStr}.md`, { signal });
+    if (resp.ok) md = await resp.text();
+  } catch {
+    md = null;
+  }
+  twitterAbMdCache.set(key, md);
+  return md;
+}
+
+function buildTwitterRenderOptions(fallbackDate: string | null, shownDate: string): TwitterReportRenderOptions {
   const dateStr = fmtDate(currentDate);
-  const shownDate = fallbackDate || dateStr;
-  setSafeContent(content, renderTwitterReportHtml(md, {
+  return {
     fallbackDate,
     currentDateStr: dateStr,
     currentDateTitle: displayDate(currentDate),
@@ -2986,12 +3038,163 @@ function renderTwitterReport(md: string, fallbackDate: string | null = null): vo
     twitterMarkdownToHtml,
     renderSourceChips,
     renderHandleChips,
-  }));
+    abHours: twitterAbIndexCache?.[shownDate],
+  };
+}
+
+function renderTwitterReport(md: string, fallbackDate: string | null = null): void {
+  const dateStr = fmtDate(currentDate);
+  const shownDate = fallbackDate || dateStr;
+  currentTwitterMd = md;
+  currentTwitterMdDate = shownDate;
+  setSafeContent(content, renderTwitterReportHtml(md, buildTwitterRenderOptions(fallbackDate, shownDate)));
   if (latestAliasRequested !== 'twitter') {
     setRuntimeIndexable(stripMarkdown(md).split(/\s+/).filter(Boolean).length >= 300);
   }
   void hydrateTweetCards(content);
   void wikifyContent(content);
+}
+
+function formatAbDuration(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = Math.round(seconds % 60);
+  return m > 0 ? `${m}m ${String(s).padStart(2, '0')}s` : `${s}s`;
+}
+
+type TwitterAbRuntime = { seconds: number | null; runUrl: string };
+
+// Agent-step runtime for a lane's cycle: status heartbeat → run_id → public
+// Actions jobs API (unauthenticated, 60 req/hr — hence the sessionStorage
+// cache; completed runs are immutable so entries never need to expire).
+// Every failure returns null and the meta strip simply shows no runtime.
+async function fetchTwitterAbRuntime(laneDir: string, dateStr: string, hour: string): Promise<TwitterAbRuntime | null> {
+  const cacheKey = `ara-ab-rt:${laneDir}:${dateStr}-${hour}`;
+  try {
+    const raw = sessionStorage.getItem(cacheKey);
+    if (raw) return JSON.parse(raw) as TwitterAbRuntime;
+  } catch {
+    /* unparseable — refetch */
+  }
+  try {
+    const statusResp = await fetch(`${DATA_BASE}/${laneDir}/status/${dateStr}-${hour}h.json`);
+    if (!statusResp.ok) return null;
+    const status = (await statusResp.json()) as { run_id?: string | number };
+    const runId = String(status.run_id ?? '');
+    if (!/^\d+$/.test(runId)) return null;
+    const runUrl = `https://github.com/${WIKI_REPO}/actions/runs/${runId}`;
+    let seconds: number | null = null;
+    const jobsResp = await fetch(
+      `https://api.github.com/repos/${WIKI_REPO}/actions/runs/${runId}/jobs?per_page=50`,
+      { headers: { Accept: 'application/vnd.github+json' } },
+    );
+    if (jobsResp.ok) {
+      const data = (await jobsResp.json()) as {
+        jobs?: Array<{ steps?: Array<{ name?: string; conclusion?: string; started_at?: string; completed_at?: string }> }>;
+      };
+      // Matrix legs echo the step as skipped/instant; the real agent step is
+      // the longest successful "Process tweets with …" across all jobs.
+      for (const job of data.jobs || []) {
+        for (const step of job.steps || []) {
+          if (step.conclusion !== 'success' || !/^Process tweets with /.test(step.name || '')) continue;
+          if (!step.started_at || !step.completed_at) continue;
+          const d = (Date.parse(step.completed_at) - Date.parse(step.started_at)) / 1000;
+          if (Number.isFinite(d) && d > (seconds ?? 1)) seconds = d;
+        }
+      }
+    }
+    const out: TwitterAbRuntime = { seconds, runUrl };
+    try {
+      sessionStorage.setItem(cacheKey, JSON.stringify(out));
+    } catch {
+      /* storage full — still return */
+    }
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+async function hydrateTwitterAbRuntimes(panel: HTMLElement, dateStr: string): Promise<void> {
+  const metas = Array.from(panel.querySelectorAll<HTMLElement>('.twitter-ab-meta'));
+  await Promise.all(metas.map(async (el) => {
+    const laneDir = el.dataset.abRt || '';
+    const hour = el.dataset.abHour || '';
+    if (!laneDir || !hour) return;
+    const rt = await fetchTwitterAbRuntime(laneDir, dateStr, hour);
+    const slot = el.querySelector<HTMLElement>('[data-ab-runtime]');
+    if (!rt || !slot || !panel.isConnected) return;
+    const label = rt.seconds != null ? 'agent ' + formatAbDuration(rt.seconds) : 'run';
+    setSafeContent(slot, '<a href="' + escapeHtml(rt.runUrl) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(label) + '</a>');
+    slot.hidden = false;
+  }));
+}
+
+function twitterAbPaneHtml(
+  laneDir: string,
+  meta: { label: string; model: string; harness: string },
+  body: string,
+  options: TwitterReportRenderOptions,
+  hour: string,
+): string {
+  return [
+    '<div class="twitter-ab-pane">',
+    '  <div class="twitter-ab-meta" data-ab-rt="' + escapeHtml(laneDir) + '" data-ab-hour="' + escapeHtml(hour) + '">',
+    '    <span class="twitter-ab-lane">' + escapeHtml(meta.label) + '</span>',
+    '    <span class="twitter-ab-model">' + escapeHtml(meta.model) + ' · ' + escapeHtml(meta.harness) + '</span>',
+    '    <span class="twitter-ab-runtime" data-ab-runtime hidden></span>',
+    '  </div>',
+    buildTwitterCycleContent(body, options).contentHtml,
+    '</div>',
+  ].join('\n');
+}
+
+async function buildTwitterAbPanel(panel: HTMLElement, hour: string, lanes: string[], activeLane: string): Promise<void> {
+  setSafeContent(panel, '<p class="twitter-ab-note">Loading comparison…</p>');
+  const dateStr = currentTwitterMdDate;
+  const laneMd = await fetchTwitterAbLaneMd(activeLane, dateStr);
+  const primaryBody = extractTwitterCycleBody(currentTwitterMd, hour);
+  const laneBody = laneMd ? extractTwitterCycleBody(laneMd, hour) : null;
+  if (!primaryBody || !laneBody || !panel.isConnected) {
+    setSafeContent(panel, '<p class="twitter-ab-note">Comparison data unavailable for this cycle.</p>');
+    return;
+  }
+  const options = buildTwitterRenderOptions(null, dateStr);
+  const meta = TWITTER_AB_LANE_META[activeLane] || { label: activeLane, model: activeLane, harness: '' };
+  const laneTabs = lanes.length > 1
+    ? '<div class="twitter-ab-lanes" role="tablist">' + lanes.map((l) => {
+        const m = TWITTER_AB_LANE_META[l];
+        return '<button type="button" class="twitter-ab-lane-tab' + (l === activeLane ? ' is-active' : '') + '" data-ab-pick="' + escapeHtml(l) + '">' + escapeHtml(m?.label || l) + '</button>';
+      }).join('') + '</div>'
+    : '';
+  setSafeContent(panel, [
+    laneTabs,
+    '<div class="twitter-ab-grid">',
+    twitterAbPaneHtml('twitter', TWITTER_AB_PRIMARY_META, primaryBody, options, hour),
+    twitterAbPaneHtml(activeLane, meta, laneBody, options, hour),
+    '</div>',
+  ].filter(Boolean).join('\n'));
+  panel.dataset.loaded = activeLane;
+  void hydrateTweetCards(panel);
+  void hydrateTwitterAbRuntimes(panel, dateStr);
+}
+
+async function toggleTwitterAbPanel(chip: HTMLButtonElement): Promise<void> {
+  const card = chip.closest('.twitter-cycle-card') as HTMLElement | null;
+  const panel = card?.querySelector('.twitter-ab-panel') as HTMLElement | null;
+  if (!card || !panel) return;
+  if (chip.getAttribute('aria-expanded') === 'true') {
+    chip.setAttribute('aria-expanded', 'false');
+    panel.hidden = true;
+    card.classList.remove('twitter-cycle-card--ab');
+    return;
+  }
+  chip.setAttribute('aria-expanded', 'true');
+  card.classList.add('twitter-cycle-card--ab');
+  panel.hidden = false;
+  const lanes = (chip.dataset.abLanes || '').split(',').filter(Boolean);
+  if (!panel.dataset.loaded && lanes.length) {
+    await buildTwitterAbPanel(panel, chip.dataset.abHour || '', lanes, lanes[0]);
+  }
 }
 
 function loadTickets(): Promise<Ticket[] | null> {
@@ -4870,7 +5073,10 @@ async function load(): Promise<void> {
         await loadManifest();
         if (requestId !== loadRequestId) return;
       }
-      const result = await withTimeout(fetchTwitter(dateStr, controller.signal), LOAD_TIMEOUT_MS, controller);
+      const [result] = await Promise.all([
+        withTimeout(fetchTwitter(dateStr, controller.signal), LOAD_TIMEOUT_MS, controller),
+        ensureTwitterAbIndex(controller.signal),
+      ]);
       if (requestId !== loadRequestId) return;
       if (result === 'timeout') {
         showError('Loading timed out', 'Network may be slow. Click to retry.');
@@ -5262,6 +5468,22 @@ content.addEventListener('click', (e) => {
   }
   if (target.closest('[data-ara-figure-close]')) {
     closeAraFigureModal();
+    return;
+  }
+  const abChip = target.closest('.twitter-ab-chip') as HTMLButtonElement | null;
+  if (abChip) {
+    void toggleTwitterAbPanel(abChip);
+    return;
+  }
+  const abPick = target.closest('[data-ab-pick]') as HTMLButtonElement | null;
+  if (abPick) {
+    const panel = abPick.closest('.twitter-ab-panel') as HTMLElement | null;
+    const chip = panel?.closest('.twitter-cycle-card')?.querySelector('.twitter-ab-chip') as HTMLButtonElement | null;
+    const lane = abPick.dataset.abPick || '';
+    const lanes = (chip?.dataset.abLanes || '').split(',').filter(Boolean);
+    if (panel && chip && lane && panel.dataset.loaded !== lane) {
+      void buildTwitterAbPanel(panel, chip.dataset.abHour || '', lanes, lane);
+    }
     return;
   }
   const figureImg = target.closest('.ara-doc .ara-figure img') as HTMLImageElement | null;

--- a/dashboard/src/render/twitter.ts
+++ b/dashboard/src/render/twitter.ts
@@ -56,6 +56,10 @@ export type TwitterReportRenderOptions = {
   twitterMarkdownToHtml: (md: string) => string;
   renderSourceChips: (urls: string[], limit?: number) => string;
   renderHandleChips: (handles: string[], limit?: number) => string;
+  // Hours ("16") that have a same-hour comparison-lane cycle (from
+  // twitter-ab.json), mapped to the lane slugs. Drives the A/B chip only —
+  // absent/empty means the report renders exactly as before.
+  abHours?: Record<string, string[]>;
 };
 
 function highlightPlainText(text: string, searchTerm: string): string {
@@ -470,6 +474,86 @@ function renderTwitterDateNav(options: TwitterReportRenderOptions): string {
   ].filter(Boolean).join('\n');
 }
 
+// Everything inside one cycle card below the header: lead brief + story
+// grid (or fallback body) + skeptic callout. Shared by the main report loop
+// and the A/B side-by-side panes so both render identically.
+export type TwitterCycleContent = {
+  leadText: string;
+  stories: TwitterStory[];
+  contentHtml: string;
+};
+
+export function buildTwitterCycleContent(sectionBody: string, options: TwitterReportRenderOptions): TwitterCycleContent {
+  const cycleSummary = stripEmptyCyclePlaceholderLines(extractCycleSummary(sectionBody));
+  const stories = parseTwitterStories(sectionBody);
+  const leadText = cycleSummary
+    ? cleanPublicLeadText(stripMarkdown(cycleSummary))
+    : truncateText(cleanPublicLeadText(stripMarkdown(stripEmptyCyclePlaceholderLines(sectionBody))), 620);
+
+  const fallbackBody = stripEmptyCyclePlaceholderLines(sectionBody
+    .replace(/\*\*Cycle summary\*\*:[\s\S]*?(?=\n#{1,3}\s|$)/i, '')
+    .replace(/###\s+[^\n]*[Ss]keptic[^\n]*\n[\s\S]*?(?=\n#{2,3}\s|$)/i, ''));
+  const fallbackHtml = fallbackBody && !isEmptyCyclePlaceholderMarkdown(fallbackBody)
+    ? '  <div class="md-content twitter-story-body twitter-cycle-fallback">' + options.twitterMarkdownToHtml(fallbackBody) + '</div>'
+    : '';
+  const structuredStoryCards = renderStructuredTwitterStories(sectionBody, options.searchTerm);
+  const storyCards = structuredStoryCards || stories.map((story) => {
+    const verification = truncateText(stripMarkdown(extractSectionText(story.body, 'Verification')), 210);
+    const watch = truncateText(stripMarkdown(extractSectionText(story.body, 'Watch')), 210);
+    const storyIntro = stripMarkdown(storyCurrentLead(story.body))
+      .replace(/^[\s\-—–]+/, '')
+      .replace(/^the originating\b/i, 'Originating');
+    const storySummary = isSourceMethodLead(storyIntro) ? '' : truncateText(cleanPublicLeadText(storyIntro), 360);
+    const storyLinks = options.renderSourceChips(story.links, 6);
+    const storyHandles = options.renderHandleChips(story.handles, 8);
+    return [
+      '<article class="twitter-story-card">',
+      '  <div class="twitter-story-rank">' + escapeHtml(story.rank) + '</div>',
+      '  <div class="twitter-story-main">',
+      '    <h3 class="twitter-story-title">' + highlightPlainText(story.title, options.searchTerm) + '</h3>',
+      storySummary ? '    <p class="twitter-story-summary">' + highlightPlainText(storySummary, options.searchTerm) + '</p>' : '',
+      '    <details class="twitter-story-details">',
+      '      <summary>Full analysis</summary>',
+      storyLinks || storyHandles ? '      <div class="twitter-story-chips">' + storyLinks + storyHandles + '</div>' : '',
+      verification || watch
+        ? '      <div class="twitter-story-signals">' +
+            (verification ? '<div><span>Verify</span>' + highlightPlainText(verification, options.searchTerm) + '</div>' : '') +
+            (watch ? '<div><span>Watch</span>' + highlightPlainText(watch, options.searchTerm) + '</div>' : '') +
+          '</div>'
+        : '',
+      '      <div class="md-content twitter-story-body">' + options.twitterMarkdownToHtml(story.body) + '</div>',
+      '    </details>',
+      '  </div>',
+      '</article>',
+    ].filter(Boolean).join('\n');
+  }).join('\n');
+
+  const skepticBody = extractSkepticCorner(sectionBody);
+  const skepticHtml = skepticBody
+    ? '<div class="ara-callout ara-callout--danger">' + options.twitterMarkdownToHtml(skepticBody) + '</div>'
+    : '';
+
+  const contentHtml = [
+    '  <div class="twitter-wire-brief">',
+    '    <div>',
+    '      <p class="twitter-brief-text">' + highlightPlainText(leadText, options.searchTerm) + '</p>',
+    '    </div>',
+    '  </div>',
+    storyCards ? '  <div class="twitter-story-grid">' + storyCards + '</div>' : fallbackHtml,
+    skepticHtml,
+  ].filter(Boolean).join('\n');
+
+  return { leadText, stories, contentHtml };
+}
+
+/** Body of the `## <hour>:00 UTC` cycle in a raw report, or null. */
+export function extractTwitterCycleBody(md: string, hour: string): string | null {
+  for (const section of splitSections(sanitizePublicReportMarkdown(md))) {
+    if (section.title === hour + ':00 UTC') return section.body;
+  }
+  return null;
+}
+
 export function renderTwitterReportHtml(md: string, options: TwitterReportRenderOptions): string {
   const sections = splitSections(sanitizePublicReportMarkdown(md)).reverse();
   const cards: string[] = [renderTwitterDateNav(options)];
@@ -481,14 +565,10 @@ export function renderTwitterReportHtml(md: string, options: TwitterReportRender
     const title = section.title || options.currentDateTitle;
     const timeInfo = options.parseUtcTime(section.title, options.currentDateStr);
     const cycleAnchor = 'cycle-' + section.title.replace(/[:\s]/g, '').toLowerCase();
-    const cycleSummary = stripEmptyCyclePlaceholderLines(extractCycleSummary(section.body));
-    const stories = parseTwitterStories(section.body);
+    const { leadText, stories, contentHtml } = buildTwitterCycleContent(section.body, options);
     const displayTime = timeInfo
       ? '<span class="twitter-cycle-time">' + escapeHtml(timeInfo.utc) + '</span><span class="local-time">' + escapeHtml(timeInfo.local) + '</span>'
       : '<span class="twitter-cycle-time">' + escapeHtml(title) + '</span>';
-    const leadText = cycleSummary
-      ? cleanPublicLeadText(stripMarkdown(cycleSummary))
-      : truncateText(cleanPublicLeadText(stripMarkdown(stripEmptyCyclePlaceholderLines(section.body))), 620);
     mindshareCycles.push({
       anchor: cycleAnchor,
       body: section.body,
@@ -503,47 +583,16 @@ export function renderTwitterReportHtml(md: string, options: TwitterReportRender
       detail: summarizeTwitterTimeline(leadText, stories, section.body),
     });
 
-    const fallbackBody = stripEmptyCyclePlaceholderLines(section.body
-      .replace(/\*\*Cycle summary\*\*:[\s\S]*?(?=\n#{1,3}\s|$)/i, '')
-      .replace(/###\s+[^\n]*[Ss]keptic[^\n]*\n[\s\S]*?(?=\n#{2,3}\s|$)/i, ''));
-    const fallbackHtml = fallbackBody && !isEmptyCyclePlaceholderMarkdown(fallbackBody)
-      ? '  <div class="md-content twitter-story-body twitter-cycle-fallback">' + options.twitterMarkdownToHtml(fallbackBody) + '</div>'
-      : '';
-    const structuredStoryCards = renderStructuredTwitterStories(section.body, options.searchTerm);
-    const storyCards = structuredStoryCards || stories.map((story) => {
-      const verification = truncateText(stripMarkdown(extractSectionText(story.body, 'Verification')), 210);
-      const watch = truncateText(stripMarkdown(extractSectionText(story.body, 'Watch')), 210);
-      const storyIntro = stripMarkdown(storyCurrentLead(story.body))
-        .replace(/^[\s\-—–]+/, '')
-        .replace(/^the originating\b/i, 'Originating');
-      const storySummary = isSourceMethodLead(storyIntro) ? '' : truncateText(cleanPublicLeadText(storyIntro), 360);
-      const storyLinks = options.renderSourceChips(story.links, 6);
-      const storyHandles = options.renderHandleChips(story.handles, 8);
-      return [
-        '<article class="twitter-story-card">',
-        '  <div class="twitter-story-rank">' + escapeHtml(story.rank) + '</div>',
-        '  <div class="twitter-story-main">',
-        '    <h3 class="twitter-story-title">' + highlightPlainText(story.title, options.searchTerm) + '</h3>',
-        storySummary ? '    <p class="twitter-story-summary">' + highlightPlainText(storySummary, options.searchTerm) + '</p>' : '',
-        '    <details class="twitter-story-details">',
-        '      <summary>Full analysis</summary>',
-        storyLinks || storyHandles ? '      <div class="twitter-story-chips">' + storyLinks + storyHandles + '</div>' : '',
-        verification || watch
-          ? '      <div class="twitter-story-signals">' +
-              (verification ? '<div><span>Verify</span>' + highlightPlainText(verification, options.searchTerm) + '</div>' : '') +
-              (watch ? '<div><span>Watch</span>' + highlightPlainText(watch, options.searchTerm) + '</div>' : '') +
-            '</div>'
-          : '',
-        '      <div class="md-content twitter-story-body">' + options.twitterMarkdownToHtml(story.body) + '</div>',
-        '    </details>',
-        '  </div>',
-        '</article>',
-      ].filter(Boolean).join('\n');
-    }).join('\n');
-
-    const skepticBody = extractSkepticCorner(section.body);
-    const skepticHtml = skepticBody
-      ? '<div class="ara-callout ara-callout--danger">' + options.twitterMarkdownToHtml(skepticBody) + '</div>'
+    // Quiet A/B affordance: only cycles with a same-hour comparison run get
+    // the chip; everyone else sees the header exactly as before. The panel
+    // div stays empty until the chip is clicked (filled by main.ts).
+    const hourMatch = /^(\d{2}):00 UTC$/.exec(section.title || '');
+    const abLanes = hourMatch ? options.abHours?.[hourMatch[1]] : undefined;
+    const abChip = abLanes?.length
+      ? '<button class="twitter-ab-chip" type="button" aria-expanded="false" ' +
+        'title="Compare this cycle side-by-side with another model" ' +
+        'data-ab-hour="' + escapeHtml(hourMatch![1]) + '" ' +
+        'data-ab-lanes="' + escapeHtml(abLanes.join(',')) + '">A/B</button>'
       : '';
 
     cards.push(
@@ -551,16 +600,14 @@ export function renderTwitterReportHtml(md: string, options: TwitterReportRender
         '<section id="' + cycleAnchor + '" class="content-card twitter-cycle-card">',
         '  <div class="twitter-cycle-header">',
         '    <div class="twitter-cycle-kicker">' + (timeInfo ? options.clockIcon(timeInfo.localHours, timeInfo.localMinutes) : '') + displayTime + '</div>',
+        abChip ? '    ' + abChip : '',
         '  </div>',
-        '  <div class="twitter-wire-brief">',
-        '    <div>',
-        '      <p class="twitter-brief-text">' + highlightPlainText(leadText, options.searchTerm) + '</p>',
-        '    </div>',
+        abChip ? '  <div class="twitter-ab-panel" hidden></div>' : '',
+        '  <div class="twitter-cycle-default">',
+        contentHtml,
         '  </div>',
-        storyCards ? '  <div class="twitter-story-grid">' + storyCards + '</div>' : fallbackHtml,
-        skepticHtml,
         '</section>',
-      ].join('\n'),
+      ].filter(Boolean).join('\n'),
     );
   }
 

--- a/dashboard/src/style.css
+++ b/dashboard/src/style.css
@@ -2025,10 +2025,102 @@ body.search-open { overflow: hidden; }
   overflow: visible;
 }
 
+/* ── Twitter A/B side-by-side (comparison lanes) ─────────
+ * The chip is the ONLY thing news readers ever see, and only on cycles
+ * that have a same-hour comparison run. Everything else appears on click. */
+.twitter-ab-chip {
+  margin-left: auto;
+  font-family: var(--font);
+  font-size: 0.66rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  color: var(--text-secondary);
+  background: transparent;
+  border: 1px solid var(--border-light);
+  border-radius: 999px;
+  padding: 3px 10px;
+  cursor: pointer;
+  transition: color 0.12s, border-color 0.12s;
+}
+.twitter-ab-chip:hover,
+.twitter-ab-chip:focus-visible { color: var(--accent-warm); border-color: var(--accent-warm); }
+.twitter-ab-chip[aria-expanded="true"] {
+  color: var(--accent-warm);
+  border-color: var(--accent-warm);
+  background: color-mix(in srgb, var(--accent-warm) 8%, transparent);
+}
+
+/* Open state swaps the default single-lane content for the panel. */
+.twitter-cycle-card--ab .twitter-cycle-default { display: none; }
+.twitter-ab-panel { padding: 0 24px 20px; }
+.twitter-ab-note {
+  margin: 16px 0 0;
+  font-size: 0.86rem;
+  color: var(--text-secondary);
+}
+.twitter-ab-lanes { display: flex; gap: 6px; margin: 14px 0 0; }
+.twitter-ab-lane-tab {
+  font-family: var(--font);
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  background: transparent;
+  border: 1px solid var(--border-light);
+  border-radius: 999px;
+  padding: 3px 10px;
+  cursor: pointer;
+}
+.twitter-ab-lane-tab.is-active { color: var(--accent-warm); border-color: var(--accent-warm); }
+.twitter-ab-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 20px;
+  margin-top: 14px;
+}
+@media (min-width: 980px) {
+  .twitter-ab-grid { grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); }
+}
+.twitter-ab-pane {
+  border: 1px solid var(--border-light);
+  border-radius: 10px;
+  padding: 4px 16px 14px;
+  min-width: 0;
+}
+.twitter-ab-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 4px 10px;
+  padding: 12px 8px 10px;
+  border-bottom: 1px solid var(--border-light);
+}
+.twitter-ab-lane {
+  font-family: var(--font);
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+.twitter-ab-model {
+  font-family: var(--font);
+  font-size: 0.72rem;
+  color: var(--text-secondary);
+}
+.twitter-ab-runtime {
+  margin-left: auto;
+  font-family: var(--font);
+  font-size: 0.72rem;
+  font-variant-numeric: tabular-nums;
+}
+.twitter-ab-runtime a { color: var(--text-secondary); text-decoration: none; }
+.twitter-ab-runtime a:hover { color: var(--accent-warm); text-decoration: underline; }
+/* Panes are narrow columns — let inner story cards breathe less. */
+.twitter-ab-pane .twitter-story-grid { grid-template-columns: 1fr; }
+
 .twitter-cycle-header {
   display: flex;
   align-items: center;
   justify-content: flex-start;
+  gap: 10px;
   padding: 16px 24px;
   border-bottom: 1px solid var(--border-light);
   background: color-mix(in srgb, var(--bg-secondary) 52%, var(--bg));


### PR DESCRIPTION
## Summary
- Cycles with a **same-hour comparison-lane run** get one muted `A/B` pill in the section header — the only visible change for news readers; cycles without comparison data render exactly as before.
- Clicking the pill swaps the cycle for a **two-pane side-by-side** (single-column stacked on mobile): each pane shows lane label + model/harness + **agent-step runtime** above the cycle content, both panes rendered through the same pipeline as the main report (`buildTwitterCycleContent` extraction), so they look identical to the normal view.
- Runtime resolves client-side: status heartbeat `run_id` → public Actions jobs API (unauthenticated, sessionStorage-cached, immutable runs) → longest successful "Process tweets with …" step; on any failure the strip degrades to a plain run link or nothing.
- Discovery is prebuild-time: `twitter-ab.json` maps date → hour → lanes by scanning primary + comparison files for matching `## HH:00 UTC` headings (37 archive dates match, mostly the deepseek tier). Comparison dirs are copied into `public/` but deliberately **not** added to `COPY_DIRS`' manifest set, so freshness rows don't report rarely-run lanes as stale.
- Lane-switcher tabs appear only when a cycle has multiple comparison lanes.

## Verification (in-browser on the built bundle)
- 2026-07-20 renders 3 cycle cards with exactly **1** chip (the 16:00 UTC cycle, which has the opencode+Kimi K3 run).
- Open: two panes with live-hydrated runtimes — `agent 7m 13s` (primary) vs `agent 13m 00s` (Kimi K3) — matching the run's actual step timings; close restores the news view and `aria-expanded` state.
- 390 px viewport stacks the panes single-column; `tsc --noEmit` green via the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)