### PR TITLE
Rebuild the research shelf as books seen edge-on, opening continuously

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -31,7 +31,11 @@
     </script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&family=Source+Serif+4:ital,opsz,wght@0,8..60,300;0,8..60,400;0,8..60,500;0,8..60,600;0,8..60,700;1,8..60,400;1,8..60,500&display=swap" rel="stylesheet">
+    <!-- Playfair Display / Space Grotesk / Libre Baskerville are the research
+         shelf's imprint faces: each model family gets its own typeface on its
+         book, the way a publishing house has a house face. Only the weights the
+         spines actually set are requested. See researchImprint() in main.ts. -->
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;700&family=Source+Serif+4:ital,opsz,wght@0,8..60,300;0,8..60,400;0,8..60,500;0,8..60,600;0,8..60,700;1,8..60,400;1,8..60,500&family=Playfair+Display:ital,wght@0,600;0,700;1,600&family=Space+Grotesk:wght@500;700&family=Libre+Baskerville:ital,wght@0,700;1,400&display=swap" rel="stylesheet">
   </head>
   <body>
     <div class="app">

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -4349,6 +4349,24 @@ function researchJacket(slug: string): number {
 }
 
 /**
+ * Model family → imprint. Each lab gets its own typeface on its books, the way
+ * a publishing house has a house face, so the shelf reads as a shelf of
+ * imprints rather than one press with twenty jacket colours. Keyed on the
+ * FAMILY, not the version: claude-opus-4-7 and claude-sonnet-5 are the same
+ * house. The faces themselves are declared in style.css on [data-imprint].
+ * Anything unrecognised falls through to the house face.
+ */
+function researchImprint(model: string): string {
+  const m = model.toLowerCase();
+  if (m.includes('claude') || m.includes('opus') || m.includes('sonnet') || m.includes('fable')) return 'claude';
+  if (m.includes('deepseek')) return 'deepseek';
+  if (m.includes('kimi') || m.includes('moonshot')) return 'kimi';
+  if (m.includes('gpt') || m.includes('codex')) return 'codex';
+  if (m.includes('glm') || m.includes('zai')) return 'glm';
+  return 'house';
+}
+
+/**
  * Jacket the index actually painted each cover with, so the article page can
  * open in the SAME colour the reader just clicked. The per-page de-duplication
  * below can move a book off its raw hash, so re-hashing on the article page
@@ -4394,32 +4412,400 @@ function decodeStoredEntities(text: string): string {
   });
 }
 
-/* Book-opening transition. Beats, in order (durations + delays live in the
- * .press-open-* rules; these constants only drive the JS handoffs):
- *   0ms    lift    — the book rises off the shelf to the middle of the screen,
- *                    scrim dims the rest to 0.62 so the shelf stays faintly
- *                    behind it. It scales from its SPINE, so the spread it is
- *                    about to occupy is already centred.
- *   240ms  open    — the front cover swings back around the spine, revealing
- *                    the article's title page. The cover's shadow slides off
- *                    the page as it goes, and the back of the cover is an
- *                    endpaper, not a mirrored jacket.
- *   560ms  deepen  — the scrim closes to 0.97 under the open book.
- *   850ms  swap    — the article renders behind that near-opaque scrim.
- *   ~900ms reveal  — the whole stage fades off, uncovering the article.
+/* Scroll drift — "like the wind blew a bit".
  *
- * There is deliberately NO full-screen veil. An earlier cut faded one in over
- * everything and back out, which read as the page flashing white on every
- * open. The scrim deepening instead hides the shelf→article ground swap
- * without ever painting the viewport a flat colour.
+ * Each board's resting angle is nudged by a few degrees as the shelf moves,
+ * driven by where the book sits in the viewport rather than by a clock, so it
+ * only ever moves when the reader does and settles the instant they stop.
+ * PHASE spreads the books apart: keyed off the jacket index, so neighbours are
+ * at different points in the swing instead of tipping in lockstep. */
+const SHELF_DRIFT_DEG = 3.2;
+let shelfDriftFrame = 0;
+
+function driftShelfBoards(): void {
+  shelfDriftFrame = 0;
+  const books = document.querySelectorAll<HTMLElement>('.press-book');
+  if (!books.length) return;
+  const h = window.innerHeight || 1;
+  books.forEach((book) => {
+    const r = book.getBoundingClientRect();
+    // Skip anything off screen: no work, and no stale angle left behind
+    // because it is reset the moment it scrolls back into view.
+    if (r.bottom < -200 || r.top > h + 200) return;
+    // -1 at the top of the viewport, +1 at the bottom.
+    const pos = ((r.top + r.height / 2) / h) * 2 - 1;
+    const phase = (Number(book.dataset.jacket || 0) / RESEARCH_JACKET_COUNT) * Math.PI * 2;
+    const deg = Math.sin(pos * Math.PI + phase) * SHELF_DRIFT_DEG;
+    book.style.setProperty('--lay-drift', `${deg.toFixed(2)}deg`);
+  });
+}
+
+function scheduleShelfDrift(): void {
+  if (shelfDriftFrame) return;
+  shelfDriftFrame = requestAnimationFrame(driftShelfBoards);
+}
+
+/** Idempotent: renderResearchIndex calls it on every paint. */
+function watchShelfDrift(): void {
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+  window.removeEventListener('scroll', scheduleShelfDrift);
+  window.addEventListener('scroll', scheduleShelfDrift, { passive: true });
+  driftShelfBoards();
+}
+
+interface ShelfMeasure {
+  L0: number;   // spine width  — the hinge line's length
+  T0: number;   // spine height — the book's thickness
+  D0: number;   // board's untransformed depth
+  lay0: number; // the board's LIVE angle, hover and drift included
+  Hx0: number;  // hinge midpoint x
+  Hy0: number;  // hinge y (the spine plate's top edge)
+}
+
+interface BookStage {
+  stage: HTMLElement;
+  volume: HTMLElement;
+  body: HTMLElement;
+  spine: HTMLElement;
+  leaf: HTMLElement;
+  sheet: HTMLElement;
+  paper: HTMLElement;
+  fallback: HTMLElement;
+}
+
+/**
+ * Measure the book as it actually sits on the shelf, right now.
  *
- * Nothing here is load-bearing: reduced-motion readers, an unmeasurable
- * element, and a stalled fetch all land on the same article. */
-const BOOK_OPEN_NAVIGATE_AT_MS = 850;
-const BOOK_OPEN_SEQUENCE_MS = 900;
+ * Everything here is read from live layout rather than from the custom
+ * properties, and that is the point:
+ *  - `--depth`/`--spine-h` are unregistered, so getPropertyValue hands back the
+ *    literal `clamp(...)` token, not a length;
+ *  - the board's angle at click time is NOT `--lay`. You are hovering when you
+ *    click, so it is the hover angle, plus whatever `--lay-drift` the scroll
+ *    handler last wrote. Both are only visible in the computed matrix.
+ */
+function measureShelfBook(book: HTMLElement): ShelfMeasure | null {
+  const spine = book.querySelector<HTMLElement>('.press-book-spine');
+  const board = book.querySelector<HTMLElement>('.press-book-board');
+  if (!spine || !board) return null;
+  const rs = spine.getBoundingClientRect();
+  if (rs.width < 1 || rs.height < 1) return null;
+  const cs = getComputedStyle(board);
+  const D0 = parseFloat(cs.height);
+  if (!(D0 > 0)) return null;
+  // rotateX(θ) lands as matrix3d with m22 = cosθ, m23 = sinθ.
+  let lay0 = 79;
+  try {
+    const m = new DOMMatrix(cs.transform);
+    lay0 = (Math.atan2(m.m23, m.m22) * 180) / Math.PI;
+  } catch {
+    /* keep the fallback */
+  }
+  return {
+    L0: rs.width,
+    T0: rs.height,
+    D0,
+    lay0,
+    Hx0: rs.left + rs.width / 2,
+    Hy0: rs.top,
+  };
+}
+
+/** Where the risen cover ends up: portrait, centred, bounded by both axes. */
+function risenCover(): { L1: number; D1: number; Hx1: number; Hy1: number } {
+  const coverH = Math.min(
+    window.innerHeight * BOOK_OPEN_FILL_H,
+    (window.innerWidth * BOOK_OPEN_FILL_W * BOOK_COVER_RATIO) / 2,
+  );
+  const coverW = coverH / BOOK_COVER_RATIO;
+  // The body's L runs ALONG the hinge and D runs hinge→fore-edge. After the
+  // volume's +90deg roll, L reads as screen height and D as screen width — so
+  // the cover's height is L and its width is D.
+  return { L1: coverH, D1: coverW, Hx1: window.innerWidth / 2, Hy1: window.innerHeight / 2 };
+}
+
+/**
+ * The article card's on-screen paper, clipped to the viewport. The open book's
+ * page settles onto exactly this so the reader never sees the page and the
+ * article swap at different sizes. Height is capped at the fold because a full
+ * article card can be twenty thousand pixels tall and only its top is on screen.
+ */
+function articlePaperRect(): { left: number; top: number; width: number; height: number } | null {
+  const card = document.querySelector<HTMLElement>('.content-card.gen-research-doc');
+  if (!card) return null;
+  const r = card.getBoundingClientRect();
+  const top = Math.max(r.top, 0);
+  const height = Math.min(r.height, window.innerHeight - top);
+  if (r.width < 1 || height < 1) return null;
+  return { left: r.left, top, width: r.width, height };
+}
+
+/**
+ * Build the overlay both directions share.
+ *
+ * The thesis: the shelf book already IS the risen book. Its spine plate is the
+ * book's thickness and its `.press-book-board` is the front cover, hinged on the
+ * spine's top edge. So the clone does not REPAINT a portrait cover next to the
+ * shelf book — it re-hosts the shelf's own elements, reusing `.press-book-spine`,
+ * `.press-book-board-face` and the three type spans verbatim. That reuse is what
+ * buys pixel identity at t=0: the gradients, the shoulders, the drop shadow and
+ * the feTurbulence grain all reproduce because they are literally the same
+ * declarations, and the grain is a fixed-px tile so reproportioning crops it
+ * rather than stretching it.
+ *
+ * The frame is three nested boxes:
+ *   .press-open-volume  a ZERO-SIZE anchor pinned to the hinge. Carries the roll
+ *                       (rotate 0deg → 90deg) that turns the book from lying
+ *                       across the column to standing portrait.
+ *   .press-open-body    the board plane. left:-L/2 top:-D width:L height:D, so
+ *                       its bottom-centre is the volume's origin for ANY L,D —
+ *                       which is why the reproportion never moves the pivot.
+ *                       Carries the tip (rotateX lay0 → 0deg).
+ *   children            spine plate, boards, page and the hinged leaf, all in
+ *                       body-local space where +x runs along the hinge.
+ *
+ * Type lives in zero-size hinge-anchored boxes carrying a counter-roll, so it is
+ * upright from its first visible pixel and never reflows while L and D animate.
+ *
+ * Built with direct DOM calls rather than setSafeContent — the inline geometry
+ * could not survive DOMPurify. Jacket and imprint ride on the stage as data
+ * attributes; both palette tables are bare attribute selectors, so CSS resolves
+ * --jacket-bg/--jacket-ink/--imprint-face for everything inside.
+ */
+function buildBookStage(spec: {
+  jacket: number;
+  imprint: string;
+  title: string;
+  author: string;
+  date: string;
+  ground: string;
+}): BookStage {
+  const rootStyle = getComputedStyle(document.documentElement);
+  const readToken = (name: string, fallback: string): string =>
+    rootStyle.getPropertyValue(name).trim() || fallback;
+
+  const stage = document.createElement('div');
+  stage.className = 'press-open-stage';
+  stage.dataset.jacket = String(spec.jacket);
+  stage.dataset.imprint = spec.imprint;
+
+  const scrim = document.createElement('div');
+  scrim.className = 'press-open-scrim';
+
+  const ground = document.createElement('div');
+  ground.className = 'press-open-ground';
+  ground.style.background = spec.ground;
+
+  const volume = document.createElement('div');
+  volume.className = 'press-open-volume';
+
+  const body = document.createElement('div');
+  body.className = 'press-open-body';
+
+  // The spine plate — the shelf's own class, so the cloth, the shoulders, the
+  // head highlight, the grain and the drop shadow all come free.
+  const spine = document.createElement('div');
+  spine.className = 'press-open-spine press-book-spine';
+  const author = document.createElement('span');
+  author.className = 'press-book-author';
+  author.textContent = spec.author;
+  const spineTitle = document.createElement('span');
+  spineTitle.className = 'press-book-title';
+  spineTitle.textContent = spec.title;
+  const imprint = document.createElement('span');
+  imprint.className = 'press-book-imprint';
+  if (spec.date) {
+    const date = document.createElement('span');
+    date.className = 'press-book-date';
+    date.textContent = spec.date;
+    imprint.appendChild(date);
+  }
+  spine.append(author, spineTitle, imprint);
+
+  // Back board and text block, invisible at t=0 — the shelf shows no page.
+  const base = document.createElement('div');
+  base.className = 'press-open-base';
+  const block = document.createElement('div');
+  block.className = 'press-open-block';
+
+  const page = document.createElement('div');
+  page.className = 'press-open-page';
+  page.style.background = readToken('--bg', '#ffffff');
+  page.style.color = readToken('--text', '#16181d');
+
+  const pageShade = document.createElement('div');
+  pageShade.className = 'press-open-page-shade';
+
+  // Hinge-anchored, counter-rolled, fixed-px: upright from the first frame and
+  // never re-typeset while the body reproportions underneath it.
+  const cover = risenCover();
+  const pageW = cover.D1 - 18;   // page inset 7px each side in body-local x
+  const pageH = cover.L1 - 14;
+
+  const pageText = document.createElement('div');
+  pageText.className = 'press-open-pagetext';
+  const pageInner = document.createElement('div');
+  pageInner.className = 'press-open-inner';
+  // Fixed px, anchored at the hinge: the one point in body-local space that
+  // does not move when L and D animate. So the type is upright from its first
+  // visible pixel and never re-typesets while the body reproportions.
+  pageInner.style.left = '0px';
+  pageInner.style.top = `${-(cover.L1 / 2 - 7)}px`;
+  pageInner.style.width = `${pageW}px`;
+  pageInner.style.height = `${pageH}px`;
+  pageInner.style.padding = `${Math.round(pageH * 0.075)}px ${Math.round(pageW * 0.09)}px`;
+  pageInner.style.fontSize = `${Math.round(cover.D1 * 0.062)}px`;
+  const eyebrow = document.createElement('span');
+  eyebrow.className = 'press-open-eyebrow';
+  eyebrow.textContent = spec.author;
+  const pageTitle = document.createElement('span');
+  pageTitle.className = 'press-open-page-title';
+  pageTitle.textContent = spec.title;
+  const pageByline = document.createElement('span');
+  pageByline.className = 'press-open-page-byline';
+  pageByline.style.color = readToken('--text-tertiary', '#6b7280');
+  pageByline.textContent = spec.date;
+  pageInner.append(eyebrow, pageTitle, pageByline);
+
+  // The article's own first page, laid on the paper. It is authored at the
+  // article card's width and scaled down to the page, so the settle can take
+  // the scale to 1 as the page grows to the card — the type never reflows and
+  // the two are the same document at the same size by the time they meet.
+  // Until the fetch lands, the synthesised title page above stands in.
+  const paper = document.createElement('div');
+  paper.className = 'press-open-paper';
+  paper.style.left = '0px';
+  paper.style.top = `${-(cover.L1 / 2 - 7)}px`;
+  paper.style.width = `${pageW}px`;
+  paper.style.height = `${pageH}px`;
+  const sheet = document.createElement('div');
+  sheet.className = 'press-open-sheet';
+  sheet.style.width = `${BOOK_SHEET_W}px`;
+  sheet.style.transform = `scale(${pageW / BOOK_SHEET_W})`;
+  paper.appendChild(sheet);
+
+  pageText.append(pageInner, paper);
+  page.append(pageShade, pageText);
+
+  // The cover: the same board, now hinged so it can swing off the page.
+  const leaf = document.createElement('div');
+  leaf.className = 'press-open-leaf';
+  const front = document.createElement('div');
+  front.className = 'press-open-face press-open-face--front';
+  const leafSkin = document.createElement('div');
+  leafSkin.className = 'press-open-leafskin';
+  const boardFace = document.createElement('div');
+  boardFace.className = 'press-book-board-face';
+  leafSkin.appendChild(boardFace);
+  const coverText = document.createElement('div');
+  coverText.className = 'press-open-covertext';
+  const coverInner = document.createElement('div');
+  coverInner.className = 'press-open-inner press-open-inner--cover';
+  coverInner.style.left = '0px';
+  coverInner.style.top = `${-cover.L1 / 2}px`;
+  coverInner.style.width = `${cover.D1}px`;
+  coverInner.style.height = `${cover.L1}px`;
+  coverInner.style.padding = `${Math.round(cover.L1 * 0.05)}px ${Math.round(cover.D1 * 0.07)}px`;
+  const coverTitle = document.createElement('span');
+  coverTitle.className = 'press-open-cover-title';
+  coverTitle.textContent = spec.title;
+  coverInner.appendChild(coverTitle);
+  coverText.appendChild(coverInner);
+  front.append(leafSkin, coverText);
+  const back = document.createElement('div');
+  back.className = 'press-open-face press-open-face--back';
+  leaf.append(front, back);
+
+  body.append(spine, base, block, page, leaf);
+  volume.appendChild(body);
+  stage.append(scrim, ground, volume);
+  return { stage, volume, body, spine, leaf, sheet, paper, fallback: pageInner };
+}
+
+/** Pose the clone as the book lying on the shelf. */
+function poseLying(s: BookStage, m: ShelfMeasure): void {
+  s.stage.style.perspectiveOrigin = `${m.Hx0}px ${m.Hy0}px`;
+  s.volume.style.left = `${m.Hx0}px`;
+  s.volume.style.top = `${m.Hy0}px`;
+  s.volume.style.transform = 'rotate(0deg)';
+  s.body.style.left = `${-m.L0 / 2}px`;
+  s.body.style.top = `${-m.D0}px`;
+  s.body.style.width = `${m.L0}px`;
+  s.body.style.height = `${m.D0}px`;
+  s.body.style.transform = `rotateX(${m.lay0}deg)`;
+  s.spine.style.height = `${m.T0}px`;
+  // The plate turns away by exactly as much as the board turns toward us, so at
+  // rest the two are complementary and the plate faces the reader square-on.
+  s.spine.style.transform = `rotateX(${-m.lay0}deg) translateZ(0.5px)`;
+  // The leaf is deliberately NOT posed here. On the open path its angle comes
+  // from the .is-open rule, and an inline transform would silently outrank it —
+  // the cover would never swing. The close path sets it explicitly instead.
+}
+
+/** Pose the clone as the book standing upright, cover shut, at the centre. */
+function poseStanding(s: BookStage, cover: ReturnType<typeof risenCover>): void {
+  s.stage.style.perspectiveOrigin = `${cover.Hx1}px ${cover.Hy1}px`;
+  s.volume.style.left = `${cover.Hx1}px`;
+  s.volume.style.top = `${cover.Hy1}px`;
+  s.volume.style.transform = 'rotate(90deg)';
+  s.body.style.left = `${-cover.L1 / 2}px`;
+  s.body.style.top = `${-cover.D1}px`;
+  s.body.style.width = `${cover.L1}px`;
+  s.body.style.height = `${cover.D1}px`;
+  s.body.style.transform = 'rotateX(0deg)';
+  // A constant, not lay0: the standing plate is the article's 12px jacket rail.
+  s.spine.style.transform = `rotateX(${-BOOK_SPINE_STANDING_DEG}deg) translateZ(0.5px)`;
+}
+
+/** Pose the body onto a screen-space rect, in the rolled frame. */
+function poseOnRect(
+  s: BookStage,
+  rect: { left: number; top: number; width: number; height: number },
+): void {
+  // Rolled 90deg, body-local +x is screen-vertical: L is the rect's height and
+  // D its width, hinged on the rect's left edge at its vertical midpoint.
+  const hx = rect.left;
+  const hy = rect.top + rect.height / 2;
+  s.stage.style.perspectiveOrigin = `${hx}px ${hy}px`;
+  s.volume.style.left = `${hx}px`;
+  s.volume.style.top = `${hy}px`;
+  s.volume.style.transform = 'rotate(90deg)';
+  s.body.style.left = `${-rect.height / 2}px`;
+  s.body.style.top = `${-rect.width}px`;
+  s.body.style.width = `${rect.height}px`;
+  s.body.style.height = `${rect.width}px`;
+  s.body.style.transform = 'rotateX(0deg)';
+}
+
+/* Opening a book. The rise and the cover-swing are one gesture, not a queue:
+ *   0ms    tip     — the board opens out from its 31px sliver toward the reader,
+ *                    everything still square to the shelf. This is the frame
+ *                    budget in which the reader confirms it is the book they
+ *                    clicked, so nothing else moves in it.
+ *   90ms   roll    — the volume turns 90deg about the hinge, taking the book
+ *                    from lying across the column to standing portrait. The
+ *                    hinge itself travels only ~43px; the pivot barely moves,
+ *                    which is the structural reason this reads as continuous.
+ *   120ms  wash    — the screen takes the book's own jacket colour.
+ *   400ms  swing   — the cover starts falling open while the book is still ~22deg
+ *                    off upright, so the two beats interlock.
+ *   560ms  ground  — the destination's ground arrives under the wash.
+ *   740ms  swap    — the article renders behind it, invisibly.
+ *   ~820ms settle  — the page grows onto the article card's exact paper.
+ *
+ * The clone is pixel-identical to the shelf book at t=0 — it re-hosts the
+ * shelf's own elements rather than repainting a portrait cover — so there is no
+ * swap to see. See buildBookStage().
+ *
+ * Nothing here is load-bearing: reduced motion, an unmeasurable book, a missing
+ * article card and a stalled fetch all still land on the article.
+ */
+const BOOK_OPEN_NAVIGATE_AT_MS = 740;
+const BOOK_OPEN_SEQUENCE_MS = 820;
+const BOOK_OPEN_SETTLE_MS = 480;
 const BOOK_OPEN_CLEAR_MS = 340;
 /** Never hold the reader on the open book if the article fetch stalls. */
