### PR TITLE
Raise the fleet default native model to claude-opus-5

### DIFF
--- a/.github/workflows/twitter-model-ab.yml
+++ b/.github/workflows/twitter-model-ab.yml
@@ -1,7 +1,9 @@
 name: Twitter Model A/B Eval
 
 # Head-to-head model evaluation on the REAL Twitter-summary workload:
-#   leg "claude"      → lane twitter-ab-claude (native Claude, claude-sonnet-5)
+#   leg "claude"      → lane twitter-ab-claude (native Claude on whatever
+#                       fallback.native_model serves in production — claude-opus-5
+#                       since 2026-08-01, claude-sonnet-5 before it)
 #   leg "zai-glm-5p2" → lane twitter-ab-zai    (GLM-5.2 via Z.ai Coding Plan)
 #
 # Cardinal rule: PARITY. Both legs get the SAME byte-identical input
@@ -382,11 +384,15 @@ jobs:
             cp "$EXEC_FILE" "$EXEC_COPY"
           fi
           cp .twitter-input/birdy-tool-log.jsonl "$STATE/claude-birdy-tool-log.jsonl" 2>/dev/null || true
+          # Leg A tracks the PRODUCTION native model, so the expectation is read
+          # from the routing SSOT rather than pinned here — a hardcoded id would
+          # mark every run contaminated the moment fallback.native_model moves.
+          EXPECTED_MODEL=$(python3 scripts/resolve_backend_lane.py --top fallback.native_model)
           jq -n \
             --arg leg "claude" \
             --arg lane "twitter-ab-claude" \
             --arg expected_provider "claude" \
-            --arg expected_model "claude-sonnet-5" \
+            --arg expected_model "$EXPECTED_MODEL" \
             --arg outcome "$OUTCOME" \
             --arg requested "$REQUESTED" \
             --arg effective "$EFFECTIVE" \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,14 +229,19 @@ back to host-level `pi --tools ... bash`.
 | `ci.yml` | push/PR on workflows/dashboard/scripts | actionlint + dashboard build + Python tests on GitHub-hosted runners |
 | `claude.yml` | `@claude` mention in issue/PR/review | Interactive Claude-Code agent |
 | `claude-code-review.yml` | PR opened/synced | Automated Claude code review |
-| `twitter-model-ab.yml` | daily `21:40` UTC (temporary — remove after the eval week) + manual dispatch | Same-input, parity-locked model A/B eval (claude-sonnet-5 vs GLM-5.2 via Z.ai) on the Twitter-summary workload with a blinded position-swapped Opus judge → `research/eval/twitter-ab/`. Contract: [`docs/twitter-model-ab.md`](docs/twitter-model-ab.md). |
+| `twitter-model-ab.yml` | daily `21:40` UTC (temporary — remove after the eval week) + manual dispatch | Same-input, parity-locked model A/B eval (leg A = the production `fallback.native_model`, `claude-opus-5` since 2026-08-01, vs GLM-5.2 via Z.ai) on the Twitter-summary workload with a blinded position-swapped Opus judge → `research/eval/twitter-ab/`. Contract: [`docs/twitter-model-ab.md`](docs/twitter-model-ab.md). |
 
 **Model convention:** scheduled workflows pass `--model opus`, but
 `agent-run` remaps that alias to whatever the resolved backend serves —
 the Fireworks or Z.ai profile model, or `native-model` (default
-**`claude-sonnet-5`**) on the native path. Direct Claude workflows pin
-`--model claude-sonnet-5` via `claude_args`. Read the workflow file
-rather than assuming one provider everywhere.
+**`claude-opus-5`** since 2026-08-01 — was `claude-sonnet-5`) on the
+native path. Direct Claude workflows are NOT covered by that default:
+the mirror lanes (`claude.yml`, `claude-code-review.yml`,
+`ai-news-research.yml`, `daily-improve.yml`, `research-issue.yml`,
+`twitter-account-explorer.yml`) still pin `--model claude-sonnet-5`
+literally via `claude_args`, and the README diagram's `native` node is
+where that split is visible. Read the workflow file rather than assuming
+one provider everywhere.
 
 ## Backends
 
