### PR TITLE
Map more model tickets to live Polymarket markets

### DIFF
--- a/research/models/tickets/moonshot-kimi-k3.md
+++ b/research/models/tickets/moonshot-kimi-k3.md
@@ -52,8 +52,14 @@ sources:
   - "@rohanpaul_ai"
   - "@EpochAIResearch"
   - "@theinformation"
+polymarket:
+  - event_slug: moonshot-publishes-kimi-k3-weights-by-july-27-20260717164254847
+    market_id: "2962189"
+    token_id: "75115059341633093064218172577665054472726102773501095008666040339558881159279"
+    question: "Moonshot publishes Kimi K3 weights by July 27?"
+    outcome: "Jul 27 2026"
 created_at: 2026-07-16
-updated_at: 2026-07-22
+updated_at: 2026-07-23
 closed_at: null
 closed_reason: null
 history:
@@ -63,6 +69,8 @@ history:
     change: "Official @Kimi_Moonshot account announced pausing new subscriptions (existing members unaffected) after demand pushed close to capacity limits over the prior 48h, and announced membership will split into separate 'Kimi Membership' and 'Kimi Code Membership' plans. Widely re-shared (@deedydas, @GavinSBaker, @quxiaoyin, @testingcatalog). A capacity-constrained, oversubscribed paid product is definitionally public and shipped → status advanced from in-testing to released; verification advanced to confirmed (official company account, primary source)."
   - ts: 2026-07-22
     change: "Corroboration + specs, no status change. Moonshot's own framing (relayed by @ryqwzrbuilds): 2.8T-parameter open model, apps/API live now, full weights due 2026-07-27. Epoch AI: 156 on the Epoch Capabilities Index, a new open-weights record, between Claude Opus 4.6 and GPT-5.4 (via @rohanpaul_ai/@EpochAIResearch RT); separately 2nd on the AA-Briefcase agentic benchmark, near Fable 5, at ~$10.57/task (~10x K2.6's cost, above Opus). @theinformation: Microsoft is evaluating K3 for Copilot features previously handled by OpenAI/Anthropic models (internal testing only, no release date/pricing). A JPMorgan note frames K3 as re-rating Zhipu AI's competitive narrative (@AlphaWireNewsAi). Status stays released; verification stays confirmed."
+  - ts: 2026-07-23
+    change: "Linked Polymarket odds (metadata-only, no status change): 'Moonshot publishes Kimi K3 weights by July 27?' (event moonshot-publishes-kimi-k3-weights-by-july-27-20260717164254847, market 2962189, Gamma snapshot ~92% Yes). Resolution requires complete official K3 weights to be publicly downloadable—API-only, partial, converted, or third-party weights do not count—exactly matching this ticket's remaining open-weights milestone; IDs read from the Gamma API."
 ---
 
 **Moonshot AI's** next flagship coding/reasoning model, **Kimi K3**, is

--- a/research/models/tickets/openai-us-govt-stake-2026-06.md
+++ b/research/models/tickets/openai-us-govt-stake-2026-06.md
@@ -74,8 +74,14 @@ sources:
   - "@Sharity"
   - "@rohanpaul_ai"
   - "@_StockMlKTNewz"
+polymarket:
+  - event_slug: which-companies-will-the-us-take-a-stake-in
+    market_id: "1323318"
+    token_id: "105746726493182224982615892012481143192604366292256699612958741853324716128080"
+    question: "Will the US federal government take a stake in OpenAI?"
+    outcome: "Dec 31 2026"
 created_at: 2026-06-07
-updated_at: 2026-07-04
+updated_at: 2026-07-23
 closed_at: null
 closed_reason: null
 history:
@@ -89,6 +95,8 @@ history:
     change: "Polymarket odds data point (~73% implied) on the government taking a stake (@_StockMlKTNewz); TechCrunch/Ars Technica reiterate Altman's ~5% donation proposal. Continuing thread, no new fact confirmation. Status stays confirmed; verification stays partial."
   - ts: 2026-07-04
     change: "Viral backlash (Digg: 1M+ views, 79.5% negative across 472 comments) plus the first on-record presidential reaction: in a CNBC interview, Trump declined to confirm or deny the 5% stake, instead citing the government's ~10% Intel stake ('$60 or $70B' paper gain in 8 months) as the operating precedent and calling it 'very American' — reproduced verbatim across 4+ independent accounts, so on-record but non-committal. CNBC follow-up: the concept has circulated over a year, Altman first pitched it to Trump in early 2025. Ars Technica-sourced relay: the 5% figure is 'far below' Sanders' ask. Status stays confirmed; verification stays partial (no OpenAI/WH confirmation of terms)."