-const BOOK_OPEN_MAX_HOLD_MS = 2400;
+const BOOK_OPEN_MAX_HOLD_MS = 2600;
 
 /** Fraction of the viewport the opened spread is allowed to fill. */
 const BOOK_OPEN_FILL_H = 0.68;
@@ -4427,138 +4813,249 @@ const BOOK_OPEN_FILL_H = 0.68;
  * height-limited case, so raising this buys presence on small screens for
  * free. */
 const BOOK_OPEN_FILL_W = 0.94;
+/** Cover proportions of the risen book (height / width) — a trade hardback. */
+const BOOK_COVER_RATIO = 7 / 5;
+/* The standing spine plate's angle. A constant rather than the measured lay,
+ * because its job at the end is to project the 12px jacket rail that
+ * .gen-research-doc[data-jacket] wears down the article card's edge. */
+const BOOK_SPINE_STANDING_DEG = 82;
+/* The width the article's first page is laid out at inside the book: the
+ * article's OWN column on a full-width desktop card (card 1102 less the 12px
+ * jacket rail and 2x32 body padding). Authoring at the column width means the
+ * settle only ever changes the sheet's scale and offset — never its width — so
+ * the type never re-wraps on the way to meeting the real article. */
+const BOOK_SHEET_W = 1026;
+/* The sheet's origin already coincides with the page's content origin, so the
+ * page's inset and the card's jacket rail need no correction on x — subtracting
+ * them landed the sheet exactly 19px (7 + 12) left of the article. Only y keeps
+ * a small residual, from the page box being bottom-anchored in the body while
+ * the card is top-anchored. Measured, not derived. */
+const BOOK_SHEET_Y_TRIM = 6;
 
