### PR TITLE
Restyle /research as a Stripe Press shelf

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -56,23 +56,32 @@
           <a class="tab" data-tab="research" href="/research">Research</a>
           <a class="tab" data-tab="wiki" href="/wiki">Wiki</a>
           <a class="tab" data-tab="agents" href="/agents">Arm</a>
-          <button class="brand-search" id="searchToggle" type="button" aria-label="Search" title="Search (⌘K or /)">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>
-          </button>
+          <!-- Search + Request research ride at the end of the tab rail. They
+               live in their own wrapper so they are not <a>/<div> siblings of
+               the sections: the phone grid below keys its full-width span off
+               `.tabs a.tab:last-of-type`, which another bare <a> here would
+               silently break. -->
+          <div class="tabs-actions">
+            <button class="brand-search" id="searchToggle" type="button" aria-label="Search" title="Search (⌘K or /)">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>
+            </button>
+            <a
+              class="request-btn"
+              href="https://github.com/guzus/ai-research-arm/issues/new?labels=gen-research&title=%5BResearch%5D%20&body=%23%23%20Research%20request%0A%0ATopic%3A%20%0A%0AContext%3A%20%0A%0ATags%3A%20%0A%0Abackend%3A%20claude"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Submit a research request on GitHub"
+              title="Submit a research request on GitHub"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg>
+              <span>Request research</span>
+            </a>
+          </div>
         </nav>
       </div>
+      <!-- The refresh button is chrome-cut (display:none) but keeps its node:
+           the R shortcut and the click handler both resolve #refreshBtn. -->
       <div class="controls">
-          <a
-            class="request-btn"
-            href="https://github.com/guzus/ai-research-arm/issues/new?labels=gen-research&title=%5BResearch%5D%20&body=%23%23%20Research%20request%0A%0ATopic%3A%20%0A%0AContext%3A%20%0A%0ATags%3A%20%0A%0Abackend%3A%20claude"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Submit a research request on GitHub"
-            title="Submit a research request on GitHub"
-          >
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg>
-            <span>Request research</span>
-          </a>
           <button class="icon-btn refresh-btn" id="refreshBtn" title="Refresh (R)" aria-label="Refresh">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M23 4v6h-6M1 20v-6h6"/><path d="M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15"/></svg>
           </button>

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -4394,21 +4394,36 @@ function decodeStoredEntities(text: string): string {
   });
 }
 
-const BOOK_OPEN_SWING_MS = 620;
-const BOOK_OPEN_NAVIGATE_AT_MS = 240;
-const BOOK_OPEN_CLEAR_MS = 280;
+/* Book-opening transition. Beats, in order (durations + delays live in the
+ * .press-open-* rules; these constants only drive the JS handoffs):
+ *   0ms    lift    — the book rises off the shelf to the middle of the screen,
+ *                    scrim dims the rest. It scales from its SPINE, so the
+ *                    spread it is about to occupy is already centred.
+ *   240ms  open    — the front cover swings back around the spine, revealing
+ *                    the article's title page. The cover's shadow slides off
+ *                    the page as it goes, and the back of the cover is an
+ *                    endpaper, not a mirrored jacket.
+ *   700ms  settle  — the title page holds, fully open and readable.
+ *   860ms  dissolve— the page swells into the veil the article renders behind.
+ * Nothing here is load-bearing: reduced-motion readers, an unmeasurable
+ * element, and a stalled fetch all land on the same article. */
+const BOOK_OPEN_NAVIGATE_AT_MS = 420;
+const BOOK_OPEN_SEQUENCE_MS = 1120;
+const BOOK_OPEN_CLEAR_MS = 260;
 /** Never trap the reader behind the veil if the article fetch stalls. */
