### PR TITLE
Clamp article TOC entries to two lines instead of cutting mid-word

### DIFF
--- a/dashboard/src/ara-enhance.ts
+++ b/dashboard/src/ara-enhance.ts
@@ -1728,7 +1728,15 @@ function renderResearchTOC(article: HTMLElement): void {
     if (h.classList.contains('ara-h3')) li.style.paddingLeft = '14px';
     const num = h.querySelector('.ara-h2-num');
     const restText = (h.textContent || '').replace(num?.textContent || '', '').trim();
-    a.textContent = restText;
+    // The label is its own span so the two-line clamp can sit on a box with no
+    // vertical padding. -webkit-line-clamp leaves the extra lines in the box
+    // and leans on overflow to hide them, and overflow clips at the PADDING
+    // edge — clamping the padded <a> directly let the top sliver of line three
+    // bleed through underneath.
+    const label = document.createElement('span');
+    label.className = 'ara-toc-label';
+    label.textContent = restText;
+    a.appendChild(label);
     // CSS clips overflow with ellipsis; surface the full title on hover.
     a.title = restText;
     a.dataset.target = h.id;

--- a/dashboard/src/components/ara-research.css
+++ b/dashboard/src/components/ara-research.css
@@ -2311,7 +2311,7 @@ body.ara-figure-modal-open {
 
 .ara-toc-link {
   display: block;
-  padding: 5px 0 5px 14px;
+  padding: 6px 0 6px 14px;
   margin-left: -2px;
   border-left: 2px solid transparent;
   font-size: 0.82rem;
@@ -2320,12 +2320,26 @@ body.ara-figure-modal-open {
   line-height: 1.35;
   transition: color 0.15s, border-color 0.15s;
   cursor: pointer;
-  /* Long subheading titles like "Bloom Energy (BE) — 16.5% combined, the
-   * keystone" would otherwise wrap to 3 lines and dominate the rail. Clip
-   * with ellipsis; full text is restored via the title= tooltip set in JS. */
+}
+
+/* Two lines, not one. The rail does have to be bounded — an unclamped
+ * "Bloom Energy (BE) — 16.5% combined, the keystone" runs to three lines and
+ * dominates it — but clipping at ONE line cut almost every real section head
+ * mid-word, so the rail read as a column of fragments. Two lines hold ~60
+ * characters at this width, which is most heads whole, and anything longer
+ * breaks at a word and ellipses at the end of the second line. Full text
+ * stays on the title= tooltip set in renderResearchTOC.
+ *
+ * This lives on the label span, not the padded <a>: -webkit-line-clamp keeps
+ * the overflowing lines in the box and relies on overflow to hide them, and
+ * overflow clips at the padding edge — so a clamped <a> with vertical padding
+ * shows the top sliver of line three below the ellipsis. */
+.ara-toc-label {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow-wrap: break-word;
 }
 
 .ara-toc-link:hover {


### PR DESCRIPTION
The floating TOC on `/research/*` clipped every entry to one line, so most section heads arrived as fragments — "Kratsios vs. Moonshot: an accusat…", "The chip numbers get specific — a…".

The bound itself is correct: an unclamped "Bloom Energy (BE) — 16.5% combined, the keystone" runs to three lines and takes over the rail. One line was just too tight. Two lines hold ~60 characters at the rail's 240px, which is most heads whole, and anything longer breaks at a word and ellipses at the end of line two. The `title=` tooltip still carries the full text.

**The clamp sits on a new `.ara-toc-label` span, not the `<a>`.** `-webkit-line-clamp` leaves the overflowing lines in the box and relies on `overflow` to hide them, and `overflow` clips at the *padding* edge — so clamping the padded anchor directly left the top sliver of line three visible under the ellipsis. The label span has no vertical padding, so it clips flush at the content edge.

## Verified

On `/research/deepseek-s-wenfeng-details-huawei-chip-access-and-tilelang-a-2`:

- 8 of 9 entries now render whole; the one that still truncates ends at a word boundary on line two.
- Label boxes measure 37px (2 lines) / 18px (1 line) with `scrollHeight - clientHeight == 0` on every unclipped entry — no bleed.
- `title=` intact (full 92-char heading), active-state border still resolves, and clicking an entry still pushes the fragment and scrolls (`#the-chip-numbers-get-specific-and-thinner`).
- `bun run build`, 13/13 dashboard tests, 48 `test_ara_dsl.py` tests.

## Catalog note

`.ara-toc-label` is a runtime TOC extra injected by `renderResearchTOC`, not an article primitive — it never appears in `.ara.md`, so it stays out of `ARA_CATALOG.json`/`COMPONENTS.md` per the "Component catalog" rule in CLAUDE.md. `test_ara_dsl.py` confirms the catalog ↔ COMPONENTS.md lockstep is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)