-/**
- * Clone the clicked cover into a fixed overlay and play the sequence above.
- * The overlay is built with direct DOM calls rather than setSafeContent, so
- * the per-book geometry and jacket colours never meet DOMPurify.
- */
+/** The shelf's ground is a BODY-scoped remap, so :root would hand back the article's. */
+function pressGround(): string {
+  return getComputedStyle(document.body).getPropertyValue('--press-ground').trim() || '#201819';
+}
+
+function articleGround(): string {
+  return (
+    getComputedStyle(document.documentElement).getPropertyValue('--bg-secondary').trim() || '#f4f5f8'
+  );
+}
+
 function openBookThen(book: HTMLElement, navigate: () => Promise<void>): void {
-  const rect = book.getBoundingClientRect();
-  const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-  if (reduce || rect.width < 1 || rect.height < 1) {
+  const m = measureShelfBook(book);
+  if (!m || window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
     void navigate();
     return;
   }
 
-  const bookStyle = getComputedStyle(book);
-  const jacketBg = bookStyle.backgroundColor;
-  const jacketInk = bookStyle.color;
-  // Read the DESTINATION palette off :root. body still carries the shelf's
-  // token remap at this point, so reading from body would hand back the press
-  // ground and the title page would come up dark before the article paints.
-  const rootStyle = getComputedStyle(document.documentElement);
-  const readToken = (name: string, fallback: string): string =>
-    rootStyle.getPropertyValue(name).trim() || fallback;
-  const paper = readToken('--bg', '#ffffff');
-  const paperInk = readToken('--text', '#16181d');
-  const paperFaint = readToken('--text-tertiary', '#6b7280');
+  const s = buildBookStage({
+    jacket: Number(book.dataset.jacket || 0),
+    imprint: book.dataset.imprint || 'house',
+    title: (book.querySelector('.press-book-title')?.textContent || '').trim(),
+    author: (book.querySelector('.press-book-author')?.textContent || '').trim(),
+    date: (book.querySelector('.press-book-date')?.textContent || '').trim(),
+    ground: articleGround(),
+  });
 
-  const text = (selector: string): string =>
-    (book.querySelector(selector)?.textContent || '').trim();
-
-  const stage = document.createElement('div');
-  stage.className = 'press-open-stage';
-
-  const scrim = document.createElement('div');
-  scrim.className = 'press-open-scrim';
-
-  const shell = document.createElement('div');
-  shell.className = 'press-open-book';
-  shell.style.left = `${rect.left}px`;
-  shell.style.top = `${rect.top}px`;
-  shell.style.width = `${rect.width}px`;
-  shell.style.height = `${rect.height}px`;
-
-  // The title page under the cover: the article's own eyebrow/title/byline, so
-  // the open book shows something worth looking at instead of a blank swatch.
-  const page = document.createElement('div');
-  page.className = 'press-open-page';
-  page.style.background = paper;
-  page.style.color = paperInk;
-  // Title-page type is sized off the cover width so it scales with the book
-  // rather than fighting the transform; the rules below are all in `em`.
-  page.style.fontSize = `${Math.round(rect.width * 0.085)}px`;
-
-  const eyebrow = document.createElement('span');
-  eyebrow.className = 'press-open-eyebrow';
-  eyebrow.style.color = jacketBg;
-  eyebrow.textContent = text('.press-book-model');
-
-  const pageTitle = document.createElement('span');
-  pageTitle.className = 'press-open-page-title';
-  pageTitle.textContent = text('.press-book-title');
-
-  const pageByline = document.createElement('span');
-  pageByline.className = 'press-open-page-byline';
-  pageByline.style.color = paperFaint;
-  pageByline.textContent = text('.press-book-date');
-
-  page.append(eyebrow, pageTitle, pageByline);
-
-  // Shadow the closed cover casts onto the page; slides away as it opens.
-  const pageShade = document.createElement('div');
-  pageShade.className = 'press-open-page-shade';
-  page.appendChild(pageShade);
-
-  // The cover, as a two-faced leaf hinged on the spine.
-  const leaf = document.createElement('div');
-  leaf.className = 'press-open-leaf';
-
-  const front = document.createElement('div');
-  front.className = 'press-open-face press-open-face--front';
-  front.style.background = jacketBg;
-  front.style.color = jacketInk;
-  const frontTitle = document.createElement('span');
-  frontTitle.className = 'press-book-title';
-  frontTitle.textContent = text('.press-book-title');
-  front.appendChild(frontTitle);
-
-  const back = document.createElement('div');
-  back.className = 'press-open-face press-open-face--back';
-  back.style.background = jacketBg;
-
-  leaf.append(front, back);
-
-  shell.append(page, leaf);
-  stage.append(scrim, shell);
-  document.body.appendChild(stage);
+  // The lying pose has to be part of the resolved BASE style, so it is set on
+  // the detached tree and flushed before the standing pose lands. Setting it
+  // after insertion instead makes it a transition TARGET, and the move to the
+  // standing pose then interpolates from a value the book had barely begun
+  // travelling toward — the rise silently does nothing. rAF will not
+  // substitute: it runs before style recalc, so both states collapse into one.
+  poseLying(s, m);
+  document.body.appendChild(s.stage);
   book.style.opacity = '0';
+  const restoreSource = (): void => { book.style.opacity = ''; };
+  void s.stage.offsetHeight;
 
-  // Scale is bounded by BOTH axes: the opened spread is twice the cover's
-  // width (the leaf swings out to the left of the spine), so a height-only
-  // fit would run the open book off the sides of a phone.
-  const byHeight = (window.innerHeight * BOOK_OPEN_FILL_H) / rect.height;
-  const byWidth = (window.innerWidth * BOOK_OPEN_FILL_W) / (rect.width * 2);
-  const scale = Math.max(1.02, Math.min(2.4, byHeight, byWidth));
-  // .press-open-book scales from `left center`, so putting the spine on the
-  // viewport centre centres the spread that is about to open around it.
-  const dx = window.innerWidth / 2 - rect.left;
-  const dy = window.innerHeight / 2 - (rect.top + rect.height / 2);
+  poseStanding(s, risenCover());
+  s.stage.classList.add('is-open');
 
-  // Force a style/layout flush so the browser resolves the stage's CLOSED
-  // style before the open state lands. Without it the whole subtree is new in
-  // the same frame, there is no "before" value to interpolate from, and every
-  // transition below jumps straight to its end value — which reads as an
-  // instant cut, not an animation. requestAnimationFrame is not enough here.
-  void stage.offsetHeight;
-
-  shell.style.transform = `translate(${dx}px, ${dy}px) scale(${scale})`;
-  stage.classList.add('is-open');
+  // Fetch the article NOW, in parallel with the rise, so the page the cover
+  // reveals is the real first page rather than a stand-in. Purely additive: if
+  // it is slow, fails, or the row is a standalone iframe doc, the synthesised
+  // title page is already there and stays.
+  const row = findResearchRow(book.dataset.slug || '');
+  if (row && row.kind !== 'standalone') {
+    const variant = researchVariant(row, activeLanguage);
+    const cached =
+      researchDocCache && researchDocCache.slug === row.slug &&
+      researchDocCache.language === activeLanguage
+        ? researchDocCache.body
+        : null;
+    const arrive = (html: string | null): void => {
+      if (!html || !s.stage.isConnected) return;
+      setSafeContent(s.sheet, html);
+      // Strip ids so this copy cannot win a getElementById race against the
+      // real article, whose TOC resolves heading ids after it renders.
+      s.sheet.querySelectorAll('[id]').forEach((el) => el.removeAttribute('id'));
+      s.fallback.style.display = 'none';
+      s.sheet.parentElement?.classList.add('has-sheet');
+    };
+    if (cached) arrive(cached);
+    else void fetchResearchDoc(variant, new AbortController().signal).then(arrive, () => {});
+  }
 
   const played = new Promise<void>((resolve) => window.setTimeout(resolve, BOOK_OPEN_SEQUENCE_MS));
   const capped = new Promise<void>((resolve) => window.setTimeout(resolve, BOOK_OPEN_MAX_HOLD_MS));
   const navigated = new Promise<void>((resolve) => {
-    window.setTimeout(() => navigate().then(resolve, resolve), BOOK_OPEN_NAVIGATE_AT_MS);
+    window.setTimeout(() => {
+      void navigate().then(() => {
+        // The page grows onto the article card's own paper — same edges, same
+        // place — while the cover and boards fade off it, so the stage lifts
+        // with nothing left to see change.
+        const rect = articlePaperRect();
+        if (rect) {
+          poseOnRect(s, rect);
+          // The hinge-anchored boxes are fixed px at the COVER's size, so they
+          // have to grow with the page or the article stays laid out for a
+          // 419px page while the paper underneath becomes 1102px.
+          s.paper.style.top = `${-rect.height / 2}px`;
+          s.paper.style.width = `${rect.width}px`;
+          s.paper.style.height = `${rect.height}px`;
+          // The sheet reaches 1:1 with the article exactly as the page reaches
+          // the card's rect, so the two are the same document at the same size
+          // when the stage lifts.
+          // Where the article sits INSIDE the card, measured off the real one
+          // rather than derived through the rotated frame. The page's own inset
+          // and the jacket rail already move the sheet's origin, so only the
+          // remainder is applied here. Measuring the CLONE instead would read a
+          // mid-transition value — the paper box is still travelling when any
+          // post-hoc correction could run, which is how an earlier cut landed
+          // the sheet 451px out.
+          const realArt = document.querySelector<HTMLElement>('#content article.ara-doc');
+          if (realArt) {
+            const ra = realArt.getBoundingClientRect();
+            s.sheet.style.transform = `scale(${ra.width / BOOK_SHEET_W})`;
+            s.sheet.style.left = `${ra.left - rect.left}px`;
+            s.sheet.style.top = `${ra.top - rect.top - BOOK_SHEET_Y_TRIM}px`;
+          } else {
+            s.sheet.style.transform = `scale(${rect.width / BOOK_SHEET_W})`;
+          }
+          s.stage.classList.add('is-settling');
+        }
+        resolve();
+      }, resolve);
+    }, BOOK_OPEN_NAVIGATE_AT_MS);
   });
 
-  // Strike the set once the sequence has played AND the article has rendered
-  // underneath — or once the cap fires, whichever comes first.
   void Promise.race([Promise.all([played, navigated]), capped]).then(() => {
-    stage.classList.add('is-clearing');
-    window.setTimeout(() => stage.remove(), BOOK_OPEN_CLEAR_MS);
+    window.setTimeout(() => {
+      s.stage.classList.add('is-clearing');
+      window.setTimeout(() => {
+        s.stage.remove();
+        restoreSource();
+      }, BOOK_OPEN_CLEAR_MS);
+    }, BOOK_OPEN_SETTLE_MS);
   });
 }
+
+/* Closing the book — the same gesture backwards. The page draws back off the
+ * article's paper into a standing cover, the cover shuts, then the volume rolls
+ * and tips back down into its slot on the shelf as the wash clears. */
+const BOOK_CLOSE_VEIL_MS = 280;
+const BOOK_CLOSE_DRAW_AT_MS = 40;
+const BOOK_CLOSE_DRAW_MS = 440;
+const BOOK_CLOSE_MAX_HOLD_MS = 2800;
+/** Backstop only; teardown is gated on the body's own transitionend. */
+const BOOK_CLOSE_FALLBACK_MS = 1500;
+
+function closeBookThen(row: GenResearchRow, navigate: () => Promise<void>): void {
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    void navigate();
+    return;
+  }
+
+  const created = new Date(row.created_at);
+  const cover = risenCover();
+  const s = buildBookStage({
+    jacket: researchJacketBySlug.get(row.slug) ?? researchJacket(row.slug),
+    imprint: researchImprint(row.model),
+    title: decodeStoredEntities(row.title),
+    author: row.model,
+    date: isNaN(created.getTime()) ? '' : timeAgo(created),
+    // The destination here is the SHELF, whose ground is a body-scoped remap.
+    ground: pressGround(),
+  });
+  s.stage.classList.add('press-open-stage--reverse');
+  s.leaf.style.transform = 'rotateX(-166deg)';   // open; shut inline on is-closing
+
+  // Start ON the article's own paper so the reader's page draws back into a
+  // book, rather than a book cutting in over it.
+  const paper = articlePaperRect();
+  if (paper) {
+    poseOnRect(s, paper);
+    s.stage.classList.add('is-settling');
+  } else {
+    poseStanding(s, cover);
+  }
+
+  document.body.appendChild(s.stage);
+  void s.stage.offsetHeight;
+  s.stage.classList.add('is-veiling');
+  if (paper) {
+    window.setTimeout(() => {
+      poseStanding(s, cover);
+      s.stage.classList.remove('is-settling');
+    }, BOOK_CLOSE_DRAW_AT_MS);
+  }
+
+  let restore: (() => void) | null = null;
+  let torn = false;
+  const teardown = (): void => {
+    if (torn) return;
+    torn = true;
+    s.stage.remove();
+    if (restore) restore();
+  };
+
+  window.setTimeout(() => {
+    void navigate().then(() => {
+      const target = document.querySelector<HTMLElement>(
+        `.press-book[data-slug="${CSS.escape(row.slug)}"]`,
+      );
+      const m = target ? measureShelfBook(target) : null;
+      if (target && m) {
+        // Assigned BEFORE anything can tear the stage down, or the cap can fire
+        // with it still null and leave a permanently blank slot on the shelf.
+        target.style.opacity = '0';
+        restore = () => { target.style.opacity = ''; };
+        poseLying(s, m);
+      } else {
+        // Not on this page of the shelf (deep link, or the reader paged on).
+        // Lie the book down in the middle of the shelf and dissolve: an honest
+        // ending through the same code path rather than a one-frame vanish.
+        const shelf = document.querySelector<HTMLElement>('.press-shelf');
+        const w = shelf ? shelf.getBoundingClientRect().width : window.innerWidth * 0.8;
+        poseLying(s, {
+          L0: w,
+          T0: 86,
+          D0: 176,
+          lay0: 79,
+          Hx0: window.innerWidth / 2,
+          Hy0: window.innerHeight * 0.62,
+        });
+        s.stage.classList.add('is-clearing');
+      }
+      s.leaf.style.transform = 'rotateX(0deg)';
+      s.stage.classList.add('is-closing');
+      // Gate on the motion actually finishing rather than on a constant that
+      // mirrors a CSS duration with nothing enforcing agreement.
+      s.body.addEventListener(
+        'transitionend',
+        (e) => { if ((e as TransitionEvent).propertyName === 'transform') teardown(); },
+        { once: true },
+      );
+      window.setTimeout(teardown, BOOK_CLOSE_FALLBACK_MS);
+    }, () => { window.setTimeout(teardown, BOOK_CLOSE_FALLBACK_MS); });
+  }, BOOK_CLOSE_VEIL_MS + BOOK_CLOSE_DRAW_MS);
+
+  window.setTimeout(teardown, BOOK_CLOSE_MAX_HOLD_MS);
+}
+
 
 function renderResearchIndex(rows: GenResearchRow[]): void {
   setDocTitle(null);
@@ -4606,16 +5103,34 @@ function renderResearchIndex(rows: GenResearchRow[]): void {
       : '';
     items.push(
       [
-        // role="link" (not the bare focusable <li> this replaced) so the cover
+        // role="link" (not the bare focusable <li> this replaced) so the book
         // announces as navigation; the content keydown handler already
-        // activates [data-slug] rows on Enter.
+        // activates [data-slug] rows on Enter. The spine truncates long titles,
+        // so title= carries the whole thing.
         '<li class="press-book" role="link" data-jacket="' + jackets[index] + '"' +
-          ' data-slug="' + escapeHtml(row.slug) + '" tabindex="0">',
-        '  <span class="press-book-title">' + title + '</span>',
-        '  <span class="press-book-byline">',
-        '    <span class="press-book-model">' + escapeHtml(row.model) + '</span>',
-        rel ? '    <span class="press-book-date">' + escapeHtml(rel) + '</span>' : '',
+          ' data-imprint="' + researchImprint(row.model) + '"' +
+          ' data-slug="' + escapeHtml(row.slug) + '" tabindex="0"' +
+          ' title="' + escapeHtml(decodeStoredEntities(row.title)) + '">',
+        // The board is nested INSIDE the spine so it can hinge off the spine's
+        // top edge (bottom: 100%) rather than a fixed offset — which is what
+        // lets the spine grow when a long title wraps and keeps the board
+        // sitting on it. Perspective moves onto the spine to match.
+        '  <span class="press-book-spine">',
+        // The front board, laid back into the screen. Bare cloth: the grain and
+        // lighting on .press-book-board-face are what keep it reading as a
+        // surface. It carried a foreshortened copy of the title for a while,
+        // before the texture landed, and that job is now the grain's.
+        '    <span class="press-book-board">',
+        '      <span class="press-book-board-face"></span>',
+        '    </span>',
+        // Author left, title centred, date right — the same three slots
+        // press.stripe.com prints on a spine.
+        '    <span class="press-book-author">' + escapeHtml(row.model) + '</span>',
+        '    <span class="press-book-title">' + title + '</span>',
+        '    <span class="press-book-imprint">',
+        rel ? '      <span class="press-book-date">' + escapeHtml(rel) + '</span>' : '',
         koHtml,
+        '    </span>',
         '  </span>',
         '</li>',
       ].filter(Boolean).join('\n'),
@@ -4643,6 +5158,7 @@ function renderResearchIndex(rows: GenResearchRow[]): void {
   // Only the index wears the press ground; the article view keeps the reading
   // chrome. Cleared centrally at the top of load().
   document.body.classList.add('research-shelf');
+  watchShelfDrift();
 }
 
 function renderResearchDoc(row: GenResearchRow, body: string): void {
@@ -5753,8 +6269,16 @@ content.addEventListener('click', (e) => {
   }
   const back = target.closest('[data-research-back]') as HTMLElement | null;
   if (back) {
-    selectedSlug = null;
-    load();
+    // Play the open in reverse when we know which book we're in. The browser's
+    // own Back button is left alone: popstate fires after the URL has already
+    // changed, so there is no clean moment to hold the article on screen.
+    const openRow = selectedSlug ? findResearchRow(selectedSlug) : null;
+    const navigate = (): Promise<void> => {
+      selectedSlug = null;
+      return load();
+    };
+    if (openRow) closeBookThen(openRow, navigate);
+    else void navigate();
     return;
   }
   if (target.closest('[data-research-file-audio-toggle]')) {

--- a/dashboard/src/style.css
+++ b/dashboard/src/style.css
@@ -3487,6 +3487,9 @@ body.research-shelf .nav-shell {
   max-width: none;
   margin-inline: calc(var(--page-gutter) * -1);
   padding-inline: var(--page-gutter);
+  /* Books scroll under the sticky rail, so the backdrop needs air below the
+   * pills — without it a spine's title arrives flush against them. */
+  padding-bottom: 16px;
 }
 
 body.research-shelf .tabs,
@@ -3506,145 +3509,315 @@ body.research-shelf .controls {
  * shelf, so a second name/tagline block was just repeating it. The covers open
  * the page. */
 
-/* The shelf proper: a grid of book covers on the press ground. Column counts
- * are explicit rather than auto-fill so the covers stay substantial (a 6-up
- * auto-fill row on a wide display shrinks them into stamps). */
+/* The shelf proper: books lying flat, spine toward the reader, front board
+ * laid back into the screen — the press.stripe.com homepage view. One book per
+ * row, full width of the reading column, stacked with air between them.
+ *
+ * Geometry, all driven off two custom properties so a book stays coherent when
+ * either is retuned:
+ *   --spine-h  height of the spine plate, i.e. the book's thickness
+ *   --depth    the board's TRUE front-to-back size before foreshortening
+ * The board is rotateX'd by --lay, so it occupies roughly --depth * cos(--lay)
+ * of vertical space on screen; the row height below bakes that in. Perspective
+ * sits on each book rather than the list, so a book at the bottom of a long
+ * shelf is projected from its own centre instead of being sheared toward a
+ * shared vanishing point halfway up the page. */
 .press-shelf {
   list-style: none;
   max-width: calc(var(--page-max) + 2 * var(--page-gutter));
   margin-inline: auto;
   padding: 0 var(--page-gutter);
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: clamp(28px, 3.4vw, 56px) clamp(20px, 2.6vw, 44px);
-  align-items: start;
-}
-
-@media (min-width: 620px) {
-  .press-shelf {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-}
-
-@media (min-width: 940px) {
-  .press-shelf {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-  }
-}
-
-/* One book. The jacket palette paints the cover; the ::before strip is the
- * spine, which is what makes it read as an object instead of a colour swatch. */
-.press-book {
-  /* Fallback jacket — every book gets a real pair from the table below. */
-  --jacket-bg: #2f2f2f;
-  --jacket-ink: #dbdbdb;
-  --cover-pad: clamp(16px, 1.5vw, 24px);
-  position: relative;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
-  gap: 16px;
-  aspect-ratio: 5 / 7;
-  padding: var(--cover-pad);
-  padding-left: calc(var(--cover-pad) + 12px);
-  overflow: hidden;
-  border-radius: 1px 4px 4px 1px;
-  background: var(--jacket-bg);
-  color: var(--jacket-ink);
+  /* Wide enough to absorb the hover tilt: tipping the board from 72deg to
+   * 62deg grows it ~46px UPWARD, which at the old gap ran it into the book
+   * above. The reference shelf is airy for the same reason. */
+  gap: clamp(46px, 7vh, 86px);
+}
+
+.press-book {
+  --jacket-bg: #2f2f2f;         /* fallback; the palette table sets the real pair */
+  --jacket-ink: #dbdbdb;
+  /* Reference proportions: the spine plate is the dominant face, about half
+   * again the visible depth of the board above it. Earlier values had that
+   * backwards (74px spine under a 90px board), which read as a thin pamphlet
+   * with a big lid rather than a bound volume. --spine-h is a FLOOR now, not a
+   * fixed height: a title that wraps to two or three lines makes its book
+   * physically thicker, which is both the honest layout and a nice tell. */
+  --spine-h: clamp(64px, 9.6vh, 106px);
+  --depth: clamp(114px, 19.5vh, 196px);
+  /* Steep: a book lying on a shelf shows you its spine and barely a sliver of
+   * the front board. At 72deg the board was 68px against a 108px spine and the
+   * cover competed with the face that actually carries the type. */
+  --lay: 79deg;
+  --lay-drift: 0deg;
+  position: relative;
+  /* Reserve the board's projected height above the spine, which is now a
+   * normal-flow box free to grow. */
+  padding-top: calc(var(--depth) * 0.21);
   cursor: pointer;
   outline: none;
-  box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.45),
-    0 14px 30px -10px rgba(0, 0, 0, 0.6);
-  transition: transform 0.28s cubic-bezier(0.2, 0.7, 0.3, 1), box-shadow 0.28s ease;
+  transition: transform 0.4s cubic-bezier(0.4, 0.03, 0.18, 1);
 }
 
-/* Spine: a darkened gradient down the leading edge plus the hinge highlight. */
-.press-book::before {
+/* The front board. Hinged along the spine's top edge (bottom: 100% against the
+ * spine, so it tracks a growing spine automatically) and laid back, so what the
+ * reader sees is the cover receding — wider at the near edge, narrower at the
+ * far one. */
+.press-book-board {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 100%;
+  height: var(--depth);
+  transform-origin: bottom center;
+  /* --lay-drift is nudged per book by the scroll handler in main.ts; see
+   * driftShelfBoards(). */
+  transform: rotateX(calc(var(--lay) + var(--lay-drift, 0deg)));
+  /* Short, because this transition also damps the scroll drift — at 0.4s the
+   * board smeared behind the scroll instead of breathing with it. Still long
+   * enough to read as a deliberate tilt on hover. */
+  transition: transform 0.34s cubic-bezier(0.4, 0.03, 0.18, 1);
+}
+
+/* Painted separately from the board so the lighting gradient does not get
+ * re-projected when the board angle changes on hover. */
+.press-book-board-face {
+  position: absolute;
+  inset: 0;
+  border-radius: 3px 3px 0 0;
+  background:
+    linear-gradient(
+      90deg,
+      rgba(0, 0, 0, 0.4) 0px,
+      rgba(0, 0, 0, 0.18) 8px,
+      rgba(255, 255, 255, 0.06) 24px,
+      rgba(255, 255, 255, 0.03) 50%,
+      rgba(255, 255, 255, 0.06) calc(100% - 24px),
+      rgba(0, 0, 0, 0.18) calc(100% - 8px),
+      rgba(0, 0, 0, 0.4) 100%
+    ),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.2) 0%, rgba(255, 255, 255, 0.03) 34%, rgba(0, 0, 0, 0.26) 100%),
+    var(--jacket-bg);
+}
+
+/* Head edge: the sliver of paper block visible along the top of the board. */
+.press-book-board-face::after {
   content: "";
   position: absolute;
-  inset: 0 auto 0 0;
-  width: 12px;
-  background: linear-gradient(
-    90deg,
-    rgba(0, 0, 0, 0.36) 0%,
-    rgba(0, 0, 0, 0.1) 58%,
-    rgba(255, 255, 255, 0.07) 100%
-  );
-  pointer-events: none;
+  inset: 0 0 auto 0;
+  height: 3px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.26), rgba(255, 255, 255, 0));
+  border-radius: 3px 3px 0 0;
 }
 
-.press-book-title {
+/* The spine plate — the face of the book pointing at the reader. In normal
+ * flow with a MINIMUM height, so a wrapped title grows the book instead of
+ * being clipped. It is also the perspective host and the board's containing
+ * block (the board hangs off its top edge). */
+.press-book-spine {
+  position: relative;
+  min-height: var(--spine-h);
+  display: flex;
+  align-items: center;
+  gap: clamp(16px, 2.4vw, 44px);
+  padding: 12px clamp(16px, 2.2vw, 38px);
+  /* A long lens. At 780px the far edge of a 262px-deep board converged to ~73%
+   * of the near edge and every book read as a hip roof; ~10% is what an actual
+   * photograph of a book at this angle gives you. */
+  perspective: 2400px;
+  perspective-origin: 50% 0%;
+  border-radius: 0 0 3px 3px;
+  /* Vertical falloff so the thickened plate reads as the rounded block of a
+   * bound spine rather than a flat colour bar, plus a horizontal falloff for
+   * the curve of the boards at each end. */
+  background-color: var(--jacket-bg);
+  background-image:
+    /* Shoulders: a hard dark edge at each end, then the rounded corner of the
+     * board catching light just inside it. This is what gives the block its
+     * thickness — a soft falloff alone read as a flat bar. */
+    linear-gradient(
+      90deg,
+      rgba(0, 0, 0, 0.46) 0px,
+      rgba(0, 0, 0, 0.26) 7px,
+      rgba(255, 255, 255, 0.08) 22px,
+      rgba(255, 255, 255, 0.045) 42%,
+      rgba(255, 255, 255, 0.045) 58%,
+      rgba(255, 255, 255, 0.08) calc(100% - 22px),
+      rgba(0, 0, 0, 0.26) calc(100% - 7px),
+      rgba(0, 0, 0, 0.46) 100%
+    ),
+    /* Head catching the light, foot falling into shade. */
+    linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.3) 0px,
+      rgba(255, 255, 255, 0.11) 4px,
+      rgba(255, 255, 255, 0.015) 16%,
+      rgba(0, 0, 0, 0.05) 62%,
+      rgba(0, 0, 0, 0.3) 100%
+    );
+  color: var(--jacket-ink);
+  /* Stamped into the cloth rather than sitting on it. */
+  text-shadow:
+    0 -1px 0 rgba(0, 0, 0, 0.3),
+    0 1px 0 rgba(255, 255, 255, 0.14);
   font-family: var(--font-serif);
-  font-size: clamp(0.96rem, 0.84rem + 0.42vw, 1.22rem);
+  /* Top highlight is the hinge where the board meets the spine; the drop
+   * shadow is what sits the book on the ground rather than floating it. */
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.3),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.45),
+    inset 0 -14px 22px -20px rgba(0, 0, 0, 0.7),
+    0 22px 42px -18px rgba(0, 0, 0, 0.9);
+}
+
+/* Cloth grain. An inline feTurbulence rasterised by the browser and laid over
+ * the plate in `overlay`, so it darkens and lightens the jacket colour rather
+ * than greying it — the same tile works on all twenty palettes. This is the
+ * single thing that makes the material read as bound cloth instead of paint. */
+.press-book-spine::before,
+.press-book-board-face::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  mix-blend-mode: overlay;
+  opacity: 0.9;
+  /* Pebbled binding leather: a coarse grain for the pebble and a fine one for
+   * the tooth, both run through feComponentTransfer to push their contrast up.
+   * Raw fractalNoise sits around mid-grey and reads as camera grain through
+   * `overlay`; the slope/intercept is what turns it into a material. An earlier
+   * pass layered a warp/weft grid on top, but the regularity read as printed
+   * fabric rather than a bound board. */
+  background-image:
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='t'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='2.6' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3CfeComponentTransfer%3E%3CfeFuncR type='linear' slope='1.5' intercept='-0.25'/%3E%3CfeFuncG type='linear' slope='1.5' intercept='-0.25'/%3E%3CfeFuncB type='linear' slope='1.5' intercept='-0.25'/%3E%3C/feComponentTransfer%3E%3C/filter%3E%3Crect width='140' height='140' filter='url(%23t)'/%3E%3C/svg%3E"),
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='p'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.55' numOctaves='3' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3CfeComponentTransfer%3E%3CfeFuncR type='linear' slope='2' intercept='-0.5'/%3E%3CfeFuncG type='linear' slope='2' intercept='-0.5'/%3E%3CfeFuncB type='linear' slope='2' intercept='-0.5'/%3E%3C/feComponentTransfer%3E%3C/filter%3E%3Crect width='200' height='200' filter='url(%23p)'/%3E%3C/svg%3E");
+  background-size: 140px 140px, 200px 200px;
+}
+
+/* The board is further from the light, so its grain sits back a little. */
+.press-book-board-face::before {
+  opacity: 0.6;
+}
+
+.press-book-author,
+.press-book-imprint {
+  flex: 0 0 auto;
+  font-size: clamp(0.72rem, 0.64rem + 0.3vw, 0.9rem);
+  font-style: italic;
+  /* Tight: model ids are long, hyphenated, and read as one token, so the
+   * default tracking pulled them apart into loose strings of syllables. */
+  letter-spacing: -0.015em;
+  white-space: nowrap;
+}
+
+.press-book-imprint {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 10px;
+}
+
+/* Titles wrap. The spine's min-height gives the plate its floor and the flow
+ * layout lets it grow, so a long title thickens the book rather than being
+ * guillotined at one line. Three lines is the ceiling — past that the plate
+ * stops looking like a spine — and the clamp sits on an element with no
+ * vertical padding of its own so it clips flush at the content edge. */
+.press-book-title {
+  flex: 1 1 auto;
+  min-width: 0;
+  text-align: center;
+  font-size: clamp(0.92rem, 0.74rem + 0.72vw, 1.34rem);
   font-weight: 600;
+  letter-spacing: 0.01em;
   line-height: 1.24;
-  letter-spacing: 0.2px;
-  text-wrap: balance;
-  /* Cover space is fixed by the aspect ratio, so a very long title truncates
-   * rather than overflowing the jacket. The full title is still the row's
-   * accessible name and is shown in full on the article page. */
+  overflow-wrap: break-word;
   display: -webkit-box;
   -webkit-box-orient: vertical;
-  -webkit-line-clamp: 7;
+  -webkit-line-clamp: 3;
   overflow: hidden;
-}
-
-.press-book-byline {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: baseline;
-  gap: 3px 8px;
-  padding-top: 11px;
-  border-top: 1px solid currentColor;
-  border-top-color: color-mix(in srgb, currentColor 42%, transparent);
-  font-family: var(--font-serif);
-  font-size: 0.8rem;
-  font-style: italic;
-  line-height: 1.35;
-  /* Full jacket ink, like Stripe's author line — the italic and the rule carry
-   * the hierarchy. Dimming it would push the two lowest-contrast jackets under
-   * AA for small text. */
-}
-
-.press-book-date::before {
-  content: "·";
-  margin-right: 8px;
 }
 
 .press-book-lang {
   font-style: normal;
   font-size: 0.86em;
-  letter-spacing: 0;
   border: 1px solid currentColor;
   border-radius: 999px;
   padding: 0 6px;
 }
 
