### PR TITLE
Front page design pass: fix brief overlap, headline scale, duplication

### DIFF
--- a/dashboard/src/render/today.ts
+++ b/dashboard/src/render/today.ts
@@ -16,6 +16,20 @@ export type TodayRenderOptions = {
   frontPageCardHtml: string | null;
 };
 
+/** Drop the first top-level list item from a markdown block, keeping any of
+ * its wrapped continuation lines with it. Returns the input unchanged when
+ * there is no leading bullet, so a paragraph-style summary is never gutted. */
+function dropFirstBullet(md: string): string {
+  const lines = md.split('\n');
+  const start = lines.findIndex((l) => /^\s*[-*]\s+/.test(l));
+  if (start === -1) return md;
+  let end = start + 1;
+  while (end < lines.length && !/^\s*[-*]\s+/.test(lines[end]) && lines[end].trim()) {
+    end += 1;
+  }
+  return [...lines.slice(0, start), ...lines.slice(end)].join('\n').trim();
+}
+
 /** Render the daily digest. Treats Executive Summary specially as a TL;DR block.
  * When `frontPageCardHtml` is supplied the layout splits into two desktop
  * columns: front page on the left, digest cards on the right. */
@@ -55,6 +69,17 @@ export function renderTodayHtml(options: TodayRenderOptions): string {
     if (section.title && isModelReleaseDigestSection(section.title)) continue;
 
     const isSummary = /^(executive summary|tl;dr|tldr|summary)$/i.test(section.title.trim());
+
+    // The front page's headline and standfirst ARE the first Executive
+    // Summary bullet (render_front_page.mjs builds them from it), so with
+    // both columns on screen the reader met the same sentence twice — once
+    // at masthead size on the left, once as bullet one on the right. Drop it
+    // from the TL;DR when the front page is showing it; no information is
+    // lost, it just stops being said twice.
+    if (isSummary && options.frontPageCardHtml) {
+      section.body = dropFirstBullet(section.body);
+      if (!section.body.trim()) continue;
+    }
     const title = section.title || options.fallbackTitle;
     const anchorId = sectionAnchorId('today', isSummary ? 'tl-dr' : title, sectionIndex);
     sectionIndex += 1;

--- a/dashboard/src/style.css
+++ b/dashboard/src/style.css
@@ -218,11 +218,17 @@ body.has-digest-player .app {
   gap: 10px;
   min-width: 0;
 }
+/* The wordmark is an <a>, and the only colour rule for it was scoped to
+ * `.tab-agents` — so on every other view it fell through to the user-agent
+ * link default and rendered as underlined #0000EE, which reads as an
+ * unstyled page rather than a brand mark. */
 .brand-title {
   font-size: 1.15rem;
   font-weight: 700;
   letter-spacing: -0.02em;
   font-family: var(--font-mono);
+  color: var(--text);
+  text-decoration: none;
   cursor: pointer;
 }
 .brand-title:hover { color: var(--accent-warm); }
@@ -360,6 +366,9 @@ body.has-digest-player .app {
   background: var(--bg);
   border: 1px solid var(--border);
   color: var(--text-secondary);
+  /* The pill already carries the affordance; the inherited anchor underline
+   * on top of it just reads as unstyled markup. */
+  text-decoration: none;
   padding: 6px 18px;
   border-radius: 20px;
   font-family: var(--font);
@@ -554,6 +563,15 @@ body.tab-today .cal-chevron { color: var(--on-accent); opacity: 0.75; }
     border: 0;
     border-radius: 0;
     box-shadow: none;
+  }
+
+  /* With an odd number of sections the last one sat alone in a two-up row
+   * with dead space beside it, which reads as a broken table rather than a
+   * control grid. Let it span the full width instead. `:nth-of-type` counts
+   * only the <a> siblings — the calendar is a <div> and search a <button> —
+   * so this stays correct if a section is ever added or removed. */
+  .tabs a.tab:last-of-type:nth-of-type(odd) {
+    grid-column: 1 / -1;
   }
 
   .calendar,
@@ -3134,6 +3152,27 @@ body.has-toc .section-nav { display: none; }
   line-height: 1.45;
 }
 