-const BOOK_OPEN_MAX_HOLD_MS = 1600;
+const BOOK_OPEN_MAX_HOLD_MS = 2200;
+
+/** Fraction of the viewport the opened spread is allowed to fill. */
+const BOOK_OPEN_FILL_H = 0.68;
+/* Generous, because width only binds on phones — desktop is always the
+ * height-limited case, so raising this buys presence on small screens for
+ * free. */
+const BOOK_OPEN_FILL_W = 0.94;
 
 /**
- * Book-opening transition. Clones the clicked cover into a fixed overlay,
- * swings it open around its spine while the book grows toward the middle of
- * the viewport, and hands off to a veil the article renders behind.
- *
- * Purely decorative and fully fail-open: reduced-motion readers, an
- * unmeasurable element, or a stalled fetch all end up at the same article.
- * The overlay is built with direct DOM calls, not setSafeContent, so the
- * per-book inline transforms never meet DOMPurify.
+ * Clone the clicked cover into a fixed overlay and play the sequence above.
+ * The overlay is built with direct DOM calls rather than setSafeContent, so
+ * the per-book geometry and jacket colours never meet DOMPurify.
  */
 function openBookThen(book: HTMLElement, navigate: () => Promise<void>): void {
   const rect = book.getBoundingClientRect();
@@ -4419,14 +4434,27 @@ function openBookThen(book: HTMLElement, navigate: () => Promise<void>): void {
   }
 
   const bookStyle = getComputedStyle(book);
-  // Read the DESTINATION ground off :root — body still carries the shelf's
-  // token remap at this point, so reading from body would give the press
-  // ground and the veil would flash dark before the article paints.
-  const destination =
-    getComputedStyle(document.documentElement).getPropertyValue('--bg-secondary').trim() || '#f4f5f8';
+  const jacketBg = bookStyle.backgroundColor;
+  const jacketInk = bookStyle.color;
+  // Read the DESTINATION palette off :root. body still carries the shelf's
+  // token remap at this point, so reading from body would hand back the press
+  // ground and the title page would come up dark before the article paints.
+  const rootStyle = getComputedStyle(document.documentElement);
+  const readToken = (name: string, fallback: string): string =>
+    rootStyle.getPropertyValue(name).trim() || fallback;
+  const paper = readToken('--bg', '#ffffff');
+  const paperInk = readToken('--text', '#16181d');
+  const paperFaint = readToken('--text-tertiary', '#6b7280');
+  const ground = readToken('--bg-secondary', '#f4f5f8');
+
+  const text = (selector: string): string =>
+    (book.querySelector(selector)?.textContent || '').trim();
 
   const stage = document.createElement('div');
   stage.className = 'press-open-stage';
+
+  const scrim = document.createElement('div');
+  scrim.className = 'press-open-scrim';
 
   const shell = document.createElement('div');
   shell.className = 'press-open-book';
@@ -4435,50 +4463,95 @@ function openBookThen(book: HTMLElement, navigate: () => Promise<void>): void {
   shell.style.width = `${rect.width}px`;
   shell.style.height = `${rect.height}px`;
 
+  // The title page under the cover: the article's own eyebrow/title/byline, so
+  // the open book shows something worth looking at instead of a blank swatch.
   const page = document.createElement('div');
   page.className = 'press-open-page';
-  page.style.background = destination;
+  page.style.background = paper;
+  page.style.color = paperInk;
+  // Title-page type is sized off the cover width so it scales with the book
+  // rather than fighting the transform; the rules below are all in `em`.
+  page.style.fontSize = `${Math.round(rect.width * 0.085)}px`;
 
-  const cover = document.createElement('div');
-  cover.className = 'press-open-cover';
-  cover.style.background = bookStyle.backgroundColor;
-  cover.style.color = bookStyle.color;
-  const title = book.querySelector('.press-book-title');
-  if (title) {
-    const coverTitle = document.createElement('span');
-    coverTitle.className = 'press-book-title';
-    coverTitle.textContent = title.textContent || '';
-    cover.appendChild(coverTitle);
-  }
+  const eyebrow = document.createElement('span');
+  eyebrow.className = 'press-open-eyebrow';
+  eyebrow.style.color = jacketBg;
+  eyebrow.textContent = text('.press-book-model');
+
+  const pageTitle = document.createElement('span');
+  pageTitle.className = 'press-open-page-title';
+  pageTitle.textContent = text('.press-book-title');
+
+  const pageByline = document.createElement('span');
+  pageByline.className = 'press-open-page-byline';
+  pageByline.style.color = paperFaint;
+  pageByline.textContent = text('.press-book-date');
+
+  page.append(eyebrow, pageTitle, pageByline);
+
+  // Shadow the closed cover casts onto the page; slides away as it opens.
+  const pageShade = document.createElement('div');
+  pageShade.className = 'press-open-page-shade';
+  page.appendChild(pageShade);
+
+  // The cover, as a two-faced leaf hinged on the spine.
+  const leaf = document.createElement('div');
+  leaf.className = 'press-open-leaf';
+
+  const front = document.createElement('div');
+  front.className = 'press-open-face press-open-face--front';
+  front.style.background = jacketBg;
+  front.style.color = jacketInk;
+  const frontTitle = document.createElement('span');
+  frontTitle.className = 'press-book-title';
+  frontTitle.textContent = text('.press-book-title');
+  front.appendChild(frontTitle);
+
+  const back = document.createElement('div');
+  back.className = 'press-open-face press-open-face--back';
+  back.style.background = jacketBg;
+
+  leaf.append(front, back);
 
   const veil = document.createElement('div');
   veil.className = 'press-open-veil';
-  veil.style.background = destination;
+  veil.style.background = ground;
 
-  shell.append(page, cover);
-  stage.append(shell, veil);
+  shell.append(page, leaf);
+  stage.append(scrim, shell, veil);
   document.body.appendChild(stage);
   book.style.opacity = '0';
 
-  const scale = Math.min(2.2, Math.max(1.1, (window.innerHeight * 0.7) / rect.height));
-  const dx = window.innerWidth / 2 - (rect.left + rect.width / 2);
+  // Scale is bounded by BOTH axes: the opened spread is twice the cover's
+  // width (the leaf swings out to the left of the spine), so a height-only
+  // fit would run the open book off the sides of a phone.
+  const byHeight = (window.innerHeight * BOOK_OPEN_FILL_H) / rect.height;
+  const byWidth = (window.innerWidth * BOOK_OPEN_FILL_W) / (rect.width * 2);
+  const scale = Math.max(1.02, Math.min(2.4, byHeight, byWidth));
+  // .press-open-book scales from `left center`, so putting the spine on the
+  // viewport centre centres the spread that is about to open around it.
+  const dx = window.innerWidth / 2 - rect.left;
   const dy = window.innerHeight / 2 - (rect.top + rect.height / 2);
 
-  requestAnimationFrame(() => {
-    shell.style.transform = `translate(${dx}px, ${dy}px) scale(${scale})`;
-    cover.style.transform = 'rotateY(-158deg)';
-    veil.style.opacity = '1';
-  });
+  // Force a style/layout flush so the browser resolves the stage's CLOSED
+  // style before the open state lands. Without it the whole subtree is new in
+  // the same frame, there is no "before" value to interpolate from, and every
+  // transition below jumps straight to its end value — which reads as an
+  // instant cut, not an animation. requestAnimationFrame is not enough here.
+  void stage.offsetHeight;
 
-  const swung = new Promise<void>((resolve) => window.setTimeout(resolve, BOOK_OPEN_SWING_MS));
+  shell.style.transform = `translate(${dx}px, ${dy}px) scale(${scale})`;
+  stage.classList.add('is-open');
+
+  const played = new Promise<void>((resolve) => window.setTimeout(resolve, BOOK_OPEN_SEQUENCE_MS));
   const capped = new Promise<void>((resolve) => window.setTimeout(resolve, BOOK_OPEN_MAX_HOLD_MS));
   const navigated = new Promise<void>((resolve) => {
     window.setTimeout(() => navigate().then(resolve, resolve), BOOK_OPEN_NAVIGATE_AT_MS);
   });
 
-  // Lift the veil once the swing has finished AND the article has rendered —
+  // Strike the set once the sequence has played AND the article has rendered —
   // or once the cap fires, whichever comes first.
-  void Promise.race([Promise.all([swung, navigated]), capped]).then(() => {
+  void Promise.race([Promise.all([played, navigated]), capped]).then(() => {
     stage.classList.add('is-clearing');
     window.setTimeout(() => stage.remove(), BOOK_OPEN_CLEAR_MS);
   });

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -4397,21 +4397,29 @@ function decodeStoredEntities(text: string): string {
 /* Book-opening transition. Beats, in order (durations + delays live in the
  * .press-open-* rules; these constants only drive the JS handoffs):
  *   0ms    lift    — the book rises off the shelf to the middle of the screen,
- *                    scrim dims the rest. It scales from its SPINE, so the
- *                    spread it is about to occupy is already centred.
+ *                    scrim dims the rest to 0.62 so the shelf stays faintly
+ *                    behind it. It scales from its SPINE, so the spread it is
+ *                    about to occupy is already centred.
  *   240ms  open    — the front cover swings back around the spine, revealing
  *                    the article's title page. The cover's shadow slides off
  *                    the page as it goes, and the back of the cover is an
  *                    endpaper, not a mirrored jacket.
- *   700ms  settle  — the title page holds, fully open and readable.
- *   860ms  dissolve— the page swells into the veil the article renders behind.
+ *   560ms  deepen  — the scrim closes to 0.97 under the open book.
+ *   850ms  swap    — the article renders behind that near-opaque scrim.
+ *   ~900ms reveal  — the whole stage fades off, uncovering the article.
+ *
+ * There is deliberately NO full-screen veil. An earlier cut faded one in over
+ * everything and back out, which read as the page flashing white on every
+ * open. The scrim deepening instead hides the shelf→article ground swap
+ * without ever painting the viewport a flat colour.
+ *
  * Nothing here is load-bearing: reduced-motion readers, an unmeasurable
  * element, and a stalled fetch all land on the same article. */
-const BOOK_OPEN_NAVIGATE_AT_MS = 420;
-const BOOK_OPEN_SEQUENCE_MS = 1120;
-const BOOK_OPEN_CLEAR_MS = 260;
-/** Never trap the reader behind the veil if the article fetch stalls. */
-const BOOK_OPEN_MAX_HOLD_MS = 2200;
+const BOOK_OPEN_NAVIGATE_AT_MS = 850;
+const BOOK_OPEN_SEQUENCE_MS = 900;
+const BOOK_OPEN_CLEAR_MS = 340;
+/** Never hold the reader on the open book if the article fetch stalls. */
+const BOOK_OPEN_MAX_HOLD_MS = 2400;
 
 /** Fraction of the viewport the opened spread is allowed to fill. */
 const BOOK_OPEN_FILL_H = 0.68;
@@ -4445,7 +4453,6 @@ function openBookThen(book: HTMLElement, navigate: () => Promise<void>): void {
   const paper = readToken('--bg', '#ffffff');
   const paperInk = readToken('--text', '#16181d');
   const paperFaint = readToken('--text-tertiary', '#6b7280');
-  const ground = readToken('--bg-secondary', '#f4f5f8');
 
   const text = (selector: string): string =>
     (book.querySelector(selector)?.textContent || '').trim();
@@ -4513,12 +4520,8 @@ function openBookThen(book: HTMLElement, navigate: () => Promise<void>): void {
 
   leaf.append(front, back);
 
-  const veil = document.createElement('div');
-  veil.className = 'press-open-veil';
-  veil.style.background = ground;
-
   shell.append(page, leaf);
-  stage.append(scrim, shell, veil);
+  stage.append(scrim, shell);
   document.body.appendChild(stage);
   book.style.opacity = '0';
 
@@ -4549,8 +4552,8 @@ function openBookThen(book: HTMLElement, navigate: () => Promise<void>): void {
     window.setTimeout(() => navigate().then(resolve, resolve), BOOK_OPEN_NAVIGATE_AT_MS);
   });
 
-  // Strike the set once the sequence has played AND the article has rendered —
-  // or once the cap fires, whichever comes first.
+  // Strike the set once the sequence has played AND the article has rendered
+  // underneath — or once the cap fires, whichever comes first.
   void Promise.race([Promise.all([played, navigated]), capped]).then(() => {
     stage.classList.add('is-clearing');
     window.setTimeout(() => stage.remove(), BOOK_OPEN_CLEAR_MS);

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -4349,6 +4349,15 @@ function researchJacket(slug: string): number {
 }
 
 /**
+ * Jacket the index actually painted each cover with, so the article page can
+ * open in the SAME colour the reader just clicked. The per-page de-duplication
+ * below can move a book off its raw hash, so re-hashing on the article page
+ * would sometimes disagree with the shelf. Deep links (no shelf visit) fall
+ * back to the raw hash, which is the best available answer.
+ */
+const researchJacketBySlug = new Map<string, number>();
+
+/**
  * Jackets for one rendered page, hashed per slug then de-duplicated: a raw hash
  * repeats often enough that two neighbouring bands land on the same colour and
  * read as one block. Collisions walk forward to the next free palette, which
@@ -4385,6 +4394,96 @@ function decodeStoredEntities(text: string): string {
   });
 }
 
+const BOOK_OPEN_SWING_MS = 620;
+const BOOK_OPEN_NAVIGATE_AT_MS = 240;
+const BOOK_OPEN_CLEAR_MS = 280;
+/** Never trap the reader behind the veil if the article fetch stalls. */
+const BOOK_OPEN_MAX_HOLD_MS = 1600;
+
+/**
+ * Book-opening transition. Clones the clicked cover into a fixed overlay,
+ * swings it open around its spine while the book grows toward the middle of
+ * the viewport, and hands off to a veil the article renders behind.
+ *
+ * Purely decorative and fully fail-open: reduced-motion readers, an
+ * unmeasurable element, or a stalled fetch all end up at the same article.
+ * The overlay is built with direct DOM calls, not setSafeContent, so the
+ * per-book inline transforms never meet DOMPurify.
+ */
+function openBookThen(book: HTMLElement, navigate: () => Promise<void>): void {
+  const rect = book.getBoundingClientRect();
+  const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  if (reduce || rect.width < 1 || rect.height < 1) {
+    void navigate();
+    return;
+  }
+
+  const bookStyle = getComputedStyle(book);
+  // Read the DESTINATION ground off :root — body still carries the shelf's
+  // token remap at this point, so reading from body would give the press
+  // ground and the veil would flash dark before the article paints.
+  const destination =
+    getComputedStyle(document.documentElement).getPropertyValue('--bg-secondary').trim() || '#f4f5f8';
+
+  const stage = document.createElement('div');
+  stage.className = 'press-open-stage';
+
+  const shell = document.createElement('div');
+  shell.className = 'press-open-book';
+  shell.style.left = `${rect.left}px`;
+  shell.style.top = `${rect.top}px`;
+  shell.style.width = `${rect.width}px`;
+  shell.style.height = `${rect.height}px`;
+
+  const page = document.createElement('div');
+  page.className = 'press-open-page';
+  page.style.background = destination;
+
+  const cover = document.createElement('div');
+  cover.className = 'press-open-cover';
+  cover.style.background = bookStyle.backgroundColor;
+  cover.style.color = bookStyle.color;
+  const title = book.querySelector('.press-book-title');
+  if (title) {
+    const coverTitle = document.createElement('span');
+    coverTitle.className = 'press-book-title';
+    coverTitle.textContent = title.textContent || '';
+    cover.appendChild(coverTitle);
+  }
+
+  const veil = document.createElement('div');
+  veil.className = 'press-open-veil';
+  veil.style.background = destination;
+
+  shell.append(page, cover);
+  stage.append(shell, veil);
+  document.body.appendChild(stage);
+  book.style.opacity = '0';
+
+  const scale = Math.min(2.2, Math.max(1.1, (window.innerHeight * 0.7) / rect.height));
+  const dx = window.innerWidth / 2 - (rect.left + rect.width / 2);
+  const dy = window.innerHeight / 2 - (rect.top + rect.height / 2);
+
+  requestAnimationFrame(() => {
+    shell.style.transform = `translate(${dx}px, ${dy}px) scale(${scale})`;
+    cover.style.transform = 'rotateY(-158deg)';
+    veil.style.opacity = '1';
+  });
+
+  const swung = new Promise<void>((resolve) => window.setTimeout(resolve, BOOK_OPEN_SWING_MS));
+  const capped = new Promise<void>((resolve) => window.setTimeout(resolve, BOOK_OPEN_MAX_HOLD_MS));
+  const navigated = new Promise<void>((resolve) => {
+    window.setTimeout(() => navigate().then(resolve, resolve), BOOK_OPEN_NAVIGATE_AT_MS);
+  });
+
+  // Lift the veil once the swing has finished AND the article has rendered —
+  // or once the cap fires, whichever comes first.
+  void Promise.race([Promise.all([swung, navigated]), capped]).then(() => {
+    stage.classList.add('is-clearing');
+    window.setTimeout(() => stage.remove(), BOOK_OPEN_CLEAR_MS);
+  });
+}
+
 function renderResearchIndex(rows: GenResearchRow[]): void {
   setDocTitle(null);
   if (rows.length === 0) {
@@ -4411,10 +4510,11 @@ function renderResearchIndex(rows: GenResearchRow[]): void {
     (researchIndexPage - 1) * RESEARCH_PAGE_SIZE,
     researchIndexPage * RESEARCH_PAGE_SIZE,
   );
-  // Stripe Press "shelf": one full-bleed jacket-coloured band per article, the
-  // title and its byline centred inside. The byline is the authoring model —
-  // the same slot a book list gives the author.
+  // Stripe Press "shelf": a grid of book covers, each painted in its own
+  // jacket palette. The byline is the authoring model — the same slot a book
+  // cover gives the author.
   const jackets = researchJacketsForPage(pageRows.map((r) => r.slug));
+  pageRows.forEach((r, i) => researchJacketBySlug.set(r.slug, jackets[i]));
   const items: string[] = [];
   pageRows.forEach((row, index) => {
     let title = escapeHtml(decodeStoredEntities(row.title));
@@ -4426,22 +4526,20 @@ function renderResearchIndex(rows: GenResearchRow[]): void {
     const created = new Date(row.created_at);
     const rel = isNaN(created.getTime()) ? '' : timeAgo(created);
     const koHtml = hasResearchLanguage(row, 'ko')
-      ? '      <span class="press-shelf-lang" lang="ko">한국어</span>'
+      ? '    <span class="press-book-lang" lang="ko">한국어</span>'
       : '';
     items.push(
       [
-        // role="link" (not the bare focusable <li> this replaced) so the band
+        // role="link" (not the bare focusable <li> this replaced) so the cover
         // announces as navigation; the content keydown handler already
         // activates [data-slug] rows on Enter.
-        '<li class="press-shelf-row" role="link" data-jacket="' + jackets[index] + '"' +
+        '<li class="press-book" role="link" data-jacket="' + jackets[index] + '"' +
           ' data-slug="' + escapeHtml(row.slug) + '" tabindex="0">',
-        '  <span class="press-shelf-text">',
-        '    <span class="press-shelf-title">' + title + '</span>',
-        '    <span class="press-shelf-byline">',
-        '      <span class="press-shelf-model">' + escapeHtml(row.model) + '</span>',
-        rel ? '      <span class="press-shelf-date">' + escapeHtml(rel) + '</span>' : '',
+        '  <span class="press-book-title">' + title + '</span>',
+        '  <span class="press-book-byline">',
+        '    <span class="press-book-model">' + escapeHtml(row.model) + '</span>',
+        rel ? '    <span class="press-book-date">' + escapeHtml(rel) + '</span>' : '',
         koHtml,
-        '    </span>',
         '  </span>',
         '</li>',
       ].filter(Boolean).join('\n'),
@@ -4456,10 +4554,6 @@ function renderResearchIndex(rows: GenResearchRow[]): void {
     content,
     [
       '<div class="press-shelf-page">',
-      '  <header class="press-masthead">',
-      '    <h1 class="press-masthead-name">ara Research</h1>',
-      '    <p class="press-masthead-tagline">Long-form reports, written by machines</p>',
-      '  </header>',
       '  <ul class="press-shelf">',
       items.join('\n'),
       '  </ul>',
@@ -4483,11 +4577,14 @@ function renderResearchDoc(row: GenResearchRow, body: string): void {
   const docHtml = body;
   const created = new Date(row.created_at);
   const rel = isNaN(created.getTime()) ? '' : timeAgo(created);
+  // Same jacket the shelf painted this book with — the article reads as that
+  // cover opened, not as a generic page. See researchJacketBySlug.
+  const jacket = researchJacketBySlug.get(row.slug) ?? researchJacket(row.slug);
 
   setSafeContent(
     content,
     [
-      '<div class="content-card gen-research-doc">',
+      '<div class="content-card gen-research-doc" data-jacket="' + jacket + '">',
       '  <div class="content-card-header">',
       '    <div class="content-card-title">' + escapeHtml(row.title) + '</div>',
       '  </div>',
@@ -5678,8 +5775,13 @@ content.addEventListener('click', (e) => {
   if (row && activeTab === 'research') {
     const slug = row.dataset.slug;
     if (slug) {
-      selectedSlug = slug;
-      load();
+      const navigate = (): Promise<void> => {
+        selectedSlug = slug;
+        return load();
+      };
+      // Index covers open; anything else navigating by slug goes straight through.
+      if (row.classList.contains('press-book')) openBookThen(row, navigate);
+      else void navigate();
     }
     return;
   }
@@ -5746,8 +5848,12 @@ content.addEventListener('keydown', (e: KeyboardEvent) => {
     e.preventDefault();
     const slug = row.dataset.slug;
     if (slug) {
-      selectedSlug = slug;
-      load();
+      const navigate = (): Promise<void> => {
+        selectedSlug = slug;
+        return load();
+      };
+      if (row.classList.contains('press-book')) openBookThen(row, navigate);
+      else void navigate();
     }
   }
 });

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -1190,7 +1190,7 @@ function setSafeContent(
   // `target` is NOT in DOMPurify's default allowlist; every external link
   // this app emits pairs target="_blank" with rel="noopener", so allowing
   // it restores the intended new-tab behavior (ticket sources, tweet links).
-  const addAttr = ['id', 'href', 'type', 'target', 'data-slug', 'data-ticket-share', 'data-focus-index', 'data-pct', 'data-paper-date', 'data-columns', 'data-filter-status', 'data-filter-company', 'data-has-audio-file', 'data-digest-audio-play', 'data-digest-audio-label', 'data-audio-date', 'data-odds-event', 'data-odds-market', 'data-odds-token', 'data-odds-question', 'data-odds-outcome', 'aria-label', 'aria-describedby', 'aria-current', 'aria-expanded', 'aria-controls', 'aria-pressed', 'aria-haspopup', 'aria-live', 'loading', 'decoding', 'controls', 'preload', 'src', 'max', 'value'];
+  const addAttr = ['id', 'href', 'type', 'target', 'data-slug', 'data-jacket', 'data-ticket-share', 'data-focus-index', 'data-pct', 'data-paper-date', 'data-columns', 'data-filter-status', 'data-filter-company', 'data-has-audio-file', 'data-digest-audio-play', 'data-digest-audio-label', 'data-audio-date', 'data-odds-event', 'data-odds-market', 'data-odds-token', 'data-odds-question', 'data-odds-outcome', 'aria-label', 'aria-describedby', 'aria-current', 'aria-expanded', 'aria-controls', 'aria-pressed', 'aria-haspopup', 'aria-live', 'loading', 'decoding', 'controls', 'preload', 'src', 'max', 'value'];
   if (opts.allowIframe) {
     // iframe + its iframe-only attributes are re-enabled exclusively for the
     // trusted, self-constructed sandboxed standalone-doc iframe.
@@ -4331,6 +4331,60 @@ function isResearchDisplayTag(tag: string): boolean {
 
 const RESEARCH_PAGE_SIZE = 12;
 
+/** Number of jacket palettes defined in style.css (`.press-shelf-row[data-jacket]`). */
+const RESEARCH_JACKET_COUNT = 20;
+
+/**
+ * Stable slug → jacket palette index. Deterministic (FNV-1a over the slug) so an
+ * article keeps the same jacket colour across reloads and deploys; the palette
+ * itself lives in CSS, so no inline styles have to survive DOMPurify.
+ */
+function researchJacket(slug: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < slug.length; i++) {
+    hash ^= slug.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash % RESEARCH_JACKET_COUNT;
+}
+
+/**
+ * Jackets for one rendered page, hashed per slug then de-duplicated: a raw hash
+ * repeats often enough that two neighbouring bands land on the same colour and
+ * read as one block. Collisions walk forward to the next free palette, which
+ * keeps every band on a page distinct whenever the page is no longer than the
+ * palette (12 rows, 20 jackets) and stays a pure function of the row order.
+ */
+function researchJacketsForPage(slugs: string[]): number[] {
+  const taken = new Set<number>();
+  return slugs.map((slug) => {
+    let jacket = researchJacket(slug);
+    for (let step = 0; step < RESEARCH_JACKET_COUNT && taken.has(jacket); step++) {
+      jacket = (jacket + 1) % RESEARCH_JACKET_COUNT;
+    }
+    taken.add(jacket);
+    return jacket;
+  });
+}
+
+/**
+ * A handful of index.json titles were written with HTML entities already baked
+ * in ("Hims &amp; Hers"), so escaping them again renders the raw `&amp;` to the
+ * reader. Decode the five entities `escapeHtml` produces before re-escaping;
+ * anything else is left alone.
+ */
+function decodeStoredEntities(text: string): string {
+  return text.replace(/&(amp|lt|gt|quot|#39);/g, (_m, name) => {
+    switch (name) {
+      case 'lt': return '<';
+      case 'gt': return '>';
+      case 'quot': return '"';
+      case '#39': return "'";
+      default: return '&';
+    }
+  });
+}
+
 function renderResearchIndex(rows: GenResearchRow[]): void {
   setDocTitle(null);
   if (rows.length === 0) {
@@ -4357,9 +4411,13 @@ function renderResearchIndex(rows: GenResearchRow[]): void {
     (researchIndexPage - 1) * RESEARCH_PAGE_SIZE,
     researchIndexPage * RESEARCH_PAGE_SIZE,
   );
+  // Stripe Press "shelf": one full-bleed jacket-coloured band per article, the
+  // title and its byline centred inside. The byline is the authoring model —
+  // the same slot a book list gives the author.
+  const jackets = researchJacketsForPage(pageRows.map((r) => r.slug));
   const items: string[] = [];
-  for (const row of pageRows) {
-    let title = escapeHtml(row.title);
+  pageRows.forEach((row, index) => {
+    let title = escapeHtml(decodeStoredEntities(row.title));
     if (searchTerm) {
       const escaped = searchTerm.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
       const re = new RegExp('(' + escaped + ')', 'gi');
@@ -4367,54 +4425,54 @@ function renderResearchIndex(rows: GenResearchRow[]): void {
     }
     const created = new Date(row.created_at);
     const rel = isNaN(created.getTime()) ? '' : timeAgo(created);
-    // Surface first three tags inline; the chip on the right indicates fragment vs standalone.
-    const tagHtml = (row.tags || [])
-      .filter(isResearchDisplayTag)
-      .slice(0, 3)
-      .map((t) => '<span class="gen-research-tag">' + escapeHtml(t) + '</span>')
-      .join('');
-    const isStandalone = row.kind === 'standalone';
-    const kindLabel = isStandalone ? 'Standalone' : 'Article';
-    const kindClass = isStandalone ? 'gen-research-kind--standalone' : 'gen-research-kind--article';
-    const languageHtml = hasResearchLanguage(row, 'ko')
-      ? '      <span class="gen-research-tag" lang="ko">한국어</span>'
+    const koHtml = hasResearchLanguage(row, 'ko')
+      ? '      <span class="press-shelf-lang" lang="ko">한국어</span>'
       : '';
     items.push(
       [
-        '<li class="gen-research-item" data-slug="' + escapeHtml(row.slug) + '" tabindex="0">',
-        '  <div class="gen-research-item-main">',
-        '    <div class="gen-research-item-title">' + title + '</div>',
-        '    <div class="gen-research-item-meta">',
-        '      <span class="gen-research-model">' + escapeHtml(row.model) + '</span>',
-        rel ? '      <span class="gen-research-time">' + escapeHtml(rel) + '</span>' : '',
-        tagHtml ? '      <span class="gen-research-tags">' + tagHtml + '</span>' : '',
-        languageHtml,
-        '    </div>',
-        '  </div>',
-        '  <span class="gen-research-kind ' + kindClass + '">' + kindLabel + '</span>',
+        // role="link" (not the bare focusable <li> this replaced) so the band
+        // announces as navigation; the content keydown handler already
+        // activates [data-slug] rows on Enter.
+        '<li class="press-shelf-row" role="link" data-jacket="' + jackets[index] + '"' +
+          ' data-slug="' + escapeHtml(row.slug) + '" tabindex="0">',
+        '  <span class="press-shelf-text">',
+        '    <span class="press-shelf-title">' + title + '</span>',
+        '    <span class="press-shelf-byline">',
+        '      <span class="press-shelf-model">' + escapeHtml(row.model) + '</span>',
+        rel ? '      <span class="press-shelf-date">' + escapeHtml(rel) + '</span>' : '',
+        koHtml,
+        '    </span>',
+        '  </span>',
         '</li>',
-      ].join('\n'),
+      ].filter(Boolean).join('\n'),
     );
-  }
+  });
 
   const empty = visible.length === 0
-    ? '<div class="empty-state-text gen-research-empty">No articles match the search.</div>'
+    ? '<p class="press-shelf-empty">No articles match the search.</p>'
     : '';
 
   setSafeContent(
     content,
     [
-      '<div class="content-card">',
-      '  <div class="content-card-body">',
-      '    <ul class="gen-research-index">',
+      '<div class="press-shelf-page">',
+      '  <header class="press-masthead">',
+      '    <h1 class="press-masthead-name">ara Research</h1>',
+      '    <p class="press-masthead-tagline">Long-form reports, written by machines</p>',
+      '  </header>',
+      '  <ul class="press-shelf">',
       items.join('\n'),
-      '    </ul>',
+      '  </ul>',
       empty,
+      '  <div class="press-shelf-foot">',
       paginationHtml(researchIndexPage, visible.length, RESEARCH_PAGE_SIZE, 'Research articles'),
       '  </div>',
       '</div>',
     ].join('\n'),
   );
+  // Only the index wears the press ground; the article view keeps the reading
+  // chrome. Cleared centrally at the top of load().
+  document.body.classList.add('research-shelf');
 }
 
 function renderResearchDoc(row: GenResearchRow, body: string): void {
@@ -4877,6 +4935,10 @@ async function load(): Promise<void> {
   // Hide the floating TOC unconditionally; renderResearchDoc shows it
   // again when it has enough sections to be useful.
   hideResearchTOC();
+
+  // The press ground belongs to the research INDEX only. Clear it on every
+  // dispatch; renderResearchIndex re-adds it when it actually paints the shelf.
+  document.body.classList.remove('research-shelf');
 
   updateRoute();
   showLoading();

--- a/dashboard/src/style.css
+++ b/dashboard/src/style.css
@@ -3397,85 +3397,276 @@ body.tab-frontpage .section-nav {
   display: none;
 }
 
-.gen-research-index {
-  list-style: none;
-  padding: 0;
+/* ── Research index: the press shelf ────────────────────
+ * Modelled on the press.stripe.com product list (its non-WebGL rendering,
+ * which is the layout underneath the 3D book carousel): the page drops to a
+ * warm near-black ground, the masthead is a serif name over an italic
+ * tagline, and every article becomes a full-bleed band painted in its own
+ * "jacket" palette with the title and byline centred inside.
+ *
+ * Two structural notes:
+ *  - The ground is a token REMAP on body.research-shelf, not a pile of
+ *    per-component overrides. Tabs, buttons, pagination and the footer all
+ *    read --bg/--border/--accent/--text-*, so they follow for free.
+ *  - Jacket colours live here, keyed by [data-jacket], because main.ts
+ *    renders through DOMPurify and inline style="" would not survive.
+ *    researchJacket() in main.ts picks the index; keep the two counts in
+ *    sync (RESEARCH_JACKET_COUNT = 20). */
+
+body.research-shelf {
+  --press-ground: #201819;
+  --press-ink: #f7f3ee;
+  --bg: #2c2321;              /* control surface (tab pills, inputs) */
+  --bg-secondary: #201819;    /* sticky .nav-shell backdrop == the ground */
+  --bg-hover: #3a2e2b;
+  --border: #4c3e39;
+  --border-light: #372b28;
+  --text: var(--press-ink);
+  --text-secondary: #cabcb2;
+  --text-tertiary: #9d8d84;
+  --accent: var(--press-ink); /* active pill: paper on ink */
+  --on-accent: var(--press-ground);
+  --accent-light: #e2cba8;
+  --accent-warm: #e2cba8;
+  --accent-warm-bg: #3a2e2b;
+  --mark-bg: #e2cba8;
+  --mark-fg: #201819;
+  background: var(--press-ground);
+  color: var(--press-ink);
+}
+
+/* The app frame keeps its gutter for the masthead and the pagination foot;
+ * only the bands break out of it (below). */
+body.research-shelf .app {
+  padding-bottom: 0;
+}
+
+/* The sticky tab rail is normally a --page-max-wide block sitting on the page
+ * ground. Over full-bleed jacket bands that leaves the bands scrolling past
+ * either side of it, so widen its backdrop to the viewport and re-centre the
+ * pills inside. */
+body.research-shelf .nav-shell {
+  max-width: none;
+  margin-inline: calc(var(--page-gutter) * -1);
+  padding-inline: var(--page-gutter);
+}
+
+body.research-shelf .tabs,
+body.research-shelf .controls {
+  max-width: var(--page-max);
+  margin-inline: auto;
+}
+
+.press-shelf-page {
+  /* Bands run edge to edge, so cancel .app's horizontal gutter here and
+   * re-apply the (larger, Stripe-matched) inset per child. */
+  margin-inline: calc(var(--page-gutter) * -1);
+}
+
+.press-masthead {
+  /* Tagline rhythm and tracking are lifted from
+   * .PressHomepageProductListHeader; the inset follows the app's own optical
+   * column (--page-max) so the name lines up under the "ai-research-arm"
+   * masthead instead of floating at its own margin. */
+  /* +2 gutters because .press-shelf-page has already cancelled .app's padding;
+   * this lands the name on the same optical edge as the app masthead. */
+  max-width: calc(var(--page-max) + 2 * var(--page-gutter));
+  margin: 0 auto clamp(26px, 7vh, 88px);
+  padding: calc(9px + 1vw) var(--page-gutter) 0;
+  letter-spacing: 0.32px;
+  line-height: 1.4;
+}
+
+.press-masthead-name,
+.press-masthead-tagline {
+  font-family: var(--font-serif);
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--press-ink);
+}
+
+.press-masthead-name {
+  margin: 0 0 6px;
+}
+
+.press-masthead-tagline {
   margin: 0;
+  font-style: italic;
+  line-height: 1.3;
 }
 
-.gen-research-item {
-  display: flex;
-  align-items: flex-start;
-  gap: 12px;
-  padding: 14px 0;
-  border-bottom: 1px solid var(--border-light);
-  cursor: pointer;
-  transition: background 0.1s;
-  margin: 0 -28px;
-  padding-left: 28px;
-  padding-right: 28px;
+.press-shelf {
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
 
-.gen-research-item-main {
-  flex: 1;
-  min-width: 0;
-}
-
-.gen-research-kind {
-  flex-shrink: 0;
-  font-family: var(--font-mono);
-  font-size: 0.65rem;
-  font-weight: 600;
-  letter-spacing: 0;
-  text-transform: uppercase;
-  padding: 3px 8px;
-  border-radius: 999px;
-  white-space: nowrap;
-  margin-top: 2px;
-}
-
-.gen-research-kind--standalone {
-  background: var(--accent-warm);
-  color: var(--on-accent);
-}
-
-.gen-research-kind--article {
-  background: transparent;
-  color: var(--text-tertiary);
-  border: 1px solid var(--border);
-}
-
-.gen-research-item:last-child {
-  border-bottom: none;
-}
-
-.gen-research-item:hover {
-  background: var(--bg-hover);
-}
-
-.gen-research-item:focus-visible {
-  outline: 2px solid var(--accent-warm);
-  outline-offset: -2px;
-  background: var(--bg-hover);
-}
-
-.gen-research-item-title {
-  font-family: var(--font);
-  font-size: 1.02rem;
-  font-weight: 600;
-  color: var(--text);
-  line-height: 1.35;
-  margin-bottom: 6px;
-}
-
-.gen-research-item-meta {
+.press-shelf-row {
+  /* Fallback jacket — every row gets a real pair from the table below. */
+  --jacket-bg: #2f2f2f;
+  --jacket-ink: #dbdbdb;
   display: flex;
   align-items: center;
-  flex-wrap: wrap;
-  gap: 8px;
-  font-size: 0.78rem;
-  color: var(--text-tertiary);
+  justify-content: center;
+  min-height: clamp(146px, 26vh, 270px);
+  padding: 30px calc(42.5px + 1.75vw);
+  background: var(--jacket-bg);
+  color: var(--jacket-ink);
+  cursor: pointer;
+  outline: none;
+  transition: filter 0.25s ease;
 }
+
+.press-shelf-text {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: center;
+  gap: 8px 50px;              /* 50px is Stripe's title→author gutter */
+  max-width: 74ch;
+  text-align: center;
+  letter-spacing: 0.32px;
+  line-height: 1.5;
+}
+
+.press-shelf-title {
+  font-family: var(--font-serif);
+  font-size: clamp(1.02rem, 0.92rem + 0.5vw, 1.34rem);
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  text-decoration-thickness: from-font;
+}
+
+.press-shelf-byline {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 10px;
+  font-family: var(--font-serif);
+  font-size: clamp(0.9rem, 0.85rem + 0.28vw, 1.06rem);
+  font-weight: 500;
+  font-style: italic;
+  /* Full jacket ink, like Stripe's author line — the italic and the missing
+   * underline carry the hierarchy. Dimming it here would push the two
+   * lowest-contrast jackets under AA for small text. */
+}
+
+.press-shelf-date::before {
+  content: "·";
+  margin-right: 10px;
+}
+
+.press-shelf-lang {
+  font-style: normal;
+  font-size: 0.76em;
+  letter-spacing: 0;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  padding: 1px 8px;
+  opacity: 0.85;
+}
+
+/* Search highlight inverts against whatever jacket it lands on, so it stays
+ * legible on all 20 palettes without a per-jacket rule. */
+.press-shelf-row mark {
+  background: currentColor;
+  color: var(--jacket-bg);
+  padding: 0 3px;
+}
+
+@media (hover: hover) {
+  .press-shelf-row:hover {
+    filter: brightness(1.09);
+  }
+
+  .press-shelf-row:hover .press-shelf-title {
+    text-decoration-thickness: 2px;
+  }
+}
+
+.press-shelf-row:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: -10px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .press-shelf-row {
+    transition: none;
+  }
+}
+
+.press-shelf-empty {
+  padding: clamp(48px, 12vh, 120px) calc(42.5px + 1.75vw);
+  font-family: var(--font-serif);
+  font-style: italic;
+  color: var(--text-secondary);
+  text-align: center;
+}
+
+.press-shelf-foot {
+  max-width: calc(var(--page-max) + 2 * var(--page-gutter));
+  margin-inline: auto;
+  padding: clamp(24px, 5vh, 56px) var(--page-gutter) clamp(28px, 6vh, 64px);
+}
+
+.press-shelf-foot .index-pagination {
+  margin-top: 0;
+  border-top-color: var(--border-light);
+}
+
+/* Long research titles need two lines more often than book titles do, so the
+ * byline drops below the title on narrow viewports instead of wrapping into
+ * an orphaned column. */
+@media (max-width: 699px) {
+  .press-shelf-text {
+    flex-direction: column;
+    /* Column flex makes align-items the HORIZONTAL axis, so `baseline` from
+     * the row layout would left-align the byline under a centred title. */
+    align-items: center;
+    gap: 12px;
+  }
+
+  .press-shelf-row {
+    min-height: clamp(130px, 22vh, 210px);
+    padding: 26px 22px;
+  }
+
+  .press-masthead,
+  .press-shelf-empty,
+  .press-shelf-foot {
+    padding-inline: 22px;
+  }
+}
+
+/* Jacket palettes — the 20 background/ink pairs press.stripe.com uses for its
+ * book covers, in shelf order. Assigned per article by researchJacket(slug),
+ * so an article keeps its colour across reloads and pagination.
+ *
+ * Two pairs are nudged off Stripe's exact values because our byline is small
+ * italic text where Stripe's is set larger: jacket 1's ground is darkened
+ * (#6e665b → #595249) and jacket 6's ink is darkened (#333032 → #2a2729).
+ * Both then clear 4.6:1. Every other pair is verbatim, and all 20 are ≥4.6:1
+ * — re-check with a contrast calculator before editing any of them. */
+.press-shelf-row[data-jacket="0"]  { --jacket-bg: #c1b676; --jacket-ink: #18185e; }
+.press-shelf-row[data-jacket="1"]  { --jacket-bg: #595249; --jacket-ink: #dfc78e; }
+.press-shelf-row[data-jacket="2"]  { --jacket-bg: #0d121f; --jacket-ink: #d0d1d4; }
+.press-shelf-row[data-jacket="3"]  { --jacket-bg: #e2e2e2; --jacket-ink: #504f4f; }
+.press-shelf-row[data-jacket="4"]  { --jacket-bg: #4d1a28; --jacket-ink: #ebadcb; }
+.press-shelf-row[data-jacket="5"]  { --jacket-bg: #143199; --jacket-ink: #dee6ff; }
+.press-shelf-row[data-jacket="6"]  { --jacket-bg: #93935f; --jacket-ink: #2a2729; }
+.press-shelf-row[data-jacket="7"]  { --jacket-bg: #96dced; --jacket-ink: #3d3d3d; }
+.press-shelf-row[data-jacket="8"]  { --jacket-bg: #442c25; --jacket-ink: #e48244; }
+.press-shelf-row[data-jacket="9"]  { --jacket-bg: #222222; --jacket-ink: #ff4445; }
+.press-shelf-row[data-jacket="10"] { --jacket-bg: #ffb55e; --jacket-ink: #0b1743; }
+.press-shelf-row[data-jacket="11"] { --jacket-bg: #303328; --jacket-ink: #f9c350; }
+.press-shelf-row[data-jacket="12"] { --jacket-bg: #2328a0; --jacket-ink: #ef9e40; }
+.press-shelf-row[data-jacket="13"] { --jacket-bg: #ff9e5a; --jacket-ink: #452121; }
+.press-shelf-row[data-jacket="14"] { --jacket-bg: #2f2f2f; --jacket-ink: #dbdbdb; }
+.press-shelf-row[data-jacket="15"] { --jacket-bg: #201e8e; --jacket-ink: #f366ff; }
+.press-shelf-row[data-jacket="16"] { --jacket-bg: #ffa6a6; --jacket-ink: #222222; }
+.press-shelf-row[data-jacket="17"] { --jacket-bg: #cad9e5; --jacket-ink: #222222; }
+.press-shelf-row[data-jacket="18"] { --jacket-bg: #353f54; --jacket-ink: #0aeb9a; }
+.press-shelf-row[data-jacket="19"] { --jacket-bg: #1d1a15; --jacket-ink: #e2cab0; }
 
 .gen-research-model {
   font-family: var(--font-mono);
@@ -3490,27 +3681,6 @@ body.tab-frontpage .section-nav {
 .gen-research-time {
   font-size: 0.78rem;
   color: var(--text-tertiary);
-}
-
-.gen-research-tags {
-  display: inline-flex;
-  flex-wrap: wrap;
-  gap: 4px;
-}
-
-.gen-research-tag {
-  font-family: var(--font-mono);
-  font-size: 0.7rem;
-  color: var(--text-secondary);
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-light);
-  padding: 1px 6px;
-  border-radius: 4px;
-}
-
-.gen-research-empty {
-  padding: 24px 0 8px;
-  text-align: center;
 }
 
 /* Shared archive pagination for Research and Wiki. Anchors preserve browser

--- a/dashboard/src/style.css
+++ b/dashboard/src/style.css
@@ -346,6 +346,34 @@ body.has-digest-player .app {
   flex-shrink: 0;
 }
 
+/* Search + Request research, pinned at the end of the tab rail. The gaps were
+ * always an even 6px; what read as uneven was HEIGHT — the search box shipped
+ * at 30px and the button at 34px against 36px pills, so both are pinned to the
+ * pill's metrics here (36px tall, 20px radius) to keep one rhythm across the
+ * whole rail. */
+.tabs-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.tabs .brand-search,
+.tabs .request-btn {
+  height: 36px;
+  min-height: 36px;
+  border-radius: 20px;
+  font-size: var(--nav-font-size);
+}
+
+.tabs .brand-search {
+  width: 36px;
+}
+
+.tabs .request-btn {
+  padding: 0 16px;
+}
+
 /* Narrow header cleanup: keep the masthead compact and hide long link labels. */
 @media (max-width: 640px) {
   .header-top {
@@ -633,11 +661,21 @@ body.tab-today .cal-chevron { color: var(--on-accent); opacity: 0.75; }
     box-shadow: inset 0 -3px 0 var(--text);
   }
 
-  .tabs .brand-search {
+  /* The actions wrapper is the grid item now, so it carries the full-width
+     span the search button used to; search stretches and Request research
+     keeps its pill at the trailing edge. */
+  .tabs-actions {
     grid-column: 1 / -1;
-    width: 100%;
-    height: 38px;
+    gap: 8px;
+    padding: 7px 10px;
+  }
+
+  .tabs .brand-search {
+    flex: 1;
+    width: auto;
+    height: 36px;
     border-top: 0;
+    border-radius: 20px;
     color: var(--text-tertiary);
   }
 }
@@ -3458,145 +3496,235 @@ body.research-shelf .controls {
 }
 
 .press-shelf-page {
-  /* Bands run edge to edge, so cancel .app's horizontal gutter here and
-   * re-apply the (larger, Stripe-matched) inset per child. */
+  /* The press ground runs edge to edge, so cancel .app's horizontal gutter
+   * here; each child re-applies it against the app's optical column. */
   margin-inline: calc(var(--page-gutter) * -1);
+  padding-top: clamp(14px, 3vh, 34px);
 }
 
-.press-masthead {
-  /* Tagline rhythm and tracking are lifted from
-   * .PressHomepageProductListHeader; the inset follows the app's own optical
-   * column (--page-max) so the name lines up under the "ai-research-arm"
-   * masthead instead of floating at its own margin. */
-  /* +2 gutters because .press-shelf-page has already cancelled .app's padding;
-   * this lands the name on the same optical edge as the app masthead. */
-  max-width: calc(var(--page-max) + 2 * var(--page-gutter));
-  margin: 0 auto clamp(26px, 7vh, 88px);
-  padding: calc(9px + 1vw) var(--page-gutter) 0;
-  letter-spacing: 0.32px;
-  line-height: 1.4;
-}
+/* No masthead: the app's own "ai-research-arm" header sits directly above the
+ * shelf, so a second name/tagline block was just repeating it. The covers open
+ * the page. */
 
-.press-masthead-name,
-.press-masthead-tagline {
-  font-family: var(--font-serif);
-  font-size: 1.1rem;
-  font-weight: 600;
-  color: var(--press-ink);
-}
-
-.press-masthead-name {
-  margin: 0 0 6px;
-}
-
-.press-masthead-tagline {
-  margin: 0;
-  font-style: italic;
-  line-height: 1.3;
-}
-
+/* The shelf proper: a grid of book covers on the press ground. Column counts
+ * are explicit rather than auto-fill so the covers stay substantial (a 6-up
+ * auto-fill row on a wide display shrinks them into stamps). */
 .press-shelf {
   list-style: none;
-  margin: 0;
-  padding: 0;
+  max-width: calc(var(--page-max) + 2 * var(--page-gutter));
+  margin-inline: auto;
+  padding: 0 var(--page-gutter);
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: clamp(28px, 3.4vw, 56px) clamp(20px, 2.6vw, 44px);
+  align-items: start;
 }
 
-.press-shelf-row {
-  /* Fallback jacket — every row gets a real pair from the table below. */
+@media (min-width: 620px) {
+  .press-shelf {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 940px) {
+  .press-shelf {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+/* One book. The jacket palette paints the cover; the ::before strip is the
+ * spine, which is what makes it read as an object instead of a colour swatch. */
+.press-book {
+  /* Fallback jacket — every book gets a real pair from the table below. */
   --jacket-bg: #2f2f2f;
   --jacket-ink: #dbdbdb;
+  --cover-pad: clamp(16px, 1.5vw, 24px);
+  position: relative;
   display: flex;
-  align-items: center;
-  justify-content: center;
-  min-height: clamp(146px, 26vh, 270px);
-  padding: 30px calc(42.5px + 1.75vw);
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 16px;
+  aspect-ratio: 5 / 7;
+  padding: var(--cover-pad);
+  padding-left: calc(var(--cover-pad) + 12px);
+  overflow: hidden;
+  border-radius: 1px 4px 4px 1px;
   background: var(--jacket-bg);
   color: var(--jacket-ink);
   cursor: pointer;
   outline: none;
-  transition: filter 0.25s ease;
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.45),
+    0 14px 30px -10px rgba(0, 0, 0, 0.6);
+  transition: transform 0.28s cubic-bezier(0.2, 0.7, 0.3, 1), box-shadow 0.28s ease;
 }
 
-.press-shelf-text {
+/* Spine: a darkened gradient down the leading edge plus the hinge highlight. */
+.press-book::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 12px;
+  background: linear-gradient(
+    90deg,
+    rgba(0, 0, 0, 0.36) 0%,
+    rgba(0, 0, 0, 0.1) 58%,
+    rgba(255, 255, 255, 0.07) 100%
+  );
+  pointer-events: none;
+}
+
+.press-book-title {
+  font-family: var(--font-serif);
+  font-size: clamp(0.96rem, 0.84rem + 0.42vw, 1.22rem);
+  font-weight: 600;
+  line-height: 1.24;
+  letter-spacing: 0.2px;
+  text-wrap: balance;
+  /* Cover space is fixed by the aspect ratio, so a very long title truncates
+   * rather than overflowing the jacket. The full title is still the row's
+   * accessible name and is shown in full on the article page. */
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 7;
+  overflow: hidden;
+}
+
+.press-book-byline {
   display: flex;
   flex-wrap: wrap;
   align-items: baseline;
-  justify-content: center;
-  gap: 8px 50px;              /* 50px is Stripe's title→author gutter */
-  max-width: 74ch;
-  text-align: center;
-  letter-spacing: 0.32px;
-  line-height: 1.5;
-}
-
-.press-shelf-title {
+  gap: 3px 8px;
+  padding-top: 11px;
+  border-top: 1px solid currentColor;
+  border-top-color: color-mix(in srgb, currentColor 42%, transparent);
   font-family: var(--font-serif);
-  font-size: clamp(1.02rem, 0.92rem + 0.5vw, 1.34rem);
-  font-weight: 600;
-  text-decoration: underline;
-  text-underline-offset: 3px;
-  text-decoration-thickness: from-font;
-}
-
-.press-shelf-byline {
-  display: inline-flex;
-  align-items: baseline;
-  gap: 10px;
-  font-family: var(--font-serif);
-  font-size: clamp(0.9rem, 0.85rem + 0.28vw, 1.06rem);
-  font-weight: 500;
+  font-size: 0.8rem;
   font-style: italic;
-  /* Full jacket ink, like Stripe's author line — the italic and the missing
-   * underline carry the hierarchy. Dimming it here would push the two
-   * lowest-contrast jackets under AA for small text. */
+  line-height: 1.35;
+  /* Full jacket ink, like Stripe's author line — the italic and the rule carry
+   * the hierarchy. Dimming it would push the two lowest-contrast jackets under
+   * AA for small text. */
 }
 
-.press-shelf-date::before {
+.press-book-date::before {
   content: "·";
-  margin-right: 10px;
+  margin-right: 8px;
 }
 
-.press-shelf-lang {
+.press-book-lang {
   font-style: normal;
-  font-size: 0.76em;
+  font-size: 0.86em;
   letter-spacing: 0;
   border: 1px solid currentColor;
   border-radius: 999px;
-  padding: 1px 8px;
-  opacity: 0.85;
+  padding: 0 6px;
 }
 
 /* Search highlight inverts against whatever jacket it lands on, so it stays
  * legible on all 20 palettes without a per-jacket rule. */
-.press-shelf-row mark {
+.press-book mark {
   background: currentColor;
   color: var(--jacket-bg);
   padding: 0 3px;
 }
 
 @media (hover: hover) {
-  .press-shelf-row:hover {
-    filter: brightness(1.09);
-  }
-
-  .press-shelf-row:hover .press-shelf-title {
-    text-decoration-thickness: 2px;
+  .press-book:hover {
+    transform: translateY(-10px);
+    box-shadow:
+      0 1px 2px rgba(0, 0, 0, 0.45),
+      0 30px 54px -12px rgba(0, 0, 0, 0.66);
   }
 }
 
-.press-shelf-row:focus-visible {
-  outline: 2px solid currentColor;
-  outline-offset: -10px;
+.press-book:focus-visible {
+  outline: 2px solid var(--press-ink);
+  outline-offset: 4px;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .press-shelf-row {
+  .press-book {
+    transition: none;
+  }
+
+  .press-book:hover {
+    transform: none;
+  }
+}
+
+/* ── Book-opening transition ────────────────────────────
+ * Built by openBookThen() in main.ts: the clicked cover is cloned into this
+ * overlay, swung open around its spine, and grown toward the middle of the
+ * viewport while a veil (painted the DESTINATION ground) fades in for the
+ * article to render behind. Durations here must stay in step with the
+ * BOOK_OPEN_* constants in main.ts. */
+.press-open-stage {
+  position: fixed;
+  inset: 0;
+  z-index: 4000;
+  perspective: 1600px;
+  pointer-events: none;
+}
+
+.press-open-book {
+  position: absolute;
+  transform-style: preserve-3d;
+  transition: transform 620ms cubic-bezier(0.4, 0, 0.2, 1);
+  will-change: transform;
+}
+
+/* The page revealed under the swinging cover. */
+.press-open-page {
+  position: absolute;
+  inset: 0;
+  border-radius: 1px 4px 4px 1px;
+  box-shadow: 0 24px 64px -14px rgba(0, 0, 0, 0.62);
+}
+
+.press-open-cover {
+  position: absolute;
+  inset: 0;
+  padding: clamp(16px, 1.5vw, 24px);
+  padding-left: calc(clamp(16px, 1.5vw, 24px) + 12px);
+  overflow: hidden;
+  border-radius: 1px 4px 4px 1px;
+  transform-origin: left center;
+  transform: rotateY(0deg);
+  transition: transform 620ms cubic-bezier(0.4, 0, 0.2, 1);
+  backface-visibility: hidden;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.45);
+  will-change: transform;
+}
+
+.press-open-veil {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  /* Held back until the swing is most of the way through, so the reader sees
+   * the book open before the page takes over. */
+  transition: opacity 260ms ease 330ms;
+}
+
+.press-open-stage.is-clearing .press-open-veil {
+  opacity: 0;
+  transition: opacity 280ms ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  /* openBookThen() bails before building the stage, but keep the belt-and-
+   * braces rule in case a stage is ever left on screen. */
+  .press-open-book,
+  .press-open-cover,
+  .press-open-veil {
     transition: none;
   }
 }
 
 .press-shelf-empty {
-  padding: clamp(48px, 12vh, 120px) calc(42.5px + 1.75vw);
+  max-width: calc(var(--page-max) + 2 * var(--page-gutter));
+  margin-inline: auto;
+  padding: clamp(48px, 12vh, 120px) var(--page-gutter);
   font-family: var(--font-serif);
   font-style: italic;
   color: var(--text-secondary);
@@ -3614,24 +3742,23 @@ body.research-shelf .controls {
   border-top-color: var(--border-light);
 }
 
-/* Long research titles need two lines more often than book titles do, so the
- * byline drops below the title on narrow viewports instead of wrapping into
- * an orphaned column. */
-@media (max-width: 699px) {
-  .press-shelf-text {
-    flex-direction: column;
-    /* Column flex makes align-items the HORIZONTAL axis, so `baseline` from
-     * the row layout would left-align the byline under a centred title. */
-    align-items: center;
-    gap: 12px;
+/* Two covers per row on phones leaves ~150px of cover width, so the title
+ * needs to drop a step and shed a couple of clamped lines. */
+@media (max-width: 619px) {
+  .press-book {
+    --cover-pad: 14px;
   }
 
-  .press-shelf-row {
-    min-height: clamp(130px, 22vh, 210px);
-    padding: 26px 22px;
+  .press-book-title {
+    font-size: 0.9rem;
+    -webkit-line-clamp: 6;
   }
 
-  .press-masthead,
+  .press-book-byline {
+    font-size: 0.74rem;
+  }
+
+  .press-shelf,
   .press-shelf-empty,
   .press-shelf-foot {
     padding-inline: 22px;
@@ -3642,31 +3769,35 @@ body.research-shelf .controls {
  * book covers, in shelf order. Assigned per article by researchJacket(slug),
  * so an article keeps its colour across reloads and pagination.
  *
+ * Selector is the bare attribute because two hosts wear a jacket: the shelf
+ * cover (.press-book) and the opened article (.gen-research-doc). Nothing else
+ * in the app emits data-jacket.
+ *
  * Two pairs are nudged off Stripe's exact values because our byline is small
  * italic text where Stripe's is set larger: jacket 1's ground is darkened
  * (#6e665b → #595249) and jacket 6's ink is darkened (#333032 → #2a2729).
  * Both then clear 4.6:1. Every other pair is verbatim, and all 20 are ≥4.6:1
  * — re-check with a contrast calculator before editing any of them. */
-.press-shelf-row[data-jacket="0"]  { --jacket-bg: #c1b676; --jacket-ink: #18185e; }
-.press-shelf-row[data-jacket="1"]  { --jacket-bg: #595249; --jacket-ink: #dfc78e; }
-.press-shelf-row[data-jacket="2"]  { --jacket-bg: #0d121f; --jacket-ink: #d0d1d4; }
-.press-shelf-row[data-jacket="3"]  { --jacket-bg: #e2e2e2; --jacket-ink: #504f4f; }
-.press-shelf-row[data-jacket="4"]  { --jacket-bg: #4d1a28; --jacket-ink: #ebadcb; }
-.press-shelf-row[data-jacket="5"]  { --jacket-bg: #143199; --jacket-ink: #dee6ff; }
-.press-shelf-row[data-jacket="6"]  { --jacket-bg: #93935f; --jacket-ink: #2a2729; }
-.press-shelf-row[data-jacket="7"]  { --jacket-bg: #96dced; --jacket-ink: #3d3d3d; }
-.press-shelf-row[data-jacket="8"]  { --jacket-bg: #442c25; --jacket-ink: #e48244; }
-.press-shelf-row[data-jacket="9"]  { --jacket-bg: #222222; --jacket-ink: #ff4445; }
-.press-shelf-row[data-jacket="10"] { --jacket-bg: #ffb55e; --jacket-ink: #0b1743; }
-.press-shelf-row[data-jacket="11"] { --jacket-bg: #303328; --jacket-ink: #f9c350; }
-.press-shelf-row[data-jacket="12"] { --jacket-bg: #2328a0; --jacket-ink: #ef9e40; }
-.press-shelf-row[data-jacket="13"] { --jacket-bg: #ff9e5a; --jacket-ink: #452121; }
-.press-shelf-row[data-jacket="14"] { --jacket-bg: #2f2f2f; --jacket-ink: #dbdbdb; }
-.press-shelf-row[data-jacket="15"] { --jacket-bg: #201e8e; --jacket-ink: #f366ff; }
-.press-shelf-row[data-jacket="16"] { --jacket-bg: #ffa6a6; --jacket-ink: #222222; }
-.press-shelf-row[data-jacket="17"] { --jacket-bg: #cad9e5; --jacket-ink: #222222; }
-.press-shelf-row[data-jacket="18"] { --jacket-bg: #353f54; --jacket-ink: #0aeb9a; }
-.press-shelf-row[data-jacket="19"] { --jacket-bg: #1d1a15; --jacket-ink: #e2cab0; }
+[data-jacket="0"]  { --jacket-bg: #c1b676; --jacket-ink: #18185e; }
+[data-jacket="1"]  { --jacket-bg: #595249; --jacket-ink: #dfc78e; }
+[data-jacket="2"]  { --jacket-bg: #0d121f; --jacket-ink: #d0d1d4; }
+[data-jacket="3"]  { --jacket-bg: #e2e2e2; --jacket-ink: #504f4f; }
+[data-jacket="4"]  { --jacket-bg: #4d1a28; --jacket-ink: #ebadcb; }
+[data-jacket="5"]  { --jacket-bg: #143199; --jacket-ink: #dee6ff; }
+[data-jacket="6"]  { --jacket-bg: #93935f; --jacket-ink: #2a2729; }
+[data-jacket="7"]  { --jacket-bg: #96dced; --jacket-ink: #3d3d3d; }
+[data-jacket="8"]  { --jacket-bg: #442c25; --jacket-ink: #e48244; }
+[data-jacket="9"]  { --jacket-bg: #222222; --jacket-ink: #ff4445; }
+[data-jacket="10"] { --jacket-bg: #ffb55e; --jacket-ink: #0b1743; }
+[data-jacket="11"] { --jacket-bg: #303328; --jacket-ink: #f9c350; }
+[data-jacket="12"] { --jacket-bg: #2328a0; --jacket-ink: #ef9e40; }
+[data-jacket="13"] { --jacket-bg: #ff9e5a; --jacket-ink: #452121; }
+[data-jacket="14"] { --jacket-bg: #2f2f2f; --jacket-ink: #dbdbdb; }
+[data-jacket="15"] { --jacket-bg: #201e8e; --jacket-ink: #f366ff; }
+[data-jacket="16"] { --jacket-bg: #ffa6a6; --jacket-ink: #222222; }
+[data-jacket="17"] { --jacket-bg: #cad9e5; --jacket-ink: #222222; }
+[data-jacket="18"] { --jacket-bg: #353f54; --jacket-ink: #0aeb9a; }
+[data-jacket="19"] { --jacket-bg: #1d1a15; --jacket-ink: #e2cab0; }
 
 .gen-research-model {
   font-family: var(--font-mono);
@@ -3760,6 +3891,29 @@ body.research-shelf .controls {
 }
 
 /* Single doc view */
+/* ── Opened book: the article page ──────────────────────
+ * The article wears the same jacket the shelf cover did (data-jacket is set by
+ * renderResearchDoc from researchJacketBySlug), so clicking a book opens into
+ * that book. Two pieces carry it: a jacket-painted meta bar across the top of
+ * the card, and a spine rail down the leading edge. The article BODY is left
+ * alone — it is compiled ara-* markup with its own type system. */
+.gen-research-doc[data-jacket] {
+  position: relative;
+  overflow: hidden;
+  border-left: 12px solid var(--jacket-bg);
+}
+
+/* Hinge highlight against the spine, matching the shelf cover's ::before. */
+.gen-research-doc[data-jacket]::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 1px;
+  background: rgba(255, 255, 255, 0.14);
+  pointer-events: none;
+  z-index: 1;
+}
+
 .gen-research-doc-meta {
   display: flex;
   align-items: center;
@@ -3768,6 +3922,51 @@ body.research-shelf .controls {
   padding: 10px 28px 0;
   font-size: 0.78rem;
   color: var(--text-tertiary);
+}
+
+.gen-research-doc[data-jacket] > .gen-research-doc-meta {
+  padding: 13px 28px;
+  margin-bottom: 4px;
+  background: var(--jacket-bg);
+  color: var(--jacket-ink);
+}
+
+/* Inside the jacket bar every control reads in jacket ink — the default chips
+ * are painted from the app accent tokens, which would clash with 20 grounds. */
+.gen-research-doc[data-jacket] > .gen-research-doc-meta .gen-research-model,
+.gen-research-doc[data-jacket] > .gen-research-doc-meta .gen-research-time,
+.gen-research-doc[data-jacket] > .gen-research-doc-meta .gen-research-language-note {
+  color: var(--jacket-ink);
+  background: transparent;
+}
+
+.gen-research-doc[data-jacket] > .gen-research-doc-meta .gen-research-model {
+  font-style: italic;
+  padding-inline: 0;
+}
+
+.gen-research-doc[data-jacket] > .gen-research-doc-meta .gen-research-back,
+.gen-research-doc[data-jacket] > .gen-research-doc-meta .gen-research-pdf,
+.gen-research-doc[data-jacket] > .gen-research-doc-meta .gen-research-file-audio,
+.gen-research-doc[data-jacket] > .gen-research-doc-meta .gen-research-audio,
+.gen-research-doc[data-jacket] > .gen-research-doc-meta .gen-research-audio-stop {
+  color: var(--jacket-ink);
+  border-color: color-mix(in srgb, var(--jacket-ink) 45%, transparent);
+  background: transparent;
+}
+
+.gen-research-doc[data-jacket] > .gen-research-doc-meta .gen-research-back:hover,
+.gen-research-doc[data-jacket] > .gen-research-doc-meta .gen-research-pdf:hover,
+.gen-research-doc[data-jacket] > .gen-research-doc-meta .gen-research-file-audio:hover,
+.gen-research-doc[data-jacket] > .gen-research-doc-meta .gen-research-audio:hover {
+  color: var(--jacket-bg);
+  background: var(--jacket-ink);
+  border-color: var(--jacket-ink);
+}
+
+.gen-research-doc[data-jacket] > .gen-research-doc-meta :focus-visible {
+  outline: 2px solid var(--jacket-ink);
+  outline-offset: 2px;
 }
 
 .gen-research-language-note {

--- a/dashboard/src/style.css
+++ b/dashboard/src/style.css
@@ -3666,17 +3666,38 @@ body.research-shelf .controls {
   pointer-events: none;
 }
 
-/* Beat 1 — dim the shelf so the book is the only thing lit. */
+/* Beats 1 + 3 — dim the shelf so the book is the only thing lit, then close
+ * down to near-opaque so the shelf→article ground swap behind it is invisible.
+ *
+ * This deepening is what replaced the old full-screen veil. The veil painted
+ * the whole viewport the destination colour and faded it back out, which read
+ * as the page flashing white on every open. Holding at 0.62 keeps the shelf
+ * faintly present while the book lifts off it; closing to 0.97 right before
+ * the swap hides the swap without ever showing a flat field of colour. */
+@keyframes pressScrimDeepen {
+  0%   { opacity: 0; }
+  28%  { opacity: 0.62; }   /* ~250ms — lift done, shelf still readable */
+  62%  { opacity: 0.62; }   /* ~560ms — held through the cover swing */
+  93%  { opacity: 0.97; }   /* ~840ms — closed, just before the swap at 850ms */
+  100% { opacity: 0.97; }
+}
+
 .press-open-scrim {
   position: absolute;
   inset: 0;
-  background: rgba(12, 8, 8, 0.62);
+  background: #141010;
   opacity: 0;
-  transition: opacity 300ms ease;
 }
 
 .press-open-stage.is-open .press-open-scrim {
-  opacity: 1;
+  animation: pressScrimDeepen 900ms ease forwards;
+}
+
+/* Beat 5 — the whole set (scrim and open book together) fades off the already
+ * rendered article. Nothing is painted over the page to get here. */
+.press-open-stage.is-clearing {
+  opacity: 0;
+  transition: opacity 340ms ease;
 }
 
 /* Beat 1 — the book itself. Perspective lives HERE, not on the stage: the
@@ -3794,36 +3815,18 @@ body.research-shelf .controls {
   box-shadow: inset -6px 0 12px -6px rgba(0, 0, 0, 0.55);
 }
 
-/* Beat 4 — the page swells into the ground the article renders on. */
-.press-open-veil {
-  position: absolute;
-  inset: 0;
-  opacity: 0;
-  transition: opacity 260ms ease 860ms;
-}
-
-.press-open-stage.is-open .press-open-veil {
-  opacity: 1;
-}
-
-.press-open-stage.is-clearing .press-open-veil {
-  opacity: 0;
-  transition: opacity 260ms ease;
-}
-
-.press-open-stage.is-clearing .press-open-scrim {
-  opacity: 0;
-}
-
 @media (prefers-reduced-motion: reduce) {
   /* openBookThen() bails before building the stage, but keep the belt-and-
-   * braces rule in case a stage is ever left on screen. */
-  .press-open-scrim,
+   * braces rules in case a stage is ever left on screen. */
+  .press-open-stage,
   .press-open-book,
   .press-open-leaf,
-  .press-open-page-shade,
-  .press-open-veil {
+  .press-open-page-shade {
     transition: none;
+  }
+
+  .press-open-stage.is-open .press-open-scrim {
+    animation: none;
   }
 }
 

--- a/dashboard/src/style.css
+++ b/dashboard/src/style.css
@@ -3654,68 +3654,174 @@ body.research-shelf .controls {
 }
 
 /* ── Book-opening transition ────────────────────────────
- * Built by openBookThen() in main.ts: the clicked cover is cloned into this
- * overlay, swung open around its spine, and grown toward the middle of the
- * viewport while a veil (painted the DESTINATION ground) fades in for the
- * article to render behind. Durations here must stay in step with the
- * BOOK_OPEN_* constants in main.ts. */
+ * Built by openBookThen() in main.ts, which adds .is-open on the next frame
+ * and .is-clearing at the end. The four beats — lift, open, settle, dissolve —
+ * are sequenced entirely by the transition delays below; main.ts only needs
+ * BOOK_OPEN_SEQUENCE_MS to match the last one finishing. Read the block
+ * comment above openBookThen() before retiming anything here. */
 .press-open-stage {
   position: fixed;
   inset: 0;
   z-index: 4000;
-  perspective: 1600px;
   pointer-events: none;
 }
 
+/* Beat 1 — dim the shelf so the book is the only thing lit. */
+.press-open-scrim {
+  position: absolute;
+  inset: 0;
+  background: rgba(12, 8, 8, 0.62);
+  opacity: 0;
+  transition: opacity 300ms ease;
+}
+
+.press-open-stage.is-open .press-open-scrim {
+  opacity: 1;
+}
+
+/* Beat 1 — the book itself. Perspective lives HERE, not on the stage: the
+ * projection has to stay centred on the book, otherwise a cover opening from
+ * the edge of the shelf is projected from the middle of the screen and skews.
+ * It scales from `left center` so the spine stays put and the spread the leaf
+ * is about to occupy is already centred (see the dx/dy maths in main.ts). */
 .press-open-book {
   position: absolute;
-  transform-style: preserve-3d;
-  transition: transform 620ms cubic-bezier(0.4, 0, 0.2, 1);
+  transform-origin: left center;
+  perspective: 1500px;
+  transition: transform 420ms cubic-bezier(0.22, 0.75, 0.28, 1);
   will-change: transform;
 }
 
-/* The page revealed under the swinging cover. */
+/* The title page under the cover. */
 .press-open-page {
   position: absolute;
   inset: 0;
-  border-radius: 1px 4px 4px 1px;
-  box-shadow: 0 24px 64px -14px rgba(0, 0, 0, 0.62);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.55em;
+  padding: 8% 9%;
+  overflow: hidden;
+  border-radius: 1px 3px 3px 1px;
+  box-shadow: 0 26px 70px -16px rgba(0, 0, 0, 0.66);
+  font-family: var(--font-serif);
 }
 
-.press-open-cover {
+.press-open-eyebrow {
+  font-size: 0.58em;
+  font-style: italic;
+  letter-spacing: 0.04em;
+}
+
+.press-open-page-title {
+  font-size: 0.95em;
+  font-weight: 600;
+  line-height: 1.22;
+  text-wrap: balance;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 6;
+  overflow: hidden;
+}
+
+.press-open-page-byline {
+  font-size: 0.56em;
+  font-style: italic;
+}
+
+/* The gutter: the permanent crease shadow where the page meets the spine.
+ * Unlike the cast shadow below it does NOT fade — an open book always has it,
+ * and it is what stops the revealed page reading as a flat white card. */
+.press-open-page::after {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 9%;
+  background: linear-gradient(90deg, rgba(0, 0, 0, 0.22) 0%, rgba(0, 0, 0, 0.05) 55%, transparent 100%);
+  pointer-events: none;
+}
+
+/* Beat 2 — the shadow the closed cover casts on the page, sliding off to the
+ * right as the leaf lifts away. */
+.press-open-page-shade {
   position: absolute;
   inset: 0;
-  padding: clamp(16px, 1.5vw, 24px);
-  padding-left: calc(clamp(16px, 1.5vw, 24px) + 12px);
-  overflow: hidden;
-  border-radius: 1px 4px 4px 1px;
+  background: linear-gradient(90deg, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.16) 45%, transparent 100%);
   transform-origin: left center;
+  transition: opacity 460ms ease 250ms, transform 460ms ease 250ms;
+}
+
+.press-open-stage.is-open .press-open-page-shade {
+  opacity: 0;
+  transform: scaleX(0.2);
+}
+
+/* Beat 2 — the cover, hinged on the spine. */
+.press-open-leaf {
+  position: absolute;
+  inset: 0;
+  transform-origin: left center;
+  transform-style: preserve-3d;
   transform: rotateY(0deg);
-  transition: transform 620ms cubic-bezier(0.4, 0, 0.2, 1);
-  backface-visibility: hidden;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.45);
+  transition: transform 620ms cubic-bezier(0.34, 0.62, 0.24, 1) 240ms;
   will-change: transform;
 }
 
+.press-open-stage.is-open .press-open-leaf {
+  transform: rotateY(-166deg);
+}
+
+.press-open-face {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  border-radius: 1px 3px 3px 1px;
+  backface-visibility: hidden;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.45);
+}
+
+.press-open-face--front {
+  padding: clamp(16px, 1.5vw, 24px);
+  padding-left: calc(clamp(16px, 1.5vw, 24px) + 12px);
+}
+
+/* The reverse of the cover is an endpaper, not a mirrored jacket: darkened
+ * board with the paper edge showing at the hinge. */
+.press-open-face--back {
+  transform: rotateY(180deg);
+  border-radius: 3px 1px 1px 3px;
+  filter: brightness(0.62) saturate(0.7);
+  box-shadow: inset -6px 0 12px -6px rgba(0, 0, 0, 0.55);
+}
+
+/* Beat 4 — the page swells into the ground the article renders on. */
 .press-open-veil {
   position: absolute;
   inset: 0;
   opacity: 0;
-  /* Held back until the swing is most of the way through, so the reader sees
-   * the book open before the page takes over. */
-  transition: opacity 260ms ease 330ms;
+  transition: opacity 260ms ease 860ms;
+}
+
+.press-open-stage.is-open .press-open-veil {
+  opacity: 1;
 }
 
 .press-open-stage.is-clearing .press-open-veil {
   opacity: 0;
-  transition: opacity 280ms ease;
+  transition: opacity 260ms ease;
+}
+
+.press-open-stage.is-clearing .press-open-scrim {
+  opacity: 0;
 }
 
 @media (prefers-reduced-motion: reduce) {
   /* openBookThen() bails before building the stage, but keep the belt-and-
    * braces rule in case a stage is ever left on screen. */
+  .press-open-scrim,
   .press-open-book,
-  .press-open-cover,
+  .press-open-leaf,
+  .press-open-page-shade,
   .press-open-veil {
     transition: none;
   }


### PR DESCRIPTION
Rebuilds the research index on the [press.stripe.com](https://press.stripe.com/) product-list design — specifically its non-WebGL rendering, which is the layout sitting underneath the 3D book carousel.

## What changed

- **Ground + masthead.** The page drops to Stripe Press's warm near-black (`#201819`) with a serif masthead — name over an italic tagline — aligned to the app's own optical column.
- **One band per article.** Each row is a full-bleed band painted in its own book-jacket palette, title underlined and centred, byline beside it. The byline is the authoring model, in the slot a book list gives the author.
- **Jackets.** The 20 real cover pairs lifted from press.stripe.com, keyed off `[data-jacket]` in CSS — index markup goes through DOMPurify, so inline `style=""` would not survive. `researchJacket()` hashes the slug so an article keeps its colour across reloads; `researchJacketsForPage()` walks collisions forward so no two bands on a page share one.
- **Contrast.** Two Stripe pairs sit under 4.5:1 for small text, and our byline is smaller than theirs. Jacket 1's ground and jacket 6's ink are darkened; all 20 now clear 4.6:1.
- **Scope.** The press ground is a token remap on `body.research-shelf`, so tabs, buttons, pagination and the footer follow with no per-component overrides. Added by `renderResearchIndex`, cleared centrally in `load()` — the article view keeps its reading chrome untouched.

Two fixes picked up along the way:

- Titles stored with baked-in HTML entities rendered raw on the index (`Why Hims &amp;amp; Hers…`). `decodeStoredEntities()` undoes that before escaping.
- Bands carry `role="link"` instead of being a bare focusable `<li>`; the existing `[data-slug]` keydown handler already activated them on Enter.

Kind/tag chips are dropped from the index. Every indexed row is a `fragment`, so the ARTICLE chip carried no information; tags remain searchable.

## Verified

- `bun run typecheck`, `bun run build`, `bun run test` (13/13) all green.
- Rendered at 1440x900 and 390x844 against the local dev server: bands, jacket assignment (12 unique per page on pages 1 and 2), sticky nav backdrop, pagination, footer.
- Navigation: clicking a band routes to the article and clears the press ground (body back to `rgb(244,245,248)`); back restores the shelf; switching to Wiki and back behaves.
- No console errors.
- Accessibility tree announces each band as a link named "&lt;title&gt; &lt;model&gt; · &lt;age&gt;".

## Notes

- Deliberately dark in both light and dark OS themes — Stripe Press is, and the token remap fully shadows the `prefers-color-scheme` block for this route.
- `searchTerm` is currently never assigned anywhere in `main.ts`, so the index's `<mark>` highlight path is dead today. Preserved as-is rather than changed in a design PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)