+/* ── Imprint faces ──────────────────────────────────────
+ * Each model family gets its own typeface, so the shelf reads as a shelf of
+ * imprints rather than one press printing twenty jacket colours. Assigned by
+ * researchImprint() in main.ts, which keys on the FAMILY — every Claude
+ * version shares a house face. Faces are requested in index.html; anything
+ * unmapped lands on `house`. */
+.press-book { --imprint-face: 'Source Serif 4', Georgia, serif; }
+
+[data-imprint="claude"]  { --imprint-face: 'Source Serif 4', Georgia, serif; }
+[data-imprint="kimi"]    { --imprint-face: 'Playfair Display', Georgia, serif; }
+[data-imprint="deepseek"]{ --imprint-face: 'Space Grotesk', 'Inter', sans-serif; }
+[data-imprint="glm"]     { --imprint-face: 'Libre Baskerville', Georgia, serif; }
+[data-imprint="codex"]   { --imprint-face: 'JetBrains Mono', ui-monospace, monospace; }
+[data-imprint="house"]   { --imprint-face: 'Inter', system-ui, sans-serif; }
+
+.press-book-spine,
+.press-book-title,
+.press-book-author,
+.press-book-imprint {
+  font-family: var(--imprint-face);
+}
+
+/* The mono and geometric faces run larger and looser at the same nominal size
+ * than the serifs do, so they get pulled back to keep every spine's title
+ * sitting on the same optical weight. */
+[data-imprint="codex"] .press-book-title {
+  font-size: clamp(0.8rem, 0.62rem + 0.58vw, 1.08rem);
+  letter-spacing: -0.02em;
+}
+
+[data-imprint="deepseek"] .press-book-title,
+[data-imprint="house"] .press-book-title {
+  font-size: clamp(0.86rem, 0.68rem + 0.64vw, 1.2rem);
+  letter-spacing: -0.015em;
+}
+
+[data-imprint="kimi"] .press-book-title {
+  letter-spacing: 0;
+}
+
 /* Search highlight inverts against whatever jacket it lands on, so it stays
  * legible on all 20 palettes without a per-jacket rule. */
