### PR TITLE
Constrain headlines at the source; merge front-page sections into Stories

### DIFF
--- a/.github/workflows/daily-digest.yml
+++ b/.github/workflows/daily-digest.yml
@@ -219,10 +219,27 @@ jobs:
             # AI Daily Digest - ${{ steps.date.outputs.date }}
 
             ## Executive Summary
-            [3-5 bullet points of the day's most important developments]
+            [3-5 bullets. Each MUST begin with a bold headline of 4-10 words,
+            then a comma or colon, then 1-2 sentences of detail. Example:
+            "- **Anthropic launched Claude Opus 5**, positioned as near-flagship
+            performance at roughly half the token price (TechCrunch, The Verge)."
+
+            The bold span is lifted verbatim onto the front page as the masthead
+            headline, so write it AS a headline: a concrete subject and verb, no
+            subordinate clauses, no em-dash asides, no citations, never over 10
+            words. "**Anthropic launched Claude Opus 5**" — good.
+            "**Anthropic launched Claude Opus 5, positioned as delivering
+            performance close to flagship Fable 5 at roughly half the token
+            price — the dominant story of the cycle**" — far too long; that
+            detail belongs after the bold span, not inside it.
+
+            Put sourcing in parentheses at the END of the bullet.]
 
             ## Breaking News
-            [Major announcements from companies]
+            [Major announcements from companies. Same shape: each bullet opens
+            with a bold 4-10 word headline, then the detail. Keep each bullet to
+            2 sentences — these are rendered as short newspaper story cards, and
+            anything longer is truncated mid-thought.]
 
             ## Model Releases & Updates
             [New models, versions, capabilities]
@@ -340,10 +357,27 @@ jobs:
             # AI Daily Digest - ${{ steps.date.outputs.date }}
 
             ## Executive Summary
-            [3-5 bullet points of the day's most important developments]
+            [3-5 bullets. Each MUST begin with a bold headline of 4-10 words,
+            then a comma or colon, then 1-2 sentences of detail. Example:
+            "- **Anthropic launched Claude Opus 5**, positioned as near-flagship
+            performance at roughly half the token price (TechCrunch, The Verge)."
+
+            The bold span is lifted verbatim onto the front page as the masthead
+            headline, so write it AS a headline: a concrete subject and verb, no
+            subordinate clauses, no em-dash asides, no citations, never over 10
+            words. "**Anthropic launched Claude Opus 5**" — good.
+            "**Anthropic launched Claude Opus 5, positioned as delivering
+            performance close to flagship Fable 5 at roughly half the token
+            price — the dominant story of the cycle**" — far too long; that
+            detail belongs after the bold span, not inside it.
+
+            Put sourcing in parentheses at the END of the bullet.]
 
             ## Breaking News
-            [Major announcements from companies]
+            [Major announcements from companies. Same shape: each bullet opens
+            with a bold 4-10 word headline, then the detail. Keep each bullet to
+            2 sentences — these are rendered as short newspaper story cards, and
+            anything longer is truncated mid-thought.]
 
             ## Model Releases & Updates
             [New models, versions, capabilities]

--- a/scripts/render_front_page.mjs
+++ b/scripts/render_front_page.mjs
@@ -428,15 +428,25 @@ function renderAraSource(images = []) {
   const leadBody = leadBodyItems.length
     ? leadBodyItems.join("\n\n")
     : "No executive-summary detail was available for this edition.";
-  const breakingItems = [...breaking, ...policy].slice(0, 6);
-  if (breakingItems.length === 0) {
-    breakingItems.push("No breaking or policy items were highlighted in this edition.");
+  // Every department contributes stories to one run, tagged with where it
+  // came from. Ordered so the day's hard news leads and the standing beats
+  // follow.
+  const storyCards = [
+    ...breaking.map((t) => ({ text: t, tag: "Breaking" })),
+    ...models.map((t) => ({ text: t, tag: "Models" })),
+    ...policy.map((t) => ({ text: t, tag: "Policy" })),
+    ...research.map((t) => ({ text: t, tag: "Research" })),
+    ...business.map((t) => ({ text: t, tag: "Capital" })),
+  ]
+    .map((card) => ({ headline: conciseStory(card.text), tag: card.tag }))
+    .filter((card) => card.headline)
+    .slice(0, 10);
+  if (storyCards.length === 0) {
+    storyCards.push({
+      headline: "No stories were highlighted in this edition.",
+      tag: "Newsroom",
+    });
   }
-  const storyItems = [
-    ["Models & Systems", models, "hot"],
-    ["Research Ledger", research, "research"],
-    ["Capital & Compute", business, "market"],
-  ];
   const source = [
     "---",
     "title: " + yamlValue("THE AGI AWARENESS POST"),
@@ -450,9 +460,8 @@ function renderAraSource(images = []) {
     "",
     ":::paper-index",
     "- label: " + yamlValue("Lead") + "\n  target: " + yamlValue("#lead-top-story"),
-    "- label: " + yamlValue("Breaking") + "\n  target: " + yamlValue("#briefs-breaking-policy"),
+    "- label: " + yamlValue("Stories") + "\n  target: " + yamlValue("#briefs-stories"),
     "- label: " + yamlValue("Signals") + "\n  target: " + yamlValue("#meter-signal-mix"),
-    "- label: " + yamlValue("Departments") + "\n  target: " + yamlValue("#deck-departments"),
     ":::",
     "",
     `:::lead(id="lead-top-story", label="Top Story", title=${directiveAttr(leadTitle)})`,
@@ -468,11 +477,15 @@ function renderAraSource(images = []) {
           ]
         : []
     ),
-    `:::briefs(id="briefs-breaking-policy", title="Breaking & Policy", columns=2)`,
-    yamlItems(breakingItems, (item, index) => {
-      const tag = index < breaking.length ? "Breaking" : "Policy";
-      return "- headline: " + yamlValue(item) + "\n  tag: " + yamlValue(tag);
-    }),
+    // One "Stories" run instead of a "Breaking & Policy" block followed by a
+    // separate "Departments" deck. The department is not a section of its own
+    // — it is what a story IS, so it rides along as the story's tag. Each
+    // headline is cut to its own bold lead-in (or first sentence), because a
+    // full digest paragraph set in a two-up card column reads as a wall and
+    // gets truncated mid-thought.
+    `:::briefs(id="briefs-stories", title="Stories", columns=2)`,
+    yamlItems(storyCards, (card) =>
+      "- headline: " + yamlValue(card.headline) + "\n  tag: " + yamlValue(card.tag)),
     ":::",
     "",
     `:::news-meter(id="meter-signal-mix", title="Signal Mix")`,
@@ -480,13 +493,6 @@ function renderAraSource(images = []) {
     "- label: " + yamlValue("Model releases") + "\n  value: " + Math.min(100, models.length * 25) + "\n  display: " + yamlValue(`${models.length} items`) + "\n  tone: watch",
     "- label: " + yamlValue("Research highlights") + "\n  value: " + Math.min(100, research.length * 20) + "\n  display: " + yamlValue(`${research.length} items`) + "\n  tone: research",
     "- label: " + yamlValue("Funding and compute") + "\n  value: " + Math.min(100, business.length * 25) + "\n  display: " + yamlValue(`${business.length} items`) + "\n  tone: market",
-    ":::",
-    "",
-    `:::story-deck(id="deck-departments", title="Departments")`,
-    yamlItems(storyItems, ([label, items, tone]) => {
-      const summary = items.slice(0, 3).join(" ");
-      return "- headline: " + yamlValue(label) + "\n  summary: " + yamlValue(summary || "No items reported in this section.") + "\n  meta: " + yamlValue(`${items.length} digest items`) + "\n  tone: " + tone;
-    }),
     ":::",
     "",
     `:::quote(label="Quote of the Day")`,
@@ -595,6 +601,57 @@ function boldLeadIn(raw) {
 const leadBoldSplit = executiveRecords[0]
   ? boldLeadIn(executiveRecords[0].raw)
   : null;
+
+// A story card is a headline, not a paragraph. Digest section bullets run to
+// several sentences; set in a two-up card column they read as a wall and get
+// truncated mid-thought. Cut to the bullet's own bold lead-in when it has one
+// (the digest prompt asks for a 4-10 word headline there), else its first
+// sentence, then hard-cap so a run-on sentence can't defeat both.
+const STORY_WORD_CAP = 14;
+// Deliberately low. A short clause cut ("Data center siting", "Soofi S") is a
+// legitimate headline once the card carries a department tag, and it beats the
+// same sentence hacked off at a word count and trailed by an ellipsis. The
+// character floor just blocks absurd two-letter fragments.
+const STORY_WORD_FLOOR = 2;
+const STORY_CHAR_FLOOR = 7;
+
+function wordCount(text) {
+  return text.split(/\s+/).filter(Boolean).length;
+}
+
+// Digest bullets hang their detail off a clause boundary — "Cognition
+// acquires Poke, an AI-companion app — TechCrunch frames the deal as ...",
+// "Claude Opus 5 (Anthropic) — new flagship-tier model; ...". Cutting there
+// yields a real headline; cutting at a word count yields a fragment ending in
+// an ellipsis, which is what made these cards read as truncated walls. Try
+// the em dash first (it almost always separates title from gloss) and accept
+// the first cut that lands in headline territory.
+function clauseCut(text) {
+  for (const sep of [" — ", " – ", "; ", ": "]) {
+    const index = text.indexOf(sep);
+    if (index === -1) continue;
+    const head = text.slice(0, index).replace(/[\s,;:.—–-]+$/, "").trim();
+    const count = wordCount(head);
+    if (count >= STORY_WORD_FLOOR && count <= STORY_WORD_CAP
+        && head.length >= STORY_CHAR_FLOOR) return head;
+  }
+  return null;
+}
+
+function conciseStory(text) {
+  const cleaned = headlineText(stripMarkdown(text));
+  if (!cleaned) return "";
+  const bold = boldLeadIn(text);
+  let head = bold ? bold[0] : splitTrailingAttribution(splitFirstSentence(cleaned)[0])[0];
+  head = head.replace(/\.$/, "");
+  if (wordCount(head) > STORY_WORD_CAP) {
+    // Ellipsis is the last resort, not the first.
+    head = clauseCut(head)
+      || head.split(/\s+/).filter(Boolean).slice(0, STORY_WORD_CAP).join(" ")
+           .replace(/[\s,;:.—–-]+$/, "") + "…";
+  }
+  return head;
+}
 
 // The editorial split both renderers share: one headline-sized phrase, with
 // the remainder plus any peeled attribution opening the body.


### PR DESCRIPTION
Two rounds of renderer patching kept producing long headlines because **the renderer was never the cause.**

Measured across every committed front page:

| | |
|---|---|
| median headline | **16 words** |
| worst | **57 words / 309 chars** (2026-06-02) |
| over 12 words | **14 of 26 (53%)** |

That is not a bad day. That is the steady state.

## The actual cause

The digest prompt said only:

```
## Executive Summary
[3-5 bullet points of the day's most important developments]
```

No shape, no length. The agent wrote analytical clauses, and the front page faithfully set a 57-word clause at masthead size.

The prompt now specifies the shape it needs: each bullet opens with a **bold 4-10 word headline**, then the detail, sourcing in parentheses at the end. It shows a good example *and the exact too-long failure*, because that failure is the one the model keeps producing.

Applied to **both** prompts — the MCP and local-source paths had drifted into identical copies of the same under-specified block. Breaking News gets the same treatment plus a 2-sentence cap, since those bullets render as story cards.

## Front page sections, per review

**"Breaking & Policy" + "Departments" → one "Stories" run.** A department is not a section of its own, it is what a story *is* — so it rides along as the story's tag (Breaking / Models / Policy / Research / Capital). The `story-deck` block and its index entry are gone.

**Story cards are cut to a headline.** They were full digest bullets, which in a two-up card column read as a wall. `conciseStory()` takes the bold lead-in when present, else the first sentence, then cuts at a **clause boundary — em dash first**, since that is where digest bullets hang their gloss (`Claude Opus 5 (Anthropic) — new flagship-tier model`). A word-count chop trailing an ellipsis is the last resort, not the first.

On 2026-07-25 that took ellipsis-truncated cards from **10/10 → 0/10**:

```
[Breaking]  5w  Anthropic launches Claude Opus 5
[Models  ]  4w  Claude Opus 5 (Anthropic)
[Models  ] 10w  Flux 3 and Flux 3 X Mimic (Black Forest Labs)
[Policy  ]  7w  US weighing its response to Chinese AI
[Policy  ]  3w  Data center siting
[Research]  8w  Robust Critics: Defending LLMs Against Multi-Turn Attacks (cs.AI)
```

The word floor for a clause cut is deliberately **2, not 4**. "Data center siting" and "Soofi S" are legitimate headlines once the card carries a department tag, and both beat the same sentence hacked off mid-phrase.

## Verification

Rendered 2026-07-25 to `.ara.md`, PNG and compiled HTML, then read the result in a browser. Re-rendered the six historically worst headlines through the new path:

| date | before | after |
|---|---|---|
| 2026-06-02 | 57w | 8w |
| 2026-07-19 | 47w | 7w |
| 2026-07-03 | 39w | 4w |
| 2026-07-13 | 39w | 9w |
| 2026-06-19 | 38w | 6w |
| 2026-07-16 | 36w | 9w |

## Not covered

The ~26 already-committed front pages keep their old headlines. They are historical artifacts and re-rendering would rewrite published editions. New editions are correct from the next digest run.

`conciseStory`/`clauseCut` have no unit test — the repo's pattern is Python ports of the JS, and porting this would add drift risk for logic I verified against real digests instead. Worth revisiting if it changes again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
