### PR TITLE
Strip lane labels and timestamps from the front-page headline

### DIFF
--- a/scripts/render_front_page.mjs
+++ b/scripts/render_front_page.mjs
@@ -135,7 +135,50 @@ const policy = policyRecords.map((item) => item.text);
 const quoteBlock = markdown.match(/## Quote of the Day\s+>\s*([\s\S]*?)(?=\n---|\n##\s+|$)/i)?.[1] ?? "";
 const quote = stripMarkdown(quoteBlock.replace(/^>\s?/gm, " "));
 
-const lead = executive[0] || paragraphs(markdown, 1)[0] || "Today's AI digest is ready.";
+// A headline names the story — not the pipe it arrived through, nor when a
+// feed stamped it. The deterministic fallback digest labels every Executive
+// Summary bullet with its source lane and keeps the source item's trailing
+// timestamp:
+//   - **RSS / Official Announcements:** [Runway launches ...](url) - 2026-07-23 17:07 UTC
+// Rendered verbatim that shipped as a TOP STORY reading "RSS / Official
+// Announcements: Runway launches ... - 2026-07-23 17:07 UTC".
+//
+// Both strips are deliberately narrow so they cannot eat real copy: the
+// prefix must be one of the fallback composer's OWN lane labels (keep in
+// lockstep with LANES in scripts/deterministic_daily_digest.py) — so a
+// genuine "OpenAI: ..." headline survives — and the suffix must be a full
+// ISO date, so "Fable 5" or "$19.2B" is untouched.
+const LANE_LABELS = [
+  "Twitter/X",
+  "RSS / Official Announcements",
+  "Hacker News",
+  "Reddit",
+  "Expert Blogs",
+  "Bluesky",
+  "arXiv Papers",
+  "YouTube",
+];
+const LANE_LABEL_RE = new RegExp(
+  `^\\s*(?:${LANE_LABELS.map((l) => l.replace(/[.*+?^${}()|[\]\\/]/g, "\\$&")).join("|")})\\s*:\\s*`,
+  "i",
+);
+const TRAILING_STAMP_RE =
+  /[\s(]*[-–—]?\s*\d{4}-\d{2}-\d{2}(?:[ T]\d{2}:\d{2}(?::\d{2})?)?\s*(?:UTC|GMT|Z)?\s*\)?\s*$/i;
+
+function headlineText(text) {
+  let out = text;
+  // Lanes can nest ("Hacker News: Reddit: ..." never happens today, but the
+  // loop costs nothing and keeps one stray label from surviving).
+  for (let i = 0; i < 3 && LANE_LABEL_RE.test(out); i += 1) {
+    out = out.replace(LANE_LABEL_RE, "");
+  }
+  out = out.replace(TRAILING_STAMP_RE, "").replace(/[\s–—-]+$/, "").trim();
+  return out || text.trim();
+}
+
+const lead = headlineText(
+  executive[0] || paragraphs(markdown, 1)[0] || "Today's AI digest is ready.",
+);
 const leadDeck = executive.slice(1, 4);
 const issue = Math.floor((new Date(`${date}T00:00:00Z`) - new Date(`${date.slice(0, 4)}-01-01T00:00:00Z`)) / 86400000) + 1;
 

--- a/scripts/test_deterministic_daily_digest.py
+++ b/scripts/test_deterministic_daily_digest.py
@@ -287,6 +287,86 @@ class FrontPageRendererParityTest(unittest.TestCase):
                 break
         return out
 
+    # Port of headlineText() in scripts/render_front_page.mjs.
+    _JS_LANE_LABEL_RE = re.compile(
+        r"^\s*(?:"
+        + "|".join(
+            re.escape(lane.label)
+            for lane in digest.LANES
+        )
+        + r")\s*:\s*",
+        re.I,
+    )
+    _JS_TRAILING_STAMP_RE = re.compile(
+        r"[\s(]*[-–—]?\s*\d{4}-\d{2}-\d{2}"
+        r"(?:[ T]\d{2}:\d{2}(?::\d{2})?)?\s*(?:UTC|GMT|Z)?\s*\)?\s*$",
+        re.I,
+    )
+
+    @classmethod
+    def _js_headline_text(cls, text: str) -> str:
+        out = text
+        for _ in range(3):
+            if not cls._JS_LANE_LABEL_RE.search(out):
+                break
+            out = cls._JS_LANE_LABEL_RE.sub("", out)
+        out = cls._JS_TRAILING_STAMP_RE.sub("", out)
+        out = re.sub(r"[\s–—-]+$", "", out).strip()
+        return out or text.strip()
+
+    def test_headline_strips_lane_label_and_trailing_timestamp(self):
+        """The 2026-07-25 front page shipped a TOP STORY reading
+        'RSS / Official Announcements: Runway launches ... - 2026-07-23 17:07 UTC'.
+        A headline names the story, not the lane it arrived through nor when
+        the feed stamped it."""
+        self.assertEqual(
+            self._js_headline_text(
+                "RSS / Official Announcements: Runway launches AI model router "
+                "as generative media gets crowded - 2026-07-23 17:07 UTC"
+            ),
+            "Runway launches AI model router as generative media gets crowded",
+        )
+        for label in (lane.label for lane in digest.LANES):
+            with self.subTest(label=label):
+                self.assertEqual(
+                    self._js_headline_text(f"{label}: Something newsworthy happened"),
+                    "Something newsworthy happened",
+                )
+        # Date shapes the composer and its sources actually emit.
+        self.assertEqual(self._js_headline_text("A title 2026-07-23"), "A title")
+        self.assertEqual(self._js_headline_text("A title (2026-07-23)"), "A title")
+        self.assertEqual(self._js_headline_text("A title — 2026-07-23 09:00 UTC"), "A title")
+
+    def test_headline_cleanup_cannot_eat_real_copy(self):
+        """Both strips must stay narrow: a non-lane colon is ordinary headline
+        punctuation, and figures like $10.3B must survive."""
+        for untouched in (
+            "Anthropic launched Claude Opus 5, near flagship Fable 5 at half the token price",
+            "OpenAI: we are shipping a new voice mode",
+            "Etched hits $10.3B valuation from big-name investors",
+            "Black Forest Labs shipped Flux 3",
+        ):
+            with self.subTest(untouched=untouched):
+                self.assertEqual(self._js_headline_text(untouched), untouched)
+
+    def test_fallback_digest_lead_is_clean_end_to_end(self):
+        """Guards the whole chain on a genuinely composed fallback digest, not
+        just the regex in isolation."""
+        with tempfile.TemporaryDirectory() as tmp:
+            markdown = self._compose_fallback_digest(Path(tmp))
+            executive = self._js_section_records(
+                self._js_section(markdown, "Executive Summary"), 5
+            )
+            lead = self._js_headline_text(executive[0])
+
+            for lane in digest.LANES:
+                self.assertFalse(
+                    lead.lower().startswith(lane.label.lower() + ":"),
+                    f"lead still carries the {lane.label} lane label: {lead!r}",
+                )
+            self.assertNotRegex(lead, r"\d{4}-\d{2}-\d{2}\s*$")
+            self.assertTrue(lead)
+
     def _compose_fallback_digest(self, root: Path) -> str:
         research = root / "research"
         (research / "summaries").mkdir(parents=True)


### PR DESCRIPTION
The 2026-07-25 TOP STORY rendered as:

> **RSS / Official Announcements: Runway launches AI model router as generative media gets crowded - 2026-07-23 17:07 UTC**

A headline names the story — not the pipe it arrived through, nor when a feed stamped it.

## Cause

`render_front_page.mjs` takes the first Executive Summary bullet verbatim as the headline. That's fine for a model-written digest, whose bullets are already prose. But the **deterministic fallback composer** labels every bullet with its source lane and keeps the source item's trailing timestamp:

```
- **RSS / Official Announcements:** [Runway launches ...](url) - 2026-07-23 17:07 UTC
```

…which then rendered at 44px on the masthead. So this was collateral damage from the same 2026-07-24 outage: the front page was built from the fallback digest.

## Fix

`headlineText()` strips both. Both strips are deliberately narrow so they cannot eat real copy:

- **Prefix** must be one of the fallback composer's *own* lane labels (kept in lockstep with `LANES` in `deterministic_daily_digest.py`). A blanket "strip anything before a colon" rule would eat `OpenAI: we are shipping a new voice mode` — a colon is ordinary headline punctuation.
- **Suffix** must be a full ISO date, so `Fable 5` and `$10.3B` survive.

Applied where `lead` is computed, so the PNG, the `.ara.md` interactive edition, and the HTML preview all get it. `leadDeck` is left alone on purpose — in a fallback digest the lane label is the only attribution the body paragraphs carry.

## Verification

Tests follow the existing `FrontPageRendererParityTest` pattern and cover both directions: every label in `LANES` strips, and real headlines / non-lane colons / figures do not. I also checked the Python port and the actual JS agree on all 12 cases rather than trusting the port — a silently drifting port would give false confidence.

```
RSS / Official Announcements: Runway launches AI model router as generative media gets crowded - 2026-07-23 17:07 UTC
  → Runway launches AI model router as generative media gets crowded
OpenAI: we are shipping a new voice mode                → unchanged
Etched hits $10.3B valuation from big-name investors    → unchanged
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
