### PR TITLE
Whitelist twitter comparison-lane dirs in .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -46,6 +46,20 @@ research/*
 !research/youtube/**
 !research/arm
 !research/arm/**
+# Twitter comparison-lane dirs: prebuild's twitter-ab.json index and the A/B
+# side-by-side view read these. A research dir consumed by prebuild MUST be
+# whitelisted here too — CI never runs the Dockerfile, so a miss ships an
+# empty index to prod silently (same failure mode as the 2026-07 Arm tab).
+!research/twitter-opencode-kimi
+!research/twitter-opencode-kimi/**
+!research/twitter-zai
+!research/twitter-zai/**
+!research/twitter-deepseek
+!research/twitter-deepseek/**
+!research/twitter-deepseek-pi
+!research/twitter-deepseek-pi/**
+!research/twitter-fireworks-pi
+!research/twitter-fireworks-pi/**
 
 node_modules
 __pycache__


### PR DESCRIPTION
## Summary
Prod served an empty `twitter-ab.json` (`{}`) after #841 because `.dockerignore`'s `research/*` exclusion keeps the comparison-lane dirs out of the Railway build context — prebuild found nothing to index. Local/CI builds can't catch this (CI never runs the Dockerfile; Load-bearing rule 3 / the 2026-07 Arm-tab incident). Whitelists the five `research/twitter-<lane>/` dirs and documents the invariant inline.

## Verification plan
After merge, prod `/research/twitter-ab.json` should contain `2026-07-20` and the A/B pill should appear on the 16:00 UTC cycle; will verify live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)