+/* Paragraphs here inherited `margin: 0`, so the lead rendered as one
+ * undifferentiated wall — the standfirst ran straight into the next story
+ * with no more separation than a line wrap. Space them, and let the first
+ * one read as a standfirst: it is the sentence that carries the headline,
+ * and giving it the same weight as everything after flattens the hierarchy
+ * the masthead just established. */
+.ara-paper-collapsible > p {
+  margin: 0 0 0.75em;
+  break-inside: avoid-column;
+}
+
+.ara-paper-collapsible > p:last-child {
+  margin-bottom: 0;
+}
+
+.ara-paper-collapsible > p:first-child {
+  font-size: 1.06em;
+  line-height: 1.38;
+  color: var(--text);
+}
+
 .ara-paper-brief-grid,
 .ara-paper-story-list {
   display: grid;
@@ -3167,9 +3206,17 @@ body.has-toc .section-nav { display: none; }
   display: none;
 }
 
+/* `1fr` resolves to `minmax(auto, 1fr)`, and that `auto` minimum is
+ * min-content — so a single unbreakable token in the headline widens the
+ * whole column past its share and the brief overflows into its neighbour in
+ * the two-up grid. Digest text carries exactly such tokens: the 2026-07-25
+ * front page cited `research/models/tickets/anthropic-opus-5-leak-2026-07.md`
+ * and brief 01 measured 280px inside a 218px cell, printing on top of brief
+ * 02. `minmax(0, 1fr)` gives the column a zero floor so it can never exceed
+ * its track. */
 .ara-paper-brief summary {
   display: grid;
-  grid-template-columns: auto 1fr;
+  grid-template-columns: auto minmax(0, 1fr);
   gap: 7px 10px;
   align-items: baseline;
 }
@@ -3189,10 +3236,14 @@ body.has-toc .section-nav { display: none; }
   text-transform: uppercase;
 }
 
+/* The grid floor above stops the column blowout; this makes the long token
+ * wrap inside the column instead of being clipped at its edge. `anywhere`
+ * (not `break-word`) so it still contributes zero to min-content. */
 .ara-paper-brief-headline {
   grid-column: 2;
   font-weight: 800;
   line-height: 1.18;
+  overflow-wrap: anywhere;
 }
 
 .ara-paper-brief p,

--- a/scripts/render_front_page.mjs
+++ b/scripts/render_front_page.mjs
@@ -573,9 +573,38 @@ function splitTrailingAttribution(title) {
   return [head, tail.join(" ")];
 }
 