@@ -255,7 +260,7 @@ derivable from the SSOT.
 
 | Backend | When | Auth | Notes |
 |---|---|---|---|
-| **Claude** | Every production agent lane; `generative-research backend=claude` (no longer that lane's default — see Opus 5 below — but still its Fireworks-unavailable fallback) | `CLAUDE_CODE_OAUTH_TOKEN` | Native Anthropic, model **`claude-sonnet-5`** (the global `fallback.native_model`). Leads the fallback chain. Its token expiring is a fleet-wide outage — see rule 14 and the Authentication table. |
+| **Claude** | Every production agent lane; `generative-research backend=claude` (no longer that lane's default — see Opus 5 below — but still its Fireworks-unavailable fallback) | `CLAUDE_CODE_OAUTH_TOKEN` | Native Anthropic, model **`claude-opus-5`** (the global `fallback.native_model`, raised from `claude-sonnet-5` on 2026-08-01 — same OAuth credential and subscription billing, so the flip is a quality/quota trade, not a new secret). Leads the fallback chain. Its token expiring is a fleet-wide outage — see rule 14 and the Authentication table. |
 | **GLM 5.2 (via Z.ai Coding Plan)** | Second link in the fallback chain; `agent-run backend=zai-glm-5p2`; default manual `hourly-twitter.yml` backend; `zai-claude-code-canary.yml` | `ZAI_API_KEY` | Anthropic-compatible Claude Code endpoint `https://api.z.ai/api/anthropic`, model `glm-5.2`, `CLAUDE_CODE_AUTO_COMPACT_WINDOW=1000000`. The `glm-5.2[1m]` alias was rejected as `Unknown Model` (canary run `28751367808`) — keep the endpoint-valid id unless a raw probe proves otherwise. Because it shares the harness and sandbox but not the credential, **the canary is the fastest way to tell a dead Claude token from a broken runner**. Selectors: `zai-glm-5p2`, `zai-glm-5.2`, `zai-glm52`, `zai`. |
 | **GLM 5.2 (via Fireworks)** | `generative-research backend=glm-5p2` | `FIREWORKS_API_KEY` | Model `accounts/fireworks/models/glm-5p2`. Selectors: `fireworks-glm-5p2`, `glm-5p2`, `glm`. In `generative-research.yml` the workflow-level `fireworks_fallback` input falls back to native Claude by default. |
 | **DeepSeek V4 Flash (via Fireworks)** | Low-cost/comparison: `generative-research backend=deepseek-v4-flash`; `hourly-twitter.yml` DeepSeek tiers | `FIREWORKS_API_KEY` | Endpoint `https://api.fireworks.ai/inference` (base URL omits `/v1`; the client appends `/v1/messages`), model `accounts/fireworks/models/deepseek-v4-flash`. Overrides `ANTHROPIC_BASE_URL`/`AUTH_TOKEN`/`MODEL` so the Claude action transparently calls Fireworks. The direct DeepSeek API is retired (billing). Scheduled DeepSeek lanes are STRICT comparison tiers that never fall back. |

--- a/README.md
+++ b/README.md
@@ -164,8 +164,8 @@ flowchart LR
         OAI["🤖 OpenAI Codex CLI<br/><i>ChatGPT auth</i>"]
         MSH["🌙 Moonshot Kimi K3<br/><i>opencode CLI</i>"]
     end
-    lanes0 -->|"claude-sonnet-5"| ANT
-    strict0 -->|"claude-sonnet-5"| ANT
+    lanes0 -->|"claude-opus-5"| ANT
+    strict0 -->|"claude-opus-5"| ANT
     strict1 -->|"deepseek-v4-flash"| FW
     strict2 -->|"glm-5.2"| ZAI
     gendef -->|"claude-opus-5"| ANT

--- a/data/agent-backends.json
+++ b/data/agent-backends.json
@@ -53,8 +53,8 @@
       "claude",
       "zai-glm-5p2"
     ],
-    "native_model": "claude-sonnet-5",
-    "notes": "ORDERED fallback chain, globally applied to every non-strict agent-run lane. When the lane's requested provider probe fails, scripts/select_backend.py walks this chain in order (skipping the already-failed requested backend if it reappears) and runs the first candidate whose provider is available. Native Claude leads the chain and serves `native_model`. Z.ai GLM-5.2 is the second link, added after the 2026-07-24 outage: the chain was [\"claude\"] only AND probe_claude() hardcoded \"always available\", so an expired CLAUDE_CODE_OAUTH_TOKEN took down every agent lane in the fleet at once with no route out (instant is_error, 1 turn, $0 cost) while ZAI_API_KEY sat configured and healthy. probe_claude() now reports down only on an explicit 401/403 credential rejection, so a rate limit, 5xx, or network blip still keeps the fleet on Claude. Lanes with \"strict\": true (zai-canary, the comparison tiers) never walk the chain — unavailability fails the run. `native_model` is the model served whenever the native claude path runs (also what the --model opus alias resolves to)."
+    "native_model": "claude-opus-5",
+    "notes": "ORDERED fallback chain, globally applied to every non-strict agent-run lane. When the lane's requested provider probe fails, scripts/select_backend.py walks this chain in order (skipping the already-failed requested backend if it reappears) and runs the first candidate whose provider is available. Native Claude leads the chain and serves `native_model`. Z.ai GLM-5.2 is the second link, added after the 2026-07-24 outage: the chain was [\"claude\"] only AND probe_claude() hardcoded \"always available\", so an expired CLAUDE_CODE_OAUTH_TOKEN took down every agent lane in the fleet at once with no route out (instant is_error, 1 turn, $0 cost) while ZAI_API_KEY sat configured and healthy. probe_claude() now reports down only on an explicit 401/403 credential rejection, so a rate limit, 5xx, or network blip still keeps the fleet on Claude. Lanes with \"strict\": true (zai-canary, the comparison tiers) never walk the chain — unavailability fails the run. `native_model` is the model served whenever the native claude path runs (also what the --model opus alias resolves to); raised from claude-sonnet-5 to claude-opus-5 on 2026-08-01, so every non-strict agent lane and the twitter-ab claude leg now run Opus 5 on the same OAuth subscription."
   },
   "lanes": {
     "rss": {
@@ -189,7 +189,7 @@
       "pinned": true,
       "pinned_provider": "claude",
       "strict": true,
-      "notes": "A/B eval blinded judge, pass 1. Native Claude with the workflow's native-model override to claude-opus-4-8 so the judge is a true non-contestant Opus, not the sonnet default either leg runs on."
+      "notes": "A/B eval blinded judge, pass 1. Native Claude with the workflow's native-model override to claude-opus-4-8 so the judge is a true non-contestant on a different model from the production fallback.native_model (claude-opus-5) leg A runs on."
     },
     "twitter-ab-judge-swapped": {
       "workflow": "twitter-model-ab.yml",

--- a/docs/backend-matrix.md
+++ b/docs/backend-matrix.md
@@ -75,34 +75,34 @@ Reading notes:
 | Lane | Workflow | Harness | Provider | Model | Token secret | Fallback |
 |---|---|---|---|---|---|---|
 | ai-news-research (×2 step variants) | `ai-news-research.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
-| arxiv | `daily-arxiv.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2` |
-| bluesky | `2h-bluesky.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2` |
+| arxiv | `daily-arxiv.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2` |
+| bluesky | `2h-bluesky.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2` |
 | claude-code-review | `claude-code-review.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
 | claude-interactive | `claude.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
-| community | `4h-community.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2` |
+| community | `4h-community.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2` |
 | daily-improve | `daily-improve.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
-| digest-audio-script | `daily-digest.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2`; then `deterministic_daily_digest.py` |
-| digest-synthesis | `daily-digest.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2`; then `deterministic_daily_digest.py` |
-| digest-synthesis-fallback | `daily-digest.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2`; then `deterministic_daily_digest.py` |
+| digest-audio-script | `daily-digest.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2`; then `deterministic_daily_digest.py` |
+| digest-synthesis | `daily-digest.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2`; then `deterministic_daily_digest.py` |
+| digest-synthesis-fallback | `daily-digest.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2`; then `deterministic_daily_digest.py` |
 | generative-research-claude (+1 retry step) | `generative-research.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
 | generative-research-default | `generative-research.yml` | dispatch default (runtime SSOT) | (per chosen backend) | default: `opus-5` | (per chosen backend) | workflow-level `fireworks_fallback` input (default `claude`) |
-| model-timeline | `24h-model-timeline.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2` |
+| model-timeline | `24h-model-timeline.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2` |
 | research-issue (×2 step variants) | `research-issue.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
-| rss | `hourly-rss.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2` |
-| twitter-ab-claude · PINNED | `twitter-model-ab.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (strict — never walks the chain) |
-| twitter-ab-judge · PINNED | `twitter-model-ab.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (strict — never walks the chain) |
-| twitter-ab-judge-swapped · PINNED | `twitter-model-ab.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (strict — never walks the chain) |
+| rss | `hourly-rss.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2` |
+| twitter-ab-claude · PINNED | `twitter-model-ab.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (strict — never walks the chain) |
+| twitter-ab-judge · PINNED | `twitter-model-ab.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (strict — never walks the chain) |
+| twitter-ab-judge-swapped · PINNED | `twitter-model-ab.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (strict — never walks the chain) |
 | twitter-ab-zai · PINNED | `twitter-model-ab.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Z.ai | `glm-5.2` | `ZAI_API_KEY` | hard fail (strict — never walks the chain) |
 | twitter-account-explorer | `twitter-account-explorer.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
-| twitter-autoresearch (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2` |
+| twitter-autoresearch (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2` |
 | twitter-deepseek (tier:deepseek-claude-code) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | DeepSeek V4 Flash via Fireworks | `accounts/fireworks/models/deepseek-v4-flash` | `FIREWORKS_API_KEY` | hard fail (strict — never walks the chain) |
 | twitter-deepseek-pi (tier:deepseek-pi) | `hourly-twitter.yml` | pi · run-pi-container (CI-enforced mirror) | fireworks (pi built-in) | `accounts/fireworks/models/deepseek-v4-flash` | `FIREWORKS_API_KEY` | — |
 | twitter-fireworks-pi (tier:fireworks-pi) | `hourly-twitter.yml` | pi · run-pi-container (CI-enforced mirror) | fireworks (pi built-in) | `accounts/fireworks/models/kimi-k2p7` | `FIREWORKS_API_KEY` | — |
-| twitter-judge (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2` |
-| twitter-primary (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2`; then `deterministic_twitter_digest.py` |
-| twitter-primary-repair (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2` |
+| twitter-judge (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2` |
+| twitter-primary (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2`; then `deterministic_twitter_digest.py` |
+| twitter-primary-repair (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2` |
 | twitter-zai (tier:zai-glm-5p2) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Z.ai | `glm-5.2` | `ZAI_API_KEY` | hard fail (strict — never walks the chain) |
-| wiki-ingest | `wiki-ingest.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2` |
+| wiki-ingest | `wiki-ingest.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2` |
 | zai-canary · PINNED | `zai-claude-code-canary.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Z.ai | `glm-5.2` | `ZAI_API_KEY` | hard fail (strict — never walks the chain) |
 | (dispatch path) backend=fireworks (+2 retry steps) | `generative-research.yml` | Claude Code · claude-code-action (env-rerouted) | Fireworks (Anthropic-compatible endpoint) | dynamic: per fireworks profile step | `FIREWORKS_API_KEY` | workflow-level `fireworks_fallback` input (default `claude`) |
 | (dispatch path) backend=codex | `generative-research.yml` | Codex CLI | OpenAI (ChatGPT subscription auth) | codex CLI default | `CODEX_AUTH_JSON` | — |
@@ -122,7 +122,7 @@ Reading notes:
 - `daily-youtube.yml`
 - `liveness-check.yml`
 
-_Global ordered fallback chain (SSOT `fallback.chain`): `claude` → `zai-glm-5p2`; native path serves `claude-sonnet-5`. 30 SSOT lanes (+6 dispatch execution paths) across 26 workflows; 8 workflows run no model._
+_Global ordered fallback chain (SSOT `fallback.chain`): `claude` → `zai-glm-5p2`; native path serves `claude-opus-5`. 30 SSOT lanes (+6 dispatch execution paths) across 26 workflows; 8 workflows run no model._
 
 <!-- END GENERATED BACKEND MATRIX -->
 

--- a/docs/backend-matrix.md
+++ b/docs/backend-matrix.md
@@ -90,8 +90,8 @@ Reading notes:
 | research-issue (×2 step variants) | `research-issue.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
 | rss | `hourly-rss.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2` |
 | twitter-ab-claude · PINNED | `twitter-model-ab.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (strict — never walks the chain) |
-| twitter-ab-judge · PINNED | `twitter-model-ab.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (strict — never walks the chain) |
-| twitter-ab-judge-swapped · PINNED | `twitter-model-ab.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (strict — never walks the chain) |
+| twitter-ab-judge · PINNED | `twitter-model-ab.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-4-8` (workflow `native-model` override) | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (strict — never walks the chain) |
+| twitter-ab-judge-swapped · PINNED | `twitter-model-ab.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-4-8` (workflow `native-model` override) | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (strict — never walks the chain) |
 | twitter-ab-zai · PINNED | `twitter-model-ab.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Z.ai | `glm-5.2` | `ZAI_API_KEY` | hard fail (strict — never walks the chain) |
 | twitter-account-explorer | `twitter-account-explorer.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
 | twitter-autoresearch (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2` |

--- a/docs/twitter-model-ab.md
+++ b/docs/twitter-model-ab.md
@@ -6,7 +6,7 @@ capability from harness/rescue effects:
 
 | Leg | Lane (SSOT) | Provider route | Served model |
 |---|---|---|---|
-| `claude` | `twitter-ab-claude` | native Claude via `agent-run` | `claude-sonnet-5` (the production native model) |
+| `claude` | `twitter-ab-claude` | native Claude via `agent-run` | whatever `fallback.native_model` serves in production — `claude-opus-5` since 2026-08-01 (`claude-sonnet-5` before it). The metrics step reads the id from the SSOT, so the leg follows production instead of pinning a literal. |
 | `zai-glm-5p2` | `twitter-ab-zai` | Z.ai Coding Plan via `agent-run` | `glm-5.2` |
 
 Outputs land under `research/eval/twitter-ab/`:
@@ -109,8 +109,9 @@ invalidates the eval. The workflow enforces it structurally:
 - The judge is a **true non-contestant**: lanes `twitter-ab-judge` /
   `twitter-ab-judge-swapped` are native Claude with the agent-run
   `native-model: claude-opus-4-8` override (that is what the `--model
-  opus` alias resolves to for these two steps only) — not the
-  `claude-sonnet-5` the claude leg ran on. Tools are `Read,Write` only.
+  opus` alias resolves to for these two steps only) — a different model
+  from the production `fallback.native_model` (`claude-opus-5`) the claude
+  leg ran on. Tools are `Read,Write` only.
 - Rubric (1–10 integers per brief): coverage, faithfulness (spot-checked
   against a pretty-printed copy of the shared snapshot), headline
   quality, skepticism/source hygiene, format compliance, plus a holistic

--- a/scripts/build_backend_matrix.py
+++ b/scripts/build_backend_matrix.py
@@ -559,7 +559,18 @@ def build_rows(lanes: dict[str, dict], observations: dict[str, Observation],
             backend = str(lane.get("backend", ""))
             profile = profiles.get(backend)
             provider = profile.display_name if profile else backend
-            model = f"`{profile.model_id}`" if profile and profile.model_id else f"`{native_fallback}`"
+            # A workflow-level `native-model:` input overrides what the native
+            # Claude path serves for that step ONLY (the judge lanes pin
+            # claude-opus-4-8 so the judge is not a contestant). It is captured
+            # at parse time; rendering it is what keeps this column honest —
+            # without it the row silently reports the global fallback.native_model.
+            override = step.native_model_override if step else ""
+            if profile and profile.model_id:
+                model = f"`{profile.model_id}`"
+            elif override:
+                model = f"`{override}` (workflow `native-model` override)"
+            else:
+                model = f"`{native_fallback}`"
             token = TOKEN_BY_PROVIDER.get(profile.provider if profile else "", "?")
             setting = (step.fireworks_fallback if step and step.fireworks_fallback
                        else fallback_default)

--- a/scripts/test_backend_matrix.py
+++ b/scripts/test_backend_matrix.py
@@ -212,6 +212,27 @@ class RoutingInvariants(unittest.TestCase):
         for lane in ("twitter-zai", "twitter-deepseek", "zai-canary"):
             self.assertTrue(self.lanes[lane].get("strict"), lane)
 
+    def test_native_model_override_is_rendered_in_the_matrix(self):
+        # A workflow `native-model:` input silently beats fallback.native_model
+        # for that step. If the Model column renders the global default anyway,
+        # the row is a lie that reads as plausible — the A/B judge lanes pin
+        # claude-opus-4-8 precisely so the judge is NOT a contestant, and the
+        # matrix claiming they run the fleet default hides an invalidated eval.
+        from build_backend_matrix import build_generated_blocks
+        matrix, _ = build_generated_blocks()
+        judge_rows = [ln for ln in matrix.splitlines()
+                      if ln.startswith("| twitter-ab-judge")]
+        self.assertEqual(2, len(judge_rows), matrix)
+        for row in judge_rows:
+            self.assertIn("claude-opus-4-8", row)
+            self.assertIn("native-model` override", row)
+        # The contestant leg has no override and must track the global default.
+        leg_a = [ln for ln in matrix.splitlines()
+                 if ln.startswith("| twitter-ab-claude")]
+        self.assertEqual(1, len(leg_a), matrix)
+        self.assertIn(self.fallback["native_model"], leg_a[0])
+        self.assertNotIn("override", leg_a[0])
+
     def test_readme_diagram_generated_and_deterministic(self):
         from build_backend_matrix import build_generated_blocks
         _, diagram1 = build_generated_blocks()


### PR DESCRIPTION
## What

`data/agent-backends.json` → `fallback.native_model`: `claude-sonnet-5` → **`claude-opus-5`**.

That field is what the `--model opus` alias resolves to on every non-strict `agent-run` lane, so this single edit moves the whole scheduled fleet — digest, rss, community, twitter (primary/repair/judge/autoresearch), bluesky, arxiv, wiki-ingest, model-timeline, digest-audio-script — onto Opus 5. Same `CLAUDE_CODE_OAUTH_TOKEN`, same subscription billing; it's a quality/quota trade, not a new credential.

## Why the extra files

- **`twitter-model-ab.yml`** hardcoded `expected_model "claude-sonnet-5"` for leg A. The SSOT defines that leg as *"production native Claude (serves `fallback.native_model`)"*, so the literal would have failed the parity check as `expected-model-not-observed` → **CONTAMINATED** on every nightly run from the first one after merge. It now reads the id from the SSOT (`resolve_backend_lane.py --top fallback.native_model`), so it can't drift again.
- **`docs/backend-matrix.md` + README diagram** are generated and `build_backend_matrix.py --check` is CI-load-bearing — regenerated.

## Explicitly NOT changed

The direct-Claude mirror lanes still pin `--model claude-sonnet-5` literally: `claude.yml`, `claude-code-review.yml`, `ai-news-research.yml`, `daily-improve.yml`, `research-issue.yml`, `twitter-account-explorer.yml`, plus `generative-research.yml`'s `backend=claude` fallback branch. Those are per-lane pins, not the default, and flipping them would put Opus on every PR review. `CLAUDE.md` now documents the split. Say the word if you want those flipped too.

## Verification

- `build_backend_matrix.py --check` → in sync
- `test_backend_matrix.py` 38 ✓, `test_select_backend.py` 17 ✓, `test_twitter_ab_metrics.py` 24 ✓, `test_workflow_time_convention.py` 4 ✓
- `actionlint .github/workflows/twitter-model-ab.yml` → clean
- Full `scripts/test_*.py` sweep green except `test_claude_sandbox_policy.py`, which fails on a local macOS `research/.DS_Store` (untracked, not in the diff, won't reproduce on `ubuntu-latest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)