### PR TITLE
List data-imprint in the sanitizer allowlist beside data-jacket

### DIFF
--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -1190,7 +1190,12 @@ function setSafeContent(
   // `target` is NOT in DOMPurify's default allowlist; every external link
   // this app emits pairs target="_blank" with rel="noopener", so allowing
   // it restores the intended new-tab behavior (ticket sources, tweet links).
-  const addAttr = ['id', 'href', 'type', 'target', 'data-slug', 'data-jacket', 'data-ticket-share', 'data-focus-index', 'data-pct', 'data-paper-date', 'data-columns', 'data-filter-status', 'data-filter-company', 'data-has-audio-file', 'data-digest-audio-play', 'data-digest-audio-label', 'data-audio-date', 'data-odds-event', 'data-odds-market', 'data-odds-token', 'data-odds-question', 'data-odds-outcome', 'aria-label', 'aria-describedby', 'aria-current', 'aria-expanded', 'aria-controls', 'aria-pressed', 'aria-haspopup', 'aria-live', 'loading', 'decoding', 'controls', 'preload', 'src', 'max', 'value'];
+  // `data-imprint` sits beside `data-jacket` on every shelf book and picks its
+  // typeface. Both survive today only because DOMPurify's ALLOW_DATA_ATTR
+  // defaults to true — but jacket is listed here and imprint was not, so
+  // tightening that default would silently drop every book's imprint face with
+  // nothing failing. Listed explicitly for the same reason jacket is.
+  const addAttr = ['id', 'href', 'type', 'target', 'data-slug', 'data-jacket', 'data-imprint', 'data-ticket-share', 'data-focus-index', 'data-pct', 'data-paper-date', 'data-columns', 'data-filter-status', 'data-filter-company', 'data-has-audio-file', 'data-digest-audio-play', 'data-digest-audio-label', 'data-audio-date', 'data-odds-event', 'data-odds-market', 'data-odds-token', 'data-odds-question', 'data-odds-outcome', 'aria-label', 'aria-describedby', 'aria-current', 'aria-expanded', 'aria-controls', 'aria-pressed', 'aria-haspopup', 'aria-live', 'loading', 'decoding', 'controls', 'preload', 'src', 'max', 'value'];
   if (opts.allowIframe) {
     // iframe + its iframe-only attributes are re-enabled exclusively for the
     // trusted, self-constructed sandboxed standalone-doc iframe.


### PR DESCRIPTION
Every book on the research shelf carries two data attributes that must travel together: `data-jacket` (its cover colours) and `data-imprint` (its typeface). Index markup goes through DOMPurify, and `data-jacket` was listed in `ADD_ATTR` — `data-imprint` was not.

It survives today only because DOMPurify's `ALLOW_DATA_ATTR` defaults to `true`. That default holding is the entire reason the shelf renders its imprint faces correctly.

If anyone ever tightens that default, every book silently falls back to the house serif. No error, no failing test, and the two attributes that are meaningless apart would stop travelling together for a reason neither of them can express. Listed explicitly for the same reason `data-jacket` already was.

## Verified

No behaviour change — 12/12 books still resolve `data-imprint`, and both Source Serif (Claude) and Playfair Display (Kimi) still render on the shelf. Open path unaffected. `bun run typecheck`, `bun run build`, 13/13 tests, no console errors.

## Context

Found while auditing what was left after [#1137](https://github.com/guzus/ai-research-arm/pull/1137). The other things that audit turned up were deliberately left, and are worth naming so they don't get rediscovered as bugs:

- **Beat scheduling should move to `element.animate()`.** Every timing defect in that area traces to a JS constant numerically mirroring a CSS duration with nothing enforcing agreement. It's a refactor of working code with no user-visible change — better done when the file is next opened.
- **No guard on t=0 identity.** Five shelf classes are now load-bearing for the open transition; a shelf *structure* change would break pixel-identity for exactly one frame and never be caught in review. A dev-only assert would catch it.
- **The settle animates layout properties** (`top`/`width`/`height`) on several boxes, profiled only on a fast Mac. Unverified on a mid-tier Android.

Probed and found fine, so not worth chasing: opening a book from deep in the shelf (scroll resets, article lands at top), closing from a scrolled article, double-clicking two books (one navigation, no stranded books), and the cost of rendering the article a second time during the animation (no injection over 2ms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)