-// The editorial split both renderers share: one headline-sized sentence,
-// with the remainder plus any peeled attribution opening the body.
+// The digest already marks where the headline ends: its Executive Summary
+// bullets open with a bold lead-in — "**Anthropic launched Claude Opus 5**,
+// positioned as delivering ..." — which is the headline, with the rest being
+// the standfirst. Using the whole first SENTENCE instead set a 27-word
+// analytical clause at masthead size, wrapping ten lines and pushing the
+// paper below the fold. Prefer the author's own emphasis; only fall back to
+// sentence-splitting for a bullet that has none (roughly one in five).
+function boldLeadIn(raw) {
+  const match = raw
+    .replace(/^\s*([-*]|\d+\.)\s+/, "")
+    .match(/^\*\*([^*]+)\*\*([\s\S]*)$/);
+  if (!match) return null;
+  const head = stripMarkdown(match[1]).replace(/[\s,:;.—–-]+$/, "").trim();
+  // A one-word bold run is emphasis, not a headline.
+  if (head.split(/\s+/).filter(Boolean).length < 2) return null;
+  const rest = stripMarkdown(match[2]).replace(/^[\s,:;—–-]+/, "").trim();
+  return [head, rest];
+}
+
+const leadBoldSplit = executiveRecords[0]
+  ? boldLeadIn(executiveRecords[0].raw)
+  : null;
+
+// The editorial split both renderers share: one headline-sized phrase, with
+// the remainder plus any peeled attribution opening the body.
 function splitLead(text) {
+  if (leadBoldSplit) {
+    const [head, rest] = leadBoldSplit;
+    // The citation rides at the end of `rest`, so it lands in the body for
+    // free — no attribution peeling needed on this path.
+    return [headlineText(head), rest];
+  }
   const [firstSentence, rest] = splitFirstSentence(text);
   const [title, attribution] = splitTrailingAttribution(firstSentence);
   const body = [attribution, rest].filter(Boolean).join(" ").trim();


### PR DESCRIPTION
Six fixes, each reproduced on localhost and measured before/after in a real browser.

## 1. Briefs printed on top of each other (the reported bug)

`.ara-paper-brief summary` used `grid-template-columns: auto 1fr`. `1fr` is `minmax(auto, 1fr)`, and **that auto minimum is min-content**. The digest cited `research/models/tickets/anthropic-opus-5-leak-2026-07.md` — an unbreakable token that set min-content wider than the column's share.

| brief | cell | headline | |
|---|---|---|---|
| 01 before | 218px | **280px** | overlapped brief 02 |
| 01 after | 218px | **194px** | fits |
| 02–05 | 218px | 192px | never affected |

`minmax(0, 1fr)` gives the column a zero floor; `overflow-wrap: anywhere` wraps the path instead of clipping.

## 2. The headline was a sentence, not a headline

27 words at masthead size, ten lines, pushing the paper below the fold.

The digest **already marks where the headline ends** — Executive Summary bullets open with a bold lead-in. The renderer ignored that and took the whole first *sentence*:

> before: "Anthropic launched Claude Opus 5, positioned as delivering performance "close to" or "near" flagship Fable 5 at roughly half the token price — the dominant story of the cycle."
> after: **"Anthropic launched Claude Opus 5"** (5 words), remainder demoted to standfirst.

Falls back to sentence-splitting for the ~1-in-5 bullets with no bold lead-in.

## 3. `/today` said the same thing twice

The front page headline and standfirst *are* the first Executive Summary bullet, which the digest panel then repeated verbatim as TL;DR bullet one — the same sentence at two sizes, side by side. The panel now drops that bullet when the front-page card is present. Nothing is lost; it just stops being said twice.

## 4. Two things were genuinely unstyled

The wordmark computed to `rgb(0, 0, 238)` — the **user-agent link default** — because the only `color` rule for `.brand-title` is scoped to `.tab-agents`. Same class of bug on `.tab`, which never cleared the anchor underline, so nav pills had underlined labels. Neither was a taste call; the styling simply wasn't reaching them.

## 5. The lead was one undifferentiated wall

All four lead paragraphs computed `margin: 0`, so a paragraph break looked identical to a line wrap. Added rhythm, and let the first paragraph read as a standfirst instead of flattening the hierarchy the masthead just established.

## 6. Mobile nav orphan

An odd number of sections left the last alone in a two-up row with dead space beside it — reads as a broken table. Now spans full width (measured 182px → 364px). `:nth-of-type` counts only the `<a>` siblings (calendar is a `<div>`, search a `<button>`), so it stays correct if a section is added or removed.

## Verification

Real browser at 1440x1200 and 390x844. No horizontal overflow on mobile (`scrollWidth == innerWidth == 390`). `bun run typecheck` and `bun run build` clean. Python suite 559 tests, 1 pre-existing unrelated failure (untracked local `research/.DS_Store`).

Generated front-page artifacts are deliberately **not** in this diff — the pipeline regenerates them, so their provenance stays the runner rather than my laptop. I'll dispatch `daily-front-page.yml` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