-.press-book mark {
+.press-book mark,
+.press-open-spine mark {
   background: currentColor;
   color: var(--jacket-bg);
   padding: 0 3px;
 }
 
+/* Hover tips the board toward the reader — the gesture of lifting a book to
+ * look at its cover — and floats the whole volume up off the shelf. */
 @media (hover: hover) {
   .press-book:hover {
-    transform: translateY(-10px);
-    box-shadow:
-      0 1px 2px rgba(0, 0, 0, 0.45),
-      0 30px 54px -12px rgba(0, 0, 0, 0.66);
+    transform: translateY(-6px);
+    /* Paint above the neighbour while the board is tipped up into its air. */
+    z-index: 2;
+  }
+
+  .press-book:hover .press-book-board {
+    transform: rotateX(63deg);
   }
 }
 
 .press-book:focus-visible {
   outline: 2px solid var(--press-ink);
-  outline-offset: 4px;
+  outline-offset: 6px;
+  border-radius: 3px;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .press-book {
+  .press-book,
+  .press-book-board {
     transition: none;
   }
 
@@ -3653,85 +3826,321 @@ body.research-shelf .controls {
   }
 }
 
-/* ── Book-opening transition ────────────────────────────
- * Built by openBookThen() in main.ts, which adds .is-open on the next frame
- * and .is-clearing at the end. The four beats — lift, open, settle, dissolve —
- * are sequenced entirely by the transition delays below; main.ts only needs
- * BOOK_OPEN_SEQUENCE_MS to match the last one finishing. Read the block
- * comment above openBookThen() before retiming anything here. */
+/* Phones cannot carry a 74deg board and a three-slot spine at once: the board
+ * collapses to a sliver and the title has no room between author and date. Lay
+ * the board flatter, drop the imprint, and let the spine run two-up. */
+@media (max-width: 719px) {
+  .press-book {
+    --spine-h: clamp(58px, 9.5vh, 84px);
+    --depth: clamp(76px, 12vh, 118px);
+    --lay: 77deg;
+  }
+
+  .press-book-spine {
+    gap: 12px;
+    padding: 0 14px;
+  }
+
+  .press-book-imprint {
+    display: none;
+  }
+
+  .press-book-title {
+    text-align: left;
+    font-size: 0.94rem;
+    /* A phone spine is a third the width, so the same title needs another
+     * line before it starts eliding. The plate grows to hold it. */
+    -webkit-line-clamp: 4;
+  }
+
+  .press-book-author {
+    order: 2;
+    font-size: 0.72rem;
+  }
+}
+
+/* ── Opening a book ─────────────────────────────────────
+ * Built by buildBookStage()/openBookThen() in main.ts. The clone re-hosts the
+ * SHELF's own elements — .press-book-spine, .press-book-board-face and the type
+ * spans are reused verbatim — so at t=0 it is pixel-identical to the book on the
+ * shelf and there is no swap to see. Read the block comment above
+ * buildBookStage() before retiming or restructuring anything here.
+ *
+ * Frame: .press-open-volume is a ZERO-SIZE anchor on the hinge carrying the roll
+ * (0deg → 90deg); .press-open-body is the board plane carrying the tip
+ * (lay → 0deg), sized left:-L/2 top:-D width:L height:D so its bottom-centre is
+ * the hinge for ANY L,D. Body-local +x runs along the hinge, which is why the
+ * gradients inside are rotated 90deg from their screen-space equivalents.
+ *
+ * C is the file's single shared curve. Plain opacity fades stay `ease`. */
 .press-open-stage {
+  --press-ease: cubic-bezier(0.4, 0.03, 0.18, 1);
   position: fixed;
   inset: 0;
   z-index: 4000;
-  pointer-events: none;
+  /* Not `none`: the shelf stays clickable for the ~740ms before navigate(), and
+   * a second click builds a second stage and strands the first book invisible.
+   * The stage is above everything and has no interactive children. */
+  pointer-events: auto;
+  /* Matches .press-book-spine's camera, so the clone's projection IS the
+   * shelf's. perspective-origin tracks the hinge, set inline. */
+  perspective: 2400px;
+  transition: perspective-origin 620ms var(--press-ease);
 }
 
-/* Beats 1 + 3 — dim the shelf so the book is the only thing lit, then close
- * down to near-opaque so the shelf→article ground swap behind it is invisible.
- *
- * This deepening is what replaced the old full-screen veil. The veil painted
- * the whole viewport the destination colour and faded it back out, which read
- * as the page flashing white on every open. Holding at 0.62 keeps the shelf
- * faintly present while the book lifts off it; closing to 0.97 right before
- * the swap hides the swap without ever showing a flat field of colour. */
-@keyframes pressScrimDeepen {
-  0%   { opacity: 0; }
-  28%  { opacity: 0.62; }   /* ~250ms — lift done, shelf still readable */
-  62%  { opacity: 0.62; }   /* ~560ms — held through the cover swing */
-  93%  { opacity: 0.97; }   /* ~840ms — closed, just before the swap at 850ms */
-  100% { opacity: 0.97; }
-}
-
+/* The screen takes the BOOK's colour, which is what press.stripe.com does on
+ * leave (its colorOverlay is painted --backgroundColor, the jacket, never
+ * black). Delayed, so the first 120ms of a pixel-identical clone is not stepped
+ * on by the shelf starting to dim in the same frame. */
 .press-open-scrim {
   position: absolute;
   inset: 0;
-  background: #141010;
+  background: var(--jacket-bg);
   opacity: 0;
+  transition: opacity 420ms var(--press-ease) 120ms;
 }
 
 .press-open-stage.is-open .press-open-scrim {
-  animation: pressScrimDeepen 900ms ease forwards;
+  opacity: 0.86;
 }
 
-/* Beat 5 — the whole set (scrim and open book together) fades off the already
- * rendered article. Nothing is painted over the page to get here. */
-.press-open-stage.is-clearing {
-  opacity: 0;
-  transition: opacity 340ms ease;
-}
-
-/* Beat 1 — the book itself. Perspective lives HERE, not on the stage: the
- * projection has to stay centred on the book, otherwise a cover opening from
- * the edge of the shelf is projected from the middle of the screen and skews.
- * It scales from `left center` so the spine stays put and the spread the leaf
- * is about to occupy is already centred (see the dx/dy maths in main.ts). */
-.press-open-book {
+/* Under the wash, the destination's own ground arrives — so by the time the
+ * article is swapped in there is nothing left to see change. */
+.press-open-ground {
   position: absolute;
-  transform-origin: left center;
-  perspective: 1500px;
-  transition: transform 420ms cubic-bezier(0.22, 0.75, 0.28, 1);
-  will-change: transform;
+  inset: 0;
+  opacity: 0;
+  transition: opacity 380ms var(--press-ease) 560ms;
 }
 
-/* The title page under the cover. */
+.press-open-stage.is-open .press-open-ground {
+  opacity: 1;
+}
+
+/* The hinge anchor. Zero-size on purpose: it is a point, so nothing about it
+ * changes when the body reproportions around it. */
+.press-open-volume {
+  position: absolute;
+  width: 0;
+  height: 0;
+  transform-origin: 0 0;
+  transform-style: preserve-3d;
+  transform: rotate(0deg);
+  transition:
+    transform 430ms var(--press-ease) 90ms,
+    left 620ms var(--press-ease),
+    top 620ms var(--press-ease);
+}
+
+/* The board plane. Its bottom-centre is the volume's origin at any size, so the
+ * pivot never moves while L and D animate. */
+.press-open-body {
+  position: absolute;
+  transform-origin: 50% 100%;
+  transform-style: preserve-3d;
+  transition:
+    transform 620ms var(--press-ease),
+    left 620ms var(--press-ease),
+    top 620ms var(--press-ease),
+    width 620ms var(--press-ease),
+    height 620ms var(--press-ease);
+}
+
+/* The spine plate. It does not vanish and is not cross-faded: it turns away by
+ * exactly as much as the board turns toward us, and lands edge-on as the jacket
+ * rail the article card wears down its left edge. */
+.press-open-spine {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 100%;
+  transform-origin: 50% 0;
+  /* The shelf class brings its own 2400px camera; override so the projection
+   * chain stays single. The spans are flat and at z=0, so nothing is lost. */
+  perspective: none;
+  transition:
+    transform 620ms var(--press-ease),
+    box-shadow 280ms ease 340ms;
+}
+
+.press-open-stage.is-open .press-open-spine {
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.3),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.45),
+    inset 0 -14px 22px -20px rgba(0, 0, 0, 0.7),
+    0 22px 42px -18px rgba(0, 0, 0, 0);
+}
+
+/* The plate's type hands over to the cover's — same string, same face, same
+ * ink, 40ms of overlap — so the identity the reader tracks is never absent. */
+.press-open-spine > span {
+  transition: opacity 220ms ease 80ms;
+}
+
+.press-open-stage.is-open .press-open-spine > span {
+  opacity: 0;
+}
+
+/* Back board and text block: invisible at t=0, because the shelf shows no page.
+ * Transitions live on the BASE rule, not inside .is-settling — the close path
+ * REMOVES that class, and anything declared only there snaps in one frame. */
+.press-open-base,
+.press-open-block,
 .press-open-page {
   position: absolute;
   inset: 0;
+  opacity: 0;
+  transition: opacity 280ms ease 240ms;
+}
+
+.press-open-stage.is-open .press-open-base,
+.press-open-stage.is-open .press-open-block,
+.press-open-stage.is-open .press-open-page,
+.press-open-stage--reverse .press-open-base,
+.press-open-stage--reverse .press-open-block,
+.press-open-stage--reverse .press-open-page {
+  opacity: 1;
+}
+
+/* Boards overhang the text block, and the block overhangs the page — so the
+ * page is inset INSIDE the body rather than the boards being grown outside it.
+ * That keeps the leaf exactly the body's box, which is what t=0 identity needs. */
+.press-open-base {
+  border-radius: 3px 3px 1px 1px;
+  background: var(--jacket-bg);
+  box-shadow: 0 28px 72px -16px rgba(0, 0, 0, 0.72);
+  transition: opacity 280ms ease 240ms, box-shadow 380ms ease 240ms;
+}
+
+.press-open-stage:not(.is-open):not(.press-open-stage--reverse) .press-open-base {
+  box-shadow: 0 28px 72px -16px rgba(0, 0, 0, 0);
+}
+
+/* Striations run along body-local +y, i.e. hinge→fore-edge, which reads as
+ * screen-horizontal once the volume has rolled. */
+.press-open-block {
+  inset: 3px 3px 5px 3px;
+  border-radius: 2px 2px 1px 1px;
+  background:
+    repeating-linear-gradient(90deg, rgba(0, 0, 0, 0.13) 0 1px, rgba(255, 255, 255, 0.5) 1px 2.5px),
+    #efeae1;
+}
+
+.press-open-page {
+  inset: 7px 7px 11px 7px;
+  border-radius: 2px 2px 1px 1px;
+  box-shadow: 0 26px 70px -16px rgba(0, 0, 0, 0.66);
+  overflow: hidden;
+}
+
+/* The gutter: the permanent crease where the page meets the spine. Body-local,
+ * so it runs along the hinge edge. */
+.press-open-page::after {
+  content: "";
+  position: absolute;
+  inset: auto 0 0 0;
+  height: 9%;
+  background: linear-gradient(0deg, rgba(0, 0, 0, 0.22) 0%, rgba(0, 0, 0, 0.05) 55%, transparent 100%);
+  pointer-events: none;
+}
+
+/* The shadow the shut cover casts on the page, sliding off as it opens. */
+.press-open-page-shade {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(0deg, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.16) 45%, transparent 100%);
+  transform-origin: center bottom;
+  transition: opacity 460ms ease 440ms, transform 460ms ease 440ms;
+}
+
+.press-open-stage.is-open .press-open-page-shade {
+  opacity: 0;
+  transform: scaleY(0.2);
+}
+
+/* Hinge-anchored type. A zero-size box at the one point in body-local space
+ * that does not move when L and D change, carrying a counter-roll so the words
+ * are upright from their first visible pixel, and an inner box in fixed px so
+ * nothing re-typesets while the body reproportions underneath. */
+.press-open-pagetext,
+.press-open-covertext {
+  position: absolute;
+  left: 50%;
+  bottom: 0;
+  width: 0;
+  height: 0;
+  transform: rotate(-90deg);
+  opacity: 0;
+}
+
+.press-open-pagetext {
+  transition: opacity 220ms ease 420ms;
+}
+
+.press-open-covertext {
+  transition: opacity 260ms ease 260ms;
+}
+
+.press-open-stage.is-open .press-open-pagetext,
+.press-open-stage.is-open .press-open-covertext,
+.press-open-stage--reverse .press-open-pagetext,
+.press-open-stage--reverse .press-open-covertext {
+  opacity: 1;
+}
+
+.press-open-inner {
+  position: absolute;
   display: flex;
   flex-direction: column;
   justify-content: center;
   gap: 0.55em;
-  padding: 8% 9%;
+  font-family: var(--imprint-face, var(--font-serif));
+}
+
+/* A cover sets its title at the head, not centred like a title page. */
+.press-open-inner--cover {
+  justify-content: flex-start;
+}
+
+/* The article's own first page, on the paper. Authored at BOOK_SHEET_W and
+ * scaled down to the page, so the settle takes the scale to 1 as the page grows
+ * onto the card and the same document meets itself at the same size. */
+.press-open-paper {
+  position: absolute;
   overflow: hidden;
-  border-radius: 1px 3px 3px 1px;
-  box-shadow: 0 26px 70px -16px rgba(0, 0, 0, 0.66);
-  font-family: var(--font-serif);
+  transition:
+    top 460ms var(--press-ease),
+    width 460ms var(--press-ease),
+    height 460ms var(--press-ease);
+}
+
+.press-open-sheet {
+  position: absolute;
+  left: 0;
+  top: 0;
+  transform-origin: 0 0;
+  transition:
+    transform 460ms var(--press-ease),
+    left 460ms var(--press-ease),
+    top 460ms var(--press-ease);
+}
+
+/* The floating TOC and the doc's own chrome are the page's furniture, not the
+ * article — and the charts never render here, since nothing enhances this copy. */
+.press-open-sheet .ara-toc,
+.press-open-sheet .gen-research-doc-meta,
+.press-open-sheet .ara-chart,
+.press-open-sheet figure.ara-figure img {
+  display: none;
 }
 
 .press-open-eyebrow {
   font-size: 0.58em;
   font-style: italic;
   letter-spacing: 0.04em;
+  /* Tinted toward the jacket but mixed with the page ink, so the pale jackets
+   * (#e2e2e2, #cad9e5) do not vanish into white paper. */
+  color: color-mix(in srgb, var(--jacket-bg) 68%, currentColor);
 }
 
 .press-open-page-title {
@@ -3750,83 +4159,208 @@ body.research-shelf .controls {
   font-style: italic;
 }
 
-/* The gutter: the permanent crease shadow where the page meets the spine.
- * Unlike the cast shadow below it does NOT fade — an open book always has it,
- * and it is what stops the revealed page reading as a flat white card. */
-.press-open-page::after {
-  content: "";
-  position: absolute;
-  inset: 0 auto 0 0;
-  width: 9%;
-  background: linear-gradient(90deg, rgba(0, 0, 0, 0.22) 0%, rgba(0, 0, 0, 0.05) 55%, transparent 100%);
-  pointer-events: none;
-}
-
-/* Beat 2 — the shadow the closed cover casts on the page, sliding off to the
- * right as the leaf lifts away. */
-.press-open-page-shade {
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(90deg, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.16) 45%, transparent 100%);
-  transform-origin: left center;
-  transition: opacity 460ms ease 250ms, transform 460ms ease 250ms;
-}
-
-.press-open-stage.is-open .press-open-page-shade {
-  opacity: 0;
-  transform: scaleX(0.2);
-}
-
-/* Beat 2 — the cover, hinged on the spine. */
+/* The cover, hinged on the same line as everything else. Delayed past the roll
+ * but strictly INSIDE the rise: at t=400 the book is still ~22deg off upright,
+ * so the cover starts falling open while the volume is visibly still turning.
+ * Sequential beats read as a queue; this is the overlap that stops that. */
 .press-open-leaf {
   position: absolute;
   inset: 0;
-  transform-origin: left center;
+  transform-origin: 50% 100%;
   transform-style: preserve-3d;
-  transform: rotateY(0deg);
-  transition: transform 620ms cubic-bezier(0.34, 0.62, 0.24, 1) 240ms;
-  will-change: transform;
+  transition: transform 700ms var(--press-ease) 400ms, opacity 320ms ease;
 }
 
 .press-open-stage.is-open .press-open-leaf {
-  transform: rotateY(-166deg);
+  transform: rotateX(-166deg);
 }
 
 .press-open-face {
   position: absolute;
   inset: 0;
-  overflow: hidden;
-  border-radius: 1px 3px 3px 1px;
   backface-visibility: hidden;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.45);
 }
 
