### PR TITLE
Move source attribution out of the front-page headline

### DIFF
--- a/scripts/render_front_page.mjs
+++ b/scripts/render_front_page.mjs
@@ -423,7 +423,7 @@ function yamlItems(items, mapper) {
 function renderAraSource(images = []) {
   // Same editorial split as the PNG: the title holds one headline-sized
   // sentence, the rest of the lead bullet opens the body.
-  const [leadTitle, leadTitleRest] = splitFirstSentence(lead);
+  const [leadTitle, leadTitleRest] = splitLead(lead);
   const leadBodyItems = [leadTitleRest, ...leadDeck].filter(Boolean);
   const leadBody = leadBodyItems.length
     ? leadBodyItems.join("\n\n")
@@ -538,6 +538,50 @@ function splitFirstSentence(text) {
   return [text.trim(), ""];
 }
 
+// Where the digest cites its sourcing. A parenthetical is only treated as
+// attribution when it names an outlet or carries engagement figures, so
+// descriptive asides like "Flux 3 (image generation)" are left alone.
+const ATTRIBUTION_HINT_RE =
+  /\b(?:TechCrunch|The Verge|The Decoder|Ars Technica|Reuters|Bloomberg|Hacker News|HN|Reddit|Bluesky|arXiv|The Information|Wired|CNBC|Financial Times|WSJ|Guardian|Axios|Semafor|Business Insider|VentureBeat|Engadget|Nikkei|SCMP|TechMeme)\b|\b\d+\s*(?:points?|comments?|upvotes?)\b|#\d+\s+on\b/i;
+
+// A masthead headline names the story; who reported it and how it did on
+// Hacker News is body copy. The digest's lead bullet routinely ends with
+// "(TechCrunch, The Verge, The Decoder; #1 on Hacker News at 680 points/386
+// comments)" — and because that bullet is one long sentence,
+// splitFirstSentence() hands the whole thing to the headline, where it
+// rendered at 36-44px. Peel the attribution off and hand it to the body so
+// the sourcing survives; it is only moved, never dropped.
+function splitTrailingAttribution(title) {
+  let head = title;
+  const tail = [];
+  for (let i = 0; i < 3; i += 1) {
+    const match = head.match(/\s*\(([^()]*)\)\s*([.!?])?\s*$/);
+    if (!match || !ATTRIBUTION_HINT_RE.test(match[1])) break;
+    tail.unshift(`(${match[1].trim()})`);
+    head = `${head.slice(0, match.index).trimEnd()}${match[2] ?? ""}`;
+  }
+  if (!tail.length) return [title, ""];
+  // Never hand back an empty or stub headline — if the parenthetical WAS
+  // the sentence ("(TechCrunch, The Verge)."), keep the original rather
+  // than render a fragment. Guard on word count, not characters: a short
+  // real headline ("OpenAI ships GPT-6") must survive, and only a
+  // genuinely empty remainder should veto the split.
+  head = head.replace(/[\s,;:–—-]+$/, "").trim();
+  if (head.replace(/[^\w\s]/g, " ").split(/\s+/).filter(Boolean).length < 2) {
+    return [title, ""];
+  }
+  return [head, tail.join(" ")];
+}
+
+// The editorial split both renderers share: one headline-sized sentence,
+// with the remainder plus any peeled attribution opening the body.
+function splitLead(text) {
+  const [firstSentence, rest] = splitFirstSentence(text);
+  const [title, attribution] = splitTrailingAttribution(firstSentence);
+  const body = [attribution, rest].filter(Boolean).join(" ").trim();
+  return [title, body];
+}
+
 function svgText(x, y, lines, options = {}) {
   const {
     size = 24,
@@ -593,11 +637,11 @@ function renderSvg(images = []) {
   const imageTop = 690;
   const leadBottom = images[0] ? imageTop - 18 : 906;
   let y = 305;
-  const [headlineText, headlineRest] = splitFirstSentence(lead);
-  const headlineSize = headlineText.length > 130 ? 36 : 44;
+  const [headlineLead, headlineRest] = splitLead(lead);
+  const headlineSize = headlineLead.length > 130 ? 36 : 44;
   const headlineWrap = headlineSize === 36 ? 31 : 25;
   const headlineLineHeight = headlineSize === 36 ? 40 : 48;
-  const headlineLines = clampText(headlineText, headlineWrap, 5);
+  const headlineLines = clampText(headlineLead, headlineWrap, 5);
   parts.push(svgText(62, y, headlineLines, { size: headlineSize, weight: "700", lineHeight: headlineLineHeight }));
   y += headlineLines.length * headlineLineHeight + 24;
   const ledeItems = [headlineRest, ...leadDeck].filter(Boolean);

--- a/scripts/test_deterministic_daily_digest.py
+++ b/scripts/test_deterministic_daily_digest.py
@@ -337,6 +337,82 @@ class FrontPageRendererParityTest(unittest.TestCase):
         self.assertEqual(self._js_headline_text("A title (2026-07-23)"), "A title")
         self.assertEqual(self._js_headline_text("A title — 2026-07-23 09:00 UTC"), "A title")
 
+    # Port of splitTrailingAttribution() in scripts/render_front_page.mjs.
+    _JS_ATTRIBUTION_HINT_RE = re.compile(
+        r"\b(?:TechCrunch|The Verge|The Decoder|Ars Technica|Reuters|Bloomberg"
+        r"|Hacker News|HN|Reddit|Bluesky|arXiv|The Information|Wired|CNBC"
+        r"|Financial Times|WSJ|Guardian|Axios|Semafor|Business Insider"
+        r"|VentureBeat|Engadget|Nikkei|SCMP|TechMeme)\b"
+        r"|\b\d+\s*(?:points?|comments?|upvotes?)\b|#\d+\s+on\b",
+        re.I,
+    )
+
+    @classmethod
+    def _js_split_trailing_attribution(cls, title: str) -> tuple[str, str]:
+        head = title
+        tail: list[str] = []
+        for _ in range(3):
+            m = re.search(r"\s*\(([^()]*)\)\s*([.!?])?\s*$", head)
+            if not m or not cls._JS_ATTRIBUTION_HINT_RE.search(m.group(1)):
+                break
+            tail.insert(0, f"({m.group(1).strip()})")
+            head = head[: m.start()].rstrip() + (m.group(2) or "")
+        if not tail:
+            return title, ""
+        head = re.sub(r"[\s,;:–—-]+$", "", head).strip()
+        if len(re.sub(r"[^\w\s]", " ", head).split()) < 2:
+            return title, ""
+        return head, " ".join(tail)
+
+    def test_headline_moves_source_attribution_to_the_body(self):
+        """A masthead headline names the story; who reported it and how it did
+        on Hacker News is body copy. The 2026-07-25 front page rendered
+        '(TechCrunch, The Verge, The Decoder; #1 on Hacker News at 680
+        points/386 comments)' at headline size."""
+        head, body = self._js_split_trailing_attribution(
+            "Anthropic launched Claude Opus 5 at roughly half the token price "
+            "— the dominant story of the cycle (TechCrunch, The Verge, The "
+            "Decoder; #1 on Hacker News at 680 points/386 comments)."
+        )
+        self.assertEqual(
+            head,
+            "Anthropic launched Claude Opus 5 at roughly half the token price "
+            "— the dominant story of the cycle.",
+        )
+        # Moved, never dropped — the sourcing has to survive somewhere.
+        self.assertEqual(
+            body,
+            "(TechCrunch, The Verge, The Decoder; #1 on Hacker News at 680 "
+            "points/386 comments)",
+        )
+
+    def test_attribution_split_leaves_descriptive_parentheticals_alone(self):
+        """Only outlet names and engagement figures count as attribution — a
+        descriptive aside is part of the sentence."""
+        for untouched in (
+            "Black Forest Labs shipped Flux 3 (image generation) alongside Flux 3 X Mimic.",
+            "Cognition acquired the AI-companion app Poke (a bet on AI personality).",
+            # Metrics outside parentheses are prose, not a citation block.
+            "A Guardian piece drew 202 points/76 comments on HN.",
+        ):
+            with self.subTest(untouched=untouched):
+                self.assertEqual(
+                    self._js_split_trailing_attribution(untouched), (untouched, "")
+                )
+
+    def test_attribution_split_never_leaves_a_stub_headline(self):
+        """If the parenthetical WAS the sentence, keep the original rather than
+        render an empty masthead."""
+        self.assertEqual(
+            self._js_split_trailing_attribution("(TechCrunch, The Verge)."),
+            ("(TechCrunch, The Verge).", ""),
+        )
+        # ...but a genuinely short headline must still get cleaned.
+        self.assertEqual(
+            self._js_split_trailing_attribution("OpenAI ships GPT-6 (TechCrunch)."),
+            ("OpenAI ships GPT-6.", "(TechCrunch)"),
+        )
+
     def test_headline_cleanup_cannot_eat_real_copy(self):
         """Both strips must stay narrow: a non-lane colon is ordinary headline
         punctuation, and figures like $10.3B must survive."""


### PR DESCRIPTION
The 2026-07-25 masthead rendered this at headline size:

> **(TechCrunch, The Verge, The Decoder; #1 on Hacker News at 680 points/386 comments)**

Who reported a story, and how it did on Hacker News, is body copy. A headline names the story.

## Cause

The digest's lead bullet ends with its sourcing, and that bullet is a *single long sentence* — so `splitFirstSentence()` had nothing to split on and handed the whole thing, citation included, to the headline.

## Fix

`splitLead()` peels a trailing attribution parenthetical off the title and passes it to the body, where it renders as a credit line directly under the headline. **The sourcing is moved, never dropped.**

Detection is narrow on purpose — a parenthetical only counts as attribution when it names a known outlet or carries engagement figures (`N points` / `N comments` / `#N on ...`):

| input | result |
|---|---|
| `... the dominant story of the cycle (TechCrunch, The Verge, The Decoder; #1 on Hacker News at 680 points/386 comments).` | attribution moved to body |
| `Black Forest Labs shipped Flux 3 (image generation) alongside ...` | unchanged |
| `Cognition acquired the AI-companion app Poke (a bet on AI personality).` | unchanged |
| `A Guardian piece drew 202 points/76 comments on HN.` | unchanged — metrics outside parens are prose |

Two guards worth calling out:

- If the parenthetical **was** the sentence (`"(TechCrunch, The Verge)."`), the original is kept rather than rendering an empty masthead.
- That guard counts **words, not characters**. My first version used a character threshold, which silently ate short-but-real headlines like `OpenAI ships GPT-6` — exactly the quiet regression a length check invites.

Both renderers now share `splitLead()`, so the PNG and the `.ara.md` interactive edition can't drift.

## Verification

- Rendered 2026-07-25 to **both** `.ara.md` and PNG locally. I installed `@resvg/resvg-js` to actually exercise the PNG path, because this change renames a binding inside it (`headlineText` → `headlineLead`, which was shadowing the module-level `headlineText()` from the lane-label fix) — a rename inside an unexecuted function is precisely what a syntax check misses.
- Checked the Python test port against the real JS on all 10 cases.
- Full suite: 555 tests, 1 pre-existing unrelated failure (an untracked local `research/.DS_Store`, not in git, cannot reach CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
