### PR TITLE
Keep empty-lane absence notices off the front page

### DIFF
--- a/scripts/render_front_page.mjs
+++ b/scripts/render_front_page.mjs
@@ -438,6 +438,7 @@ function renderAraSource(images = []) {
     ...research.map((t) => ({ text: t, tag: "Research" })),
     ...business.map((t) => ({ text: t, tag: "Capital" })),
   ]
+    .filter((card) => !isAbsenceNotice(stripMarkdown(card.text)))
     .map((card) => ({ headline: conciseStory(card.text), tag: card.tag }))
     .filter((card) => card.headline)
     .slice(0, 10);
@@ -636,6 +637,21 @@ function clauseCut(text) {
         && head.length >= STORY_CHAR_FLOOR) return head;
   }
   return null;
+}
+
+// When a lane lands nothing, the digest says so in prose — "No new arXiv
+// papers surfaced in today's sweep". That is honest inside the digest, but as
+// a front-page card it is filler: the 2026-07-26 edition ran three of eight
+// cards on absence notices, and they were the only truncated ones. A paper
+// prints the stories it has and stays quiet about the ones it doesn't.
+//
+// Anchored on a leading "No" as a whole word plus an absence verb, so a real
+// headline is safe: "No-code AI tools surge" fails \bNo\s, and "Nokia ships"
+// fails both.
+const ABSENCE_RE = /^No\s+(?=[\s\S]*\b(surfaced|reported|identified|landed|available|signal|in today's|this cycle)\b)/i;
+
+function isAbsenceNotice(text) {
+  return ABSENCE_RE.test(text.trim());
 }
 
 function conciseStory(text) {


### PR DESCRIPTION
The first edition rendered under the new prompt (2026-07-26) ran **three of its eight story cards** on notices that nothing happened:

```
[Models  ] No other new model releases surfaced in today's RSS sweep
[Research] No new arXiv papers surfaced in today's RSS-sourced sweep (b…
[Capital ] No funding, acquisition, or partnership signal in today's…
```

Saying so *inside the digest* is honest reporting about coverage. Printing it as a front-page story card is filler — and these were also the only cards still truncating, because an absence notice is a plain sentence with no clause boundary to cut at, so it falls through to the ellipsis path.

A paper prints the stories it has and stays quiet about the ones it doesn't.

## Safety of the match

Anchored on a leading `No` **as a whole word** AND an absence verb elsewhere in the line — a bare `/^No/` would eat real headlines. Verified:

| input | filtered |
|---|---|
| No other new model releases surfaced in today's RSS sweep | yes |
| No new arXiv papers surfaced in today's RSS-sourced sweep | yes |
| No funding, acquisition, or partnership signal in today's available sources | yes |
| No-code AI tools surge among enterprise buyers | **no** |
| Nokia ships an AI radio stack | **no** |
| No Man's Sky adds an AI companion | **no** |

## Result

- 2026-07-26: **8 cards → 5**, truncated **1 → 0**
- 2026-07-25 regression check: 10 → 10, truncated 0 (that edition had no absence notices, so it is untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)