-.press-open-face--front {
-  padding: clamp(16px, 1.5vw, 24px);
-  padding-left: calc(clamp(16px, 1.5vw, 24px) + 12px);
+/* No flat jacket fill: the cover's face is the shelf's own cloth, permanently,
+ * which is what carries the grain and the lighting into the risen book. */
+.press-open-leafskin {
+  position: absolute;
+  inset: 0;
 }
 
-/* The reverse of the cover is an endpaper, not a mirrored jacket: darkened
- * board with the paper edge showing at the hinge. */
+/* The reverse of the cover is an endpaper, not a mirrored jacket. */
 .press-open-face--back {
-  transform: rotateY(180deg);
-  border-radius: 3px 1px 1px 3px;
+  background: var(--jacket-bg);
+  transform: rotateX(180deg);
+  border-radius: 0 0 3px 3px;
   filter: brightness(0.62) saturate(0.7);
-  box-shadow: inset -6px 0 12px -6px rgba(0, 0, 0, 0.55);
+  box-shadow: inset 0 -6px 12px -6px rgba(0, 0, 0, 0.55);
+}
+
+/* Cover typography. Deliberately not .press-book-title — that is the SPINE's
+ * clamped centred block, which would misrender the cover. */
+.press-open-cover-title {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 7;
+  overflow: hidden;
+  font-family: var(--imprint-face, var(--font-serif));
+  font-size: clamp(1rem, 0.86rem + 0.5vw, 1.28rem);
+  font-weight: 600;
+  line-height: 1.24;
+  letter-spacing: 0.2px;
+  color: var(--jacket-ink);
+  text-wrap: balance;
+}
+
+/* Search highlights must survive into the clone. */
+.press-open-stage mark {
+  background: currentColor;
+  color: var(--jacket-bg);
+  padding: 0 3px;
+}
+
+/* Settled: everything that belongs to the BOOK rather than the page gets out of
+ * the way, leaving a plain sheet sitting exactly on the article card. The stage
+ * then lifts off it with nothing to jump. */
+.press-open-stage.is-settling .press-open-leaf,
+.press-open-stage.is-settling .press-open-base,
+.press-open-stage.is-settling .press-open-block,
+.press-open-stage.is-settling .press-open-page-shade,
+.press-open-stage.is-settling .press-open-spine,
+.press-open-stage--reverse.is-settling .press-open-leaf,
+.press-open-stage--reverse.is-settling .press-open-base,
+.press-open-stage--reverse.is-settling .press-open-block,
+.press-open-stage--reverse.is-settling .press-open-spine {
+  opacity: 0;
+}
+
+.press-open-stage.is-settling .press-open-pagetext,
+.press-open-stage--reverse.is-settling .press-open-pagetext {
+  opacity: 0;
+}
+
+.press-open-stage.is-settling .press-open-page,
+.press-open-stage--reverse.is-settling .press-open-page {
+  inset: 0;
+  border-radius: var(--radius, 12px);
+  box-shadow: none;
+  /* The article card carries this rail (.gen-research-doc[data-jacket]); the
+   * page has to grow it or the settle lands 12px off and the sheet inside sits
+   * left of the real article. It is also where the spine plate has been
+   * heading the whole time. */
+  border-left: 12px solid var(--jacket-bg);
+  transition: opacity 280ms ease, inset 460ms var(--press-ease),
+    border-radius 420ms ease, box-shadow 420ms ease;
+}
+
+.press-open-stage.is-settling .press-open-page::after {
+  opacity: 0;
+}
+
+.press-open-stage.is-clearing {
+  opacity: 0;
+  transition: opacity 320ms ease;
+}
+
+/* ── Closing the book (the reverse) ─────────────────────
+ * The same frame, run backwards: the page draws back off the article's paper
+ * into a standing cover, the cover shuts, then the volume rolls and tips down
+ * into its slot on the shelf as the wash clears. Every transition it needs is
+ * declared on a base rule above, because this path REMOVES .is-settling. */
+.press-open-stage--reverse .press-open-scrim,
+.press-open-stage--reverse .press-open-ground {
+  opacity: 0;
+  transition: opacity 360ms var(--press-ease);
+}
+
+.press-open-stage--reverse.is-veiling .press-open-scrim {
+  opacity: 0.86;
+}
+
+.press-open-stage--reverse.is-veiling .press-open-ground {
+  opacity: 1;
+}
+
+.press-open-stage--reverse .press-open-page-shade {
+  opacity: 0;
+  transform: scaleY(0.2);
+  transition: opacity 460ms ease, transform 460ms ease;
+}
+
+/* Beat order on the way back is the reverse of the way out: the cover shuts
+ * FIRST, then the volume rolls and tips down into its slot. The base rules
+ * carry a 400ms leaf delay for the OPEN (where the swing must lag the rise), so
+ * the close has to invert it — and the descent's delay lives on .is-closing
+ * rather than the base rule, because the base rules are also what drive beat 1,
+ * the draw-back off the article's paper, which must not be delayed. */
+.press-open-stage--reverse .press-open-leaf {
+  transition: transform 620ms var(--press-ease), opacity 320ms ease;
+}
+
+.press-open-stage--reverse.is-closing .press-open-volume {
+  transition:
+    transform 520ms var(--press-ease) 360ms,
+    left 620ms var(--press-ease) 360ms,
+    top 620ms var(--press-ease) 360ms;
+}
+
+.press-open-stage--reverse.is-closing .press-open-body {
+  transition:
+    transform 620ms var(--press-ease) 360ms,
+    left 620ms var(--press-ease) 360ms,
+    top 620ms var(--press-ease) 360ms,
+    width 620ms var(--press-ease) 360ms,
+    height 620ms var(--press-ease) 360ms;
+}
+
+.press-open-stage--reverse.is-closing .press-open-spine {
+  transition: transform 620ms var(--press-ease) 360ms;
+}
+
+.press-open-stage--reverse.is-closing .press-open-leaf {
+  transform: rotateX(0deg);
+}
+
+.press-open-stage--reverse.is-closing .press-open-page-shade {
+  opacity: 1;
+  transform: none;
+}
+
+.press-open-stage--reverse.is-closing .press-open-spine > span {
+  opacity: 1;
+  transition: opacity 260ms ease 340ms;
+}
+
+.press-open-stage--reverse .press-open-spine > span {
+  opacity: 0;
+}
+
+/* The boards and page go out as the cover shuts over them. */
+.press-open-stage--reverse.is-closing .press-open-base,
+.press-open-stage--reverse.is-closing .press-open-block,
+.press-open-stage--reverse.is-closing .press-open-page,
+.press-open-stage--reverse.is-closing .press-open-pagetext,
+.press-open-stage--reverse.is-closing .press-open-covertext {
+  opacity: 0;
+  transition: opacity 260ms ease 300ms;
+}
+
+.press-open-stage--reverse.is-closing .press-open-scrim,
+.press-open-stage--reverse.is-closing .press-open-ground {
+  opacity: 0;
+  transition: opacity 520ms var(--press-ease) 400ms;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  /* openBookThen() bails before building the stage, but keep the belt-and-
-   * braces rules in case a stage is ever left on screen. */
+  /* openBookThen()/closeBookThen() bail before building the stage, but keep the
+   * belt-and-braces rules in case a stage is ever left on screen. */
   .press-open-stage,
-  .press-open-book,
-  .press-open-leaf,
-  .press-open-page-shade {
-    transition: none;
-  }
-
-  .press-open-stage.is-open .press-open-scrim {
-    animation: none;
+  .press-open-stage *,
+  .press-open-volume,
+  .press-open-body,
+  .press-open-leaf {
+    transition: none !important;
   }
 }
 
@@ -3854,19 +4388,6 @@ body.research-shelf .controls {
 /* Two covers per row on phones leaves ~150px of cover width, so the title
  * needs to drop a step and shed a couple of clamped lines. */
 @media (max-width: 619px) {
-  .press-book {
-    --cover-pad: 14px;
-  }
-
-  .press-book-title {
-    font-size: 0.9rem;
-    -webkit-line-clamp: 6;
-  }
-
-  .press-book-byline {
-    font-size: 0.74rem;
-  }
-
   .press-shelf,
   .press-shelf-empty,
   .press-shelf-foot {


### PR DESCRIPTION
Replaces the cover grid on `/research` with the [press.stripe.com](https://press.stripe.com/) homepage view — books lying flat, spine toward the reader, front board laid back — and makes opening one a single continuous gesture rather than a swap.

## The shelf

One book per row, full width of the reading column. The spine plate carries author / title / date in the three slots a real spine prints them; the front board recedes above it at 79°.

- **Perspective is a long lens (2400px).** At 780px the far edge of the board converged to ~73% of the near edge and every book read as a hip roof; ~10% is what a photograph at this angle gives you.
- **Bookcloth, not paint.** Two `feTurbulence` layers — a coarse pebble and a fine tooth — run through `feComponentTransfer` to push their contrast up. Raw `fractalNoise` sits at mid-grey and reads as camera grain through `overlay`; the slope/intercept is what turns it into a material. Hard shoulders at each end and a lit head edge give the block its thickness.
- **Per-lab imprint faces**, keyed on the model FAMILY so every Claude release shares a house face: Source Serif (Claude), Playfair Display (Kimi), Space Grotesk (DeepSeek), Libre Baskerville (GLM), JetBrains Mono (Codex).
- **Titles wrap.** `--spine-h` is a floor rather than a fixed height, so a long title makes its book physically thicker.
- **Boards drift ±3.2° with scroll**, driven by viewport position rather than a clock, so they only move when the reader does and settle when they stop. Phase is keyed off the jacket index so neighbours aren't in lockstep.

## Opening one

The old transition repainted the book as a portrait cover *beside* the shelf book. Two different objects, so t=0 was a visible swap.

The clone now **re-hosts the shelf's own elements** — `.press-book-spine`, `.press-book-board-face` and the type spans are reused verbatim, so the gradients, shoulders, shadow and grain reproduce because they are the same declarations.

> Measured at t=0: board delta `[0, 0, 0, 0]`, spine `[-0.12, 0, 0.25, 0.02]`.

The rise is then one rotation rather than a second animation. Three nested boxes:

- `.press-open-volume` — a **zero-size** anchor on the hinge, carrying the roll `0° → 90°`
- `.press-open-body` — the board plane, sized `left:-L/2 top:-D width:L height:D` so its bottom-centre **is** the hinge for any L,D. That's why reproportioning never moves the pivot.
- the spine plate turns away by exactly as much as the board turns toward us — a solid turning, not two things cross-fading — and lands edge-on as the article card's 12px jacket rail

The page the cover reveals is the **article's own first page**, fetched at click time in parallel with the rise. It's authored at the article's column width and scaled, so the settle changes only scale and offset, never the column — the type never re-wraps. It lands on the real article at `[0, 0, 0]`, so the stage lifts with nothing moving.

Closing runs the same frame backwards, cover-first.

## Verified

- t=0 identity and settle alignment measured in-browser (numbers above)
- rise samples: `t=0` leaf at `[130, 407, 1180, 35]` (the shelf board exactly) → `[720, 144, 437, 612]` at the end of the rise
- `bun run typecheck`, `bun run build`, 13/13 dashboard tests, 48 `test_ara_dsl.py` tests
- full round trips on desktop and 390px, leaving no hidden books; keyboard (Enter) path too, which enters at a different board angle since the angle is measured live rather than read from `--lay`
- no console errors

## Design provenance

Chosen from a 10-agent workflow that measured the discontinuity, proposed three approaches from different premises, and adversarially verified the winner. Its rigid-rotation branch was rejected on taste: physically perfect, but it forces the risen book to keep the shelf book's proportions — a 1.77:1 atlas rather than a hardback.

Not taken, and worth doing before this file grows again: moving beat scheduling to `element.animate()`. Every timing defect in this area traces to a JS constant numerically mirroring a CSS duration with nothing enforcing agreement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)