+  - ts: 2026-07-23
+    change: "Linked Polymarket odds (metadata-only, no status change): 'Will the US federal government take a stake in OpenAI?' (event which-companies-will-the-us-take-a-stake-in, market 1323318, Gamma snapshot ~27% Yes). The market's resolution criteria require direct federal equity or a binding acquisition agreement, exactly matching this ticket's unresolved question; IDs read from the Gamma API."
 ---
 
 Per **NOTUS, TechCrunch, and The Decoder** (2026-06-06), the **Trump

--- a/research/models/tickets/reliance-intelligence-2026-06.md
+++ b/research/models/tickets/reliance-intelligence-2026-06.md
@@ -33,13 +33,26 @@ sources:
   - https://x.com/investor1397/status/2068230147606475240
   - "@gaze_observer"
   - "@investor1397"
+polymarket:
+  - event_slug: jio-platforms-ipo-byptptpt-20260629175823569
+    market_id: "2734705"
+    token_id: "106288975322599844817998715240962735449402266747474973473213248062206417629461"
+    question: "Will Jio Platforms IPO by July 31, 2026?"
+    outcome: "Jul 31 2026"
+  - event_slug: jio-platforms-ipo-byptptpt-20260629175823569
+    market_id: "2734708"
+    token_id: "87218132281162226192564134544957766898701908105269167897566982880770950467378"
+    question: "Will Jio Platforms IPO by December 31, 2026?"
+    outcome: "Dec 31 2026"
 created_at: 2026-06-20
-updated_at: 2026-06-20
+updated_at: 2026-07-23
 closed_at: null
 closed_reason: null
 history:
   - ts: 2026-06-20
     change: "Created — at Reliance's 49th AGM (2026-06-19) Mukesh Ambani moved Reliance Intelligence to execution: first 120 MW of Jamnagar AI compute by end-2026 (NVIDIA GB300 first phase, ~75k H100-equiv; scalable to >200k H100-equiv; Kutch solar-powered), free Google AI Pro (Gemini) for hundreds of millions of Jio users, a Meta/Llama JV, and a 22-language AI app suite. Same day, Jio Platforms filed a DRHP for a potential India-record IPO (~₹40,000 cr fresh issue; ~$120-150B est. valuation). Sourced from detailed secondary AGM recaps (no captured Reliance primary handle in-window) → status confirmed (official AGM event, multi-account corroboration), verification partial. @gaze_observer 2068232851724947827, @investor1397 2068230147606475240."
+  - ts: 2026-07-23
+    change: "Linked Polymarket IPO timing odds (metadata-only, no status change): Jio Platforms IPO by July 31 (market 2734705, Gamma snapshot ~14% Yes) and December 31, 2026 (market 2734708, Gamma snapshot ~59% Yes) in event jio-platforms-ipo-byptptpt-20260629175823569. Both markets require Jio's first public stock sale on a recognized exchange, exactly matching this ticket's pending IPO leg; IDs read from the Gamma API."
 ---
 
 At **Reliance Industries' 49th AGM on 2026-06-19**, Mukesh Ambani declared


### PR DESCRIPTION
## Summary

- map the OpenAI federal-stake ticket to its exact active Polymarket market
- map the Kimi K3 full-weights milestone to its exact July 27 market
- map the Jio IPO leg to active July 31 and December 31 timing markets
- record Gamma snapshot prices and exact market/token metadata in ticket history
- omit two superficially similar markets after sibling resolutions showed their semantics did not match the tickets

## Validation

- `uv run python scripts/check_model_tickets.py` — 162 tickets valid
- `python -m unittest scripts.test_check_model_tickets` — 12 passed
- `node --test dashboard/scripts/forecast-seo.test.mjs` — 3 passed
- `git diff --check`
- independent read-only review of live Gamma questions, event slugs, market IDs, YES token IDs, and open state

Source: `codex/polymarket-ticket-mappings`
Base: `main`