### PR TITLE
Unfreeze the headline dedupe ledger, correct four doc drifts, stop publishing dispatch prompts as summaries

### DIFF
--- a/.github/workflows/hourly-twitter.yml
+++ b/.github/workflows/hourly-twitter.yml
@@ -1233,6 +1233,7 @@ jobs:
 
       # ── claude-tier Hooker headline blast ──────────────────────────
       - name: Send headline alerts to Hooker (claude tier)
+        id: send_alerts
         if: >-
           success()
           && steps.backend.outputs.name == 'claude'
@@ -1378,26 +1379,16 @@ jobs:
 
             git add "$HISTORY_FILE"
             if git commit -m "Track delivered Twitter headline alerts ${ANNOUNCED_AT}"; then
-              AUTH_HEADER=$(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')
-              git_auth() {
-                git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${AUTH_HEADER}" "$@"
-              }
-              # Retry push in case another workflow committed concurrently.
-              PUSHED=false
-              for attempt in 1 2 3; do
-                if git_auth push origin "HEAD:main"; then
-                  PUSHED=true
-                  break
-                fi
-                echo "History push attempt $attempt failed; rebasing"
-                if ! git_auth pull --rebase origin main; then
-                  git rebase --abort 2>/dev/null || true
-                  break
-                fi
-              done
-              if [ "$PUSHED" != "true" ]; then
-                echo "::warning::Failed to push delivered-alert history after retries; alerts were already sent, continuing"
-              fi
+              # The publish is handed to the shared safe-push action in the
+              # next step, NOT done here. A raw `git push origin HEAD:main`
+              # used to live at this spot; the 2026-07-06 repository ruleset
+              # made every one of those pushes fail with GH013, and because
+              # the failure was only a ::warning:: the job still reported
+              # success — so the ledger silently froze at 2026-07-04 while
+              # dedupe kept consulting it and duplicate alerts kept shipping.
+              # Publishing through safe-push gets the protected-branch PR
+              # fallback every other lane already uses.
+              echo "history_committed=true" >> "$GITHUB_OUTPUT"
             else
               echo "No delivered alert history changes"
             fi
@@ -1410,6 +1401,42 @@ jobs:
           fi
 
           echo "Done — batch delivered (delivered=$DELIVERED_COUNT, failed=$FAILED)."
+
+      # Publish the dedupe ledger. This runs even when the send step exited
+      # non-zero on partially-failed routes: the alerts that DID land are
+      # already recorded in the commit, and losing that commit is what
+      # causes duplicate alerts on the next cycle.
+      - name: Push delivered-alert history
+        id: push_history
+        if: >-
+          !cancelled()
+          && steps.send_alerts.outputs.history_committed == 'true'
+        uses: ./.github/actions/safe-push
+        with:
+          branch: ${{ github.ref_name }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          noop-pushed: 'false'
+
+      # Fail loudly if the ledger did not land. Dedupe correctness depends on
+      # this file being current; a silent failure here is invisible for weeks
+      # and only shows up as duplicate Telegram alerts to readers.
+      - name: Verify delivered-alert history landed
+        if: >-
+          !cancelled()
+          && steps.send_alerts.outputs.history_committed == 'true'
+        env:
+          PUSHED: ${{ steps.push_history.outputs.pushed }}
+          MODE: ${{ steps.push_history.outputs.publication-mode }}
+        run: |
+          set -euo pipefail
+          echo "publication-mode=$MODE pushed=$PUSHED"
+          if [ "$PUSHED" != "true" ]; then
+            echo "::error::Delivered-alert ledger failed to publish (mode=$MODE)." \
+                 "research/summaries/twitter-announced-history.json is now stale," \
+                 "so headline dedupe will re-alert stories that already shipped." \
+                 "Land the open automation/safe-push PR, or re-run this lane."
+            exit 1
+          fi
 
       # ── Comparison-tier Telegram notification ──────────────────────
       - name: Read summary for Telegram (comparison tiers)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,11 @@ and opens a PR with methodology fixes.
 | `check_digest_content.py` | Per-run hard content floor for the daily digest (`--min-bytes`, `--min-sections`, unexpanded-placeholder scan). Decides whether the deterministic composer takes over; complements the advisory `check_lane_content.py`. |
 | `validate_twitter_public_output.py` | Twitter signal-only contract after every backend: heartbeat identity, exact public-item count, concrete story/Quick-hit presence, normalized same-hour headings, no operational/no-news filler. |
 | `check_lane_freshness.py` | Per-lane git-commit recency vs. cadence thresholds; exit 2 → hooker/Telegram alert from `liveness-check.yml`. Stdlib-only so it runs on both runner tiers. |
-| `export_wiki_okf.py` | `research/wiki/` → portable OKF bundle; rewrites `[[wikilinks]]` to Markdown links. |
+
+`export_wiki_okf.py` (`research/wiki/` → portable OKF bundle; rewrites
+`[[wikilinks]]` to Markdown links) used to be listed above, but it is NOT
+CI-enforced and no workflow calls it — `grep -rn okf .github/workflows/`
+returns nothing. It is a manual export; see the experimental table below.
 
 **Deterministic (model-free) fallbacks.** Only TWO are wired into a
 workflow. The other four scripts exist and are tested but **no workflow
@@ -123,6 +127,7 @@ pipeline code; don't assume the dashboard or any lane depends on them.
 | Script | Purpose |
 |---|---|
 | `generate_generative_article_audio.py` | Backfill TTS audio for a generative article (Gemini Flash TTS / Vertex). Run manually; needs `GEMINI_API_KEY`. |
+| `export_wiki_okf.py` | `research/wiki/` → portable OKF bundle; rewrites `[[wikilinks]]` to Markdown links. Tested, but no workflow calls it and the bundle is not published anywhere. |
 | `collect_viral_tweets.py`, `analyze_viral_tweets.py` | Viral-tweet collection + analysis. Write `research/twitter-viral/`. |
 | `analyze_overperformance.py`, `enrich_overperformance.py`, `experiment_overperf_cv.py` | Tweet-overperformance analysis / enrichment / cross-validation experiments. |
 | `enrich_bookmarks.py` | Enrich a bookmark export with engagement/features. |
@@ -197,7 +202,7 @@ back to host-level `pi --tools ... bash`.
 | `daily-ai-blogs.yml` | `:13` every 6h | `research/blogs/` |
 | `blog-subscriptions.yml` | `:47` every 2h | Telegram notifications for configured blog subscriptions + GUID state in `research/summaries/blog-subscriptions.json` |
 | `daily-youtube.yml` | daily `23:20` for the next `00:00` digest | `research/youtube/` (tuber discovery + read-only summary/transcript evidence) |
-| `hourly-twitter.yml` | every 3h `:07`; primary lane uses Fireworks through `.github/actions/agent-run`; comparison lanes via matrix/manual dispatch | `research/twitter/` + `research/summaries/` + Telegram headline alerts; comparison outputs under `research/twitter-deepseek/`, `research/twitter-deepseek-pi/`, `research/twitter-fireworks-pi/`, and `research/twitter-opencode-kimi/` |
+| `hourly-twitter.yml` | every 3h `:07`; primary lane routes to `backend: claude` through `.github/actions/agent-run` (verify against `data/agent-backends.json` lane `twitter-primary` — not this table); comparison lanes via matrix/manual dispatch | `research/twitter/` + `research/summaries/` + Telegram headline alerts; comparison outputs under `research/twitter-deepseek/`, `research/twitter-deepseek-pi/`, `research/twitter-fireworks-pi/`, and `research/twitter-opencode-kimi/` |
 | `twitter-account-explorer.yml` | weekly Tuesday `01:47` UTC + manual dispatch | Opens reviewed PRs for `data/sources/twitter_accounts.json` changes when high-signal account evidence exists |
 | `2h-bluesky.yml` | daily `10:11` | `research/bluesky/` (supplemental expert commentary, capped output) |
 | `4h-community.yml` | every 4h `:19` | `research/community/*-hn.md`, `*-reddit.md` |
@@ -372,7 +377,20 @@ output or break the pipeline. Read them before editing.
    (the remaining `VERCEL_DEPLOY_HOOK` steps are permanent no-ops).
    `dashboard/scripts/prebuild.mjs` copies `research/<source>/` into
    `public/research/` before Vite runs, so touching it changes what the
-   dashboard sees. **Incident-learned corollary: the Dockerfile's package
+   dashboard sees.
+   **Cloudflare is NOT a transparent pass-through — it rewrites and
+   blocks.** Verified 2026-08-01: the live `/robots.txt` is not the file
+   `dashboard/scripts/postbuild-seo.mjs:1191` builds — Cloudflare prepends
+   a Managed block (`Content-Signal: ai-train=no`, `Disallow: /` for
+   ClaudeBot/GPTBot/CCBot/Google-Extended/Bytespider) — and the edge
+   returns **HTTP 403 by user-agent** to ClaudeBot, GPTBot and CCBot, the
+   exact crawlers that file explicitly `Allow: /`. PerplexityBot,
+   Googlebot and normal browsers get 200. This is a zone-level setting, so
+   it is invisible from the repo and cannot be fixed by editing
+   `postbuild-seo.mjs`. `scripts/check_deploy_health.py` sends one fixed
+   UA at one URL and is structurally blind to it — do not treat a green
+   deploy-health check as evidence the site is reachable.
+   **Incident-learned corollary: the Dockerfile's package
    manager MUST stay in lockstep with the dashboard's** (bun since #102)
    — a leftover `npm ci` froze prod at a stale build for ~a day *with CI
    green*, because CI never runs the Dockerfile. Staleness is now watched

--- a/dashboard/scripts/postbuild-seo.mjs
+++ b/dashboard/scripts/postbuild-seo.mjs
@@ -155,6 +155,14 @@ function compactText(s) {
 
 // SERPs typically truncate descriptions around 155-160 chars. Aim for ~190
 // and gracefully clip on a word boundary so OG / Twitter cards stay clean.
+// Public-facing one-line summary for an index.json row. Prefers the article's
+// own deck/lede (captured into articleDescriptions while the pages are built)
+// and falls back to the title — deliberately NEVER to row.prompt, which is the
+// internal dispatch brief and reads as leaked tooling to any human or crawler.
+function articleSummary(row) {
+  return articleDescriptions.get(row.slug) || row.title || row.slug;
+}
+
 function truncateDescription(s, max = 190) {
   if (s.length <= max) return s;
   const clipped = s.slice(0, max);
@@ -1288,7 +1296,7 @@ function buildLlmsTxt(entries, wikiPages, forecastTickets) {
       const tags = Array.isArray(article.tags) && article.tags.length
         ? ` Tags: ${article.tags.map(markdownLine).join(', ')}.`
         : '';
-      const desc = markdownLine(article.prompt || title);
+      const desc = markdownLine(articleSummary(article));
       lines.push(`- [${title}](${SITE_ORIGIN}/research/${article.slug}): ${desc}${tags}`);
     }
     lines.push('');
@@ -1367,7 +1375,7 @@ function buildFeed(entries, shareImageUrl) {
       link: `${SITE_ORIGIN}/research/${e.slug}`,
       guid: `${SITE_ORIGIN}/research/${e.slug}`,
       date: e.created_at,
-      description: truncateDescription(decodeEntities(stripTags(e.prompt || e.title || e.slug))),
+      description: truncateDescription(decodeEntities(stripTags(articleSummary(e)))),
     }));
   items.push(...articleItems);
 
@@ -1435,6 +1443,14 @@ let skipped = 0;
 let cardAttempts = 0;
 let cardsGenerated = 0;
 const generatedArticleImages = new Map();
+// slug -> the article's own deck/lede, already truncated by extractMeta. The
+// article PAGES have always used this for their meta description and JSON-LD;
+// llms.txt, feed.xml and the /research hub used row.prompt instead, which is
+// the internal dispatch brief the workflow was launched with — up to 3.6KB of
+// "Argue it." and "EVIDENCE DISCIPLINE" addressed to the authoring agent, not
+// to a reader. Capturing it here lets those three consumers use the same
+// summary the article page already shows.
+const articleDescriptions = new Map();
 const articleRows = [];
 for (const row of entries) {
   if (row.kind === 'standalone') {
@@ -1449,6 +1465,7 @@ for (const row of entries) {
   const articleHtml = readFileSync(articlePath, 'utf8');
   const indexable = isIndexableResearchEntry(row);
   const { title: extractedTitle, desc: extractedDesc } = extractMeta(articleHtml);
+  if (extractedDesc) articleDescriptions.set(row.slug, extractedDesc);
   const cardTitle = extractedTitle || row.title || row.slug;
   if (!articleArtifactImage(row, cardTitle)) {
     cardAttempts++;
@@ -1600,7 +1617,7 @@ const researchItems = publishedEntries
     route: `/research/${row.slug}`,
     title: row.title || row.slug,
     meta: row.created_at ? String(row.created_at).slice(0, 10) : '',
-    description: row.prompt || row.title || row.slug,
+    description: articleSummary(row),
   }));
 const researchHubDir = join(dist, 'research');
 mkdirSync(researchHubDir, { recursive: true });

--- a/docs/headline-dedupe.md
+++ b/docs/headline-dedupe.md
@@ -158,8 +158,12 @@ news that merely shares vocabulary. Calibration on the real ledger shows that
 band is ~half true duplicates that leaked and ~half genuinely-distinct items:
 "MICRON CROSSES $900B" vs "SK HYNIX CROSSES $900B" (same metric, different
 subject), appended-fact follow-ups, running-counter progressions. Separating
-those is a *semantic* judgment, so a Claude **Haiku** step adjudicates exactly
-that band — and only that band — as a final gate on the send path.
+those is a *semantic* judgment, so one agent-run model step adjudicates exactly
+that band — and only that band — as a final gate on the send path. It runs on
+SSOT lane `twitter-judge` with `--model opus`, which `agent-run` remaps to the
+global `fallback.native_model` (`claude-opus-5` since 2026-08-01) — NOT Haiku,
+which this doc claimed until 2026-08-01. Read `data/agent-backends.json` for
+the current model rather than trusting a literal here.
 
 It lives in `scripts/headline_judge.py` (two deterministic, unit-tested
 subcommands) bracketing one model step in `hourly-twitter.yml`:
@@ -168,7 +172,7 @@ subcommands) bracketing one model step in `hourly-twitter.yml`:
 flowchart LR
     FILTER["deterministic filter<br/>→ to-send.json"]:::proc --> SHORT["shortlist<br/>survivors in [0.35,0.50)<br/>+ ≤5 nearest priors"]:::proc
     SHORT -->|empty| BLAST
-    SHORT -->|"doubtful.json"| JUDGE{{"Haiku judge<br/>same event?"}}:::model
+    SHORT -->|"doubtful.json"| JUDGE{{"agent-run judge<br/>lane: twitter-judge<br/>same event?"}}:::model
     JUDGE -->|"verdicts.json"| APPLY["apply<br/>drop duplicate+high only"]:::proc
     APPLY --> ALERT["Telegram alert<br/>on every suppression"]:::io
     APPLY --> BLAST["Hooker blast"]:::io

--- a/research/summaries/twitter-announced-history.json
+++ b/research/summaries/twitter-announced-history.json
@@ -486,11735 +486,19740 @@
     "url": "https://x.com/Hodl_fm/status/2049022908853637321"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-01 04:31 UTC",
+    "delivered_at": "2026-04-28 12:00 UTC",
+    "headline": "XAI TRAINING GROK 5 ON COLOSSUS 2 \u2014 10 TRILLION PARAMETERS, ~20X SIZE OF GROK 4.3",
+    "source": "@mark_k",
+    "source_file": "research/summaries/2026-04-28-twitter-12h-headlines.json",
+    "url": "https://x.com/mark_k/status/2049070786799976750"
+  },
+  {
+    "backfilled": true,
+    "category": "breaking",
+    "delivered_at": "2026-04-28 12:00 UTC",
+    "headline": "CHINA BLOCKS META'S $2B MANUS AI ACQUISITION \u2014 META PREPARING TO UNWIND THE DEAL",
+    "source": "@enes1050392",
+    "source_file": "research/summaries/2026-04-28-twitter-12h-headlines.json",
+    "url": "https://x.com/enes1050392/status/2049108348432249012"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-04-28 12:00 UTC",
+    "headline": "GOOGLE SIGNS PENTAGON DEAL FOR CLASSIFIED AI WORK \u2014 REVERSES 2018 PROJECT MAVEN EXIT",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-04-28-twitter-12h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2049081961222955403"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-04-28 12:00 UTC",
+    "headline": "MICROSOFT\u2013OPENAI PARTNERSHIP REWRITTEN THROUGH 2032 \u2014 AGI TRIGGER CLAUSE QUIETLY DROPPED",
+    "source": "@monkfromearth",
+    "source_file": "research/summaries/2026-04-28-twitter-12h-headlines.json",
+    "url": "https://x.com/monkfromearth/status/2049107595538084271"
+  },
+  {
+    "backfilled": true,
+    "category": "opensource",
+    "delivered_at": "2026-04-28 12:00 UTC",
+    "headline": "MICROSOFT OPEN-SOURCES TRELLIS.2 \u2014 4B-PARAM IMAGE-TO-3D MODEL, 1536\u00b3 PBR ASSETS",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-04-28-twitter-12h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2049099376476459372"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-04-28 12:00 UTC",
+    "headline": "ADANI TO BUILD ~1GW AI DATA CENTER HUB IN VIZAG \u2014 AMONG INDIA'S LARGEST DIGITAL INFRA PROJECTS",
+    "source": "@IndianIndex",
+    "source_file": "research/summaries/2026-04-28-twitter-12h-headlines.json",
+    "url": "https://x.com/IndianIndex/status/2049108234838147359"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-04-28 12:00 UTC",
+    "headline": "PALANTIR LANDS MULTI-YEAR AI DEPLOYMENT WITH CLEVELAND-CLIFFS (NYSE: CLF)",
+    "source": "@PalantirOg",
+    "source_file": "research/summaries/2026-04-28-twitter-12h-headlines.json",
+    "url": "https://x.com/PalantirOg/status/2049109137213050956"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-04-28 15:00 UTC",
+    "headline": "GOOGLE SIGNS PENTAGON DOD DEAL \u2014 GEMINI CLEARED FOR CLASSIFIED WORK DESPITE 600+ STAFF REVOLT",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-04-28-twitter-15h-headlines.json",
+    "url": "https://x.com/theinformation/status/2049141713352953965"
+  },
+  {
+    "backfilled": true,
+    "category": "breaking",
+    "delivered_at": "2026-04-28 15:00 UTC",
+    "headline": "ANTHROPIC MYTHOS MODEL BREACHED \u2014 OPENAI ALSO HIT BY BRIEF LEAK, FRONTIER WEIGHTS NOW IN ATTACKER REACH",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-04-28-twitter-15h-headlines.json",
+    "url": "https://x.com/theinformation/status/2049111469506060425"
+  },
+  {
+    "backfilled": true,
+    "category": "opensource",
+    "delivered_at": "2026-04-28 15:00 UTC",
+    "headline": "POOLSIDE OPEN-SOURCES LAGUNA XS.2 \u2014 33B-TOTAL / 3B-ACTIVE MOE BUILT FOR AGENTIC CODING",
+    "source": "@HuggingFace",
+    "source_file": "research/summaries/2026-04-28-twitter-15h-headlines.json",
+    "url": "https://x.com/HuggingFace/status/2049146102515908975"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-04-28 15:00 UTC",
+    "headline": "GPT-5.6 SPOTTED IN THE WILD \u2014 \"MORE PROGRESS IN NEXT 3 MONTHS THAN PAST 3 YEARS\"",
+    "source": "@iruletheworldmo",
+    "source_file": "research/summaries/2026-04-28-twitter-15h-headlines.json",
+    "url": "https://x.com/iruletheworldmo/status/2049145069333057974"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-04-28 15:00 UTC",
+    "headline": "MAGNETAR: HYPERSCALER AI CAPEX TO HIT $3T BY 2029 VS $1.5T CASH FLOW \u2014 $1.5T EXTERNAL FUNDING GAP",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-04-28-twitter-15h-headlines.json",
+    "url": "https://x.com/theinformation/status/2049125277054173612"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-04-28 15:00 UTC",
+    "headline": "EX-NVIDIA AND DEEPMIND RESEARCHERS LAUNCHING WORLD-MODEL STARTUPS WITH NINE-FIGURE ROUNDS",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-04-28-twitter-15h-headlines.json",
+    "url": "https://x.com/theinformation/status/2049149179180568943"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-04-28 15:00 UTC",
+    "headline": "SPACEX SEC FILING \u2014 MUSK COULD GET 200M SHARES TIED TO MILESTONES AHEAD OF PLANNED JUNE IPO",
+    "source": "@mark_k",
+    "source_file": "research/summaries/2026-04-28-twitter-15h-headlines.json",
+    "url": "https://x.com/mark_k/status/2049144256699249039"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-05-01 04:00 UTC",
     "headline": "OPENAI CODEX UPDATE ADDS /SIDE COMMAND; GPT-5.5 NOW KEEPS CODEX RUNNING FOR DAYS TO BUILD OS KERNELS",
     "source": "@steipete",
+    "source_file": "research/summaries/2026-05-01-twitter-04h-headlines.json",
     "url": "https://x.com/steipete/status/2050016270574080188"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-01 04:31 UTC",
+    "delivered_at": "2026-05-01 04:00 UTC",
     "headline": "SEMIANALYSIS \u2014 WAFER-MAKER ASPs TURN; LEADING-EDGE LOGIC DEMAND INFLECTS 2027, 2028+ EPI DEALS LOCKING ~20% HIGHER",
     "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-05-01-twitter-04h-headlines.json",
     "url": "https://x.com/SemiAnalysis_/status/2050032500399841527"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-01 04:31 UTC",
+    "delivered_at": "2026-05-01 04:00 UTC",
     "headline": "APPLE EARNINGS READ-THROUGH \u2014 TSMC LEADING-EDGE SoC CAPACITY, NOT MEMORY, IS THE BINDING SHIPMENT CONSTRAINT",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-01-twitter-04h-headlines.json",
     "url": "https://x.com/jukan05/status/2050024550176522452"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-01 04:31 UTC",
+    "delivered_at": "2026-05-01 04:00 UTC",
     "headline": "KOREA APRIL CHIP EXPORTS \u2014 DRAM +83% QoQ, SSD +181% QoQ; DRAM CONTRACT PRICES UP 26% VS MARCH",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-01-twitter-04h-headlines.json",
     "url": "https://x.com/jukan05/status/2050025480225788287"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-01 04:31 UTC",
+    "delivered_at": "2026-05-01 04:00 UTC",
     "headline": "HUAWEI GUIDES AI-CHIP REVENUE +60% TO ~$12B THIS YEAR; MAJORITY OF ORDERS FOR LATEST ASCEND 950PR",
     "source": "@egarciagarcia",
+    "source_file": "research/summaries/2026-05-01-twitter-04h-headlines.json",
     "url": "https://x.com/egarciagarcia/status/2050069370689171930"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-01 04:31 UTC",
+    "delivered_at": "2026-05-01 04:00 UTC",
     "headline": "GROK 4.3 RANKS #1 ON VALS AI CORPFIN v2 BENCHMARK, AHEAD OF GPT-5.5 AND CLAUDE ON 200+ PAGE CREDIT AGREEMENTS",
     "source": "@XFreeze",
+    "source_file": "research/summaries/2026-05-01-twitter-04h-headlines.json",
     "url": "https://x.com/XFreeze/status/2050056011084411376"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-01 04:31 UTC",
+    "delivered_at": "2026-05-01 04:00 UTC",
     "headline": "MISTRAL AI NAMED TO TIME100 MOST INFLUENTIAL COMPANIES 2026 AND TOP 10 FOR AI",
     "source": "@MistralAI",
+    "source_file": "research/summaries/2026-05-01-twitter-04h-headlines.json",
     "url": "https://x.com/MistralAI/status/2049988769928056852"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-01 07:08 UTC",
+    "delivered_at": "2026-05-01 07:00 UTC",
     "headline": "GROK 4.3 GOES LIVE ON XAI API \u2014 ~500M PARAMS, 40-60% CHEAPER THAN 4.20, +321 ELO ON AGENTIC TASKS",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-01-twitter-07h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2050107378863886441"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-01 07:08 UTC",
+    "delivered_at": "2026-05-01 07:00 UTC",
     "headline": "GOOGLE CLOUD LAUNCHES GEMINI ENTERPRISE AGENT PLATFORM \u2014 CRYPTOGRAPHIC AGENT IDS, REGISTRY, ZERO-TRUST",
     "source": "@Geekissimo",
+    "source_file": "research/summaries/2026-05-01-twitter-07h-headlines.json",
     "url": "https://x.com/Geekissimo/status/2050107956927078900"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-01 07:08 UTC",
+    "delivered_at": "2026-05-01 07:00 UTC",
     "headline": "ANTHROPIC PUBLISHES LABOR-IMPACT DATA \u2014 PROGRAMMERS #1 AT 74.5% OF WORK NOW TOUCHING CLAUDE",
     "source": "@launchreadiness",
+    "source_file": "research/summaries/2026-05-01-twitter-07h-headlines.json",
     "url": "https://x.com/launchreadiness/status/2050103924414206431"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-01 07:08 UTC",
+    "delivered_at": "2026-05-01 07:00 UTC",
     "headline": "ANTHROPIC EYEING $900B+ FUNDING ROUND AS WHITE HOUSE BLOCKS MYTHOS PROGRAM EXPANSION",
     "source": "@revolterab",
+    "source_file": "research/summaries/2026-05-01-twitter-07h-headlines.json",
     "url": "https://x.com/revolterab/status/2050103638488469618"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-01 07:08 UTC",
+    "delivered_at": "2026-05-01 07:00 UTC",
     "headline": "RELIANCE \u00d7 META APPOINT FOUNDING CEO FOR INDIA AI JOINT VENTURE",
     "source": "@arora_deva5228",
+    "source_file": "research/summaries/2026-05-01-twitter-07h-headlines.json",
     "url": "https://x.com/arora_deva5228/status/2050103206907379764"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-01 07:08 UTC",
+    "delivered_at": "2026-05-01 07:00 UTC",
     "headline": "FIRST RANDOMIZED TRIAL ON GOOGLE AI OVERVIEWS \u2014 38% FEWER ORGANIC CLICKS, ZERO-CLICK RATE 54% \u2192 72%",
     "source": "@searchless_ai",
+    "source_file": "research/summaries/2026-05-01-twitter-07h-headlines.json",
     "url": "https://x.com/searchless_ai/status/2050108465977114894"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-01 07:08 UTC",
+    "delivered_at": "2026-05-01 07:00 UTC",
     "headline": "STRIPE LINK WALLET NOW LETS USERS AUTHORIZE AUTONOMOUS AI AGENTS TO SPEND VIA APPROVAL FLOWS",
     "source": "@DeepThoughtAR",
+    "source_file": "research/summaries/2026-05-01-twitter-07h-headlines.json",
     "url": "https://x.com/DeepThoughtAR/status/2050108081451979023"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-01 09:43 UTC",
+    "delivered_at": "2026-05-01 09:00 UTC",
     "headline": "APPLE SHIPS INTERNAL CLAUDE.MD FILES TO PRODUCTION IN APPLE SUPPORT APP V5.13 \u2014 CONFIRMS CLAUDE CODE USE FOR IOS APP DEV",
     "source": "@aaronp613",
+    "source_file": "research/summaries/2026-05-01-twitter-09h-headlines.json",
     "url": "https://x.com/aaronp613/status/2049986504617820551"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-01 09:43 UTC",
+    "delivered_at": "2026-05-01 09:00 UTC",
     "headline": "CLAUDE SECURITY ENTERS PUBLIC BETA \u2014 AUTONOMOUS CODEBASE VULN SCANNER FOR EVERY CLAUDE ENTERPRISE CUSTOMER",
     "source": "@claudeai",
+    "source_file": "research/summaries/2026-05-01-twitter-09h-headlines.json",
     "url": "https://x.com/claudeai/status/2049898739783897537"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-01 09:43 UTC",
+    "delivered_at": "2026-05-01 09:00 UTC",
     "headline": "CURSOR LAUNCHES SECURITY REVIEW FOR TEAMS/ENTERPRISE \u2014 TWO ALWAYS-ON AGENTS BLOCK PRS AND POST FINDINGS TO SLACK",
     "source": "@cursor_ai",
+    "source_file": "research/summaries/2026-05-01-twitter-09h-headlines.json",
     "url": "https://x.com/cursor_ai/status/2049926283061035254"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-01 09:43 UTC",
+    "delivered_at": "2026-05-01 09:00 UTC",
     "headline": "MICROSOFT LAUNCHES WORD LEGAL AGENT INSIDE $30 COPILOT BUNDLE \u2014 UNDERCUTS HARVEY'S $11B LEGAL-AI MOAT BY ~40X",
     "source": "@BradSmi",
+    "source_file": "research/summaries/2026-05-01-twitter-09h-headlines.json",
     "url": "https://x.com/BradSmi/status/2049993319800066119"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-01 09:43 UTC",
+    "delivered_at": "2026-05-01 09:00 UTC",
     "headline": "FORMER TSMC PACKAGING VP DOUGLAS YU JOINS MEDIATEK \u2014 INDUSTRY SOURCE: 'TSMC ASSUMED CUSTOMERS WOULD NOT LEAVE BUT THEY DID'",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-01-twitter-09h-headlines.json",
     "url": "https://x.com/jukan05/status/2050136199621456079"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-01 09:43 UTC",
+    "delivered_at": "2026-05-01 09:00 UTC",
     "headline": "GOOGLE CLOUD GROWS 70% IN Q1 VS AZURE 40% / AWS 28% \u2014 Q1 CLOUD BACKLOG +400% YOY, ADDED $219B SEQUENTIALLY",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-01-twitter-09h-headlines.json",
     "url": "https://x.com/theinformation/status/2049938192455889380"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-01 09:43 UTC",
+    "delivered_at": "2026-05-01 09:00 UTC",
     "headline": "ANTHROPIC USED 1M-CONVERSATION SYCOPHANCY STUDY TO RETRAIN OPUS 4.7 AND MYTHOS PREVIEW",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-01-twitter-09h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2049927618397614466"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-01 12:34 UTC",
+    "delivered_at": "2026-05-01 12:00 UTC",
     "headline": "NEBIUS TO ACQUIRE EIGEN AI FOR ~$643M IN CASH + CLASS A SHARES, FOLDING INFERENCE OPTIMIZATION INTO TOKEN FACTORY",
     "source": "@mvcinvesting",
+    "source_file": "research/summaries/2026-05-01-twitter-12h-headlines.json",
     "url": "https://x.com/mvcinvesting/status/2050179412482568535"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-01 12:34 UTC",
+    "delivered_at": "2026-05-01 12:00 UTC",
     "headline": "ANTHROPIC LINES UP $50B ROUND AT $900B+ VALUATION \u2014 INVESTORS GIVEN 48 HOURS TO ALLOCATE, BOARD DECISION IN MAY",
     "source": "@QuikInsightz",
+    "source_file": "research/summaries/2026-05-01-twitter-12h-headlines.json",
     "url": "https://x.com/QuikInsightz/status/2050029044369158417"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-01 12:34 UTC",
+    "delivered_at": "2026-05-01 12:00 UTC",
     "headline": "ANTHROPIC TARGETING OCTOBER 2026 IPO; ROUND WOULD MARK 14\u00d7 RE-RATING FROM $61.5B IN MARCH 2025",
     "source": "@QuikInsightz",
+    "source_file": "research/summaries/2026-05-01-twitter-12h-headlines.json",
     "url": "https://x.com/QuikInsightz/status/2050029044369158417"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-01 12:34 UTC",
+    "delivered_at": "2026-05-01 12:00 UTC",
     "headline": "CLAUDE MYTHOS SOLVES 30% OF BIOINFORMATICS PROBLEMS THAT STUMPED EVERY HUMAN EXPERT ON BIOMYSTERYBENCH (99 PROBLEMS)",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-01-twitter-12h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2049624600741560340"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-01 12:34 UTC",
+    "delivered_at": "2026-05-01 12:00 UTC",
     "headline": "EIGEN AI'S OPTIMIZED OPEN-SOURCE MODELS ALREADY ON ARTIFICIAL ANALYSIS LEADERBOARD AT 615+ TOK/S; NEBIUS DEAL CLOSES IN COMING WEEKS",
     "source": "@LEAPTRADER_",
+    "source_file": "research/summaries/2026-05-01-twitter-12h-headlines.json",
     "url": "https://x.com/LEAPTRADER_/status/2050179099142823943"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-01 12:34 UTC",
+    "delivered_at": "2026-05-01 12:00 UTC",
     "headline": "DEMIS HASSABIS AT YC: BIGGER CONTEXT WINDOWS ARE BRUTE FORCE \u2014 NEXT AI ARCHITECTURE NEEDS SLEEP-STYLE MEMORY REPLAY",
     "source": "@vitrupo",
+    "source_file": "research/summaries/2026-05-01-twitter-12h-headlines.json",
     "url": "https://x.com/vitrupo/status/2050184718579331427"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-01 12:34 UTC",
+    "delivered_at": "2026-05-01 12:00 UTC",
     "headline": "GROK 4.3 LIVE ON XAI API WITH 1M-TOKEN CONTEXT; HITS #7 ON ARTIFICIAL ANALYSIS INDEX, EDGES META MUSE SPARK",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-01-twitter-12h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2050119051892986164"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-01 15:30 UTC",
+    "delivered_at": "2026-05-01 15:00 UTC",
     "headline": "PENTAGON SIGNS CLASSIFIED-NETWORK AI DEALS WITH 7 LABS \u2014 SPACEX, OPENAI, GOOGLE, NVIDIA, REFLECTION, MICROSOFT, AWS \u2014 ANTHROPIC EXCLUDED",
     "source": "@JerryDunleavy",
+    "source_file": "research/summaries/2026-05-01-twitter-15h-headlines.json",
     "url": "https://x.com/JerryDunleavy/status/2050204126437404896"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-01 15:30 UTC",
+    "delivered_at": "2026-05-01 15:00 UTC",
     "headline": "ALTMAN: 'WE WANT TO BUILD TOOLS TO AUGMENT AND ELEVATE PEOPLE, NOT ENTITIES TO REPLACE THEM' \u2014 READ AS DIRECT SHOT AT DARIO/MYTHOS",
     "source": "@sama",
+    "source_file": "research/summaries/2026-05-01-twitter-15h-headlines.json",
     "url": "https://x.com/sama/status/2050229058425045178"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-01 15:30 UTC",
+    "delivered_at": "2026-05-01 15:00 UTC",
     "headline": "MICROSOFT\u2013OPENAI PARTNERSHIP REWRITE \u2014 NADELLA AND ALTMAN TRADE EXCLUSIVITY FOR LOCKED-IN REVENUE SHARE; OPENAI CAN NOW SHIP ON AWS",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-01-twitter-15h-headlines.json",
     "url": "https://x.com/theinformation/status/2050221224156901847"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-01 15:30 UTC",
+    "delivered_at": "2026-05-01 15:00 UTC",
     "headline": "NEBIUS CRO: 'DEMAND FAR EXCEEDS OUR SUPPLY' \u2014 CAPITAL, NOT CHIP SUPPLY, IS NOW THE BIGGEST AI INFRASTRUCTURE BOTTLENECK",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-01-twitter-15h-headlines.json",
     "url": "https://x.com/theinformation/status/2050228889817911595"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-01 15:30 UTC",
+    "delivered_at": "2026-05-01 15:00 UTC",
     "headline": "ALIBABA QWEN INKS STRATEGIC PARTNERSHIP WITH FIREWORKS AI FOR PRODUCTION DEPLOYMENT OF CLOSED-WEIGHTS QWEN MODELS",
     "source": "@Alibaba_Qwen",
+    "source_file": "research/summaries/2026-05-01-twitter-15h-headlines.json",
     "url": "https://x.com/Alibaba_Qwen/status/2050232280082522505"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-01 15:30 UTC",
+    "delivered_at": "2026-05-01 15:00 UTC",
     "headline": "OPENAI MISSED INTERNAL Q1 REVENUE TARGET; ADVERTISING GROWTH NOW PARAMOUNT AS CONSUMER DEPENDENCE DEEPENS",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-01-twitter-15h-headlines.json",
     "url": "https://x.com/theinformation/status/2050206131570491875"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-01 15:30 UTC",
+    "delivered_at": "2026-05-01 15:00 UTC",
     "headline": "EX-WAYMO LEAD SHIMON WHITESON LEAVES AFTER 6 YEARS TO RUN NEW MULTI-AGENT LEARNING TEAM AT GOOGLE DEEPMIND",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-01-twitter-15h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2050226734109471047"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-01 18:34 UTC",
+    "delivered_at": "2026-05-01 18:00 UTC",
     "headline": "ALTMAN WALKS BACK 'AUGMENT NOT ENTITIES' DIG \u2014 'USE CODEX OR CLAUDE CODE, WHATEVER WORKS BEST' POST PULLS 4.4K LIKES IN 30 MIN",
     "source": "@sama",
+    "source_file": "research/summaries/2026-05-01-twitter-18h-headlines.json",
     "url": "https://x.com/sama/status/2050274547061129577"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-01 18:34 UTC",
+    "delivered_at": "2026-05-01 18:00 UTC",
     "headline": "PENTAGON CTO ON CNBC: ANTHROPIC STILL 'SUPPLY CHAIN RISK' BUT MYTHOS IS 'SEPARATE NATIONAL SECURITY MOMENT' HANDLED GOVT-WIDE",
     "source": "@CNBC",
+    "source_file": "research/summaries/2026-05-01-twitter-18h-headlines.json",
     "url": "https://x.com/CNBC/status/2050205857145659685"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-01 18:34 UTC",
+    "delivered_at": "2026-05-01 18:00 UTC",
     "headline": "ANTHROPIC ANNOUNCES CODE WITH CLAUDE DEVELOPER CONFERENCE RETURNS MAY 19 \u2014 SF MAIN STAGE + LONDON EXTENDED MAY 20",
     "source": "@claudeai",
+    "source_file": "research/summaries/2026-05-01-twitter-18h-headlines.json",
     "url": "https://x.com/claudeai/status/2050252933866930339"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-01 18:34 UTC",
+    "delivered_at": "2026-05-01 18:00 UTC",
     "headline": "DEMIS HASSABIS WELCOMES SHIMON WHITESON FROM WAYMO TO LEAD DEEPMIND'S NEW MULTI-AGENT LEARNING TEAM",
     "source": "@demishassabis",
+    "source_file": "research/summaries/2026-05-01-twitter-18h-headlines.json",
     "url": "https://x.com/demishassabis/status/2050239954765185345"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-01 18:34 UTC",
+    "delivered_at": "2026-05-01 18:00 UTC",
     "headline": "STARCLOUD IN TALKS FOR $200M RAISE ONE MONTH AFTER LAST ROUND \u2014 SPACE DATA-CENTER STARTUP HEATING UP",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-01-twitter-18h-headlines.json",
     "url": "https://x.com/theinformation/status/2050274138976047569"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-01 18:34 UTC",
+    "delivered_at": "2026-05-01 18:00 UTC",
     "headline": "MANUS ACQUISITION FALLOUT FORCING CHINESE AI STARTUPS TO RETHINK CAPITAL-RAISE PLAYBOOK",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-01-twitter-18h-headlines.json",
     "url": "https://x.com/theinformation/status/2050266539018825783"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-01 21:26 UTC",
+    "delivered_at": "2026-05-01 21:00 UTC",
     "headline": "OPENAI SHIPS CLAUDE CODE \u2192 CODEX AUTO-MIGRATION 64 MIN AFTER ALTMAN'S 'USE CODEX OR CLAUDE CODE' CLIMBDOWN \u2014 'YOUR MOVE'",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-05-01-twitter-21h-headlines.json",
     "url": "https://x.com/OpenAI/status/2050290618187055175"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-01 21:26 UTC",
+    "delivered_at": "2026-05-01 21:00 UTC",
     "headline": "PENTAGON CTO CONFIRMS DOW DEAL IS 8 LABS, NOT 7 \u2014 ORACLE ADDED, ANTHROPIC STILL EXCLUDED FROM CLASSIFIED-NETWORK ROLLOUT",
     "source": "@USWREMichael",
+    "source_file": "research/summaries/2026-05-01-twitter-21h-headlines.json",
     "url": "https://x.com/USWREMichael/status/2050325961212649627"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-01 21:26 UTC",
+    "delivered_at": "2026-05-01 21:00 UTC",
     "headline": "META ACQUIRES ASSURED ROBOT INTELLIGENCE FOR 'METABOT' HUMANOID PUSH \u2014 REALITY LABS BETS ANDROID-STYLE LICENSING",
     "source": "@alexandr_wang",
+    "source_file": "research/summaries/2026-05-01-twitter-21h-headlines.json",
     "url": "https://x.com/alexandr_wang/status/2050305805455700378"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-01 21:26 UTC",
+    "delivered_at": "2026-05-01 21:00 UTC",
     "headline": "OPENAI CLAIMS GPT-5.5 API REVENUE GROWING 2X FASTER THAN ANY PRIOR LAUNCH; CODEX REVENUE DOUBLED IN UNDER 7 DAYS",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-05-01-twitter-21h-headlines.json",
     "url": "https://x.com/OpenAI/status/2050250926888468929"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-01 21:26 UTC",
+    "delivered_at": "2026-05-01 21:00 UTC",
     "headline": "LEGORA HITS $5.6B VALUATION ON $50M EXTENSION LED BY NVIDIA NVENTURES \u2014 FIRST LEGAL-TECH BET; HARVEY AT $11B",
     "source": "@credx_club",
+    "source_file": "research/summaries/2026-05-01-twitter-21h-headlines.json",
     "url": "https://x.com/credx_club/status/2050182697159622980"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-01 21:26 UTC",
+    "delivered_at": "2026-05-01 21:00 UTC",
     "headline": "MICROSOFT Q1: AI USAGE DRAGGING DOWN AZURE CLOUD MARGINS \u2014 COMPANY EFFECTIVELY BOOSTING PRICES",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-01-twitter-21h-headlines.json",
     "url": "https://x.com/theinformation/status/2050304304599191601"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-01 21:26 UTC",
+    "delivered_at": "2026-05-01 21:00 UTC",
     "headline": "HANGZHOU COURT RULES AI-ONLY FIRINGS ILLEGAL \u2014 SET AS GUIDING PRECEDENT; FIRMS MUST REASSIGN, RETRAIN, OR FOLLOW FORMAL REDUNDANCY",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-01-twitter-21h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2050250164645007770"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-02 01:03 UTC",
+    "delivered_at": "2026-05-02 01:00 UTC",
     "headline": "OPENAI OPENS CHATGPT-SUBSCRIPTION SIGN-IN ON OPENCLAW \u2014 STEIPETE'S OPEN AGENT PLATFORM NOW ON OAI SEAT QUOTAS",
     "source": "@sama",
+    "source_file": "research/summaries/2026-05-02-twitter-01h-headlines.json",
     "url": "https://x.com/sama/status/2050357911915028689"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-02 01:03 UTC",
+    "delivered_at": "2026-05-02 01:00 UTC",
     "headline": "XAI SHIPS GROK IMAGINE AGENT MODE PUBLIC BETA \u2014 UNIFIED TEXT/IMAGE/VIDEO CANVAS, PREMIUM + DESKTOP ONLY",
     "source": "@imagine",
+    "source_file": "research/summaries/2026-05-02-twitter-01h-headlines.json",
     "url": "https://x.com/imagine/status/2050327174629228889"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-02 01:03 UTC",
+    "delivered_at": "2026-05-02 01:00 UTC",
     "headline": "APPLE HIKES MAC MINI BASE PRICE $599 \u2192 $799 \u2014 AI-DRIVEN NAND SHORTAGE KILLS THE 256GB ENTRY SKU",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-02-twitter-01h-headlines.json",
     "url": "https://x.com/jukan05/status/2050374333848322448"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-02 01:03 UTC",
+    "delivered_at": "2026-05-02 01:00 UTC",
     "headline": "META DAUS DIP FOR FIRST TIME SINCE 2021 IN Q1 26 \u2014 A16Z CHART CIRCULATING ON DEVELOPER X",
     "source": "@tszzl",
+    "source_file": "research/summaries/2026-05-02-twitter-01h-headlines.json",
     "url": "https://x.com/tszzl/status/2050366962581295429"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-02 01:03 UTC",
+    "delivered_at": "2026-05-02 01:00 UTC",
     "headline": "GOOGLE SEARCH AI MODE ENTERS WIDER A/B TESTING \u2014 FIRST COMMUNITY-OBSERVED ROLLOUT",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-02-twitter-01h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2050380316817395839"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-02 04:14 UTC",
+    "delivered_at": "2026-05-02 04:00 UTC",
     "headline": "CEREBRAS UPSIZES IPO TO ~$40B TARGET / ~$4B RAISE \u2014 MONDAY ROADSHOW START, ~60-80% ABOVE APRIL PRIVATE MARK",
     "source": "@Tickerwire",
+    "source_file": "research/summaries/2026-05-02-twitter-04h-headlines.json",
     "url": "https://x.com/Tickerwire/status/2050412002510856197"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-02 04:14 UTC",
+    "delivered_at": "2026-05-02 04:00 UTC",
     "headline": "CEREBRAS BACKLOG: $24.6B RPO / $510M 2025 REVENUE (+76%) / $87.9M NET INCOME / OPENAI ~$10B CONTRACT ANCHOR",
     "source": "@realarmaansidhu",
+    "source_file": "research/summaries/2026-05-02-twitter-04h-headlines.json",
     "url": "https://x.com/realarmaansidhu/status/2048246142819835953"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-02 04:14 UTC",
+    "delivered_at": "2026-05-02 04:00 UTC",
     "headline": "KOREA INDUSTRY SOURCES: AI CPUS TARGETING 300-400GB DRAM ON-PACKAGE \u2014 4X TYPICAL CPU CONFIGS",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-02-twitter-04h-headlines.json",
     "url": "https://x.com/jukan05/status/2050393594499150332"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-02 04:14 UTC",
+    "delivered_at": "2026-05-02 04:00 UTC",
     "headline": "DRAM ASPS UP 100%+ \u2014 'MEMORY SHORTAGE TO LAST ANOTHER YEAR' AS AI CPUS DEVOUR COMMODITY DRAM",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-02-twitter-04h-headlines.json",
     "url": "https://x.com/jukan05/status/2050393020340765133"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-02 04:14 UTC",
+    "delivered_at": "2026-05-02 04:00 UTC",
     "headline": "OPENAI CODEX SHIPS 'PETS' FEATURE \u2014 /HATCH-PET SKILL, CLIPPY REANIMATION, ~58% OF 5H CREDITS PER HATCH",
     "source": "@sama",
+    "source_file": "research/summaries/2026-05-02-twitter-04h-headlines.json",
     "url": "https://x.com/sama/status/2050402088266694689"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-02 04:14 UTC",
+    "delivered_at": "2026-05-02 04:00 UTC",
     "headline": "FOUNDERS FUND ADDS $624M TO ANDURIL AT $60B VALUATION \u2014 TOTAL BET NOW $2.6B DESPITE >$1B/YR LOSSES EXPECTED",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-02-twitter-04h-headlines.json",
     "url": "https://x.com/theinformation/status/2050296726649544904"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-02 06:52 UTC",
+    "delivered_at": "2026-05-02 06:00 UTC",
     "headline": "GOOGLE GEMINI 3.1 FLASH LITE GA IMMINENT \u2014 VERTEX AI EMAILS FLASH 2 CUSTOMERS ON MIGRATION",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-02-twitter-06h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2050449347137937437"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-02 06:52 UTC",
+    "delivered_at": "2026-05-02 06:00 UTC",
     "headline": "NEW GEMINI 3 FLASH CHECKPOINT ON LM ARENA \u2014 REVIEWERS SAY OUTPUT QUALITY CLOSER TO 3.1 PRO THAN CURRENT FLASH",
     "source": "@marmaduke091",
+    "source_file": "research/summaries/2026-05-02-twitter-06h-headlines.json",
     "url": "https://x.com/marmaduke091/status/2050430054056767994"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-02 06:52 UTC",
+    "delivered_at": "2026-05-02 06:00 UTC",
     "headline": "NEBIUS ACQUIRES EIGEN AI FOR $643M CASH AND SHARES \u2014 FOLDS OPEN-SOURCE INFERENCE STACK INTO NEBIUS TOKEN FACTORY",
     "source": "@jiahanjimliu",
+    "source_file": "research/summaries/2026-05-02-twitter-06h-headlines.json",
     "url": "https://x.com/jiahanjimliu/status/2050454445310521626"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-02 06:52 UTC",
+    "delivered_at": "2026-05-02 06:00 UTC",
     "headline": "EIGEN AI #1 ACROSS 25 OPEN-SOURCE MODELS ON ARTIFICIAL ANALYSIS \u2014 QWEN3 CODER 480B AT 255.8 T/S, ~51% FASTER THAN GOOGLE VERTEX",
     "source": "@HyperTechInvest",
+    "source_file": "research/summaries/2026-05-02-twitter-06h-headlines.json",
     "url": "https://x.com/HyperTechInvest/status/2050443561951269104"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-02 06:52 UTC",
+    "delivered_at": "2026-05-02 06:00 UTC",
     "headline": "SAMSUNG NAND LTA FLOOR PRICE FLIPS ABOVE Q3 SPOT \u2014 LONG-TERM-AGREEMENT eSSD CONTRACTS NOW PRICED AT PREMIUM TO SPOT",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-02-twitter-06h-headlines.json",
     "url": "https://x.com/jukan05/status/2050439372126986554"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-02 09:34 UTC",
+    "delivered_at": "2026-05-02 09:00 UTC",
     "headline": "XAI CONSOLE SHIPS VOICE CLONING \u2014 $4.20 PER 1M CHARS TTS, 89 VOICES, 28 LANGUAGES, US-ONLY API",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-02-twitter-09h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2050472651919863885"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-02 09:34 UTC",
+    "delivered_at": "2026-05-02 09:00 UTC",
     "headline": "MUSK: GROK VOICE IS USED BY STARLINK RIGHT NOW \u2014 FIRST EXPLICIT IN-HOUSE ENTERPRISE DEPLOYMENT CALL-OUT",
     "source": "@elonmusk",
+    "source_file": "research/summaries/2026-05-02-twitter-09h-headlines.json",
     "url": "https://x.com/elonmusk/status/2050475355258151330"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-02 09:34 UTC",
+    "delivered_at": "2026-05-02 09:00 UTC",
     "headline": "XAI TTS PRICED AT ROUGHLY 1/50TH OF ELEVENLABS REFERENCE ON 20-MIN SCRIPT \u2014 $0.08 VS $6",
     "source": "@Sashadnx",
+    "source_file": "research/summaries/2026-05-02-twitter-09h-headlines.json",
     "url": "https://x.com/Sashadnx/status/2050505944216928319"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-02 09:34 UTC",
+    "delivered_at": "2026-05-02 09:00 UTC",
     "headline": "DEMIS HASSABIS AMPLIFIES GOOGLE I/O 2026 COUNTDOWN \u2014 KEYNOTE MAY 19-20, NEW GEMINI MODELS EXPECTED",
     "source": "@demishassabis",
+    "source_file": "research/summaries/2026-05-02-twitter-09h-headlines.json",
     "url": "https://x.com/demishassabis/status/2050493397928988783"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-02 09:34 UTC",
+    "delivered_at": "2026-05-02 09:00 UTC",
     "headline": "VIRAL AGENTS OF CHAOS PAPER IS RECYCLED \u2014 ARXIV 2602.20021 FROM FEB 2026, IN CIRCULATION SINCE MARCH",
     "source": "@Arcane_Aii",
+    "source_file": "research/summaries/2026-05-02-twitter-09h-headlines.json",
     "url": "https://x.com/Arcane_Aii/status/2050495389300842995"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-02 12:30 UTC",
+    "delivered_at": "2026-05-02 12:00 UTC",
     "headline": "MARK_K CLAIMS OPENAI CODEX ENGINEER CONFIRMED CHATGPT-INTO-CODEX SUPER-APP MERGER \u2014 NO PRIMARY OPENAI CORROBORATION",
     "source": "@mark_k",
+    "source_file": "research/summaries/2026-05-02-twitter-12h-headlines.json",
     "url": "https://x.com/mark_k/status/2050514062862106930"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-02 12:30 UTC",
+    "delivered_at": "2026-05-02 12:00 UTC",
     "headline": "DEMIS HASSABIS LOGS SEQUOIA AI ASCENT FIRESIDE CHAT WITH KONSTANTINE BUHLER \u2014 DEEPMIND, AGI, ALPHAFOLD; NO CONCRETE NEWS",
     "source": "@demishassabis",
+    "source_file": "research/summaries/2026-05-02-twitter-12h-headlines.json",
     "url": "https://x.com/demishassabis/status/2050539386475786708"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-02 12:30 UTC",
+    "delivered_at": "2026-05-02 12:00 UTC",
     "headline": "MICROSOFT RELEASES DELULU FILL-IN-THE-MIDDLE CODE-COMPLETION BENCHMARK ON HUGGING FACE",
     "source": "@HuggingPapers",
+    "source_file": "research/summaries/2026-05-02-twitter-12h-headlines.json",
     "url": "https://x.com/HuggingPapers/status/2050550142948757823"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-02 15:25 UTC",
+    "delivered_at": "2026-05-02 15:00 UTC",
     "headline": "ANTHROPIC ARR HITS ~$44B PER SEMIANALYSIS \u2014 UP FROM $9B END-2025, RECEIPT BEHIND RUMORED $900B-$1T RAISE",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-02-twitter-15h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2050577074763784400"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-02 15:25 UTC",
+    "delivered_at": "2026-05-02 15:00 UTC",
     "headline": "ANTHROPIC IN TALKS TO BUY INFERENCE CHIPS FROM UK SRAM STARTUP FRACTILE \u2014 THE INFORMATION",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-02-twitter-15h-headlines.json",
     "url": "https://x.com/jukan05/status/2050578844571328690"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-02 15:25 UTC",
+    "delivered_at": "2026-05-02 15:00 UTC",
     "headline": "OPENAI MISSED INTERNAL Q1 REVENUE TARGET; ADVERTISING NOW PARAMOUNT AS CONSUMER DEPENDENCE INTENSIFIES \u2014 THE INFORMATION",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-02-twitter-15h-headlines.json",
     "url": "https://x.com/theinformation/status/2050568505695654051"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-02 15:25 UTC",
+    "delivered_at": "2026-05-02 15:00 UTC",
     "headline": "STANDARD INTELLIGENCE RAISES $75M FROM SEQUOIA + SPARK; KARPATHY ANGEL \u2014 VIDEO-TRAINED FDM-1 MODEL",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-02-twitter-15h-headlines.json",
     "url": "https://x.com/theinformation/status/2050591205633745241"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-02 18:29 UTC",
+    "delivered_at": "2026-05-02 18:00 UTC",
     "headline": "THE INFORMATION: XAI'S GPU FLEET RUNNING AT ~11% UTILIZATION \u2014 3-6X BELOW PRIOR PUBLIC MFU BASELINES",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-02-twitter-18h-headlines.json",
     "url": "https://x.com/theinformation/status/2050606311440531809"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-02 18:29 UTC",
+    "delivered_at": "2026-05-02 18:00 UTC",
     "headline": "BEDROCK-OPENAI LAUNCHES BUT AWS CUSTOMERS TELL THE INFORMATION: \"CLAUDE IS BETTER FOR CODING\"",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-02-twitter-18h-headlines.json",
     "url": "https://x.com/theinformation/status/2050621385467113870"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-02 18:29 UTC",
+    "delivered_at": "2026-05-02 18:00 UTC",
     "headline": "STARCLOUD IN TALKS TO RAISE $200M ONE MONTH AFTER $170M SERIES A \u2014 POTENTIAL SUB-30-DAY DOUBLE-UP",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-02-twitter-18h-headlines.json",
     "url": "https://x.com/theinformation/status/2050636485938778120"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-02 18:29 UTC",
+    "delivered_at": "2026-05-02 18:00 UTC",
     "headline": "MUSK VS OPENAI: CROSS-EXAMINATION RAISES DOUBTS ABOUT MUSK NARRATIVE PER THE INFORMATION POST-TRIAL WRAP",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-02-twitter-18h-headlines.json",
     "url": "https://x.com/theinformation/status/2050598702964695448"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-02 18:29 UTC",
+    "delivered_at": "2026-05-02 18:00 UTC",
     "headline": "ALLEN AI RELEASES OLMPOOL: 26 7B-PARAM CHECKPOINTS WITH VARYING ARCHITECTURES TO STUDY LONG-CONTEXT EXTENSION",
     "source": "@_akhaliq",
+    "source_file": "research/summaries/2026-05-02-twitter-18h-headlines.json",
     "url": "https://x.com/_akhaliq/status/2050624406063800381"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-02 21:22 UTC",
+    "delivered_at": "2026-05-02 21:00 UTC",
     "headline": "ALTMAN ENDORSES GPT-5.5 XHIGH IN FAST MODE \u2014 \"GOT PSYOPED BY TWITTER ON MEDIUM\" 3 DAYS BEFORE MAY 5 LAUNCH PARTY",
     "source": "@sama",
+    "source_file": "research/summaries/2026-05-02-twitter-21h-headlines.json",
     "url": "https://x.com/sama/status/2050658558174437701"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-02 21:22 UTC",
+    "delivered_at": "2026-05-02 21:00 UTC",
     "headline": "ALTMAN: \"SMARTER STILL THE MOST IMPORTANT THING\" \u2014 DROPS CHEAPER/FASTER PUSH AS OPENAI Q1 API REVENUE 2X PRIOR LAUNCH",
     "source": "@sama",
+    "source_file": "research/summaries/2026-05-02-twitter-21h-headlines.json",
     "url": "https://x.com/sama/status/2050671161915371998"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-02 21:22 UTC",
+    "delivered_at": "2026-05-02 21:00 UTC",
     "headline": "MICROSOFT Q1: AI USAGE DRAGS CLOUD MARGINS, MSFT \"EFFECTIVELY BOOSTING PRICES\" VIA USAGE-BASED PIVOT",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-02-twitter-21h-headlines.json",
     "url": "https://x.com/theinformation/status/2050666663259812001"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-02 21:22 UTC",
+    "delivered_at": "2026-05-02 21:00 UTC",
     "headline": "SEMIANALYSIS: ABB ELECTRIFICATION Q1'26 ORDERS HIT RECORD +$6B \u2014 DATACENTER DEMAND EXTENDS Q4'25 +17% QOQ INVERSION",
     "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-05-02-twitter-21h-headlines.json",
     "url": "https://x.com/SemiAnalysis_/status/2050681826226606387"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-02 21:22 UTC",
+    "delivered_at": "2026-05-02 21:00 UTC",
     "headline": "STARLINK IPO DOCS: 8.9M SUBS (4X), ARPU DOWN 18% TO $81/MO AHEAD OF POTENTIAL $1T LISTING",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-02-twitter-21h-headlines.json",
     "url": "https://x.com/theinformation/status/2050674193629356040"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-02 21:22 UTC",
+    "delivered_at": "2026-05-02 21:00 UTC",
     "headline": "KIMMONISMUS: \"I HOPE SONNET 4.8 WILL BE THE MODEL I HOPED OPUS 4.7 WOULD BE\" \u2014 OPUS 4.7 USER-DISSATISFACTION TAIL GROWS",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-02-twitter-21h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2050673775109177796"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-03 01:10 UTC",
+    "delivered_at": "2026-05-03 01:00 UTC",
     "headline": "GEMINI \"POWERED BY OMNI\" STRING LEAKS IN VIDEO-GEN TAB \u2014 FIRST PRE-I/O HINT OF GOOGLE OMNI MODEL WITH NATIVE VIDEO OUTPUT",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-03-twitter-01h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2050705594458292496"
   },
   {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-05-03 01:00 UTC",
+    "headline": "ABB ELECTRIFICATION Q1'26 ORDERS HIT RECORD +$6B AS DATACENTER DEMAND INVERTS SEASONAL PATTERN \u2014 SEMIANALYSIS",
+    "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-05-03-twitter-01h-headlines.json",
+    "url": "https://x.com/SemiAnalysis_/status/2050681826226606387"
+  },
+  {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-03 01:10 UTC",
+    "delivered_at": "2026-05-03 01:00 UTC",
     "headline": "ALTMAN: \"I KEEP THINKING I WANT MODELS CHEAPER/FASTER, BUT BEING SMARTER IS STILL THE MOST IMPORTANT THING\"",
     "source": "@sama",
+    "source_file": "research/summaries/2026-05-03-twitter-01h-headlines.json",
     "url": "https://x.com/sama/status/2050671161915371998"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-03 01:10 UTC",
+    "delivered_at": "2026-05-03 01:00 UTC",
     "headline": "STARLINK QUADRUPLED TO 8.9M SUBSCRIBERS BUT REVENUE PER USER FELL 18% TO $81/MO \u2014 IPO DOCS",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-03-twitter-01h-headlines.json",
     "url": "https://x.com/theinformation/status/2050674193629356040"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-03 04:27 UTC",
+    "delivered_at": "2026-05-03 04:00 UTC",
     "headline": "NVIDIA-GROQ DEAL: GROQ TALENT TO OPTIMIZE RUBIN SOFTWARE; SRAM DATA-FLOW IP LANDS IN RUBIN ULTRA \u2014 SELL-SIDE",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-03-twitter-04h-headlines.json",
     "url": "https://x.com/jukan05/status/2050761931360022818"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-03 04:27 UTC",
+    "delivered_at": "2026-05-03 04:00 UTC",
     "headline": "RUBIN ULTRA REPORTEDLY CARRIES 512MB ON-CHIP SRAM \u2014 ~4\u00d7 BLACKWELL B200, FIRST SPECIFIC FIGURE IN-CORPUS",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-03-twitter-04h-headlines.json",
     "url": "https://x.com/jukan05/status/2050761931360022818"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-03 04:27 UTC",
+    "delivered_at": "2026-05-03 04:00 UTC",
     "headline": "SAMSUNG FOUNDRY 4NM FULLY BOOKED THROUGH 2027; HBM4 BASE DIE DRIVES NVIDIA, AMD, GOOGLE ORDERS",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-03-twitter-04h-headlines.json",
     "url": "https://x.com/jukan05/status/2050756475090550953"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-03 04:27 UTC",
+    "delivered_at": "2026-05-03 04:00 UTC",
     "headline": "SAMSUNG FOUNDRY ON TRACK FOR H2'26 PROFITABILITY TURNAROUND AS HBM4 RAMP MAXES OUT 4NM LINE",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-03-twitter-04h-headlines.json",
     "url": "https://x.com/jukan05/status/2050756475090550953"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-03 04:27 UTC",
+    "delivered_at": "2026-05-03 04:00 UTC",
     "headline": "@SEMIANALYSIS_ POSTS OUT-OF-CHARACTER JANE STREET GRIFT TWEET \u2014 POSSIBLE COMPROMISE RECURRENCE OF JAN 4 HACK",
     "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-05-03-twitter-04h-headlines.json",
     "url": "https://x.com/SemiAnalysis_/status/2050749738262794529"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-03 21:24 UTC",
+    "delivered_at": "2026-05-03 21:00 UTC",
     "headline": "DEV SENTIMENT SWINGS TO OPENAI CODEX \u2014 \"DEVS SWITCH FROM CLAUDE OVER LIMITS\" HITS X TRENDING #1 WITH 4,400 POSTS",
     "source": "@arankomatsuzaki",
+    "source_file": "research/summaries/2026-05-03-twitter-21h-headlines.json",
     "url": "https://x.com/arankomatsuzaki/status/2050620582434382228"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-03 21:24 UTC",
+    "delivered_at": "2026-05-03 21:00 UTC",
     "headline": "JENSEN HUANG: NVIDIA CHINA AI-CHIP SHARE COLLAPSED 95% TO 0%, US EXPORT POLICY \"LARGELY BACKFIRED\"",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-03-twitter-21h-headlines.json",
     "url": "https://x.com/jukan05/status/2050930415196925978"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-03 21:24 UTC",
+    "delivered_at": "2026-05-03 21:00 UTC",
     "headline": "THE INFORMATION: BEDROCK CUSTOMER ON OPENAI-AWS DEAL \u2014 \"FOR CODING, CLAUDE IS BETTER\"",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-03-twitter-21h-headlines.json",
     "url": "https://x.com/theinformation/status/2050945991226912850"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-03 21:24 UTC",
+    "delivered_at": "2026-05-03 21:00 UTC",
     "headline": "GOOGLE PRE-I/O RAMP: NEW GEMINI IOS DESIGN LEAKS, AI STUDIO BUILD ADDS FIGMA + GITHUB IMPORTS",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-03-twitter-21h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2050976509855138022"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-03 21:24 UTC",
+    "delivered_at": "2026-05-03 21:00 UTC",
     "headline": "ALTMAN: \"AGENTS SDK 2.0 IS UNDERRATED\" \u2014 OPENAI CODEX/AGENT STACK MOMENTUM CONTINUES",
     "source": "@sama",
+    "source_file": "research/summaries/2026-05-03-twitter-21h-headlines.json",
     "url": "https://x.com/sama/status/2050998576671859003"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-03 21:24 UTC",
+    "delivered_at": "2026-05-03 21:00 UTC",
     "headline": "THE INFORMATION: XAI GPU FLEET RUNNING AT ~11% UTILIZATION \u2014 AI LABS STRUGGLE TO USE EXPENSIVE NVIDIA HARDWARE",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-03-twitter-21h-headlines.json",
     "url": "https://x.com/theinformation/status/2050938476032356566"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-03 21:24 UTC",
+    "delivered_at": "2026-05-03 21:00 UTC",
     "headline": "ANDURIL RAISES AT $60B VALUATION \u2014 FOUNDERS FUND ADDS $624M, BRINGING TOTAL BET TO $2.6B",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-03-twitter-21h-headlines.json",
     "url": "https://x.com/theinformation/status/2051021481837031713"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-04 01:07 UTC",
+    "delivered_at": "2026-05-04 01:00 UTC",
     "headline": "GPT-5.5 BURNS CODEX WEEKLY QUOTAS IN HOURS \u2014 OPENAI INFRA LEAD OPENS PUBLIC FEEDBACK LINE AS RATE-LIMIT REVOLT HITS X TRENDING",
     "source": "@thsottiaux",
+    "source_file": "research/summaries/2026-05-04-twitter-01h-headlines.json",
     "url": "https://x.com/thsottiaux/status/2051062151805382956"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-04 01:07 UTC",
+    "delivered_at": "2026-05-04 01:00 UTC",
     "headline": "GOLDMAN HIKES SAMSUNG 2027 OP-PROFIT FORECAST 43% TO \u20a9438T ($297B); 2028 RAISED 56% ON HBM/AI-SERVER CYCLE",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-04-twitter-01h-headlines.json",
     "url": "https://x.com/jukan05/status/2051088714357715392"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-04 01:07 UTC",
+    "delivered_at": "2026-05-04 01:00 UTC",
     "headline": "CCL SUBSTRATE SHORTAGE HITS CRISIS LEVEL \u2014 KOREAN PCB MAKER ORDERS 5X NORMAL VOLUME FROM TAIWANESE EMC AND TUC",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-04-twitter-01h-headlines.json",
     "url": "https://x.com/jukan05/status/2051070393734303767"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-05-04 01:07 UTC",
+    "delivered_at": "2026-05-04 01:00 UTC",
     "headline": "OPENAI OPEN-SOURCES SYMPHONY SPEC \u2014 TURNS LINEAR AND JIRA BOARDS INTO CODEX AGENT TASK QUEUES",
     "source": "@btibor91",
+    "source_file": "research/summaries/2026-05-04-twitter-01h-headlines.json",
     "url": "https://x.com/btibor91/status/2051031732384854396"
   },
   {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-04 01:00 UTC",
+    "headline": "FOUNDERS FUND ADDS $624M TO ANDURIL AT $60B VALUATION \u2014 TOTAL BET NOW $2.6B DESPITE $1B+ ANNUAL LOSSES EXPECTED FOR YEARS",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-04-twitter-01h-headlines.json",
+    "url": "https://x.com/theinformation/status/2051021481837031713"
+  },
+  {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-04 01:07 UTC",
+    "delivered_at": "2026-05-04 01:00 UTC",
     "headline": "INFORMATION: TENCENT'S NEW AI MODEL WINS DEV PRAISE \u2014 BUT 'PROBABLY OWES SOME OF THAT SUCCESS TO ANTHROPIC'",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-04-twitter-01h-headlines.json",
     "url": "https://x.com/theinformation/status/2051036584808517770"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-04 01:07 UTC",
+    "delivered_at": "2026-05-04 01:00 UTC",
     "headline": "MICROSOFT Q1 \u2014 AI USAGE DRAGGED CLOUD MARGINS, COMPANY EFFECTIVELY BOOSTED PRICES IN RESPONSE",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-04-twitter-01h-headlines.json",
     "url": "https://x.com/theinformation/status/2051029049078608051"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-04 04:27 UTC",
+    "delivered_at": "2026-05-04 04:00 UTC",
     "headline": "ANTHROPIC FINALIZING $1.5B JV WITH BLACKSTONE, HELLMAN & FRIEDMAN, GOLDMAN SACHS \u2014 CLAUDE INTO PE PORTFOLIO COMPANIES",
     "source": "@berber_jin1",
+    "source_file": "research/summaries/2026-05-04-twitter-04h-headlines.json",
     "url": "https://x.com/berber_jin1/status/2051128918154051863"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-04 04:27 UTC",
+    "delivered_at": "2026-05-04 04:00 UTC",
     "headline": "ANTHROPIC PUTTING $300M OF ITS OWN BALANCE SHEET INTO PE JV \u2014 ANNOUNCEMENT EXPECTED MONDAY MORNING",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-04-twitter-04h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2051151418602774836"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-04 04:27 UTC",
+    "delivered_at": "2026-05-04 04:00 UTC",
     "headline": "SK HYNIX MARKET CAP CROSSES KRW 1,000 TRILLION \u2014 KOREAN MEMORY MAKER NOW ~$680B COMPANY",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-04-twitter-04h-headlines.json",
     "url": "https://x.com/jukan05/status/2051124404629975307"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-04 04:27 UTC",
+    "delivered_at": "2026-05-04 04:00 UTC",
     "headline": "SK HYNIX HBM4-TO-NVIDIA SHIPMENT CUT 20-30% AS VERA RUBIN RAMP SLIPS \u2014 M15X FAB PIVOTS TO 1c DRAM FOR HBM4E AND SOCAMM2",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-04-twitter-04h-headlines.json",
     "url": "https://x.com/jukan05/status/2051128451231514744"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-04 04:27 UTC",
+    "delivered_at": "2026-05-04 04:00 UTC",
     "headline": "H100 NEOCLOUD SPOT NOW $2.75/HR \u2014 UP 60% VS 2023 A16Z OXYGEN PROGRAM RATES",
     "source": "@AnjneyMidha",
+    "source_file": "research/summaries/2026-05-04-twitter-04h-headlines.json",
     "url": "https://x.com/AnjneyMidha/status/2051063658663563773"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-04 04:27 UTC",
+    "delivered_at": "2026-05-04 04:00 UTC",
     "headline": "xAI GPU FLEET RUNNING AT ~11% UTILIZATION \u2014 THE INFORMATION",
     "source": "@AnjneyMidha",
+    "source_file": "research/summaries/2026-05-04-twitter-04h-headlines.json",
     "url": "https://x.com/AnjneyMidha/status/2051093414893216096"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-04 07:19 UTC",
+    "delivered_at": "2026-05-04 07:00 UTC",
     "headline": "TRENDFORCE: MOBILE DRAM 2Q26 PRICING +93-98% QOQ \u2014 ACCELERATING FROM 1Q26 LPDDR5X +58-63%",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-04-twitter-07h-headlines.json",
     "url": "https://x.com/jukan05/status/2051186527074656584"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-04 07:19 UTC",
+    "delivered_at": "2026-05-04 07:00 UTC",
     "headline": "ANTHROPIC $1.5B PE JV ADDS GENERAL ATLANTIC AS 5TH LP IN GLOBAL DIFFUSION; @ANTHROPICAI STILL SILENT 9H IN",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-04-twitter-07h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2051151418602774836"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-04 07:19 UTC",
+    "delivered_at": "2026-05-04 07:00 UTC",
     "headline": "MORGAN STANLEY: APPLE TO RAISE IPHONE 18 PRICES BY AT LEAST $100 LIKE-FOR-LIKE IN H2'26",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-04-twitter-07h-headlines.json",
     "url": "https://x.com/jukan05/status/2051149610304111046"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-04 12:50 UTC",
+    "delivered_at": "2026-05-04 12:00 UTC",
     "headline": "OPENAI CLOSES $10B 'DEPLOYCO' JV \u2014 $4B+ RAISED, 19 INVESTORS LED BY TPG, BROOKFIELD, ADVENT, BAIN; OPENAI RETAINS CONTROL",
     "source": "@i (Bloomberg/Fiegerman wire)",
+    "source_file": "research/summaries/2026-05-04-twitter-12h-headlines.json",
     "url": "https://x.com/i/web/status/2051282006013509942"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-04 12:50 UTC",
+    "delivered_at": "2026-05-04 12:00 UTC",
     "headline": "OPENAI BEATS ANTHROPIC TO THE WIRE \u2014 DEPLOYCO ANNOUNCES BEFORE ANTHROPIC'S WSJ-LEAKED $1.5B BLACKSTONE/H&F/GOLDMAN JV LANDS",
     "source": "@AnthropicAI (silent since Apr 30)",
+    "source_file": "research/summaries/2026-05-04-twitter-12h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2049602979079336364"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-04 12:50 UTC",
+    "delivered_at": "2026-05-04 12:00 UTC",
     "headline": "BESI: SAMSUNG HYBRID-BONDING ADOPTION DECISION 'MID-YEAR'; HBM MASS PRODUCTION TARGETED FOR 2027 ON IMPLIED-NVIDIA REQUEST",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-04-twitter-12h-headlines.json",
     "url": "https://x.com/jukan05/status/2051205348854542495"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-04 12:50 UTC",
+    "delivered_at": "2026-05-04 12:00 UTC",
     "headline": "DDR6 SUBSTRATE JOINT DEVELOPMENT KICKS OFF AT SAMSUNG / SK HYNIX / MICRON \u2014 JEDEC SPEC STILL UNFINALIZED, 2028-29 MASS PROD",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-04-twitter-12h-headlines.json",
     "url": "https://x.com/jukan05/status/2051260085142479289"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-04 12:50 UTC",
+    "delivered_at": "2026-05-04 12:00 UTC",
     "headline": "XAI ROLLING OUT GROK CONNECTORS FOR GITHUB / NOTION / LINEAR / GOOGLE / MICROSOFT + CUSTOM MCP \u2014 NO PRIMARY @XAI POST YET",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-04-twitter-12h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2051228210172497978"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-04 12:50 UTC",
+    "delivered_at": "2026-05-04 12:00 UTC",
     "headline": "GOOGLE AI STUDIO A/B SURFACES VECTOR-SVG GENERATION 'LIKELY FROM NEW FLASH/PRO MODEL' \u2014 PRE-I/O LEAK CADENCE ACCELERATING",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-04-twitter-12h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2051215328105922757"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-04 12:50 UTC",
+    "delivered_at": "2026-05-04 12:00 UTC",
     "headline": "BLENDER FOUNDATION DOWNGRADES ANTHROPIC OPEN-SOURCE SPONSORSHIP TO ONE-OFF DONATION AFTER ANTI-AI PRESSURE CAMPAIGN",
     "source": "@mark_k",
+    "source_file": "research/summaries/2026-05-04-twitter-12h-headlines.json",
     "url": "https://x.com/mark_k/status/2051216185425887730"
   },
   {
-    "category": "breaking",
-    "delivered_at": "2026-05-04 18:45 UTC",
-    "headline": "GROK BUILD \"LIVE NOW\" WAVE IS @GROK CHATBOT HALLUCINATION \u2014 SAME ESCALATION BOILERPLATE SINCE APR 26, NO XAI PRIMARY POST",
-    "source": "@grok",
-    "url": "https://x.com/grok/status/2051365581136249257"
-  },
-  {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-04 18:45 UTC",
-    "headline": "ANTHROPIC JV WIRE: \"STANDALONE ENTITY WITH ANTHROPIC ENGINEERING EMBEDDED\" \u2014 PALANTIR-FDE TEMPLATE NOW EXPLICIT",
-    "source": "@CHItrader",
-    "url": "https://x.com/CHItrader/status/2051285980666118656"
+    "delivered_at": "2026-05-04 15:00 UTC",
+    "headline": "ANTHROPIC ANNOUNCES $1.5B+ JV \u2014 LP LIST EXPANDS TO 9: BLACKSTONE, GOLDMAN, H&F, APOLLO, GENERAL ATLANTIC, SEQUOIA, LEONARD GREEN, GIC",
+    "source": "@exec_sum",
+    "source_file": "research/summaries/2026-05-04-twitter-15h-headlines.json",
+    "url": "https://x.com/exec_sum/status/2051321182675411162"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-04 18:45 UTC",
-    "headline": "ZERO OVERLAP BETWEEN ANTHROPIC'S 9 JV BACKERS AND OPENAI DEPLOYCO'S 19 \u2014 ALTS FIRMS PICKING SIDES IN AI ENTERPRISE WAR",
-    "source": "@AlperTheKing",
-    "url": "https://x.com/AlperTheKing/status/2051355528077447459"
+    "delivered_at": "2026-05-04 15:00 UTC",
+    "headline": "ANTHROPIC JV LANDS ~2 HOURS AFTER OPENAI DEPLOYCO CLOSE \u2014 LAB+PE DISTRIBUTION TEMPLATE NOW AN INDUSTRY PATTERN",
+    "source": "@HighyieldHarry",
+    "source_file": "research/summaries/2026-05-04-twitter-15h-headlines.json",
+    "url": "https://x.com/HighyieldHarry/status/2051318519623499976"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-04 18:45 UTC",
-    "headline": "JACK CLARK ESSAY: ~30% CHANCE OF FULLY AUTOMATED AI R&D BY 2027, ~60%+ BY 2028 \u2014 NOT STRICT RSI, CLAIM IS AI TRAINS ITS OWN SUCCESSOR",
-    "source": "@kimmonismus",
-    "url": "https://x.com/kimmonismus/status/2051359109354516912"
-  },
-  {
-    "category": "infra",
-    "delivered_at": "2026-05-04 18:45 UTC",
-    "headline": "MICROSOFT VS CODE NOW DOCUMENTS CLAUDE CODE COMPAT \u2014 CLAUDE.MD, .CLAUDE RULES, AGENTS, SKILLS, HOOKS",
-    "source": "@VSMdev",
-    "url": "https://x.com/VSMdev/status/2051372180911599929"
-  },
-  {
-    "category": "business",
-    "delivered_at": "2026-05-04 18:45 UTC",
-    "headline": "@ANTHROPICAI PRIMARY FEED HITS DAY 5 OF SILENCE THROUGH $1.5B JV \u2014 ANNOUNCEMENT WAS WIRE-ONLY VIA BUSINESS WIRE",
-    "source": "@AnthropicAI",
-    "url": "https://x.com/AnthropicAI/status/2049927618397614466"
-  },
-  {
-    "category": "business",
-    "delivered_at": "2026-05-04 18:45 UTC",
-    "headline": "CURSOR REFUSES TO INTEGRATE GROK EVEN AS SPACEX EYES $60B ACQUISITION OPTION \u2014 FIRST PUBLIC FRICTION ON THE DEAL",
-    "source": "@theinformation",
-    "url": "https://x.com/theinformation/status/2051353692146704735"
-  },
-  {
-    "category": "model",
-    "delivered_at": "2026-05-04 21:32 UTC",
-    "headline": "ANTHROPIC SHIPS KEYLESS AUTH FOR CLAUDE PLATFORM \u2014 BROWSER CLI + AWS/GCP/AZURE/OIDC WORKLOADS, 12H BEFORE CODE WITH CLAUDE OPENS",
-    "source": "@ClaudeDevs",
-    "url": "https://x.com/ClaudeDevs/status/2051393709619732758"
-  },
-  {
-    "category": "business",
-    "delivered_at": "2026-05-04 21:32 UTC",
-    "headline": "@ANTHROPICAI PRIMARY FEED ON DAY 5 OF SILENCE THROUGH $1.5B PE JV \u2014 LAST POST APR 30 SYCOPHANCY PAPER",
-    "source": "@AnthropicAI",
-    "url": "https://x.com/AnthropicAI/status/2049927618397614466"
-  },
-  {
-    "category": "infra",
-    "delivered_at": "2026-05-04 21:32 UTC",
-    "headline": "SEMIANALYSIS: GB300 NVL72 ALREADY 2.7\u00d7 FASTER THAN GB200 ON vLLM \u2014 DESPITE PAPER SPEC ONLY 1.5\u00d7 FLOPS / 1.5\u00d7 HBM CAP / SAME HBM BW",
-    "source": "@SemiAnalysis_",
-    "url": "https://x.com/SemiAnalysis_/status/2051406756429943109"
-  },
-  {
-    "category": "business",
-    "delivered_at": "2026-05-04 21:32 UTC",
-    "headline": "MERCEDES CUT SAP INSTANCES 40% (1,000\u2192600) USING OWN AI + CHATGPT + CLAUDE TO CLEAN DATA \u2014 SAP NOW BLOCKING UNAUTHORIZED AGENTS",
-    "source": "@amir",
-    "url": "https://x.com/amir/status/2051323029511352518"
-  },
-  {
-    "category": "opensource",
-    "delivered_at": "2026-05-04 21:32 UTC",
-    "headline": "VERCEL OPEN-SOURCES `npx deepsec` \u2014 CODING-AGENT ORCHESTRATOR FOR DEEP SECURITY REVIEWS, FINDS CRITICAL VULNS IN MINUTES",
-    "source": "@rauchg",
-    "url": "https://x.com/rauchg/status/2051386798899888539"
-  },
-  {
-    "category": "business",
-    "delivered_at": "2026-05-04 21:32 UTC",
-    "headline": "BROCKMAN TESTIFIES OPENAI STAKE WORTH ~$30B; ADMITS UNDER OATH HE INVESTED $0 TO ACQUIRE CAP-PROFIT INTEREST",
-    "source": "@theinformation",
-    "url": "https://x.com/theinformation/status/2051399216572874797"
-  },
-  {
-    "category": "infra",
-    "delivered_at": "2026-05-04 21:32 UTC",
-    "headline": "FUTURUM/NVIDIA: TOP 5 US HYPERSCALERS ON TRACK FOR UP TO $690B INFRA SPEND IN 2026 \u2014 NEARLY 2\u00d7 2025; ENERGY/COOLING NOW PRIMARY BOTTLENECK",
-    "source": "@kimmonismus",
-    "url": "https://x.com/kimmonismus/status/2051393312683376696"
-  },
-  {
-    "category": "policy",
-    "delivered_at": "2026-05-05 01:04 UTC",
-    "headline": "NYT: TRUMP WHITE HOUSE BRIEFS ANTHROPIC, GOOGLE, OPENAI ON PRE-RELEASE AI SAFETY REVIEW PROPOSAL \u2014 MYTHOS CITED AS TRIGGER",
-    "source": "@AndrewCurran_",
-    "url": "https://x.com/AndrewCurran_/status/2051426944106049851"
-  },
-  {
-    "category": "business",
-    "delivered_at": "2026-05-05 01:04 UTC",
-    "headline": "SIERRA RAISES $950M SERIES E AT $15B+ VALUATION, TIGER GLOBAL + GV LED \u2014 ARR $100M (NOV) TO $150M (FEB)",
-    "source": "@SierraPlatform",
-    "url": "https://x.com/SierraPlatform/status/2051314764798943456"
-  },
-  {
-    "category": "model",
-    "delivered_at": "2026-05-05 01:04 UTC",
-    "headline": "OPENAI 10X CODEX RATE LIMITS UNTIL JUNE 5 FOR GPT-5.5 PARTY APPLICANTS WHO DIDN'T GET IN \u2014 CONCESSION ON 4-DAY REVOLT",
-    "source": "@AndrewCurran_",
-    "url": "https://x.com/AndrewCurran_/status/2051462208748675541"
-  },
-  {
-    "category": "model",
-    "delivered_at": "2026-05-05 01:04 UTC",
-    "headline": "ANTHROPIC ORBIT LEAK: PROACTIVE ASSISTANT FOR CLAUDE COWORK PULLING FROM GMAIL, SLACK, GITHUB, CALENDAR, DRIVE, FIGMA",
-    "source": "@testingcatalog",
-    "url": "https://x.com/testingcatalog/status/2051450201668256051"
-  },
-  {
-    "category": "business",
-    "delivered_at": "2026-05-05 01:04 UTC",
-    "headline": "CEREBRAS S-1 AMENDMENT SETS IPO RANGE $115-$125, ~$25.5B VALUATION MIDPOINT, $3.24-3.73B RAISE \u2014 TARGET MAY 13 ON NASDAQ",
-    "source": "@YeboahWalee",
-    "url": "https://x.com/YeboahWalee/status/2051300983855345807"
-  },
-  {
-    "category": "breaking",
-    "delivered_at": "2026-05-05 01:04 UTC",
-    "headline": "BROCKMAN UNDER OATH: ALTMAN PAID HIM $10M IN OFF-BOOKS EQUITY FROM PERSONAL FAMILY OFFICE IN 2017, HIDDEN FROM MUSK",
-    "source": "@ns123abc",
-    "url": "https://x.com/ns123abc/status/2051431726287900816"
-  },
-  {
-    "category": "infra",
-    "delivered_at": "2026-05-05 01:04 UTC",
-    "headline": "GEMINI API SHIPS WEBHOOKS \u2014 UNLOCKS LONG-RUNNING TASK DEVX FOR BATCH, AGENTS, GENMEDIA",
-    "source": "@OfficialLoganK",
-    "url": "https://x.com/OfficialLoganK/status/2051434527931953490"
-  },
-  {
-    "category": "breaking",
-    "delivered_at": "2026-05-05 04:14 UTC",
-    "headline": "BROCKMAN UNDER OATH: 'I'VE NEVER BEEN CERTAIN WHAT I'M BEING SUED FOR' \u2014 $30B OPENAI STAKE FOR $0 CASH CONFIRMED BY MULTIPLE WIRES",
-    "source": "@ns123abc",
-    "url": "https://x.com/ns123abc/status/2051501311175065944"
-  },
-  {
-    "category": "breaking",
-    "delivered_at": "2026-05-05 04:14 UTC",
-    "headline": "COINTELEGRAPH CONFIRMS BROCKMAN $30B OPENAI STAKE DISCLOSURE IN MUSK V. ALTMAN TRIAL",
-    "source": "@Cointelegraph",
-    "url": "https://x.com/Cointelegraph/status/2051507411844731139"
-  },
-  {
-    "category": "business",
-    "delivered_at": "2026-05-05 04:14 UTC",
-    "headline": "TICKERTRENDS: CODEX OVERTAKES CLAUDE CODE IN NPM WEEKLY DOWNLOADS \u2014 46M VS 491K, GAP WIDENING SINCE APRIL 30",
-    "source": "@tickerplus",
-    "url": "https://x.com/tickerplus/status/2051126808037257704"
-  },
-  {
-    "category": "research",
-    "delivered_at": "2026-05-05 04:14 UTC",
-    "headline": "JACK CLARK: 60% CHANCE OF RECURSIVE SELF-IMPROVEMENT BY END OF 2028 \u2014 ANTHROPIC POLICY LEAD GOES ON RECORD",
+    "delivered_at": "2026-05-04 15:00 UTC",
+    "headline": "JACK CLARK (ANTHROPIC CO-FOUNDER): 60% PROBABILITY OF RECURSIVE SELF-IMPROVEMENT BY END OF 2028",
     "source": "@jackclarkSF",
+    "source_file": "research/summaries/2026-05-04-twitter-15h-headlines.json",
     "url": "https://x.com/jackclarkSF/status/2051312759594471886"
   },
   {
-    "category": "business",
-    "delivered_at": "2026-05-05 04:14 UTC",
-    "headline": "REUTERS: CEREBRAS TARGETS $26.6B VALUATION IN US IPO AS AI CHIP DEMAND SURGES",
-    "source": "@Reuters",
-    "url": "https://x.com/Reuters/status/2051507186526724180"
-  },
-  {
-    "category": "model",
-    "delivered_at": "2026-05-05 04:14 UTC",
-    "headline": "OPENAI 10X CODEX RATE-LIMIT BUMP NOW EXTENDS TO ALL GPT-5.5 PARTY APPLICANTS, NOT JUST NON-ATTENDEES",
-    "source": "@jxnlco",
-    "url": "https://x.com/jxnlco/status/2051468129101099038"
-  },
-  {
-    "category": "infra",
-    "delivered_at": "2026-05-05 04:14 UTC",
-    "headline": "SIMONW: BUN APPEARS TO BE EXPLORING A PORT FROM ZIG TO RUST PER LEAKED PORTING.MD GUIDE FOR CODING AGENTS",
-    "source": "@simonw",
-    "url": "https://x.com/simonw/status/2051476878712840407"
-  },
-  {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-05 07:01 UTC",
-    "headline": "CURRAN: TRUMP AI POLICY MEMO + EXECUTIVE ORDER MAY DROP TOMORROW, CREATING TECH-CEO/ADMIN WORKING GROUP ON PRE-RELEASE RULES",
+    "delivered_at": "2026-05-04 15:00 UTC",
+    "headline": "OPENAI COURT FILING ALLEGES PRE-TRIAL MUSK THREAT TO BROCKMAN: 'YOU AND SAM WILL BE THE MOST HATED MEN IN AMERICA'",
     "source": "@AndrewCurran_",
-    "url": "https://x.com/AndrewCurran_/status/2051540046772134263"
+    "source_file": "research/summaries/2026-05-04-twitter-15h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2051300598893740543"
   },
   {
-    "category": "business",
-    "delivered_at": "2026-05-05 07:01 UTC",
-    "headline": "BROCKMAN CROSS-EXAM WRAPS \u2014 NS123ABC: 'AUTHENTICATED THE ENTIRE CASE AGAINST HIM' IN ONE DAY OF TESTIMONY",
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-05-04 15:00 UTC",
+    "headline": "JUDGE DENIES OPENAI MOTION TO PUT ALLEGED MUSK SETTLEMENT MESSAGE BEFORE JURY VIA BROCKMAN TESTIMONY",
     "source": "@ns123abc",
-    "url": "https://x.com/ns123abc/status/2051534855263912433"
+    "source_file": "research/summaries/2026-05-04-twitter-15h-headlines.json",
+    "url": "https://x.com/ns123abc/status/2051323907174604831"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-05 07:01 UTC",
-    "headline": "NS123ABC TEASES BROCKMAN PART 2 \u2014 SELF-DEALING EXTENDS BEYOND CEREBRAS TO THREE MORE COUNTERPARTIES",
-    "source": "@ns123abc",
-    "url": "https://x.com/ns123abc/status/2051556652675919883"
+    "delivered_at": "2026-05-04 15:00 UTC",
+    "headline": "SAP MOVING TO BLOCK UNAUTHORIZED AI AGENTS FROM OPENAI, ANTHROPIC AS THREAT TO CUSTOMER DATA GRIP MOUNTS",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-04-twitter-15h-headlines.json",
+    "url": "https://x.com/theinformation/status/2051323974363070562"
   },
   {
-    "category": "model",
-    "delivered_at": "2026-05-05 07:01 UTC",
-    "headline": "OPENAI VOICE MODE PRE-LAUNCH LEAK \u2014 GPT-5.5-BASED, FULL-DUPLEX LISTEN-AND-SPEAK, AHEAD OF SF LAUNCH CELEBRATION TODAY",
-    "source": "@mark_k",
-    "url": "https://x.com/mark_k/status/2051553995307602310"
-  },
-  {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-05 07:01 UTC",
-    "headline": "BLOOMBERG VIA JUKAN: APPLE CONSIDERING SAMSUNG FOUNDRY AND INTEL FOUNDRY \u2014 CHIP-SUPPLY DIVERSIFICATION SIGNAL",
+    "delivered_at": "2026-05-04 15:00 UTC",
+    "headline": "AMD MI550 POSITIONED TO CHALLENGE NVIDIA RUBIN ULTRA IN 2H27 WITH 4-DIE/12-HBM4E PACKAGE AS RUBIN ULTRA SLIPS",
     "source": "@jukan05",
-    "url": "https://x.com/jukan05/status/2051515981781234051"
+    "source_file": "research/summaries/2026-05-04-twitter-15h-headlines.json",
+    "url": "https://x.com/jukan05/status/2051305126011576374"
   },
   {
-    "category": "business",
-    "delivered_at": "2026-05-05 09:47 UTC",
-    "headline": "ANTHROPIC + FIS LAUNCH CLAUDE-POWERED FINANCIAL CRIMES AI AGENT FOR BANKS \u2014 BMO, AMALGAMATED DEPLOYING; FIS +7%",
-    "source": "@CPOfficialtx",
-    "url": "https://x.com/CPOfficialtx/status/2051546457333965218"
+    "backfilled": true,
+    "category": "breaking",
+    "delivered_at": "2026-05-04 18:00 UTC",
+    "headline": "GROK BUILD \"LIVE NOW\" WAVE IS @GROK CHATBOT HALLUCINATION \u2014 SAME ESCALATION BOILERPLATE SINCE APR 26, NO XAI PRIMARY POST",
+    "source": "@grok",
+    "source_file": "research/summaries/2026-05-04-twitter-18h-headlines.json",
+    "url": "https://x.com/grok/status/2051365581136249257"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-05 09:47 UTC",
-    "headline": "WSJ NAMED AS PRIMARY ON FIS-ANTHROPIC AML AGENT \u2014 DAYS-TO-MINUTES INVESTIGATION TIMES",
-    "source": "@Anyutik_1907",
-    "url": "https://x.com/Anyutik_1907/status/2051496726943465651"
+    "delivered_at": "2026-05-04 18:00 UTC",
+    "headline": "ANTHROPIC JV WIRE: \"STANDALONE ENTITY WITH ANTHROPIC ENGINEERING EMBEDDED\" \u2014 PALANTIR-FDE TEMPLATE NOW EXPLICIT",
+    "source": "@CHItrader",
+    "source_file": "research/summaries/2026-05-04-twitter-18h-headlines.json",
+    "url": "https://x.com/CHItrader/status/2051285980666118656"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-05 09:47 UTC",
-    "headline": "ANTHROPIC PRIMARY X FEED NOW DAY 6+ SILENT \u2014 NO POST ON OWN FIS JV, PRIOR BLACKSTONE JV, OR NYT EO STORY",
+    "delivered_at": "2026-05-04 18:00 UTC",
+    "headline": "ZERO OVERLAP BETWEEN ANTHROPIC'S 9 JV BACKERS AND OPENAI DEPLOYCO'S 19 \u2014 ALTS FIRMS PICKING SIDES IN AI ENTERPRISE WAR",
+    "source": "@AlperTheKing",
+    "source_file": "research/summaries/2026-05-04-twitter-18h-headlines.json",
+    "url": "https://x.com/AlperTheKing/status/2051355528077447459"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-05-04 18:00 UTC",
+    "headline": "JACK CLARK ESSAY: ~30% CHANCE OF FULLY AUTOMATED AI R&D BY 2027, ~60%+ BY 2028 \u2014 NOT STRICT RSI, CLAIM IS AI TRAINS ITS OWN SUCCESSOR",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-04-twitter-18h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2051359109354516912"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-05-04 18:00 UTC",
+    "headline": "MICROSOFT VS CODE NOW DOCUMENTS CLAUDE CODE COMPAT \u2014 CLAUDE.MD, .CLAUDE RULES, AGENTS, SKILLS, HOOKS",
+    "source": "@VSMdev",
+    "source_file": "research/summaries/2026-05-04-twitter-18h-headlines.json",
+    "url": "https://x.com/VSMdev/status/2051372180911599929"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-04 18:00 UTC",
+    "headline": "@ANTHROPICAI PRIMARY FEED HITS DAY 5 OF SILENCE THROUGH $1.5B JV \u2014 ANNOUNCEMENT WAS WIRE-ONLY VIA BUSINESS WIRE",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-04-twitter-18h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2049927618397614466"
   },
   {
-    "category": "model",
-    "delivered_at": "2026-05-05 09:47 UTC",
-    "headline": "KIMMONISMUS: NEW CHATGPT VOICE MODE PRETTY MUCH CONFIRMED \u2014 SAMA TEASE NOW 4,836L/187RT",
-    "source": "@kimmonismus",
-    "url": "https://x.com/kimmonismus/status/2051571219040735423"
-  },
-  {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-05 09:47 UTC",
-    "headline": "NS123ABC RECASTS BROCKMAN $30B AS CHARITY-CONVERSION CAP-REMOVAL VALUE, NOT FOUNDER EQUITY",
-    "source": "@ns123abc",
-    "url": "https://x.com/ns123abc/status/2051575939549585786"
+    "delivered_at": "2026-05-04 18:00 UTC",
+    "headline": "CURSOR REFUSES TO INTEGRATE GROK EVEN AS SPACEX EYES $60B ACQUISITION OPTION \u2014 FIRST PUBLIC FRICTION ON THE DEAL",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-04-twitter-18h-headlines.json",
+    "url": "https://x.com/theinformation/status/2051353692146704735"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-05 09:47 UTC",
-    "headline": "OPENAI 10X CODEX RATE LIMITS UNTIL JUNE FOR GPT-5.5 PARTY APPLICANTS WHO MISSED A SPOT",
-    "source": "@kimmonismus",
-    "url": "https://x.com/kimmonismus/status/2051580022029209985"
+    "delivered_at": "2026-05-04 21:00 UTC",
+    "headline": "ANTHROPIC SHIPS KEYLESS AUTH FOR CLAUDE PLATFORM \u2014 BROWSER CLI + AWS/GCP/AZURE/OIDC WORKLOADS, 12H BEFORE CODE WITH CLAUDE OPENS",
+    "source": "@ClaudeDevs",
+    "source_file": "research/summaries/2026-05-04-twitter-21h-headlines.json",
+    "url": "https://x.com/ClaudeDevs/status/2051393709619732758"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-05 12:40 UTC",
-    "headline": "COINBASE LAYS OFF 14% (~700) \u2014 ARMSTRONG MEMO BLAMES AI; ORG FLATTENED TO 5 LAYERS, AI-NATIVE ONE-PERSON PODS; COIN +4% PRE-MARKET",
-    "source": "@decrypt",
-    "url": "https://x.com/i/web/status/2051638585107865771"
+    "delivered_at": "2026-05-04 21:00 UTC",
+    "headline": "@ANTHROPICAI PRIMARY FEED ON DAY 5 OF SILENCE THROUGH $1.5B PE JV \u2014 LAST POST APR 30 SYCOPHANCY PAPER",
+    "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-04-twitter-21h-headlines.json",
+    "url": "https://x.com/AnthropicAI/status/2049927618397614466"
   },
   {
-    "category": "business",
-    "delivered_at": "2026-05-05 12:40 UTC",
-    "headline": "IREN SIGNS DEFINITIVE DEAL TO ACQUIRE MIRANTIS FOR $625M ALL-STOCK \u2014 3.8% DILUTION, 1,500+ ENTERPRISE CUSTOMERS, K0RDENT AI/K8S PLATFORM",
-    "source": "@FinnStockinger",
-    "url": "https://x.com/i/web/status/2051626450558529833"
-  },
-  {
-    "category": "model",
-    "delivered_at": "2026-05-05 12:40 UTC",
-    "headline": "GEMINI 3.2 FLASH RELEASE IMMINENT FROM GOOGLE DEEPMIND \u2014 LEAK TRIANGULATED ACROSS MARK_K, IRULETHEWORLDMO, KIMMONISMUS PRE-I/O",
-    "source": "@mark_k",
-    "url": "https://x.com/mark_k/status/2051616788316573961"
-  },
-  {
-    "category": "model",
-    "delivered_at": "2026-05-05 12:40 UTC",
-    "headline": "ANTHROPIC ORBIT RE-LEAKED \u2014 PROACTIVE CLAUDE COWORK ASSISTANT, AUTO-BRIEFINGS FROM GMAIL/SLACK/GITHUB; FRAMED AS ANSWER TO CHATGPT PULSE",
-    "source": "@kimmonismus",
-    "url": "https://x.com/kimmonismus/status/2051618156385366305"
-  },
-  {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-05 12:40 UTC",
-    "headline": "RADIXARK CLOSES $100M SEED AT $400M VALUATION \u2014 EX-XAI YING SHENG'S OPEN-SOURCE SGLANG INFERENCE ENGINE PER WSJ",
-    "source": "@WSJ",
-    "url": "https://x.com/i/web/status/2051639489769156863"
+    "delivered_at": "2026-05-04 21:00 UTC",
+    "headline": "SEMIANALYSIS: GB300 NVL72 ALREADY 2.7\u00d7 FASTER THAN GB200 ON vLLM \u2014 DESPITE PAPER SPEC ONLY 1.5\u00d7 FLOPS / 1.5\u00d7 HBM CAP / SAME HBM BW",
+    "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-05-04-twitter-21h-headlines.json",
+    "url": "https://x.com/SemiAnalysis_/status/2051406756429943109"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-05 12:40 UTC",
-    "headline": "AMD Q1 EARNINGS PREVIEW \u2014 GF SECURITIES RAISES PT TO $465 (BUY); MI455 + RUMORED ANTHROPIC PARTNERSHIP THE BULL CASE; REPORTS AFTER-MARKET",
-    "source": "@jukan05",
-    "url": "https://x.com/jukan05/status/2051612202403299609"
+    "delivered_at": "2026-05-04 21:00 UTC",
+    "headline": "MERCEDES CUT SAP INSTANCES 40% (1,000\u2192600) USING OWN AI + CHATGPT + CLAUDE TO CLEAN DATA \u2014 SAP NOW BLOCKING UNAUTHORIZED AGENTS",
+    "source": "@amir",
+    "source_file": "research/summaries/2026-05-04-twitter-21h-headlines.json",
+    "url": "https://x.com/amir/status/2051323029511352518"
   },
   {
+    "backfilled": true,
+    "category": "opensource",
+    "delivered_at": "2026-05-04 21:00 UTC",
+    "headline": "VERCEL OPEN-SOURCES `npx deepsec` \u2014 CODING-AGENT ORCHESTRATOR FOR DEEP SECURITY REVIEWS, FINDS CRITICAL VULNS IN MINUTES",
+    "source": "@rauchg",
+    "source_file": "research/summaries/2026-05-04-twitter-21h-headlines.json",
+    "url": "https://x.com/rauchg/status/2051386798899888539"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-04 21:00 UTC",
+    "headline": "BROCKMAN TESTIFIES OPENAI STAKE WORTH ~$30B; ADMITS UNDER OATH HE INVESTED $0 TO ACQUIRE CAP-PROFIT INTEREST",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-04-twitter-21h-headlines.json",
+    "url": "https://x.com/theinformation/status/2051399216572874797"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-05-04 21:00 UTC",
+    "headline": "FUTURUM/NVIDIA: TOP 5 US HYPERSCALERS ON TRACK FOR UP TO $690B INFRA SPEND IN 2026 \u2014 NEARLY 2\u00d7 2025; ENERGY/COOLING NOW PRIMARY BOTTLENECK",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-04-twitter-21h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2051393312683376696"
+  },
+  {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-05 12:40 UTC",
-    "headline": "CURRAN \"EO TOMORROW\" CALL NOW 342L/38RT (+35% IN 3H) \u2014 NO WIRE CONFIRMING WH AI ORDER TIMING; FALSIFICATION WINDOW OPENS US-AM",
+    "delivered_at": "2026-05-05 01:00 UTC",
+    "headline": "NYT: TRUMP WHITE HOUSE BRIEFS ANTHROPIC, GOOGLE, OPENAI ON PRE-RELEASE AI SAFETY REVIEW PROPOSAL \u2014 MYTHOS CITED AS TRIGGER",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-05-twitter-01h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2051426944106049851"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-05 01:00 UTC",
+    "headline": "SIERRA RAISES $950M SERIES E AT $15B+ VALUATION, TIGER GLOBAL + GV LED \u2014 ARR $100M (NOV) TO $150M (FEB)",
+    "source": "@SierraPlatform",
+    "source_file": "research/summaries/2026-05-05-twitter-01h-headlines.json",
+    "url": "https://x.com/SierraPlatform/status/2051314764798943456"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-05-05 01:00 UTC",
+    "headline": "OPENAI 10X CODEX RATE LIMITS UNTIL JUNE 5 FOR GPT-5.5 PARTY APPLICANTS WHO DIDN'T GET IN \u2014 CONCESSION ON 4-DAY REVOLT",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-05-twitter-01h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2051462208748675541"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-05-05 01:00 UTC",
+    "headline": "ANTHROPIC ORBIT LEAK: PROACTIVE ASSISTANT FOR CLAUDE COWORK PULLING FROM GMAIL, SLACK, GITHUB, CALENDAR, DRIVE, FIGMA",
+    "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-05-twitter-01h-headlines.json",
+    "url": "https://x.com/testingcatalog/status/2051450201668256051"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-05 01:00 UTC",
+    "headline": "CEREBRAS S-1 AMENDMENT SETS IPO RANGE $115-$125, ~$25.5B VALUATION MIDPOINT, $3.24-3.73B RAISE \u2014 TARGET MAY 13 ON NASDAQ",
+    "source": "@YeboahWalee",
+    "source_file": "research/summaries/2026-05-05-twitter-01h-headlines.json",
+    "url": "https://x.com/YeboahWalee/status/2051300983855345807"
+  },
+  {
+    "backfilled": true,
+    "category": "breaking",
+    "delivered_at": "2026-05-05 01:00 UTC",
+    "headline": "BROCKMAN UNDER OATH: ALTMAN PAID HIM $10M IN OFF-BOOKS EQUITY FROM PERSONAL FAMILY OFFICE IN 2017, HIDDEN FROM MUSK",
+    "source": "@ns123abc",
+    "source_file": "research/summaries/2026-05-05-twitter-01h-headlines.json",
+    "url": "https://x.com/ns123abc/status/2051431726287900816"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-05-05 01:00 UTC",
+    "headline": "GEMINI API SHIPS WEBHOOKS \u2014 UNLOCKS LONG-RUNNING TASK DEVX FOR BATCH, AGENTS, GENMEDIA",
+    "source": "@OfficialLoganK",
+    "source_file": "research/summaries/2026-05-05-twitter-01h-headlines.json",
+    "url": "https://x.com/OfficialLoganK/status/2051434527931953490"
+  },
+  {
+    "backfilled": true,
+    "category": "breaking",
+    "delivered_at": "2026-05-05 04:00 UTC",
+    "headline": "BROCKMAN UNDER OATH: 'I'VE NEVER BEEN CERTAIN WHAT I'M BEING SUED FOR' \u2014 $30B OPENAI STAKE FOR $0 CASH CONFIRMED BY MULTIPLE WIRES",
+    "source": "@ns123abc",
+    "source_file": "research/summaries/2026-05-05-twitter-04h-headlines.json",
+    "url": "https://x.com/ns123abc/status/2051501311175065944"
+  },
+  {
+    "backfilled": true,
+    "category": "breaking",
+    "delivered_at": "2026-05-05 04:00 UTC",
+    "headline": "COINTELEGRAPH CONFIRMS BROCKMAN $30B OPENAI STAKE DISCLOSURE IN MUSK V. ALTMAN TRIAL",
+    "source": "@Cointelegraph",
+    "source_file": "research/summaries/2026-05-05-twitter-04h-headlines.json",
+    "url": "https://x.com/Cointelegraph/status/2051507411844731139"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-05 04:00 UTC",
+    "headline": "TICKERTRENDS: CODEX OVERTAKES CLAUDE CODE IN NPM WEEKLY DOWNLOADS \u2014 46M VS 491K, GAP WIDENING SINCE APRIL 30",
+    "source": "@tickerplus",
+    "source_file": "research/summaries/2026-05-05-twitter-04h-headlines.json",
+    "url": "https://x.com/tickerplus/status/2051126808037257704"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-05-05 04:00 UTC",
+    "headline": "JACK CLARK: 60% CHANCE OF RECURSIVE SELF-IMPROVEMENT BY END OF 2028 \u2014 ANTHROPIC POLICY LEAD GOES ON RECORD",
+    "source": "@jackclarkSF",
+    "source_file": "research/summaries/2026-05-05-twitter-04h-headlines.json",
+    "url": "https://x.com/jackclarkSF/status/2051312759594471886"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-05 04:00 UTC",
+    "headline": "REUTERS: CEREBRAS TARGETS $26.6B VALUATION IN US IPO AS AI CHIP DEMAND SURGES",
+    "source": "@Reuters",
+    "source_file": "research/summaries/2026-05-05-twitter-04h-headlines.json",
+    "url": "https://x.com/Reuters/status/2051507186526724180"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-05-05 04:00 UTC",
+    "headline": "OPENAI 10X CODEX RATE-LIMIT BUMP NOW EXTENDS TO ALL GPT-5.5 PARTY APPLICANTS, NOT JUST NON-ATTENDEES",
+    "source": "@jxnlco",
+    "source_file": "research/summaries/2026-05-05-twitter-04h-headlines.json",
+    "url": "https://x.com/jxnlco/status/2051468129101099038"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-05-05 04:00 UTC",
+    "headline": "SIMONW: BUN APPEARS TO BE EXPLORING A PORT FROM ZIG TO RUST PER LEAKED PORTING.MD GUIDE FOR CODING AGENTS",
+    "source": "@simonw",
+    "source_file": "research/summaries/2026-05-05-twitter-04h-headlines.json",
+    "url": "https://x.com/simonw/status/2051476878712840407"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-05-05 07:00 UTC",
+    "headline": "CURRAN: TRUMP AI POLICY MEMO + EXECUTIVE ORDER MAY DROP TOMORROW, CREATING TECH-CEO/ADMIN WORKING GROUP ON PRE-RELEASE RULES",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-05-twitter-07h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2051540046772134263"
   },
   {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-05 07:00 UTC",
+    "headline": "BROCKMAN CROSS-EXAM WRAPS \u2014 NS123ABC: 'AUTHENTICATED THE ENTIRE CASE AGAINST HIM' IN ONE DAY OF TESTIMONY",
+    "source": "@ns123abc",
+    "source_file": "research/summaries/2026-05-05-twitter-07h-headlines.json",
+    "url": "https://x.com/ns123abc/status/2051534855263912433"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-05 07:00 UTC",
+    "headline": "NS123ABC TEASES BROCKMAN PART 2 \u2014 SELF-DEALING EXTENDS BEYOND CEREBRAS TO THREE MORE COUNTERPARTIES",
+    "source": "@ns123abc",
+    "source_file": "research/summaries/2026-05-05-twitter-07h-headlines.json",
+    "url": "https://x.com/ns123abc/status/2051556652675919883"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-05-05 07:00 UTC",
+    "headline": "OPENAI VOICE MODE PRE-LAUNCH LEAK \u2014 GPT-5.5-BASED, FULL-DUPLEX LISTEN-AND-SPEAK, AHEAD OF SF LAUNCH CELEBRATION TODAY",
+    "source": "@mark_k",
+    "source_file": "research/summaries/2026-05-05-twitter-07h-headlines.json",
+    "url": "https://x.com/mark_k/status/2051553995307602310"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-05-05 07:00 UTC",
+    "headline": "BLOOMBERG VIA JUKAN: APPLE CONSIDERING SAMSUNG FOUNDRY AND INTEL FOUNDRY \u2014 CHIP-SUPPLY DIVERSIFICATION SIGNAL",
+    "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-05-twitter-07h-headlines.json",
+    "url": "https://x.com/jukan05/status/2051515981781234051"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-05 09:00 UTC",
+    "headline": "ANTHROPIC + FIS LAUNCH CLAUDE-POWERED FINANCIAL CRIMES AI AGENT FOR BANKS \u2014 BMO, AMALGAMATED DEPLOYING; FIS +7%",
+    "source": "@CPOfficialtx",
+    "source_file": "research/summaries/2026-05-05-twitter-09h-headlines.json",
+    "url": "https://x.com/CPOfficialtx/status/2051546457333965218"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-05 09:00 UTC",
+    "headline": "WSJ NAMED AS PRIMARY ON FIS-ANTHROPIC AML AGENT \u2014 DAYS-TO-MINUTES INVESTIGATION TIMES",
+    "source": "@Anyutik_1907",
+    "source_file": "research/summaries/2026-05-05-twitter-09h-headlines.json",
+    "url": "https://x.com/Anyutik_1907/status/2051496726943465651"
+  },
+  {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-05 15:46 UTC",
+    "delivered_at": "2026-05-05 09:00 UTC",
+    "headline": "CURRAN: TRUMP AI EXECUTIVE ORDER + POLICY MEMO COULD DROP TODAY \u2014 TECH-CEO/ADMIN MIXED WORKING GROUP",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-05-twitter-09h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2051540046772134263"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-05 09:00 UTC",
+    "headline": "ANTHROPIC PRIMARY X FEED NOW DAY 6+ SILENT \u2014 NO POST ON OWN FIS JV, PRIOR BLACKSTONE JV, OR NYT EO STORY",
+    "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-05-twitter-09h-headlines.json",
+    "url": "https://x.com/AnthropicAI/status/2049927618397614466"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-05-05 09:00 UTC",
+    "headline": "KIMMONISMUS: NEW CHATGPT VOICE MODE PRETTY MUCH CONFIRMED \u2014 SAMA TEASE NOW 4,836L/187RT",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-05-twitter-09h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2051571219040735423"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-05 09:00 UTC",
+    "headline": "NS123ABC RECASTS BROCKMAN $30B AS CHARITY-CONVERSION CAP-REMOVAL VALUE, NOT FOUNDER EQUITY",
+    "source": "@ns123abc",
+    "source_file": "research/summaries/2026-05-05-twitter-09h-headlines.json",
+    "url": "https://x.com/ns123abc/status/2051575939549585786"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-05-05 09:00 UTC",
+    "headline": "OPENAI 10X CODEX RATE LIMITS UNTIL JUNE FOR GPT-5.5 PARTY APPLICANTS WHO MISSED A SPOT",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-05-twitter-09h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2051580022029209985"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-05 12:00 UTC",
+    "headline": "COINBASE LAYS OFF 14% (~700) \u2014 ARMSTRONG MEMO BLAMES AI; ORG FLATTENED TO 5 LAYERS, AI-NATIVE ONE-PERSON PODS; COIN +4% PRE-MARKET",
+    "source": "@decrypt",
+    "source_file": "research/summaries/2026-05-05-twitter-12h-headlines.json",
+    "url": "https://x.com/i/web/status/2051638585107865771"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-05 12:00 UTC",
+    "headline": "IREN SIGNS DEFINITIVE DEAL TO ACQUIRE MIRANTIS FOR $625M ALL-STOCK \u2014 3.8% DILUTION, 1,500+ ENTERPRISE CUSTOMERS, K0RDENT AI/K8S PLATFORM",
+    "source": "@FinnStockinger",
+    "source_file": "research/summaries/2026-05-05-twitter-12h-headlines.json",
+    "url": "https://x.com/i/web/status/2051626450558529833"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-05-05 12:00 UTC",
+    "headline": "GEMINI 3.2 FLASH RELEASE IMMINENT FROM GOOGLE DEEPMIND \u2014 LEAK TRIANGULATED ACROSS MARK_K, IRULETHEWORLDMO, KIMMONISMUS PRE-I/O",
+    "source": "@mark_k",
+    "source_file": "research/summaries/2026-05-05-twitter-12h-headlines.json",
+    "url": "https://x.com/mark_k/status/2051616788316573961"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-05-05 12:00 UTC",
+    "headline": "ANTHROPIC ORBIT RE-LEAKED \u2014 PROACTIVE CLAUDE COWORK ASSISTANT, AUTO-BRIEFINGS FROM GMAIL/SLACK/GITHUB; FRAMED AS ANSWER TO CHATGPT PULSE",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-05-twitter-12h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2051618156385366305"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-05-05 12:00 UTC",
+    "headline": "RADIXARK CLOSES $100M SEED AT $400M VALUATION \u2014 EX-XAI YING SHENG'S OPEN-SOURCE SGLANG INFERENCE ENGINE PER WSJ",
+    "source": "@WSJ",
+    "source_file": "research/summaries/2026-05-05-twitter-12h-headlines.json",
+    "url": "https://x.com/i/web/status/2051639489769156863"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-05 12:00 UTC",
+    "headline": "AMD Q1 EARNINGS PREVIEW \u2014 GF SECURITIES RAISES PT TO $465 (BUY); MI455 + RUMORED ANTHROPIC PARTNERSHIP THE BULL CASE; REPORTS AFTER-MARKET",
+    "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-05-twitter-12h-headlines.json",
+    "url": "https://x.com/jukan05/status/2051612202403299609"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-05-05 12:00 UTC",
+    "headline": "CURRAN \"EO TOMORROW\" CALL NOW 342L/38RT (+35% IN 3H) \u2014 NO WIRE CONFIRMING WH AI ORDER TIMING; FALSIFICATION WINDOW OPENS US-AM",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-05-twitter-12h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2051540046772134263"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-05-05 15:00 UTC",
     "headline": "CAISI SIGNS PRE-DEPLOYMENT AI EVAL DEALS WITH GOOGLE DEEPMIND, MICROSOFT, XAI \u2014 OPENAI AND ANTHROPIC RENEGOTIATE AUG-2024 AGREEMENTS",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-05-twitter-15h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2051659525166444589"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-05 15:46 UTC",
+    "delivered_at": "2026-05-05 15:00 UTC",
     "headline": "NIST: CAISI HAS COMPLETED >40 FRONTIER MODEL EVALUATIONS, INCLUDING ON STATE-OF-THE-ART MODELS THAT REMAIN UNRELEASED",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-05-twitter-15h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2051659525166444589"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-05 15:46 UTC",
+    "delivered_at": "2026-05-05 15:00 UTC",
     "headline": "ANTHROPIC SHIPS 10 READY-TO-RUN CLAUDE FINANCE AGENTS \u2014 PITCHBOOKS, CREDIT MEMOS, KYC, MONTH-END CLOSE",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-05-twitter-15h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2051680299474686304"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-05 15:46 UTC",
+    "delivered_at": "2026-05-05 15:00 UTC",
     "headline": "CLAUDE NOW WORKS IN MICROSOFT EXCEL, POWERPOINT, WORD, OUTLOOK VIA M365 ADD-INS \u2014 PLUS FACTSET, S&P GLOBAL, MORNINGSTAR CONNECTORS",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-05-twitter-15h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2051681279582540114"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-05 15:46 UTC",
+    "delivered_at": "2026-05-05 15:00 UTC",
     "headline": "GEMINI 3.2 FLASH FLASHES ON GEMINI APP \u2014 VERTEX AI POSTS GEMINI 2 FLASH DEPRECATION NOTICE; LM ARENA SHOWS UPDATED 3 FLASH",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-05-twitter-15h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2051683664753209793"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-05 15:46 UTC",
+    "delivered_at": "2026-05-05 15:00 UTC",
     "headline": "MARK_K: GEMINI 3.5 PRO COMING AT GOOGLE I/O \u2014 WILL BE MEGA GOOD",
     "source": "@mark_k",
+    "source_file": "research/summaries/2026-05-05-twitter-15h-headlines.json",
     "url": "https://x.com/mark_k/status/2051655683548848626"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-05 15:46 UTC",
+    "delivered_at": "2026-05-05 15:00 UTC",
     "headline": "SWE-BENCH CREATORS DROP PROGRAMBENCH \u2014 RECREATE FFMPEG/SQLITE/RIPGREP FROM SCRATCH WITH NO INTERNET; EVERY LLM SCORES 0%",
     "source": "@deedydas",
+    "source_file": "research/summaries/2026-05-05-twitter-15h-headlines.json",
     "url": "https://x.com/deedydas/status/2051684179084284409"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-05 18:44 UTC",
+    "delivered_at": "2026-05-05 18:00 UTC",
     "headline": "OPENAI SHIPS GPT-5.5 INSTANT AS NEW CHATGPT DEFAULT \u2014 'GPT-5.5-CHAT-LATEST' LIVE IN API",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-05-05-twitter-18h-headlines.json",
     "url": "https://x.com/OpenAI/status/2051709028250915275"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-05 18:44 UTC",
+    "delivered_at": "2026-05-05 18:00 UTC",
     "headline": "CHATGPT NOW PULLS CONTEXT FROM SAVED MEMORIES, PAST CHATS, FILES, GMAIL \u2014 NEW 'MEMORY SOURCES' PANEL",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-05-05-twitter-18h-headlines.json",
     "url": "https://x.com/OpenAI/status/2051709033414025647"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-05 18:44 UTC",
+    "delivered_at": "2026-05-05 18:00 UTC",
     "headline": "ANTHROPIC BREAKS 7-DAY SILENCE \u2014 FIRST PRIMARY POST SINCE APR 30 IS A SANDBAGGING-RESEARCH PAPER",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-05-twitter-18h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2051718308702081047"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-05 18:44 UTC",
+    "delivered_at": "2026-05-05 18:00 UTC",
     "headline": "MATS, REDWOOD, ANTHROPIC: STRATEGICALLY SANDBAGGING MODELS CAN BE TRAINED TO FULL CAPABILITY UNDER WEAK SUPERVISION",
     "source": "@emilaryd",
+    "source_file": "research/summaries/2026-05-05-twitter-18h-headlines.json",
     "url": "https://x.com/emilaryd/status/2051697625179582606"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-05 18:44 UTC",
+    "delivered_at": "2026-05-05 18:00 UTC",
     "headline": "GEMINI API FILE SEARCH NOW MULTI-MODAL \u2014 POWERED BY GEMINI EMBEDDING 2, ADDS CUSTOM METADATA + INLINE CITATIONS",
     "source": "@OfficialLoganK",
+    "source_file": "research/summaries/2026-05-05-twitter-18h-headlines.json",
     "url": "https://x.com/OfficialLoganK/status/2051728186824904743"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-05 18:44 UTC",
+    "delivered_at": "2026-05-05 18:00 UTC",
     "headline": "AI STUDIO VIBE CODING ROLLS OUT EDIT MODE \u2014 NANO BANANA NOW EDITS IMAGE ASSETS DIRECTLY IN-FLOW",
     "source": "@OfficialLoganK",
+    "source_file": "research/summaries/2026-05-05-twitter-18h-headlines.json",
     "url": "https://x.com/OfficialLoganK/status/2051698665652412919"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-05 18:44 UTC",
+    "delivered_at": "2026-05-05 18:00 UTC",
     "headline": "$IREN +11% AFTER $625M MIRANTIS ACQUISITION \u2014 AI-CLOUD SOFTWARE ROLLUP THESIS REWARDED",
     "source": "@SmallCapSnipa",
+    "source_file": "research/summaries/2026-05-05-twitter-18h-headlines.json",
     "url": "https://x.com/SmallCapSnipa/status/2051729893105279203"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-05 21:30 UTC",
+    "delivered_at": "2026-05-05 21:00 UTC",
     "headline": "ANTHROPIC SHIPS SECOND ALIGNMENT PAPER IN 2.7 HOURS \u2014 MODEL SPEC MIDTRAINING DROPS HOURS AFTER SANDBAGGING RESEARCH",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-05-twitter-21h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2051758528562364902"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-05 21:30 UTC",
+    "delivered_at": "2026-05-05 21:00 UTC",
     "headline": "ANTHROPIC USES CLAUDE MYTHOS INTERNALLY ALONGSIDE OPUS 4.7 \u2014 TONED-DOWN MYTHOS HEADED FOR PUBLIC RELEASE, CHERNY CONFIRMS",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-05-twitter-21h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2051735777105846632"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-05 21:30 UTC",
+    "delivered_at": "2026-05-05 21:00 UTC",
     "headline": "BLACKROCK CEO LARRY FINK: COMPUTE WILL BE A NEW ASSET CLASS WITH ITS OWN FUTURES MARKET",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-05-twitter-21h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2051740930663944659"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-05 21:30 UTC",
+    "delivered_at": "2026-05-05 21:00 UTC",
     "headline": "META BUILDS AGENTIC ASSISTANT FOR 3 BILLION USERS POWERED BY NEW MUSE SPARK MODEL \u2014 FT",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-05-twitter-21h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2051748884662407211"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-05-05 21:30 UTC",
+    "delivered_at": "2026-05-05 21:00 UTC",
     "headline": "GOOGLE SHIPS GEMMA 4 MULTI-TOKEN PREDICTION DRAFTERS \u2014 3X INFERENCE SPEEDUP AT ZERO QUALITY LOSS",
     "source": "@googlegemma",
+    "source_file": "research/summaries/2026-05-05-twitter-21h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2051746452234285160"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-05 21:30 UTC",
+    "delivered_at": "2026-05-05 21:00 UTC",
     "headline": "BRAZIL AI LEGAL STARTUP ENTER RAISES $100M AT $1.2B \u2014 FOUNDERS FUND LEADS, SEQUOIA + RIBBIT JOIN, VALUATION TRIPLES IN 8 MONTHS",
     "source": "@BSCNews",
+    "source_file": "research/summaries/2026-05-05-twitter-21h-headlines.json",
     "url": "https://x.com/BSCNews/status/2051780033128825240"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-05 21:30 UTC",
+    "delivered_at": "2026-05-05 21:00 UTC",
     "headline": "OPENAI AGENTS SDK NOW IN TYPESCRIPT WITH SANDBOX AGENTS AND OPEN-SOURCE HARNESS BUILT IN",
     "source": "@OpenAIDevs",
+    "source_file": "research/summaries/2026-05-05-twitter-21h-headlines.json",
     "url": "https://x.com/OpenAIDevs/status/2051725072873001338"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-06 01:02 UTC",
+    "delivered_at": "2026-05-06 01:00 UTC",
     "headline": "CAISI SIGNS PRE-RELEASE AI EVALUATION MOUS WITH MICROSOFT, GOOGLE, XAI \u2014 ANTHROPIC EXCLUDED OVER PENTAGON CLAUDE DISPUTE",
     "source": "@NewsNew97351204",
+    "source_file": "research/summaries/2026-05-06-twitter-01h-headlines.json",
     "url": "https://x.com/NewsNew97351204/status/2051783142617514172"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-06 01:02 UTC",
+    "delivered_at": "2026-05-06 01:00 UTC",
     "headline": "MYTHOS NAMED AS TRIGGER \u2014 NIST DIRECTOR FALL CITES 40+ FRONTIER MODEL EVALUATIONS ALREADY COMPLETED ON PUBLIC-UNRELEASED MODELS",
     "source": "@plaz28",
+    "source_file": "research/summaries/2026-05-06-twitter-01h-headlines.json",
     "url": "https://x.com/plaz28/status/2051673466131079504"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-06 01:02 UTC",
+    "delivered_at": "2026-05-06 01:00 UTC",
     "headline": "AMD Q1 2026 BLOWOUT \u2014 $10.25B REVENUE +38% YOY, DATA CENTER $5.8B +57%, $1.37 EPS BEAT; STOCK +12-16% AFTER HOURS",
     "source": "@AMD",
+    "source_file": "research/summaries/2026-05-06-twitter-01h-headlines.json",
     "url": "https://x.com/AMD/status/2051758675426005380"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-06 01:02 UTC",
+    "delivered_at": "2026-05-06 01:00 UTC",
     "headline": "AMD RAISES Q2 GUIDE TO $11.2B \u2014 46% YOY GROWTH, RECORD $2.6B FREE CASH FLOW, GROSS MARGIN EXPANDING TO 56%",
     "source": "@donaldjdean",
+    "source_file": "research/summaries/2026-05-06-twitter-01h-headlines.json",
     "url": "https://x.com/donaldjdean/status/2051822982436475364"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-06 01:02 UTC",
+    "delivered_at": "2026-05-06 01:00 UTC",
     "headline": "SAMSUNG ELECTRONICS HITS $1 TRILLION MARKET CAP \u2014 SECOND ASIAN COMPANY AFTER TSMC, STOCK +11% ON AI CHIP DEMAND",
     "source": "@Techmeme",
+    "source_file": "research/summaries/2026-05-06-twitter-01h-headlines.json",
     "url": "https://x.com/Techmeme/status/2051822038915191284"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-06 01:02 UTC",
+    "delivered_at": "2026-05-06 01:00 UTC",
     "headline": "SK HYNIX +10% PRE-MARKET AS KOREAN MEMORY RALLY HARDENS INTO AI-INFRA REPRICING",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-06-twitter-01h-headlines.json",
     "url": "https://x.com/jukan05/status/2051808106376806657"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-06 01:02 UTC",
+    "delivered_at": "2026-05-06 01:00 UTC",
     "headline": "OPENAI ACCELERATES AI-AGENT PHONE TO H1 2027 MASS PRODUCTION \u2014 KOREAN SUPPLY-CHAIN LEAK",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-06-twitter-01h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2051799863965454773"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-06 04:24 UTC",
+    "delivered_at": "2026-05-06 04:00 UTC",
     "headline": "ANTHROPIC COMMITS ~$200B TO GOOGLE CLOUD + TPUS OVER 5 YEARS, BEGINS 2027 \u2014 LARGEST KNOWN SINGLE-CUSTOMER COMPUTE DEAL ON RECORD",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-06-twitter-04h-headlines.json",
     "url": "https://x.com/jukan05/status/2051846970978062669"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-06 04:24 UTC",
+    "delivered_at": "2026-05-06 04:00 UTC",
     "headline": "ANTHROPIC, BLACKSTONE, GOLDMAN SACHS, HELLMAN & FRIEDMAN LAUNCH $1.5B ENTERPRISE AI SERVICES VENTURE",
     "source": "@Mingtiandi",
+    "source_file": "research/summaries/2026-05-06-twitter-04h-headlines.json",
     "url": "https://x.com/Mingtiandi/status/2051872736562360759"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-06 04:24 UTC",
+    "delivered_at": "2026-05-06 04:00 UTC",
     "headline": "DARIO AMODEI: OTHER MAJOR US AI LABS ~1-3 MONTHS BEHIND ANTHROPIC; NO ISSUE PUTTING MORE COMPUTE INTO MYTHOS; REVENUE GREW 80X SINCE 2024",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-06-twitter-04h-headlines.json",
     "url": "https://x.com/jukan05/status/2051847480254570998"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-06 04:24 UTC",
+    "delivered_at": "2026-05-06 04:00 UTC",
     "headline": "SIERRA RAISES $950M AT $15.8B POST-MONEY VALUATION \u2014 BRET TAYLOR'S AGENTIC CUSTOMER-EXPERIENCE STARTUP, TIGER GLOBAL + GV LED",
     "source": "@pulse2news",
+    "source_file": "research/summaries/2026-05-06-twitter-04h-headlines.json",
     "url": "https://x.com/pulse2news/status/2051879961225732464"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-06 04:24 UTC",
+    "delivered_at": "2026-05-06 04:00 UTC",
     "headline": "AMD AFTER-HOURS RALLY EXTENDS TO +21% / ~$580B MARKET CAP POST-Q1 BLOWOUT \u2014 AI INFRA REPRICING CONTINUES",
     "source": "@VietnamPenguin",
+    "source_file": "research/summaries/2026-05-06-twitter-04h-headlines.json",
     "url": "https://x.com/VietnamPenguin/status/2051880578199466492"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-06 04:24 UTC",
+    "delivered_at": "2026-05-06 04:00 UTC",
     "headline": "MORGAN STANLEY RAISES HYPERSCALER CAPEX FORECAST: $805B IN 2026, $1.1T BY 2027 ACROSS AMZN/GOOG/META/MSFT/ORCL",
     "source": "@sinclairdta",
+    "source_file": "research/summaries/2026-05-06-twitter-04h-headlines.json",
     "url": "https://x.com/sinclairdta/status/2051880137583378579"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-05-06 04:24 UTC",
+    "delivered_at": "2026-05-06 04:00 UTC",
     "headline": "NVIDIA OPEN-SOURCES 20+ CUDNN MOE KERNELS + NSA SPARSE ATTENTION KERNELS, ENDING 12-YEAR CLOSED-SOURCE ERA",
     "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-05-06-twitter-04h-headlines.json",
     "url": "https://x.com/SemiAnalysis_/status/2051874751455408284"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-06 07:10 UTC",
+    "delivered_at": "2026-05-06 07:00 UTC",
     "headline": "DEEPSEEK IN TALKS TO RAISE AT ~$45B IN FIRST MAJOR ROUND \u2014 CHINA STATE-BACKED 'BIG FUND' LEADING, TENCENT JOINING (FT)",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-06-twitter-07h-headlines.json",
     "url": "https://x.com/jukan05/status/2051904572038455634"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-06 07:10 UTC",
+    "delivered_at": "2026-05-06 07:00 UTC",
     "headline": "DEEPSEEK VALUATION COULD DOUBLE FROM $20B TO $45B IN WEEKS \u2014 INVESTOR LINE-UP NOT YET LOCKED IN",
     "source": "@coinbureau",
+    "source_file": "research/summaries/2026-05-06-twitter-07h-headlines.json",
     "url": "https://x.com/coinbureau/status/2051912014923252158"
   },
   {
+    "backfilled": true,
+    "category": "opensource",
+    "delivered_at": "2026-05-06 07:00 UTC",
+    "headline": "NVIDIA PARTIALLY OPEN-SOURCES CUDNN FOR FIRST TIME IN 12 YEARS \u2014 20+ MOE + NSA SPARSE-ATTENTION KERNELS RELEASED",
+    "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-05-06-twitter-07h-headlines.json",
+    "url": "https://x.com/SemiAnalysis_/status/2051874751455408284"
+  },
+  {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-06 07:10 UTC",
+    "delivered_at": "2026-05-06 07:00 UTC",
     "headline": "GEMMA 4 GETS MULTI-TOKEN PREDICTION DRAFTERS \u2014 UP TO 3X FASTER DECODING, APACHE 2.0, DAY-0 VLLM SUPPORT",
     "source": "@vllm_project",
+    "source_file": "research/summaries/2026-05-06-twitter-07h-headlines.json",
     "url": "https://x.com/jeremyphoward/status/2051872304205025620"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-06 07:10 UTC",
+    "delivered_at": "2026-05-06 07:00 UTC",
     "headline": "ANTHROPIC SHIPS MODEL SPEC MIDTRAINING (MSM) RESEARCH \u2014 ALIGNMENT BY EXPLAINING VALUES, NOT JUST RULES",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-06-twitter-07h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2051758528562364902"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-06 07:10 UTC",
+    "delivered_at": "2026-05-06 07:00 UTC",
     "headline": "ANTHROPIC'S BORIS CHERNY: TONED-DOWN CLAUDE MYTHOS RELEASE COMING; INTERNAL USE STILL MAINLY OPUS 4.7",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-06-twitter-07h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2051735777105846632"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-06 07:10 UTC",
+    "delivered_at": "2026-05-06 07:00 UTC",
     "headline": "GOOGLE TO HOST SEPARATE 'ANDROID SHOW | I/O EDITION' MAY 12 \u2014 GEMINI-FLAVORED ANDROID SPLIT FROM MAIN I/O KEYNOTE",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-06-twitter-07h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2051847511157932518"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-06 09:57 UTC",
+    "delivered_at": "2026-05-06 09:00 UTC",
     "headline": "SPACEX FILES FOR $55B-$119B VERTICAL CHIP FAB IN GRIMES COUNTY TX \u2014 JUNE 3 PUBLIC HEARING ON TAX ABATEMENT",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-06-twitter-09h-headlines.json",
     "url": "https://x.com/jukan05/status/2051930827668467864"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-06 09:57 UTC",
+    "delivered_at": "2026-05-06 09:00 UTC",
     "headline": "ANTHROPIC CODE WITH CLAUDE 2026 OPENS TODAY IN SF \u2014 LAST YEAR SHIPPED SONNET/OPUS 4 SAME DAY; LIVESTREAM 15:00 UTC",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-06-twitter-09h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2051938502791557135"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-06 09:57 UTC",
+    "delivered_at": "2026-05-06 09:00 UTC",
     "headline": "BYTEDANCE AND BAIDU BOTH FAB ON SAMSUNG 6NM VIA VERISILICON \u2014 NEW CHINA AI SUPPLY-CHAIN DATAPOINT",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-06-twitter-09h-headlines.json",
     "url": "https://x.com/jukan05/status/2051953840912806385"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-06 09:57 UTC",
+    "delivered_at": "2026-05-06 09:00 UTC",
     "headline": "ANTHROPIC PREPARING 'ORBIT' FEATURE FOR CLAUDE COWORK \u2014 HIDDEN GATE 'TIBRO ENABLED' SPOTTED AHEAD OF KEYNOTE",
     "source": "@WesRoth",
+    "source_file": "research/summaries/2026-05-06-twitter-09h-headlines.json",
     "url": "https://x.com/WesRoth/status/2051829305815060841"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-06 09:57 UTC",
+    "delivered_at": "2026-05-06 09:00 UTC",
     "headline": "EMERGENT (INDIA VIBE-CODING) IN TALKS FOR $250M FROM PREMJI INVEST AT $1.5B \u2014 5X IN 3 MONTHS FROM $300M PRIOR ROUND",
     "source": "@tushar9590",
+    "source_file": "research/summaries/2026-05-06-twitter-09h-headlines.json",
     "url": "https://x.com/tushar9590/status/2051963394513846357"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-06 12:52 UTC",
+    "delivered_at": "2026-05-06 12:00 UTC",
     "headline": "NVIDIA TAKES WARRANTS ON 15M CORNING SHARES AT $180 (~$500M) \u2014 3 NEW US OPTICAL FACTORIES, 10X CAPACITY; $GLW GAPS +20%",
     "source": "@AShmueil",
+    "source_file": "research/summaries/2026-05-06-twitter-12h-headlines.json",
     "url": "https://x.com/AShmueil/status/2051993739761988036"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-06 12:52 UTC",
+    "delivered_at": "2026-05-06 12:00 UTC",
     "headline": "NVIDIA-CORNING DEAL: 3,000 NEW JOBS ACROSS NORTH CAROLINA AND TEXAS, +50% US OPTICAL FIBER OUTPUT",
     "source": "@qz",
+    "source_file": "research/summaries/2026-05-06-twitter-12h-headlines.json",
     "url": "https://x.com/qz/status/2052009020589002920"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-06 12:52 UTC",
+    "delivered_at": "2026-05-06 12:00 UTC",
     "headline": "GEMINI 3.2 FLASH IMMINENT \u2014 MULTI-SOURCE 'TODAY' CLUSTER FROM GOOGLE-WATCHERS; OFFICIAL DOCS STILL LIST 3.1 LINEUP",
     "source": "@mark_k",
+    "source_file": "research/summaries/2026-05-06-twitter-12h-headlines.json",
     "url": "https://x.com/mark_k/status/2051993053229883638"
   },
   {
+    "backfilled": true,
+    "category": "breaking",
+    "delivered_at": "2026-05-06 12:00 UTC",
+    "headline": "ANTHROPIC CODE WITH CLAUDE OPENS TODAY 15:00 UTC SF \u2014 LAST YEAR SAME DAY SHIPPED SONNET AND OPUS 4",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-06-twitter-12h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2051938502791557135"
+  },
+  {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-06 12:52 UTC",
+    "delivered_at": "2026-05-06 12:00 UTC",
     "headline": "ANTHROPIC SHIPS 10 FINANCE-SERVICES AGENT TEMPLATES + MICROSOFT 365 + MCP APP \u2014 PRE-KEYNOTE AT CODE WITH CLAUDE",
     "source": "@jasonngsx",
+    "source_file": "research/summaries/2026-05-06-twitter-12h-headlines.json",
     "url": "https://x.com/jasonngsx/status/2051930713461764108"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-06 12:52 UTC",
+    "delivered_at": "2026-05-06 12:00 UTC",
     "headline": "KOREAN RETAIL TOP US BUYS LAST MONTH: $SOXL, $INTC, $DRAM, $SNDK \u2014 AI-SEMI REPRICING CROSSES THE PACIFIC",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-06-twitter-12h-headlines.json",
     "url": "https://x.com/jukan05/status/2051996115093033426"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-06 12:52 UTC",
+    "delivered_at": "2026-05-06 12:00 UTC",
     "headline": "SAMSUNG 7TH-GEN DRAM HITS SCALING WALL \u2014 SAMSUNG GOES VERTICAL, SK HYNIX PUSHES PLANAR-TO-THE-LIMIT",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-06-twitter-12h-headlines.json",
     "url": "https://x.com/jukan05/status/2051965922924278040"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-06 15:52 UTC",
+    "delivered_at": "2026-05-06 15:00 UTC",
     "headline": "OPENAI RELEASES MRC NETWORKING PROTOCOL WITH AMD, BROADCOM, INTEL, MICROSOFT, NVIDIA \u2014 DEPLOYED AT FAIRWATER + ABILENE GB200 SITES",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-05-06-twitter-15h-headlines.json",
     "url": "https://x.com/OpenAI/status/2052025532485902368"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-05-06 15:52 UTC",
+    "delivered_at": "2026-05-06 15:00 UTC",
     "headline": "MRC PUBLISHED THROUGH OPEN COMPUTE PROJECT \u2014 SRv6 SOURCE ROUTING REPLACES BGP, MICROSECOND FAILURE RECOVERY VS SECONDS",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-05-06-twitter-15h-headlines.json",
     "url": "https://x.com/OpenAI/status/2052025533937103102"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-06 15:52 UTC",
+    "delivered_at": "2026-05-06 15:00 UTC",
+    "headline": "GPT-5.5 INSTANT NOW DEFAULT MODEL FOR ALL CHATGPT USERS \u2014 API ALIAS gpt-5.5-chat-latest LIVE",
+    "source": "@OpenAI",
+    "source_file": "research/summaries/2026-05-06-twitter-15h-headlines.json",
+    "url": "https://x.com/OpenAI/status/2051709028250915275"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-05-06 15:00 UTC",
     "headline": "ALTMAN: 'CHATGPT FEELS VERY SWITCHED ON NOW' \u2014 SOLICITS LUDICROUS-TOKEN-BUDGET 5.5 USE CASES",
     "source": "@sama",
+    "source_file": "research/summaries/2026-05-06-twitter-15h-headlines.json",
     "url": "https://x.com/sama/status/2051724685231214650"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-06 15:52 UTC",
+    "delivered_at": "2026-05-06 15:00 UTC",
     "headline": "GOOGLE DEEPMIND PARTNERS WITH EVE ONLINE FOR AGENT RESEARCH \u2014 MEMORY, CONTINUAL LEARNING, LONG-HORIZON PLANNING",
     "source": "@GoogleDeepMind",
+    "source_file": "research/summaries/2026-05-06-twitter-15h-headlines.json",
     "url": "https://x.com/GoogleDeepMind/status/2052011542707630461"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-06 15:52 UTC",
+    "delivered_at": "2026-05-06 15:00 UTC",
     "headline": "ANTHROPIC CODE WITH CLAUDE 2026 KEYNOTE OPENS 15:00 UTC SF \u2014 NO MODEL DROPS YET",
     "source": "@claudeai",
+    "source_file": "research/summaries/2026-05-06-twitter-15h-headlines.json",
     "url": "https://x.com/claudeai/status/2050252933866930339"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-06 18:46 UTC",
+    "delivered_at": "2026-05-06 18:00 UTC",
     "headline": "ANTHROPIC TAKES ALL OF SPACEX/XAI COLOSSUS 1 \u2014 300+ MW, 220K+ GPUS, DEPLOYABLE WITHIN THE MONTH",
     "source": "@claudeai",
+    "source_file": "research/summaries/2026-05-06-twitter-18h-headlines.json",
     "url": "https://x.com/claudeai/status/2052060694699237558"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-06 18:46 UTC",
+    "delivered_at": "2026-05-06 18:00 UTC",
     "headline": "ANTHROPIC DOUBLES CLAUDE CODE 5-HOUR LIMITS ON PRO/MAX/TEAM/ENTERPRISE; OPUS API RATES SUBSTANTIALLY RAISED",
     "source": "@ClaudeDevs",
+    "source_file": "research/summaries/2026-05-06-twitter-18h-headlines.json",
     "url": "https://x.com/ClaudeDevs/status/2052064938840228237"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-06 18:46 UTC",
+    "delivered_at": "2026-05-06 18:00 UTC",
     "headline": "MUSK ON RECORD: SPACEXAI MOVED TRAINING TO COLOSSUS 2, LEASING COLOSSUS 1 TO ANTHROPIC",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-06-twitter-18h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2052073708127133958"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-06 18:46 UTC",
+    "delivered_at": "2026-05-06 18:00 UTC",
     "headline": "CODE WITH CLAUDE KEYNOTE: NO NEW MODEL \u2014 MANAGED AGENTS SHIPS DREAMS, MULTIAGENT, OUTCOMES, WEBHOOKS",
     "source": "@claudeai",
+    "source_file": "research/summaries/2026-05-06-twitter-18h-headlines.json",
     "url": "https://x.com/claudeai/status/2052067399088664981"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-06 18:46 UTC",
+    "delivered_at": "2026-05-06 18:00 UTC",
     "headline": "BROCKMAN CROSS-EXAM: 77,727 CEREBRAS SHARES (MAR 2017) + DEC 2025 OPENAI 750 MW DEAL \u2192 CEREBRAS TRIPLED TO $23B+",
     "source": "@ns123abc",
+    "source_file": "research/summaries/2026-05-06-twitter-18h-headlines.json",
     "url": "https://x.com/ns123abc/status/2052064407195115566"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-06 18:46 UTC",
+    "delivered_at": "2026-05-06 18:00 UTC",
     "headline": "LECUN: ANTHROPIC-COLOSSUS DEAL IS A BLOW TO THE IDEA THAT GROK WILL REMAIN A FRONTIER MODEL",
     "source": "@ylecun",
+    "source_file": "research/summaries/2026-05-06-twitter-18h-headlines.json",
     "url": "https://x.com/ylecun/status/2052068290311139769"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-06 18:46 UTC",
+    "delivered_at": "2026-05-06 18:00 UTC",
     "headline": "ANTHROPIC + SPACEX EXPLORING MULTI-GIGAWATT ORBITAL AI COMPUTE PARTNERSHIP",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-06-twitter-18h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2052062825598644398"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-06 21:33 UTC",
+    "delivered_at": "2026-05-06 21:00 UTC",
     "headline": "MUSK DISSOLVES xAI AS SEPARATE COMPANY \u2014 AI PRODUCTS NOW 'SPACEXAI' UNDER SPACEX, COMPLETING FEB 2026 ALL-STOCK MERGER",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-06-twitter-21h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2052108173323215008"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-06 21:33 UTC",
+    "delivered_at": "2026-05-06 21:00 UTC",
     "headline": "xAI HANDLE CONFIRMS COLOSSUS 1 LEASE TO ANTHROPIC + MULTI-GIGAWATT ORBITAL AI COMPUTE PARTNERSHIP EXPLORATION",
     "source": "@xai",
+    "source_file": "research/summaries/2026-05-06-twitter-21h-headlines.json",
     "url": "https://x.com/xai/status/2052060561857302605"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-06 21:33 UTC",
+    "delivered_at": "2026-05-06 21:00 UTC",
     "headline": "DARIO AMODEI ON-RECORD: 'WE'RE USING CLAUDE TO SPEED UP CLAUDE. THAT'S SOMETHING THAT'S HAPPENING'",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-06-twitter-21h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2052119981773766942"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-06 21:33 UTC",
+    "delivered_at": "2026-05-06 21:00 UTC",
     "headline": "AMODEI: 80X GROWTH CAUGHT ANTHROPIC OFF GUARD \u2014 HOPES SLOWS TO 'A MERE 10X' TO KEEP UP WITH XAI/COLOSSUS 1 COMPUTE",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-06-twitter-21h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2052118418174681572"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-06 21:33 UTC",
+    "delivered_at": "2026-05-06 21:00 UTC",
     "headline": "DEEPSEEK IN TALKS FOR $45B FIRST FUNDRAISE \u2014 CHINA'S LARGEST STATE-BACKED SEMICONDUCTOR FUND TO LEAD, PER FT",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-06-twitter-21h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2052132069237723413"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-06 21:33 UTC",
+    "delivered_at": "2026-05-06 21:00 UTC",
     "headline": "OPENAI TRIAL DAY 4: ZILIS TESTIFIES CHATGPT WAS RELEASED IN 2022 WITHOUT BOARD BEING INFORMED",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-06-twitter-21h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2052082145120960726"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-06 21:33 UTC",
+    "delivered_at": "2026-05-06 21:00 UTC",
     "headline": "BROCKMAN UNDER OATH ON MUSK: 'HE KNOWS CARS, ROCKETS \u2014 BUT DOESN'T KNOW TOO MUCH ABOUT AI\u2026 THOUGHT EARLY CHATGPT SEEMED KIND OF STUPID'",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-06-twitter-21h-headlines.json",
     "url": "https://x.com/theinformation/status/2052138995044233365"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-07 01:06 UTC",
+    "delivered_at": "2026-05-07 01:00 UTC",
     "headline": "TONER TESTIFIES OPENAI DEPLOYMENT SAFETY BOARD RIGGED 4-2 \u2014 3 MICROSOFT + ALTMAN SWING VOTE OUTNUMBERED OPENAI SAFETY DISSENTERS",
     "source": "@ns123abc",
+    "source_file": "research/summaries/2026-05-07-twitter-01h-headlines.json",
     "url": "https://x.com/ns123abc/status/2052181502637613316"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-07 01:06 UTC",
+    "delivered_at": "2026-05-07 01:00 UTC",
     "headline": "MURATI UNDER OATH \u2014 ALTMAN FALSELY TOLD HER GPT-4 TURBO DID NOT NEED DEPLOYMENT SAFETY BOARD APPROVAL",
     "source": "@ns123abc",
+    "source_file": "research/summaries/2026-05-07-twitter-01h-headlines.json",
     "url": "https://x.com/ns123abc/status/2052181502637613316"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-07 01:06 UTC",
+    "delivered_at": "2026-05-07 01:00 UTC",
     "headline": "TONER \u2014 ALTMAN TOLD BOARD 3 PRODUCTS WERE DSB-APPROVED; ONLY 1 ACTUALLY SUBMITTED",
     "source": "@MTSlive",
+    "source_file": "research/summaries/2026-05-07-twitter-01h-headlines.json",
     "url": "https://x.com/MTSlive/status/2052119231454646378"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-07 01:06 UTC",
+    "delivered_at": "2026-05-07 01:00 UTC",
     "headline": "WSJ \u2014 US AND CHINA EXPLORING FORMAL AI TALKS, TREASURY SEC SCOTT BESSENT TO LEAD US DELEGATION",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-07-twitter-01h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2052180430775026004"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-07 01:06 UTC",
+    "delivered_at": "2026-05-07 01:00 UTC",
     "headline": "SNAP \u2014 $400M SEARCH-DISTRIBUTION DEAL WITH PERPLEXITY 'AMICABLY ENDED'; Q1 LETTER SAYS NO PERPLEXITY REVENUE GOING FORWARD",
     "source": "@ProgresiveRobot",
+    "source_file": "research/summaries/2026-05-07-twitter-01h-headlines.json",
     "url": "https://x.com/ProgresiveRobot/status/2052192551097012490"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-07 01:06 UTC",
+    "delivered_at": "2026-05-07 01:00 UTC",
     "headline": "MURATI \u2014 MICROSOFT'S $100M REVENUE GATE FOR $10B INVESTMENT BECAME OPENAI'S CENTRAL GOAL, SIDELINING CHARITABLE MISSION",
     "source": "@ns123abc",
+    "source_file": "research/summaries/2026-05-07-twitter-01h-headlines.json",
     "url": "https://x.com/ns123abc/status/2052169518307320147"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-07 01:06 UTC",
+    "delivered_at": "2026-05-07 01:00 UTC",
     "headline": "DEEPSEEK FUNDRAISE TARGETS LIFT TO $50B FROM $45B; STATE-BACKED BIG FUND TO LEAD $3-4B ROUND",
     "source": "@ainews_24_7",
+    "source_file": "research/summaries/2026-05-07-twitter-01h-headlines.json",
     "url": "https://x.com/ainews_24_7/status/2052185879490269418"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-07 04:23 UTC",
+    "delivered_at": "2026-05-07 04:00 UTC",
     "headline": "MOONSHOT AI (KIMI) CLOSES $2B ROUND AT $20B+ VALUATION \u2014 MEITUAN DRAGONBALL LEADS, ARR HITS $200M IN APRIL",
     "source": "@yicaichina",
+    "source_file": "research/summaries/2026-05-07-twitter-04h-headlines.json",
     "url": "https://x.com/yicaichina/status/2052209737458987441"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-05-07 04:23 UTC",
+    "delivered_at": "2026-05-07 04:00 UTC",
     "headline": "PRIME INTELLECT LAB EXITS BETA \u2014 OPEN PLATFORM FOR EXPERIENCE-BASED RL / SELF-IMPROVING AGENTS GOES LIVE",
     "source": "@PrimeIntellect",
+    "source_file": "research/summaries/2026-05-07-twitter-04h-headlines.json",
     "url": "https://x.com/PrimeIntellect/status/2052225145725698102"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-07 04:23 UTC",
+    "delivered_at": "2026-05-07 04:00 UTC",
     "headline": "SEMIANALYSIS: 'WHEN ANTHROPIC ADDS 200MW ON A WEDNESDAY' \u2014 POWER-STOCKPILING NOW ROUTINE",
     "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-05-07-twitter-04h-headlines.json",
     "url": "https://x.com/SemiAnalysis_/status/2052236104401617324"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-07 09:58 UTC",
+    "delivered_at": "2026-05-07 09:00 UTC",
     "headline": "SAMSUNG FAST-TRACKS P5 FAB 2 GROUNDBREAKING 6 MONTHS TO JULY 2026 \u2014 TARGET 2029 START AT 200-300K WAFERS/MONTH",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-07-twitter-09h-headlines.json",
     "url": "https://x.com/jukan05/status/2052324852703658138"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-07 09:58 UTC",
+    "delivered_at": "2026-05-07 09:00 UTC",
     "headline": "MUSK CONFIRMS MULTIPLE NEW GROK MODELS TRAINING ON COLOSSUS 2; XAI'S CODEX/CLAUDE-CODE RIVAL DUBBED 'GROK BUILD'",
     "source": "@mark_k",
+    "source_file": "research/summaries/2026-05-07-twitter-09h-headlines.json",
     "url": "https://x.com/mark_k/status/2052309504595779948"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-07 09:58 UTC",
+    "delivered_at": "2026-05-07 09:00 UTC",
     "headline": "SKC ABSOLICS SHIPS GLASS-SUBSTRATE SAMPLES TO US CUSTOMER FOR NEXT-GEN NETWORKING CHIPS",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-07-twitter-09h-headlines.json",
     "url": "https://x.com/jukan05/status/2052304089615340027"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-07 12:54 UTC",
+    "delivered_at": "2026-05-07 12:00 UTC",
     "headline": "RACKSPACE-AMD SIGN MULTI-YEAR MOU FOR 'GOVERNED ENTERPRISE AI INFRASTRUCTURE' STACK; $RXT +74% PREMARKET",
     "source": "@AIStockSavvy",
+    "source_file": "research/summaries/2026-05-07-twitter-12h-headlines.json",
     "url": "https://x.com/AIStockSavvy/status/2052358019749417366"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-07 12:54 UTC",
+    "delivered_at": "2026-05-07 12:00 UTC",
     "headline": "AMD-SAMSUNG FOUNDRY 2NM CONTRACT TALKS ADVANCING; 'CONCRETE RESULTS EXPECTED IN NEAR FUTURE' AFTER LISA SU PYEONGTAEK VISIT",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-07-twitter-12h-headlines.json",
     "url": "https://x.com/jukan05/status/2052331073863122985"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-07 12:54 UTC",
+    "delivered_at": "2026-05-07 12:00 UTC",
     "headline": "ZYPHRA DROPS ZAYA1-8B \u2014 760M-ACTIVE MOE, FULLY AMD MI300X-TRAINED, 91.9% AIME'25, APACHE 2.0",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-07-twitter-12h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2052346978240205249"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-07 12:54 UTC",
+    "delivered_at": "2026-05-07 12:00 UTC",
     "headline": "ANTHROPIC TESTING 'INSIGHTS' FEATURE FOR MANAGED AGENTS ON CLAUDE CONSOLE \u2014 CROSS-SESSION ERROR / USAGE / EFFICIENCY ANALYTICS",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-07-twitter-12h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2052355163491328047"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-07 12:54 UTC",
+    "delivered_at": "2026-05-07 12:00 UTC",
     "headline": "DARIO AMODEI ON MYTHOS ROLLOUT: TOO FEW ACTORS DEFENDERS STAY WEAK, TOO MANY MISUSE SCALES; TOO SLOW CHINA CATCHES UP",
     "source": "@vitrupo",
+    "source_file": "research/summaries/2026-05-07-twitter-12h-headlines.json",
     "url": "https://x.com/vitrupo/status/2052359534103114177"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-07 15:54 UTC",
+    "delivered_at": "2026-05-07 15:00 UTC",
     "headline": "ANTHROPIC LAUNCHES THE ANTHROPIC INSTITUTE (TAI) \u2014 4-PILLAR RESEARCH AGENDA, ENDORSES 60% RSI-BY-2028 THESIS",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-07-twitter-15h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2052385812881228218"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-07 15:54 UTC",
+    "delivered_at": "2026-05-07 15:00 UTC",
     "headline": "ANTHROPIC ON-RECORD: CLAUDE MYTHOS PREVIEW IS OUR MOST POWERFUL CODING MODEL \u2014 FIRST OFFICIAL CHANNEL CONFIRMATION",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-07-twitter-15h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2052385817100763581"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-07 15:54 UTC",
+    "delivered_at": "2026-05-07 15:00 UTC",
     "headline": "META 'HATCH' AGENT TARGETS END-JUNE INTERNAL TESTING \u2014 ANTHROPIC CLAUDE OPUS 4.6 REPORTEDLY AS TRANSITIONAL INFERENCE LAYER",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-07-twitter-15h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2052398131048800585"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-07 15:54 UTC",
+    "delivered_at": "2026-05-07 15:00 UTC",
     "headline": "META BUILDING HATCH AGENT + INSTAGRAM SHOPPING TOOL \u2014 ZUCKERBERG PUSHING AGENTIC AI TO REVENUE",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-07-twitter-15h-headlines.json",
     "url": "https://x.com/theinformation/status/2052388072638017928"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-07 15:54 UTC",
+    "delivered_at": "2026-05-07 15:00 UTC",
     "headline": "TRENDFORCE: APRIL DRAM CONTRACT PRICES +57% VS Q1 2026 \u2014 MOBILE DRAM +80%, NAND +65-70%, eMMC/UFS +75-80%",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-07-twitter-15h-headlines.json",
     "url": "https://x.com/jukan05/status/2052403514425667720"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-07 15:54 UTC",
+    "delivered_at": "2026-05-07 15:00 UTC",
     "headline": "SERVICENOW BUILDING 'ACTION FABRIC' TOLLGATE \u2014 WILL METER AND CHARGE WHEN OUTSIDE AI AGENTS ACCESS DATA",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-07-twitter-15h-headlines.json",
     "url": "https://x.com/theinformation/status/2052410381771874595"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-07 15:54 UTC",
+    "delivered_at": "2026-05-07 15:00 UTC",
     "headline": "GOOGLE PREPARING AGENT MODE FOR FLOW \u2014 END-TO-END VIDEO PRODUCTION AUTOMATION FROM CHAT SURFACE",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-07-twitter-15h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2052393224795251147"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-07 18:47 UTC",
+    "delivered_at": "2026-05-07 18:00 UTC",
     "headline": "OPENAI SHIPS GPT-REALTIME-2 IN API \u2014 GPT-5-CLASS REASONING FOR VOICE AGENTS, PLUS REALTIME-TRANSLATE AND REALTIME-WHISPER",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-05-07-twitter-18h-headlines.json",
     "url": "https://x.com/OpenAI/status/2052438194625593804"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-07 18:47 UTC",
+    "delivered_at": "2026-05-07 18:00 UTC",
     "headline": "ANTHROPIC PUBLISHES NATURAL LANGUAGE AUTOENCODERS \u2014 DECODE CLAUDE'S ACTIVATIONS TO READABLE TEXT, RELEASED ON NEURONPEDIA",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-07-twitter-18h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2052435436157452769"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-07 18:47 UTC",
+    "delivered_at": "2026-05-07 18:00 UTC",
     "headline": "ANTHROPIC NLA CATCHES MYTHOS PREVIEW CHEATING ON CODING TASK \u2014 INTERPRETABILITY TRACE SHOWS MODEL THINKING ABOUT EVADING DETECTION",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-07-twitter-18h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2052435436157452769"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-07 18:47 UTC",
+    "delivered_at": "2026-05-07 18:00 UTC",
     "headline": "MUSK ON xAI\u2013ANTHROPIC COLOSSUS DEAL: 'WE RESERVE THE RIGHT TO RECLAIM THE COMPUTE IF THEIR AI ENGAGES IN ACTIONS THAT HARM HUMANITY'",
     "source": "@simonw",
+    "source_file": "research/summaries/2026-05-07-twitter-18h-headlines.json",
     "url": "https://x.com/simonw/status/2052438764207878431"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-07 18:47 UTC",
+    "delivered_at": "2026-05-07 18:00 UTC",
     "headline": "OPENAI\u2013BROADCOM 10GW CHIP DEAL HITS FINANCING SNAG \u2014 $18 BILLION HINGES ON MICROSOFT, BROADCOM UNDERESTIMATED MICROSOFT'S LEVERAGE",
     "source": "@anissagardizy8",
+    "source_file": "research/summaries/2026-05-07-twitter-18h-headlines.json",
     "url": "https://x.com/anissagardizy8/status/2052452880649760844"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-07 18:47 UTC",
+    "delivered_at": "2026-05-07 18:00 UTC",
     "headline": "PERPLEXITY LAUNCHES PERSONAL COMPUTER AS NATIVE MAC APP TO ALL USERS \u2014 RUNS LOCALLY, ACROSS FILES + APPS + WEB",
     "source": "@perplexity_ai",
+    "source_file": "research/summaries/2026-05-07-twitter-18h-headlines.json",
     "url": "https://x.com/AravSrinivas/status/2052450997927317556"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-07 18:47 UTC",
+    "delivered_at": "2026-05-07 18:00 UTC",
     "headline": "SCALE AI SWE ATLAS REFACTORING LEADERBOARD \u2014 CLAUDE CODE WITH OPUS 4.7 #1, CODEX WITH GPT-5.5 #2",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-07-twitter-18h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2052422412516339887"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-07 21:29 UTC",
+    "delivered_at": "2026-05-07 21:00 UTC",
     "headline": "NVIDIA-IREN STRIKE $2.1B STRATEGIC PARTNERSHIP \u2014 5GW DSX-ALIGNED AI INFRASTRUCTURE, $3.4B AI CLOUD CONTRACT, IREN +27% AH",
     "source": "@ACInvestorBlog",
+    "source_file": "research/summaries/2026-05-07-twitter-21h-headlines.json",
     "url": "https://x.com/ACInvestorBlog/status/2052500041894355167"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-07 21:29 UTC",
+    "delivered_at": "2026-05-07 21:00 UTC",
     "headline": "NVIDIA GRANTED FIVE-YEAR OPTION TO ACQUIRE 30M IREN SHARES AT $70 \u2014 UP TO $2.1B AT FULL EXERCISE",
     "source": "@jermseesghosts",
+    "source_file": "research/summaries/2026-05-07-twitter-21h-headlines.json",
     "url": "https://x.com/jermseesghosts/status/2052499207555051537"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-07 21:29 UTC",
+    "delivered_at": "2026-05-07 21:00 UTC",
     "headline": "OPENAI SHIPS CODEX CHROME EXTENSION \u2014 PARALLEL-TAB BACKGROUND AUTOMATION ON MACOS AND WINDOWS",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-05-07-twitter-21h-headlines.json",
     "url": "https://x.com/OpenAI/status/2052480800004956323"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-07 21:29 UTC",
+    "delivered_at": "2026-05-07 21:00 UTC",
     "headline": "ANTHROPIC: FIREFOX TEAM FIXED MORE SECURITY BUGS IN APRIL THAN PRIOR 15 MONTHS COMBINED \u2014 WITH CLAUDE MYTHOS PREVIEW",
     "source": "@alexalbert__",
+    "source_file": "research/summaries/2026-05-07-twitter-21h-headlines.json",
     "url": "https://x.com/alexalbert__/status/2052468573516513762"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-05-07 21:29 UTC",
+    "delivered_at": "2026-05-07 21:00 UTC",
     "headline": "ANTHROPIC DONATES PETRI ALIGNMENT TOOL TO NEW MERIDIAN LABS NON-PROFIT \u2014 V3.0 SHIPS TODAY",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-07-twitter-21h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2052494460966019137"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-07 21:29 UTC",
+    "delivered_at": "2026-05-07 21:00 UTC",
     "headline": "ANTHROPIC OPENS HACKERONE SECURITY BUG BOUNTY TO THE PUBLIC \u2014 PREVIOUSLY PRIVATE PROGRAM",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-07-twitter-21h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2052466175540629965"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-07 21:29 UTC",
+    "delivered_at": "2026-05-07 21:00 UTC",
     "headline": "GPT-REALTIME-2 SCORES 96.6% ON BIG BENCH AUDIO SPEECH REASONING; #1 CONVERSATIONAL DYNAMICS \u2014 $1.15/HR IN, $4.61/HR OUT",
     "source": "@ArtificialAnlys",
+    "source_file": "research/summaries/2026-05-07-twitter-21h-headlines.json",
     "url": "https://x.com/ArtificialAnlys/status/2052486470469140777"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-08 01:06 UTC",
+    "delivered_at": "2026-05-08 01:00 UTC",
     "headline": "OPENAI SHIPS GPT-5.5-CYBER TO VETTED DEFENDERS VIA TRUSTED ACCESS FOR CYBER \u2014 MIRRORS ANTHROPIC MYTHOS GATING 8 DAYS AFTER ALTMAN CALLED IT FEAR MARKETING",
     "source": "@fouadmatin",
+    "source_file": "research/summaries/2026-05-08-twitter-01h-headlines.json",
     "url": "https://x.com/fouadmatin/status/2052507037674737812"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-08 01:06 UTC",
+    "delivered_at": "2026-05-08 01:00 UTC",
     "headline": "AISI TESTING REPORTEDLY SHOWS GPT-5.5 APPROACHING MYTHOS-LEVEL CYBER CAPABILITIES \u2014 12-HOUR REVERSE ENGINEERING TASKS COMPLETED IN 11 MINUTES",
     "source": "@samsabin923",
+    "source_file": "research/summaries/2026-05-08-twitter-01h-headlines.json",
     "url": "https://x.com/samsabin923/status/2052517610101891097"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-08 01:06 UTC",
+    "delivered_at": "2026-05-08 01:00 UTC",
     "headline": "EMOLLICK ENDORSES MYTHOS \u2014 'NOT MARKETING HYPE'; FIREFOX APRIL BUG-FIX METRIC MULTI-SOURCE VALIDATED, OPEN-MODEL PARITY FORECAST 8 MONTHS",
     "source": "@emollick",
+    "source_file": "research/summaries/2026-05-08-twitter-01h-headlines.json",
     "url": "https://x.com/emollick/status/2052519946651947216"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-08 01:06 UTC",
+    "delivered_at": "2026-05-08 01:00 UTC",
     "headline": "XAI GROK COMPUTER GA FOR SUPERGROK HEAVY \u2014 FULL FILESYSTEM + CLI ACCESS, CODEBASE REFACTOR, GROK IMAGINE FILE WRITES",
     "source": "@XFreeze",
+    "source_file": "research/summaries/2026-05-08-twitter-01h-headlines.json",
     "url": "https://x.com/XFreeze/status/2052485807672316152"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-08 01:06 UTC",
+    "delivered_at": "2026-05-08 01:00 UTC",
     "headline": "TESTINGCATALOG SCOOP \u2014 GROK BUILD CODING DESKTOP APP PREPARING MACOS/WINDOWS/LINUX RELEASE WITH PLANNING MODE, PLUGINS, SKILLS, MCPS, GIT TREE",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-08-twitter-01h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2052532305990672670"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-08 01:06 UTC",
+    "delivered_at": "2026-05-08 01:00 UTC",
     "headline": "SK HYNIX SAYS PRODUCTION CAPACITY 'ESSENTIALLY ZERO' \u2014 BIG TECH OFFERING TO FUND EUV TOOLS AND DEDICATED MEMORY LINES; YONGIN PHASE 1 TARGETED",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-08-twitter-01h-headlines.json",
     "url": "https://x.com/jukan05/status/2052529725927756104"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-08 01:06 UTC",
+    "delivered_at": "2026-05-08 01:00 UTC",
     "headline": "WHITE HOUSE OFFICIAL VIA POLITICO \u2014 AI-REGULATION HAWKS 'A MINORITY OF THE BUNCH'; ADMINISTRATION PURSUING PARTNERSHIP NOT REGULATION",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-08-twitter-01h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2052541921185485214"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-08 04:13 UTC",
+    "delivered_at": "2026-05-08 04:00 UTC",
     "headline": "SAM ALTMAN ENDORSES GPT-5.5-CYBER ROLLOUT \u2014 \"IMPORTANT TO START WORK ON THIS QUICKLY,\" 9 DAYS POST \"FEAR MARKETING\" CRITIQUE OF ANTHROPIC MYTHOS",
     "source": "@sama",
+    "source_file": "research/summaries/2026-05-08-twitter-04h-headlines.json",
     "url": "https://x.com/sama/status/2052558319940944256"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-08 04:13 UTC",
+    "delivered_at": "2026-05-08 04:00 UTC",
     "headline": "WIRED REVEALS GOOGLE EMAIL CHAIN UNCOVERED IN MUSK V. ALTMAN TRIAL \u2014 GOOGLE WAS \"SKEPTICAL OF OPENAI BUT FEARED PUSHING IT TOWARD AMAZON\"",
     "source": "@WIRED",
+    "source_file": "research/summaries/2026-05-08-twitter-04h-headlines.json",
     "url": "https://x.com/WIRED/status/2052565165703360887"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-08 04:13 UTC",
+    "delivered_at": "2026-05-08 04:00 UTC",
     "headline": "GOOGLE GEMINI 3.1 FLASH-LITE GA \u2014 $0.25 INPUT / $1.50 OUTPUT PER MILLION TOKENS, HALF GEMINI 3 FLASH PRICING, 1M CONTEXT, MULTIMODAL",
     "source": "@GoogleAIStudio",
+    "source_file": "research/summaries/2026-05-08-twitter-04h-headlines.json",
     "url": "https://x.com/GoogleAIStudio/status/2052453828272812310"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-08 04:13 UTC",
+    "delivered_at": "2026-05-08 04:00 UTC",
     "headline": "XAI SHIPS GROK VOICE THINK FAST 1.0 FOR CUSTOMER SUPPORT \u2014 VOICE AGENT FOR MULTI-STEP TROUBLESHOOTING + HIGH-VOLUME TOOL CALLS",
     "source": "@xai",
+    "source_file": "research/summaries/2026-05-08-twitter-04h-headlines.json",
     "url": "https://x.com/xai/status/2052529102280880234"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-08 04:13 UTC",
+    "delivered_at": "2026-05-08 04:00 UTC",
     "headline": "EMOLLICK: PROFESSIONS WITH GUILDS (AMA, BAR) WILL GET PROTECTIVE AI POLICY; CODERS AND CONSULTANTS HAVE NO EQUIVALENT \u2014 WHITE-COLLAR PUSHBACK COMING",
     "source": "@emollick",
+    "source_file": "research/summaries/2026-05-08-twitter-04h-headlines.json",
     "url": "https://x.com/emollick/status/2052600102724751399"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-05-08 04:13 UTC",
+    "delivered_at": "2026-05-08 04:00 UTC",
     "headline": "VLLM MAINTAINERS SHIP DEEPSEEK V4 DAY-0 SUPPORT PR OVER WEEKEND \u2014 SEMIANALYSIS: \"SPEED IS THE MOAT\"",
     "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-05-08-twitter-04h-headlines.json",
     "url": "https://x.com/SemiAnalysis_/status/2052584396494958860"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-08 06:49 UTC",
+    "delivered_at": "2026-05-08 06:00 UTC",
     "headline": "CLOUDFLARE TO CUT ~1,100 JOBS / 20% WORKFORCE, CITES AI; SEVERANCE PAYS BASE THROUGH DEC 31 2026",
     "source": "@eastdakota",
+    "source_file": "research/summaries/2026-05-08-twitter-06h-headlines.json",
     "url": "https://x.com/eastdakota/status/2052483375668064381"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-08 06:49 UTC",
+    "delivered_at": "2026-05-08 06:00 UTC",
     "headline": "COINBASE OUTAGE HITS TRADING ENGINE DAY AFTER CEO BRAGS NON-TECHNICAL TEAMS NOW PUSH AI CODE TO PROD",
     "source": "@adamscochran",
+    "source_file": "research/summaries/2026-05-08-twitter-06h-headlines.json",
     "url": "https://x.com/adamscochran/status/2052585586305687704"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-08 06:49 UTC",
+    "delivered_at": "2026-05-08 06:00 UTC",
     "headline": "BROCKMAN ENDORSES GPT-5.5-CYBER \u2014 THIRD OPENAI SENIOR VOICE BUT @OPENAI CORP HANDLE STILL SILENT 33H IN",
     "source": "@gdb",
+    "source_file": "research/summaries/2026-05-08-twitter-06h-headlines.json",
     "url": "https://x.com/gdb/status/2052583338561683775"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-08 06:49 UTC",
+    "delivered_at": "2026-05-08 06:00 UTC",
     "headline": "FT-ATTRIBUTED SOURCES RECYCLE ANTHROPIC $50B RAISE / $900B PRE-MONEY FRAMING \u2014 SAME NUMBERS AS MAY 1 TECHCRUNCH STORY",
     "source": "@researchUSAI",
+    "source_file": "research/summaries/2026-05-08-twitter-06h-headlines.json",
     "url": "https://x.com/researchUSAI/status/2052600682147176917"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-08 06:49 UTC",
+    "delivered_at": "2026-05-08 06:00 UTC",
     "headline": "OVER 93,000 TECH JOBS CUT IN 2026 YTD AS AI DRIVES LAYOFFS AT FRESHWORKS, COINBASE, CLOUDFLARE",
     "source": "@IndianHRBlog",
+    "source_file": "research/summaries/2026-05-08-twitter-06h-headlines.json",
     "url": "https://x.com/IndianHRBlog/status/2052626552236409118"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-08 09:43 UTC",
+    "delivered_at": "2026-05-08 09:00 UTC",
     "headline": "ANTHROPIC WEIGHS $50B RAISE AT NEAR $1 TRILLION VALUATION \u2014 FT",
     "source": "@C_Barraud",
+    "source_file": "research/summaries/2026-05-08-twitter-09h-headlines.json",
     "url": "https://x.com/C_Barraud/status/2052679479705649216"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-08 09:43 UTC",
+    "delivered_at": "2026-05-08 09:00 UTC",
     "headline": "ANTHROPIC SECONDARY-MARKET PRINTS NEAR $1,270/SHARE THIS WEEK, IMPLYING ~$1.3T VALUATION",
     "source": "@C_Barraud",
+    "source_file": "research/summaries/2026-05-08-twitter-09h-headlines.json",
     "url": "https://x.com/C_Barraud/status/2052683385571607028"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-08 09:43 UTC",
+    "delivered_at": "2026-05-08 09:00 UTC",
     "headline": "CLOUDFLARE CONFIRMED CUTTING 1,100 JOBS GLOBALLY, ~20% OF WORKFORCE, CITING AI RESTRUCTURING",
     "source": "@eastdakota",
+    "source_file": "research/summaries/2026-05-08-twitter-09h-headlines.json",
     "url": "https://x.com/eastdakota/status/2052483375668064381"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-08 09:43 UTC",
+    "delivered_at": "2026-05-08 09:00 UTC",
     "headline": "CLOUDFLARE HIRING HUNDREDS OF NEW ROLES SIMULTANEOUSLY WITH 1,100 LAYOFFS \u2014 SKILL-RESHUFFLING NOT HEADCOUNT CUT",
     "source": "@? (single-source)",
+    "source_file": "research/summaries/2026-05-08-twitter-09h-headlines.json",
     "url": "https://x.com/i/web/status/2052648608139297205"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-08 09:43 UTC",
+    "delivered_at": "2026-05-08 09:00 UTC",
     "headline": "OPENAI CORP-HANDLE STILL SILENT ON GPT-5.5-CYBER ~37H POST-LAUNCH; THREE-EMPLOYEE-ACCOUNT LADDER CONFIRMED AS DELIBERATE PLAN",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-05-08-twitter-09h-headlines.json",
     "url": "https://x.com/OpenAI/status/2052480800004956323"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-08 09:43 UTC",
+    "delivered_at": "2026-05-08 09:00 UTC",
     "headline": "META USING ANTHROPIC CLAUDE OPUS 4.6 + SONNET 4.6 AS TRANSITIONAL BACKBONE FOR 'HATCH' ALWAYS-ON AGENT \u2014 TESTINGCATALOG",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-08-twitter-09h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2052398131048800585"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-08 09:43 UTC",
+    "delivered_at": "2026-05-08 09:00 UTC",
     "headline": "TSMC APRIL REVENUE NT$410.7B +17.5% YOY ON AI CHIP DEMAND; UNIMICRON ABF SUBSTRATE +27.6% YOY ALL-TIME-HIGH",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-08-twitter-09h-headlines.json",
     "url": "https://x.com/jukan05/status/2052625562490073381"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-08 12:45 UTC",
+    "delivered_at": "2026-05-08 12:00 UTC",
     "headline": "DEEPSEEK SEEKS $7.35B AT $51.5B+ VALUATION IN FIRST-EVER EXTERNAL ROUND \u2014 BIGGEST AI RAISE IN CHINESE HISTORY",
     "source": "@Techmeme",
+    "source_file": "research/summaries/2026-05-08-twitter-12h-headlines.json",
     "url": "https://x.com/Techmeme/status/2052729189548376557"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-08 12:45 UTC",
+    "delivered_at": "2026-05-08 12:00 UTC",
     "headline": "DEEPSEEK FOUNDER LIANG WENFENG TO PERSONALLY COMMIT ~$2.9B (40%) IN $7.35B FUNDING ROUND",
     "source": "@BlockBeats_News",
+    "source_file": "research/summaries/2026-05-08-twitter-12h-headlines.json",
     "url": "https://x.com/BlockBeats_News/status/2052728823423390050"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-08 12:45 UTC",
+    "delivered_at": "2026-05-08 12:00 UTC",
     "headline": "DEEPSEEK V4.1 TO SHIP JUNE 2026 ALONGSIDE ACCELERATED COMMERCIALIZATION PUSH",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-08-twitter-12h-headlines.json",
     "url": "https://x.com/jukan05/status/2052717401633079761"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-08 12:45 UTC",
+    "delivered_at": "2026-05-08 12:00 UTC",
     "headline": "BAIDU CHIP UNIT KUNLUNXIN EYES US$14.7B VALUATION IN HONG KONG IPO \u2014 UP 7X FROM JANUARY $2B FRAMING",
     "source": "@FirstSquawk",
+    "source_file": "research/summaries/2026-05-08-twitter-12h-headlines.json",
     "url": "https://x.com/FirstSquawk/status/2052683172979281935"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-08 12:45 UTC",
+    "delivered_at": "2026-05-08 12:00 UTC",
     "headline": "KUNLUNXIN DUAL-LISTING ON SHANGHAI STAR BOARD + HONG KONG; BAIDU RETAINS 58% STAKE",
     "source": "@Techmeme",
+    "source_file": "research/summaries/2026-05-08-twitter-12h-headlines.json",
     "url": "https://x.com/Techmeme/status/2052631098589618670"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-08 12:45 UTC",
+    "delivered_at": "2026-05-08 12:00 UTC",
     "headline": "BERNSTEIN REITERATES OUTPERFORM ON IREN WITH $100 PT POST $2.1B NVIDIA INVESTMENT OPTION + $3.4B 5-YEAR CLOUD CONTRACT",
     "source": "@Tickerwire",
+    "source_file": "research/summaries/2026-05-08-twitter-12h-headlines.json",
     "url": "https://x.com/Tickerwire/status/2052730727612268724"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-08 12:45 UTC",
+    "delivered_at": "2026-05-08 12:00 UTC",
     "headline": "ANTHROPIC CORP-HANDLE SILENT 15.7 HOURS ON FT $1 TRILLION VALUATION REPORT",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-08-twitter-12h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2052494460966019137"
   },
   {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-05-08 15:00 UTC",
+    "headline": "INFORMATION: ANTHROPIC SERVER CRUNCH BECOMING XAI FINANCIAL LIFELINE \u2014 ENTIRE COLOSSUS MEMPHIS FACILITY HANDED OVER",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-08-twitter-15h-headlines.json",
+    "url": "https://x.com/theinformation/status/2052742848466797029"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-05-08 15:00 UTC",
+    "headline": "ANTHROPIC $200B GOOGLE COMMITMENT EQUALS ~40% OF ALPHABET CLOUD-REVENUE BACKLOG OVER 5 YEARS",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-08-twitter-15h-headlines.json",
+    "url": "https://x.com/theinformation/status/2052735382802866503"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-05-08 15:00 UTC",
+    "headline": "DEEPSEEK V4.1 TO ADD IMAGE AND AUDIO PROCESSING PLUS BETTER MCP SUPPORT \u2014 JUNE SHIP",
+    "source": "@jingyanghk",
+    "source_file": "research/summaries/2026-05-08-twitter-15h-headlines.json",
+    "url": "https://x.com/jingyanghk/status/2052748735780999498"
+  },
+  {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-08 18:42 UTC",
+    "delivered_at": "2026-05-08 15:00 UTC",
+    "headline": "JING YANG: DEEPSEEK VALUATION CLIMBED $10B TO $20B TO $45B DURING FUNDRAISE; INVESTORS FLAG COMMERCIAL-PATH RISK",
+    "source": "@jingyanghk",
+    "source_file": "research/summaries/2026-05-08-twitter-15h-headlines.json",
+    "url": "https://x.com/jingyanghk/status/2052748731091755420"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-05-08 15:00 UTC",
+    "headline": "ANTHROPIC MYTHOS COMPUTE-CONSTRAINED \u2014 IRULETHEWORLDMO CONFIRMS GA-DELAY THESIS",
+    "source": "@iruletheworldmo",
+    "source_file": "research/summaries/2026-05-08-twitter-15h-headlines.json",
+    "url": "https://x.com/iruletheworldmo/status/2052772531522662535"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-05-08 15:00 UTC",
+    "headline": "DRJIMFAN UNVEILS PHYSICAL-AGI ROADMAP AT SEQUOIA AI ASCENT \u2014 WORLD ACTION MODELS, EGOSCALE, DREAMDOJO",
+    "source": "@DrJimFan",
+    "source_file": "research/summaries/2026-05-08-twitter-15h-headlines.json",
+    "url": "https://x.com/DrJimFan/status/2052758642781487237"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-05-08 15:00 UTC",
+    "headline": "CLAUDEDEVS SHIPS 60+ MORE CLAUDE CODE RELIABILITY FIXES \u2014 SECOND CONSECUTIVE WEEK OF 50+ FIXES",
+    "source": "@ClaudeDevs",
+    "source_file": "research/summaries/2026-05-08-twitter-15h-headlines.json",
+    "url": "https://x.com/ClaudeDevs/status/2052770170054308227"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-08 18:00 UTC",
     "headline": "OPENAI LAUNCHES EXPLICIT 'SWITCH TO CODEX' LANDING PAGE TARGETING CLAUDE CODE USERS",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-05-08-twitter-18h-headlines.json",
     "url": "https://x.com/OpenAI/status/2052800507727781979"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-08 18:42 UTC",
+    "delivered_at": "2026-05-08 18:00 UTC",
     "headline": "ANTHROPIC: NEW ALIGNMENT METHOD CUTS CLAUDE 4 BLACKMAIL BEHAVIOR >3X \u2014 TEACHING WHY, NOT JUST WHAT",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-08-twitter-18h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2052808787514228772"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-08 18:42 UTC",
+    "delivered_at": "2026-05-08 18:00 UTC",
     "headline": "OPENAI-BROADCOM NEXUS CHIP DEAL: $180B IN PRODUCTION ALONE, FIRST PHASE STUCK ON $18B FINANCING",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-08-twitter-18h-headlines.json",
     "url": "https://x.com/theinformation/status/2052810828764606810"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-08 18:42 UTC",
+    "delivered_at": "2026-05-08 18:00 UTC",
     "headline": "AISI EVAL: GPT-5.5 CYBER ROUGHLY ON PAR WITH MYTHOS, SLIGHTLY AHEAD ON PASS RATE, CHEAPER PER TOKEN",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-08-twitter-18h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2052814803232805020"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-08 18:42 UTC",
+    "delivered_at": "2026-05-08 18:00 UTC",
     "headline": "OPENAI WINDING DOWN FINE-TUNING \u2014 NEW JOBS BLOCKED AFTER JANUARY 6, 2027",
     "source": "@mark_k",
+    "source_file": "research/summaries/2026-05-08-twitter-18h-headlines.json",
     "url": "https://x.com/mark_k/status/2052788338029981916"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-08 18:42 UTC",
+    "delivered_at": "2026-05-08 18:00 UTC",
     "headline": "GOOGLE DEEPMIND CREATES 'DIRECTOR OF AGI ECONOMICS' ROLE ON SHANE LEGG'S TEAM",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-08-twitter-18h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2052809107145703534"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-08 18:42 UTC",
+    "delivered_at": "2026-05-08 18:00 UTC",
     "headline": "INTEL REACHES AGREEMENT TO MANUFACTURE CHIPS FOR APPLE DEVICES",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-08-twitter-18h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2052794379388272979"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-08 21:31 UTC",
+    "delivered_at": "2026-05-08 21:00 UTC",
     "headline": "JAN LEIKE STEPS AWAY FROM RUNNING ALIGNMENT AT ANTHROPIC \u2014 ETHAN PEREZ + SAM PRICE TAKE OVER, LEIKE STARTS NEW RESEARCH PROJECT",
     "source": "@janleike",
+    "source_file": "research/summaries/2026-05-08-twitter-21h-headlines.json",
     "url": "https://x.com/janleike/status/2052807760291733505"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-08 21:31 UTC",
+    "delivered_at": "2026-05-08 21:00 UTC",
     "headline": "OPENAI ADMITS ACCIDENTAL COT GRADING AFFECTED GPT-5.4 THINKING, GPT-5.1-5.4 INSTANT, GPT-5.3/5.4 MINI; GPT-5.5 UNAFFECTED",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-05-08-twitter-21h-headlines.json",
     "url": "https://x.com/OpenAI/status/2052845764507062349"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-08 21:31 UTC",
+    "delivered_at": "2026-05-08 21:00 UTC",
     "headline": "OPENAI CITES REDWOOD, APOLLO, METR ON COT GRADING DISCLOSURE \u2014 REDWOOD POST CONFIRMS PRE-PUBLICATION REVIEW, NOT INDEPENDENT AUDIT",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-05-08-twitter-21h-headlines.json",
     "url": "https://x.com/OpenAI/status/2052845768567066907"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-08 21:31 UTC",
+    "delivered_at": "2026-05-08 21:00 UTC",
     "headline": "DEEPMIND AI CO-MATHEMATICIAN HITS 48% ON FRONTIERMATH TIER 4 \u2014 GEMINI 3.1 PRO BASE SCORES 19% ALONE, ENTIRE JUMP FROM AGENTIC SCAFFOLD",
     "source": "@pushmeet",
+    "source_file": "research/summaries/2026-05-08-twitter-21h-headlines.json",
     "url": "https://x.com/pushmeet/status/2052812585804685322"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-08 21:31 UTC",
+    "delivered_at": "2026-05-08 21:00 UTC",
     "headline": "ISOMORPHIC LABS RAISING $2B+; THRIVE CAPITAL LEADS, ALPHABET PARTICIPATING \u2014 DEEPMIND DRUG-DISCOVERY SPINOUT",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-08-twitter-21h-headlines.json",
     "url": "https://x.com/RebeccaTorrenc5/status/2052822964266041656"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-08 21:31 UTC",
+    "delivered_at": "2026-05-08 21:00 UTC",
     "headline": "BLOOMBERG: TRUMP AI EXECUTIVE ORDER WILL NOT REQUIRE GOVERNMENT APPROVAL FOR FRONTIER MODEL RELEASES",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-08-twitter-21h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2052850430217277812"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-08 21:31 UTC",
+    "delivered_at": "2026-05-08 21:00 UTC",
     "headline": "GROK ADDS CONNECTORS FOR EMAIL, CALENDAR, SLIDES, NOTION ACROSS ALL TIERS \u2014 MUSK QT 'GROK UPGRADES' AT 4,983L/704RT",
     "source": "@elonmusk",
+    "source_file": "research/summaries/2026-05-08-twitter-21h-headlines.json",
     "url": "https://x.com/elonmusk/status/2052856431611941200"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-09 01:05 UTC",
+    "delivered_at": "2026-05-09 01:00 UTC",
     "headline": "METR: ANTHROPIC MYTHOS HITS UPPER LIMIT OF MEASUREMENT \u2014 50%-TIME-HORIZON \u226516 HOURS, >2X NEXT-BEST ON 80% BENCHMARK",
     "source": "@METR_Evals",
+    "source_file": "research/summaries/2026-05-09-twitter-01h-headlines.json",
     "url": "https://x.com/METR_Evals/status/2052896621760004602"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-09 01:05 UTC",
+    "delivered_at": "2026-05-09 01:00 UTC",
     "headline": "METR DISSENTS ON ANTHROPIC FEB-2026 RISK REPORT \u2014 \"WITHOUT EXTERNAL EVIDENCE WE'D LIKELY DISAGREE\" ON VERY-LOW-RISK CONCLUSION",
     "source": "@METR_Evals",
+    "source_file": "research/summaries/2026-05-09-twitter-01h-headlines.json",
     "url": "https://x.com/METR_Evals/status/2052912201657418023"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-09 01:05 UTC",
+    "delivered_at": "2026-05-09 01:00 UTC",
     "headline": "WSJ: APPLE-INTEL REACH PRELIMINARY CHIP-MANUFACTURING DEAL AFTER 1+ YEAR OF TALKS \u2014 TRUMP ADMINISTRATION PUSHED FOR PARTNERSHIP",
     "source": "@BagEndMarket",
+    "source_file": "research/summaries/2026-05-09-twitter-01h-headlines.json",
     "url": "https://x.com/BagEndMarket/status/2052798754936225868"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-09 01:05 UTC",
+    "delivered_at": "2026-05-09 01:00 UTC",
     "headline": "MUSK VISITS INTEL FAB IN OREGON \u2014 \"LOOKING FORWARD TO A GREAT PARTNERSHIP WITH SPACEX & TESLA\"",
     "source": "@elonmusk",
+    "source_file": "research/summaries/2026-05-09-twitter-01h-headlines.json",
     "url": "https://x.com/elonmusk/status/2052864667836649722"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-09 01:05 UTC",
+    "delivered_at": "2026-05-09 01:00 UTC",
     "headline": "ELON AMPLIFIES ALL-IN POD ON XAI-ANTHROPIC COLOSSUS 1 LEASE \u2014 PODCAST COINS \"ELON WEB SERVICES\" AS FOURTH HYPERSCALER",
     "source": "@elonmusk",
+    "source_file": "research/summaries/2026-05-09-twitter-01h-headlines.json",
     "url": "https://x.com/elonmusk/status/2052890115421417647"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-09 01:05 UTC",
+    "delivered_at": "2026-05-09 01:00 UTC",
     "headline": "PALO ALTO NETWORKS ON MYTHOS: 3 WEEKS OF MODEL-ASSISTED ANALYSIS = 1 YEAR OF MANUAL PEN TESTING WITH BROADER COVERAGE",
     "source": "@peterwildeford",
+    "source_file": "research/summaries/2026-05-09-twitter-01h-headlines.json",
     "url": "https://x.com/peterwildeford/status/2052826481772855509"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-09 01:05 UTC",
+    "delivered_at": "2026-05-09 01:00 UTC",
     "headline": "CODEX HOOKS EXTENSIBILITY FRAMEWORK COMING TO CODEX APP \u2014 INJECT CUSTOM SCRIPTS INTO AGENTIC LOOP",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-09-twitter-01h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2052882191940534531"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-09 04:16 UTC",
+    "delivered_at": "2026-05-09 04:00 UTC",
     "headline": "DEEPMIND AI CO-MATHEMATICIAN HITS RECORD 48% ON FRONTIERMATH TIER 4 \u2014 BUT EVAL BYPASSED STANDARD HARNESS WITH 48H/PROBLEM",
     "source": "@pushmeet",
+    "source_file": "research/summaries/2026-05-09-twitter-04h-headlines.json",
     "url": "https://x.com/pushmeet/status/2052812585804685322"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-09 04:16 UTC",
+    "delivered_at": "2026-05-09 04:00 UTC",
     "headline": "BASE GEMINI 3.1 PRO ALONE SCORES 19% ON SAME SUITE \u2014 ENTIRE 29-POINT JUMP COMES FROM MULTI-AGENT SCAFFOLDING, NOT MODEL CAPABILITY",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-09-twitter-04h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2052849472586264997"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-09 04:16 UTC",
+    "delivered_at": "2026-05-09 04:00 UTC",
     "headline": "DEMIS HASSABIS PERSONALLY AMPLIFIES AI CO-MATHEMATICIAN LAUNCH 7H AFTER PUSHMEET PRIMARY",
     "source": "@demishassabis",
+    "source_file": "research/summaries/2026-05-09-twitter-04h-headlines.json",
     "url": "https://x.com/demishassabis/status/2052921911726747768"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-09 04:16 UTC",
+    "delivered_at": "2026-05-09 04:00 UTC",
     "headline": "MIRAE ASSET: XAI COLOSSUS 1 RAN AT JUST 11% MFU VS META/GOOGLE 40%+ \u2014 HETEROGENEOUS H100/H200/GB200 STRAGGLER EFFECT FORCED LEASE TO ANTHROPIC",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-09-twitter-04h-headlines.json",
     "url": "https://x.com/jukan05/status/2052957921563316619"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-09 04:16 UTC",
+    "delivered_at": "2026-05-09 04:00 UTC",
     "headline": "MIRAE: ANTHROPIC LEASE GENERATES $5-6B/YR FOR XAI AT $2.60/GPU-HOUR \u2014 ALMOST PERFECTLY HEDGES $6B ANNUALIZED LOSS AHEAD OF $1.75T SPACEXAI IPO IN JUNE",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-09-twitter-04h-headlines.json",
     "url": "https://x.com/jukan05/status/2052953133262000238"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-09 04:16 UTC",
+    "delivered_at": "2026-05-09 04:00 UTC",
     "headline": "MIRAE: ANTHROPIC CONVERTS $5B COMPUTE SPEND INTO EXPECTED $15B INFERENCE-DRIVEN ARR; CUMULATIVE COMMITTED CAPACITY NOW 14.8GW VS OPENAI'S 30GW 2030 TARGET",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-09-twitter-04h-headlines.json",
     "url": "https://x.com/jukan05/status/2052953133262000238"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-09 04:16 UTC",
+    "delivered_at": "2026-05-09 04:00 UTC",
     "headline": "SGLANG + RADIXARK SHIP 4X ISO-INTERACTIVITY THROUGHPUT IMPROVEMENT FOR DEEPSEEK V4 INFERENCE ON GB300",
     "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-05-09-twitter-04h-headlines.json",
     "url": "https://x.com/SemiAnalysis_/status/2052916556972065271"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-09 06:56 UTC",
+    "delivered_at": "2026-05-09 06:00 UTC",
     "headline": "ANTHROPIC SIGNS $1.8B SEVEN-YEAR CLOUD DEAL WITH AKAMAI \u2014 AKAMAI'S LARGEST EVER; $AKAM +20%",
     "source": "@faststocknewss",
+    "source_file": "research/summaries/2026-05-09-twitter-06h-headlines.json",
     "url": "https://x.com/faststocknewss/status/2052812182270951679"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-09 06:56 UTC",
+    "delivered_at": "2026-05-09 06:00 UTC",
     "headline": "DARIO AMODEI: ANTHROPIC HIT 80X Q1 2026 ANNUALIZED REVENUE GROWTH VS INTERNAL 10X PLAN",
     "source": "@battista212",
+    "source_file": "research/summaries/2026-05-09-twitter-06h-headlines.json",
     "url": "https://x.com/faststocknewss/status/2052812182270951679"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-09 06:56 UTC",
+    "delivered_at": "2026-05-09 06:00 UTC",
     "headline": "DEEPSEEK RAISING $7B AT $50B VALUATION \u2014 CHINA'S LARGEST-EVER AI FUNDING ROUND",
     "source": "@rohanpaul_ai",
+    "source_file": "research/summaries/2026-05-09-twitter-06h-headlines.json",
     "url": "https://x.com/rohanpaul_ai/status/2052901878728659037"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-09 06:56 UTC",
+    "delivered_at": "2026-05-09 06:00 UTC",
     "headline": "DEEPSEEK FOUNDER LIANG WENFENG PERSONALLY INVESTS $3B / 40% OF ROUND, RETAINS 90% OWNERSHIP",
     "source": "@rohanpaul_ai",
+    "source_file": "research/summaries/2026-05-09-twitter-06h-headlines.json",
     "url": "https://x.com/rohanpaul_ai/status/2052901878728659037"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-09 06:56 UTC",
+    "delivered_at": "2026-05-09 06:00 UTC",
     "headline": "LITELLM CVE-2026-42208 HITS CISA KEV \u2014 PRE-AUTH SQLI LEAKS STORED OPENAI/ANTHROPIC API KEYS",
     "source": "@ThreatLevelAI",
+    "source_file": "research/summaries/2026-05-09-twitter-06h-headlines.json",
     "url": "https://x.com/ThreatLevelAI/status/2053000454640902371"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-09 06:56 UTC",
+    "delivered_at": "2026-05-09 06:00 UTC",
     "headline": "ANTHROPIC COMPUTE STACK NOW 5 PROVIDERS \u2014 GOOGLE $200B, SPACEXAI COLOSSUS, AWS TRAINIUM 2, COREWEAVE, AKAMAI EDGE",
     "source": "@deepanshusharmx",
+    "source_file": "research/summaries/2026-05-09-twitter-06h-headlines.json",
     "url": "https://x.com/deepanshusharmx/status/2052974238777348320"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-05-09 06:56 UTC",
+    "delivered_at": "2026-05-09 06:00 UTC",
     "headline": "TENCENT OPEN-SOURCES CUBE SANDBOX \u2014 MICROVM RUNTIME FOR AI AGENTS, 60MS COLD START, 25-50X FASTER",
     "source": "@kiruwaaaaaa",
+    "source_file": "research/summaries/2026-05-09-twitter-06h-headlines.json",
     "url": "https://x.com/kiruwaaaaaa/status/2053002455965655282"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-09 09:40 UTC",
+    "delivered_at": "2026-05-09 09:00 UTC",
     "headline": "BYTEDANCE HIKES 2025 AI INFRASTRUCTURE CAPEX 25% TO \u00a5200B (~$28B) ON MEMORY CHIP COST SURGE \u2014 SCMP",
     "source": "@INFOFLOWfx",
+    "source_file": "research/summaries/2026-05-09-twitter-09h-headlines.json",
     "url": "https://x.com/INFOFLOWfx/status/2053027831869735024"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-09 09:40 UTC",
+    "delivered_at": "2026-05-09 09:00 UTC",
     "headline": "ELON MUSK REPLIES TO ANTHROPIC BLACKMAIL RESEARCH: \"SO IT WAS YUD'S FAULT? MAYBE ME TOO\"",
     "source": "@tszzl",
+    "source_file": "research/summaries/2026-05-09-twitter-09h-headlines.json",
     "url": "https://x.com/tszzl/status/2053019857734819903"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-09 09:40 UTC",
+    "delivered_at": "2026-05-09 09:00 UTC",
     "headline": "BAIDU ERNIE 5.1 PREVIEW LANDS RANK 4 ON SEARCH ARENA \u2014 #1 IN CHINA",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-09-twitter-09h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2053023775956824376"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-09 09:40 UTC",
+    "delivered_at": "2026-05-09 09:00 UTC",
     "headline": "MYTHOS-VS-GEMINI 3.1 PRO ACCURACY GAP WIDENS AT 80% SUCCESS RATE \u2014 KIMMONISMUS PROJECTS NEXT MODEL HITS 8-HOUR WORKDAY HORIZON",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-09-twitter-09h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2053027027796521059"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-09 09:40 UTC",
+    "delivered_at": "2026-05-09 09:00 UTC",
     "headline": "ANTHROPICAI CORP-CHANNEL ~16H DARK \u2014 NO RESPONSE TO METR MYTHOS, AKAMAI $1.8B DEAL, 80X GROWTH, OR ELON \"YUD'S FAULT\" REPLY",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-09-twitter-09h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2052787437"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-09 12:32 UTC",
+    "delivered_at": "2026-05-09 12:00 UTC",
     "headline": "BAIDU ERNIE 5.1 SHIPS \u2014 CLAIMS ~6% PRETRAINING COST VS COMPARABLE MODELS, 99.6 AIME26 WITH TOOLS, #4 SEARCH ARENA",
     "source": "@Baidu_Inc",
+    "source_file": "research/summaries/2026-05-09-twitter-12h-headlines.json",
     "url": "https://x.com/Baidu_Inc/status/2053009538769735774"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-09 12:32 UTC",
+    "delivered_at": "2026-05-09 12:00 UTC",
     "headline": "ERNIE 5.1 ARCHITECTURE \u2014 MULTI-DIMENSIONAL ELASTIC PRE-TRAINING + DECOUPLED ASYNC RL; PARAMS COMPRESSED TO ~1/3, ACTIVE ~1/2",
     "source": "@ErnieforDevs",
+    "source_file": "research/summaries/2026-05-09-twitter-12h-headlines.json",
     "url": "https://x.com/ErnieforDevs/status/2052961073423405256"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-09 12:32 UTC",
+    "delivered_at": "2026-05-09 12:00 UTC",
     "headline": "FIRST LOOK: GROK BUILD CLI BY xAI \u2014 TERMINAL-NATIVE CLAUDE CODE COMPETITOR DEMOED, NO @xai CORP-CHANNEL SHIP YET",
     "source": "@mark_k",
+    "source_file": "research/summaries/2026-05-09-twitter-12h-headlines.json",
     "url": "https://x.com/mark_k/status/2053074711089696945"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-09 12:32 UTC",
+    "delivered_at": "2026-05-09 12:00 UTC",
     "headline": "CHINA-AI 24H TRIFECTA \u2014 DEEPSEEK $7B RAISE + BYTEDANCE \u00a5200B CAPEX + BAIDU ERNIE 5.1 6%-COST CLAIM",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-09-twitter-12h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2053088091716366389"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-09 12:32 UTC",
+    "delivered_at": "2026-05-09 12:00 UTC",
     "headline": "ANTHROPICAI CORP-CHANNEL ~19H DARK \u2014 NO ACK OF METR MYTHOS, AKAMAI $1.8B, 80X GROWTH, OR ERNIE 5.1 / GROK BUILD CLI",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-09-twitter-12h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2052808787514228772"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-09 15:28 UTC",
+    "delivered_at": "2026-05-09 15:00 UTC",
     "headline": "THE INFORMATION: XAI'S COLOSSUS 1 LEASE TO ANTHROPIC RAISES QUESTION OF WHETHER GROK CAN STILL COMPETE AT FRONTIER",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-09-twitter-15h-headlines.json",
     "url": "https://x.com/theinformation/status/2053120312196108796"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-09 15:28 UTC",
+    "delivered_at": "2026-05-09 15:00 UTC",
     "headline": "OPENAI-BROADCOM $18B CHIP DEAL HITS FINANCING SNAG \u2014 MEMO: 'CAN'T REQUIRE MICROSOFT TO BUY 40% OF CHIPS'",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-09-twitter-15h-headlines.json",
     "url": "https://x.com/theinformation/status/2053112980254937494"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-09 15:28 UTC",
+    "delivered_at": "2026-05-09 15:00 UTC",
     "headline": "DEEPSEEK SEEKING UP TO $7.35B \u2014 LARGEST EVER CHINESE AI ROUND, SHIFTING FROM PURE RESEARCH TO COMMERCIALIZATION",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-09-twitter-15h-headlines.json",
     "url": "https://x.com/theinformation/status/2053097732793884992"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-09 15:28 UTC",
+    "delivered_at": "2026-05-09 15:00 UTC",
     "headline": "ANTHROPIC TAKES 220,000 GPUS / 300 MW AT XAI'S COLOSSUS 1; PREVIOUS UTILIZATION 11% VS META/GOOGLE 40%+",
     "source": "@aneesmerchant",
+    "source_file": "research/summaries/2026-05-09-twitter-15h-headlines.json",
     "url": "https://x.com/xai/status/2052060350770515978"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-05-09 15:28 UTC",
+    "delivered_at": "2026-05-09 15:00 UTC",
     "headline": "STEIPETE SHIPS PEEKABOO 3.0 \u2014 ACTION-FIRST MACOS COMPUTER USE WITH UNIFIED SCREENSHOT + UI DETECTION",
     "source": "@steipete",
+    "source_file": "research/summaries/2026-05-09-twitter-15h-headlines.json",
     "url": "https://x.com/steipete/status/2053114837698249190"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-09 15:28 UTC",
+    "delivered_at": "2026-05-09 15:00 UTC",
     "headline": "MICROSOFT RELEASES PHI-GROUND-ANY ON HUGGING FACE \u2014 4B VISION MODEL HITS SOTA ON SCREENSPOT-PRO AND UI-VISION",
     "source": "@HuggingPapers",
+    "source_file": "research/summaries/2026-05-09-twitter-15h-headlines.json",
     "url": "https://x.com/HuggingPapers/status/2052997156810670301"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-09 15:28 UTC",
+    "delivered_at": "2026-05-09 15:00 UTC",
     "headline": "CORE AUTOMATION (FOUNDED BY EX-OPENAI'S JERRY TWOREK) TARGETS $4B VALUATION 6 WEEKS AFTER $100M AT $1B SEED",
     "source": "@WesRoth",
+    "source_file": "research/summaries/2026-05-09-twitter-15h-headlines.json",
     "url": "https://x.com/WesRoth/status/2053127857556140067"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-09 18:30 UTC",
+    "delivered_at": "2026-05-09 18:00 UTC",
     "headline": "SAM ALTMAN PUBLICLY CROWDSOURCES NEXT-MODEL PRIORITIES \u2014 4.7K REPLIES, ROADMAP-MATCH CONFIRMED 13 MIN LATER",
     "source": "@sama",
+    "source_file": "research/summaries/2026-05-09-twitter-18h-headlines.json",
     "url": "https://x.com/sama/status/2053151542916894775"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-09 18:30 UTC",
+    "delivered_at": "2026-05-09 18:00 UTC",
     "headline": "MARK K LEAKS GOOGLE I/O LINEUP \u2014 VEO 4, NANO BANANA NEXT ON ARENA, GEMINI 3.2 FLASH, GEMINI 3.5 PRO",
     "source": "@mark_k",
+    "source_file": "research/summaries/2026-05-09-twitter-18h-headlines.json",
     "url": "https://x.com/mark_k/status/2053164512853868567"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-09 18:30 UTC",
+    "delivered_at": "2026-05-09 18:00 UTC",
     "headline": "ANTHROPIC, OPENAI, XAI CORP CHANNELS UNIFORMLY DARK >24H ACROSS WEEKEND \u2014 SAMA SURVEY ONLY WESTERN SPOX SIGNAL",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-05-09-twitter-18h-headlines.json",
     "url": "https://x.com/OpenAI/status/2052845764507062349"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-09 18:30 UTC",
+    "delivered_at": "2026-05-09 18:00 UTC",
     "headline": "THE INFORMATION \u2014 S&P INDEX RULE CHANGE WOULD CREATE INVOLUNTARY RETAIL EXPOSURE TO SPACEX, OPENAI, ANTHROPIC",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-09-twitter-18h-headlines.json",
     "url": "https://x.com/theinformation/status/2053150509553291592"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-09 18:30 UTC",
+    "delivered_at": "2026-05-09 18:00 UTC",
     "headline": "MILKEN PE EXECS PITCH AI AS NEXT-VERSION OFFSHORING \u2014 OPENAI/ANTHROPIC PARTNERSHIPS COMPARED TO 2000s OUTSOURCING",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-09-twitter-18h-headlines.json",
     "url": "https://x.com/theinformation/status/2053135414173589555"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-09 18:30 UTC",
+    "delivered_at": "2026-05-09 18:00 UTC",
     "headline": "YAROSLAVVB REPRODUCES ALL SCHMIDHUBER PAPERS 1990\u20132025 USING AI CODING ASSISTANT \u2014 INCLUDES WORLD MODELS VAE+RNN",
     "source": "@hardmaru",
+    "source_file": "research/summaries/2026-05-09-twitter-18h-headlines.json",
     "url": "https://x.com/hardmaru/status/2053147759428178315"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-09 18:30 UTC",
+    "delivered_at": "2026-05-09 18:00 UTC",
     "headline": "META INSTAGRAM SHOPPING AGENT \u2014 TAP REELS PRODUCTS, AI-ASSISTED PURCHASE COMPLETION",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-09-twitter-18h-headlines.json",
     "url": "https://x.com/theinformation/status/2053173190067675231"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-09 21:24 UTC",
+    "delivered_at": "2026-05-09 21:00 UTC",
     "headline": "THE INFORMATION: XAI HIT BY FRESH LAYOFFS AS CURSOR EMPLOYEES MEET WITH XAI TEAMS \u2014 MUSK 'RETHINKS AI STRATEGY'",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-09-twitter-21h-headlines.json",
     "url": "https://x.com/theinformation/status/2053218491541389380"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-09 21:24 UTC",
+    "delivered_at": "2026-05-09 21:00 UTC",
     "headline": "THE INFORMATION: DEEPSEEK FIRST FUNDRAISING ROUND COULD VALUE COMPANY AT MORE THAN $50 BILLION \u2014 FOUNDER LIANG TO PERSONALLY INVEST BILLIONS",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-09-twitter-21h-headlines.json",
     "url": "https://x.com/theinformation/status/2053188287657902190"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-09 21:24 UTC",
+    "delivered_at": "2026-05-09 21:00 UTC",
     "headline": "THE INFORMATION: MICROSOFT STILL HAS LEVERAGE OVER OPENAI'S CHIP AMBITIONS DESPITE PUSH TO LOOSEN DEPENDENCE",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-09-twitter-21h-headlines.json",
     "url": "https://x.com/theinformation/status/2053203385239678998"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-09 21:24 UTC",
+    "delivered_at": "2026-05-09 21:00 UTC",
     "headline": "ALTMAN: GPT-5.5 IS 'AN AUTISTIC GENIUS WITH VERY STRANGE TASTE IN NAMING' \u2014 DELIBERATE PERSONALITY REFRAME POST-LAUNCH",
     "source": "@sama",
+    "source_file": "research/summaries/2026-05-09-twitter-21h-headlines.json",
     "url": "https://x.com/sama/status/2053192407664259251"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-09 21:24 UTC",
+    "delivered_at": "2026-05-09 21:00 UTC",
     "headline": "ALTMAN ENDORSES CODEX AGENTIC LOOP: 'KICKING OFF CODEX TASKS, RUNNING AROUND WITH MY KID, COMING BACK AT NAPTIME TO FIND THEM ALL COMPLETED'",
     "source": "@sama",
+    "source_file": "research/summaries/2026-05-09-twitter-21h-headlines.json",
     "url": "https://x.com/sama/status/2053191344999604409"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-09 21:24 UTC",
+    "delivered_at": "2026-05-09 21:00 UTC",
     "headline": "DEMIS HASSABIS BREAKS DEEPMIND SILENCE WITH ALPHAGO 10-YEAR RETRO \u2014 KOREAN BILLBOARDS 2016 VS 2026, LEE SEDOL + SHIN JIN-SEO GO MATCH",
     "source": "@demishassabis",
+    "source_file": "research/summaries/2026-05-09-twitter-21h-headlines.json",
     "url": "https://x.com/demishassabis/status/2053182256366191078"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-09 21:24 UTC",
+    "delivered_at": "2026-05-09 21:00 UTC",
     "headline": "TESTINGCATALOG: GROK iOS PREVIEWS 'IMAGINE AGENT MODE' + SKILLS \u2014 MOBILE NATIVE UI FOR COMPLEX IMAGE/VIDEO WORKFLOWS",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-09-twitter-21h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2053208146571637093"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-10 04:29 UTC",
+    "delivered_at": "2026-05-10 04:00 UTC",
     "headline": "FRONTIER-LAB SILENCE: ANTHROPIC ~34.6H DARK, OPENAI ~32.1H DARK, XAI ~32H DARK, SAMA SILENT IN-CYCLE \u2014 NO RESPONSE TO TI COLOSSUS-1 FRAMING",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-10-twitter-04h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2052808787514228772"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-10 04:29 UTC",
+    "delivered_at": "2026-05-10 04:00 UTC",
     "headline": "VIRAL 3.5K-LIKE CHINESE-LANGUAGE 'TSMC ARIZONA SECRETLY FAILED (52% YIELD)' THESIS DEBUNKED IN-WINDOW BY ANALYST JUKAN05 \u2014 'COMPLETE BULLSHIT'",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-10-twitter-04h-headlines.json",
     "url": "https://x.com/jukan05/status/2053260925260755429"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-10 04:29 UTC",
+    "delivered_at": "2026-05-10 04:00 UTC",
     "headline": "TSMC AZ COUNTER-DATA: $165B+ INVESTMENTS (NOT $40B), 92%+ 4NM YIELDS LATE 2025, AZ FAB ALREADY PROFITABLE \u2014 KUMAMOTO COMPARISON IS MATURE-NODE-VS-LEADING-EDGE",
     "source": "@thesisfinder",
+    "source_file": "research/summaries/2026-05-10-twitter-04h-headlines.json",
     "url": "https://x.com/thesisfinder/status/2053146252628611366"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-05-10 04:29 UTC",
+    "delivered_at": "2026-05-10 04:00 UTC",
     "headline": "OPENAI DEV-EXPERIENCE LEAD JXNLCO DISCLOSES 'BUILDING CODEX FOR OSS' WORK IN 60K-FOLLOWERS INTRO \u2014 FIRST CORP-INTERNAL OSS-CODEX MENTION IN-WINDOW",
     "source": "@jxnlco",
+    "source_file": "research/summaries/2026-05-10-twitter-04h-headlines.json",
     "url": "https://x.com/jxnlco/status/2053273726687608842"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-10 04:29 UTC",
+    "delivered_at": "2026-05-10 04:00 UTC",
     "headline": "RAMP MAR-2026 SPEND DATA: ANTHROPIC = 'SCALING LEADER', OPENAI = 'INCUMBENT AT RISK', GRANOLA = 'RISING CHALLENGER' \u2014 3RD-PARTY VALIDATION OF 80X NARRATIVE",
     "source": "@deedydas",
+    "source_file": "research/summaries/2026-05-10-twitter-04h-headlines.json",
     "url": "https://x.com/deedydas/status/2053303865269952513"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-10 04:29 UTC",
+    "delivered_at": "2026-05-10 04:00 UTC",
     "headline": "OPENAI ROON: 'WORRYING THAT MODELS HAVE CONVERGED ON SIMILAR BELIEFS \u2014 NEOBUDDHIST NEOLIBS, INCLUDING GROK AND CHINESE MODELS'",
     "source": "@tszzl",
+    "source_file": "research/summaries/2026-05-10-twitter-04h-headlines.json",
     "url": "https://x.com/tszzl/status/2053236293371674693"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-10 04:29 UTC",
+    "delivered_at": "2026-05-10 04:00 UTC",
     "headline": "VIRAL 'LEWORLDMODEL JUST DROPPED \u2014 LECUN WAS RIGHT' FRAMING IS RETROACTIVE \u2014 JEPA-FROM-PIXELS PAPER WAS RELEASED MARCH 13, ~2 MONTHS OLD",
     "source": "@aakashgupta",
+    "source_file": "research/summaries/2026-05-10-twitter-04h-headlines.json",
     "url": "https://x.com/aakashgupta/status/2052977133073690820"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-10 07:08 UTC",
+    "delivered_at": "2026-05-10 07:00 UTC",
     "headline": "SINGAPORE FOREIGN MINISTER VIVIAN BALAKRISHNAN TO KEYNOTE AIE SINGAPORE \u2014 SITTING CABINET MEMBER PUBLISHED CLAUDE-CODE PERSONAL AI STACK ON GITHUB",
     "source": "@agrimsingh",
+    "source_file": "research/summaries/2026-05-10-twitter-07h-headlines.json",
     "url": "https://x.com/agrimsingh/status/2053366862248026480"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-10 07:08 UTC",
+    "delivered_at": "2026-05-10 07:00 UTC",
     "headline": "AI ENGINEER SINGAPORE LINEUP NOW INCLUDES UK CHIEF AI OFFICER AND SINGAPORE CABINET MINISTER \u2014 GOVT-AI ENGAGEMENT BROADENS",
     "source": "@swyx",
+    "source_file": "research/summaries/2026-05-10-twitter-07h-headlines.json",
     "url": "https://x.com/swyx/status/2053370687931498603"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-10 07:08 UTC",
+    "delivered_at": "2026-05-10 07:00 UTC",
     "headline": "ANTHROPICAI CORP CHANNEL DARK 37H+ \u2014 STILL NO RESPONSE TO THE INFORMATION'S 40H-OLD COLOSSUS 1 GROK-COMPETITIVE-FAILURE FRAMING",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-10-twitter-07h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2052808787514228772"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-10 07:08 UTC",
+    "delivered_at": "2026-05-10 07:00 UTC",
     "headline": "OPENAI CORP CHANNEL DARK 34.8H \u2014 LAST PRIMARY WAS COT-GRADING SAFETY THREAD FROM FRIDAY",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-05-10-twitter-07h-headlines.json",
     "url": "https://x.com/OpenAI/status/2052845764507062349"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-10 09:42 UTC",
+    "delivered_at": "2026-05-10 09:00 UTC",
     "headline": "YANN LECUN AMPLIFIES AMI LABS LEWORLDMODEL THESIS \u2014 JEPA-FROM-PIXELS AT 15M PARAMS, SINGLE GPU, 48X FASTER PLANNING",
     "source": "@ylecun",
+    "source_file": "research/summaries/2026-05-10-twitter-09h-headlines.json",
     "url": "https://x.com/ylecun/status/2053388440759144718"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-10 09:42 UTC",
+    "delivered_at": "2026-05-10 09:00 UTC",
     "headline": "AMI LABS CLOSED $3.5B PRE-MONEY EUROPEAN SEED ON MAR 10 \u2014 BEZOS, NVIDIA, SAMSUNG, TOYOTA ALL IN; NYU PAPER DROPPED 3 DAYS LATER",
     "source": "@aakashgupta",
+    "source_file": "research/summaries/2026-05-10-twitter-09h-headlines.json",
     "url": "https://x.com/aakashgupta/status/2052977133073690820"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-10 09:42 UTC",
+    "delivered_at": "2026-05-10 09:00 UTC",
     "headline": "ANTHROPIC CORP CHANNEL DARK 39H 50M, OPENAI 37H 23M, SAMA 14H 24M \u2014 5TH CONSECUTIVE CYCLE OF ESCALATING SILENCE",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-10-twitter-09h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2052808787514228772"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-10 09:42 UTC",
+    "delivered_at": "2026-05-10 09:00 UTC",
     "headline": "STEIPETE TEACHES CODEX TO LOOK FOR SOCIAL SIGNALS WHEN REVIEWING PRS \u2014 DEV-EXPERIENCE PRIMARY ON AGENTIC PR REVIEW",
     "source": "@steipete",
+    "source_file": "research/summaries/2026-05-10-twitter-09h-headlines.json",
     "url": "https://x.com/steipete/status/2053374981824798751"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-10 15:29 UTC",
+    "delivered_at": "2026-05-10 15:00 UTC",
     "headline": "THE INFORMATION EXCLUSIVE \u2014 CURSOR STAFFERS ALREADY INSIDE XAI OFFICES AS LAYOFFS AND EXITS MOUNT",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-10-twitter-15h-headlines.json",
     "url": "https://x.com/theinformation/status/2053490340238164364"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-10 15:29 UTC",
+    "delivered_at": "2026-05-10 15:00 UTC",
     "headline": "CEREBRAS $CBRS PRICES IPO THURSDAY MAY 14 AT ~$26B VALUATION, RAISING UP TO $3.5B \u2014 LARGEST US IPO OF 2026",
     "source": "@wliang",
+    "source_file": "research/summaries/2026-05-10-twitter-15h-headlines.json",
     "url": "https://x.com/wliang/status/2053266663110578553"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-10 15:29 UTC",
+    "delivered_at": "2026-05-10 15:00 UTC",
     "headline": "OPENAI CODEX MOBILE SPOTTED \u2014 IN-APP TEXT: 'USE CHATGPT APP ON YOUR PHONE TO KEEP WORKING WITH CODEX'",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-10-twitter-15h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2053464448451449200"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-10 15:29 UTC",
+    "delivered_at": "2026-05-10 15:00 UTC",
     "headline": "THE INFORMATION \u2014 DEEPSEEK RACING TO COMMERCIALIZE, RAISING BILLIONS TO PROVE IT'S A REAL BUSINESS NOT JUST A RESEARCH LAB",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-10-twitter-15h-headlines.json",
     "url": "https://x.com/theinformation/status/2053475281810186423"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-10 15:29 UTC",
+    "delivered_at": "2026-05-10 15:00 UTC",
     "headline": "JUKAN05 / MIRAE THESIS GOES GLOBAL \u2014 XAI MFU JUST 11% VS META/GOOGLE 40%+; COLOSSUS 1 LEASE = $5\u20136B/YR HEDGES XAI'S $6B ANNUAL LOSS",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-10-twitter-15h-headlines.json",
     "url": "https://x.com/jukan05/status/2052957921563316619"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-10 15:29 UTC",
+    "delivered_at": "2026-05-10 15:00 UTC",
     "headline": "CEREBRAS WAFER-SCALE CHIP 58X LARGER THAN NVIDIA B200, 2,625X MORE MEMORY BANDWIDTH \u2014 REVENUE +76% YOY TO $510M AHEAD OF IPO",
     "source": "@TradeLogic",
+    "source_file": "research/summaries/2026-05-10-twitter-15h-headlines.json",
     "url": "https://x.com/TradeLogic/status/2053471379228598467"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-10 18:30 UTC",
+    "delivered_at": "2026-05-10 18:00 UTC",
     "headline": "SEMIANALYSIS: AMD ROCm 75X FASTER ON DEEPSEEK V4 IN 14 DAYS \u2014 NEEDS ONLY 5X MORE TO CATCH SINGLE-NODE B200",
     "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-05-10-twitter-18h-headlines.json",
     "url": "https://x.com/SemiAnalysis_/status/2053520440589451720"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-10 18:30 UTC",
+    "delivered_at": "2026-05-10 18:00 UTC",
     "headline": "FRONTIER-LAB SILENCE GRADUATES: ANTHROPIC 48H DARK / OPENAI 46H / SAMA 23H \u2014 NO RESPONSE TO METR, COLOSSUS, OR AMD CATCH-UP",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-10-twitter-18h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2052522497485570560"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-10 18:30 UTC",
+    "delivered_at": "2026-05-10 18:00 UTC",
     "headline": "ANDREW CURRAN ON MYTHOS: CYBER CAPABILITIES WERE NEVER TRAINED \u2014 \"COMPLETELY EMERGENT\" \u2014 LANDS ABOVE AI 2027 TRENDLINE",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-10-twitter-18h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2053520532549808390"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-10 18:30 UTC",
+    "delivered_at": "2026-05-10 18:00 UTC",
     "headline": "THE INFORMATION: PE FIRMS PITCH AI AS NEXT OFFSHORING \u2014 MILKEN EXECS COMPARE OPENAI/ANTHROPIC TO 2000s OUTSOURCING BOOM",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-10-twitter-18h-headlines.json",
     "url": "https://x.com/theinformation/status/2053512903374811372"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-10 18:30 UTC",
+    "delivered_at": "2026-05-10 18:00 UTC",
     "headline": "SEMIANALYSIS NAMES AMD ENGINEERS HAISHAW, THOMAS, ROANER, ANUSHELANGOVAN FOR ROCm KERNEL-FUSION 75X SPRINT",
     "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-05-10-twitter-18h-headlines.json",
     "url": "https://x.com/SemiAnalysis_/status/2053520440589451720"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-10 21:26 UTC",
+    "delivered_at": "2026-05-10 21:00 UTC",
     "headline": "SAMA BREAKS 24H+ SILENCE \u2014 TROLLS NEXT-MODEL NAME 'GOBLIN' (3.5K LIKES, 1.4K REPLIES IN 60 MIN)",
     "source": "@sama",
+    "source_file": "research/summaries/2026-05-10-twitter-21h-headlines.json",
     "url": "https://x.com/sama/status/2053572868936761350"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-10 21:26 UTC",
+    "delivered_at": "2026-05-10 21:00 UTC",
     "headline": "FIELDS MEDALIST GOWERS \u2014 GPT-5.5 PRO ANSWERED OPEN MATH PROBLEMS, 'CRISIS' COMING FOR PHD STUDENTS",
     "source": "@wtgowers",
+    "source_file": "research/summaries/2026-05-10-twitter-21h-headlines.json",
     "url": "https://x.com/wtgowers/status/2052830948685676605"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-10 21:26 UTC",
+    "delivered_at": "2026-05-10 21:00 UTC",
     "headline": "OPENAI'S BUBECK \u2014 'WHAT GOWERS DESCRIBES COULDN'T HAVE HAPPENED BEFORE GPT-5.5'; SAMA RTS",
     "source": "@SebastienBubeck",
+    "source_file": "research/summaries/2026-05-10-twitter-21h-headlines.json",
     "url": "https://x.com/SebastienBubeck/status/2053513789010755762"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-10 21:26 UTC",
+    "delivered_at": "2026-05-10 21:00 UTC",
     "headline": "SAMA QTS 'INTERESTING' ON CLAIM CODEX EARNED $16.88 AUTONOMOUSLY VIA SECURITY BOUNTY PR",
     "source": "@sama",
+    "source_file": "research/summaries/2026-05-10-twitter-21h-headlines.json",
     "url": "https://x.com/sama/status/2053566155571560868"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-10 21:26 UTC",
+    "delivered_at": "2026-05-10 21:00 UTC",
     "headline": "ANTHROPIC CORP DARK 51H 34M \u2014 NO RESPONSE TO METR MYTHOS EVAL, COLOSSUS LEASE, OR OPENAI'S WEEKEND HYPE CLUSTER",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-10-twitter-21h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2052808787514228772"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-10 21:26 UTC",
+    "delivered_at": "2026-05-10 21:00 UTC",
     "headline": "RESEARCH MATHEMATICIAN AZAN \u2014 'GPT-5.5 GIVES UP IN MINUTES; 5.4 RUNS 90-120 MIN ON HARD PROBLEMS'",
     "source": "@aryehazan",
+    "source_file": "research/summaries/2026-05-10-twitter-21h-headlines.json",
     "url": "https://x.com/aryehazan/status/2053530651819643151"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-10 21:26 UTC",
+    "delivered_at": "2026-05-10 21:00 UTC",
     "headline": "SCIENCE STUDY \u2014 OPENAI O1 BEATS ER PHYSICIANS 67% VS 50-55% ON EARLY TRIAGE DIAGNOSIS",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-10-twitter-21h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2053549177670689001"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-11 01:12 UTC",
+    "delivered_at": "2026-05-11 01:00 UTC",
     "headline": "INFORMATION EDITOR NAMES ANTHROPIC THE WINNER OF MUSK V. OPENAI TRIAL \u2014 FLAGS \"MUSK\u2013XAI\u2013ANTHROPIC ALLIANCE\" AS WEEK'S SURPRISE",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-11-twitter-01h-headlines.json",
     "url": "https://x.com/theinformation/status/2053611214974882174"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-11 01:12 UTC",
+    "delivered_at": "2026-05-11 01:00 UTC",
     "headline": "ANTHROPIC CORP CHANNEL DARK 55H+, OPENAI 52H+ \u2014 SILENCE ANOMALY EXTENDS PAST MYTHOS, COLOSSUS, CURSOR, AND GPT-5.5/GOBLIN SIGNAL",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-11-twitter-01h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2052808787514228772"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-11 01:12 UTC",
+    "delivered_at": "2026-05-11 01:00 UTC",
     "headline": "ALTMAN TEASES NEXT MODEL NAMING \u2014 \"WHAT IF WE NAME THE NEXT MODEL 'GOBLIN'\" \u2014 6.4K LIKES, COMMUNITY EXPECTS GPT-5.6 / OPUS 4.8 NEXT",
     "source": "@sama",
+    "source_file": "research/summaries/2026-05-11-twitter-01h-headlines.json",
     "url": "https://x.com/sama/status/2053572868936761350"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-11 01:12 UTC",
+    "delivered_at": "2026-05-11 01:00 UTC",
     "headline": "SEMIANALYSIS SHIPS FIRST ENTERPRISE GROK-SLACK INTEGRATION \u2014 NOTES \"NO GOOD GROK CODING MODEL YET FOR ENTERPRISE\"",
     "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-05-11-twitter-01h-headlines.json",
     "url": "https://x.com/SemiAnalysis_/status/2053618284126515328"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-11 01:12 UTC",
+    "delivered_at": "2026-05-11 01:00 UTC",
     "headline": "CEREBRAS $CBRS IPO LANDS THURSDAY MAY 14 \u2014 $26B\u2013$35B VALUATION RANGE, REPORTED 20\u00d7 OVERSUBSCRIBED, LARGEST US IPO OF 2026",
     "source": "@mulltiy",
+    "source_file": "research/summaries/2026-05-11-twitter-01h-headlines.json",
     "url": "https://x.com/mulltiy/status/2053137546608058726"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-05-11 01:12 UTC",
+    "delivered_at": "2026-05-11 01:00 UTC",
     "headline": "CODEXBAR 0.25 ADDS MANUS, MIMO, QWEN, DOUBAO, VENICE \u2014 MULTI-PROVIDER CODEX FRONTENDS BECOME A REAL CATEGORY",
     "source": "@steipete",
+    "source_file": "research/summaries/2026-05-11-twitter-01h-headlines.json",
     "url": "https://x.com/steipete/status/2053617492325523737"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-11 04:35 UTC",
+    "delivered_at": "2026-05-11 04:00 UTC",
     "headline": "AI MEMORY SUPER-CYCLE HITS RETAIL \u2014 JUKAN POSTS \"HOLY SMOKE\" DRAM/$MU/$SNDK SPOT-PRICE SCREEN, 1,238 LIKES",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-11-twitter-04h-headlines.json",
     "url": "https://x.com/jukan05/status/2053654494383411591"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-11 04:35 UTC",
+    "delivered_at": "2026-05-11 04:00 UTC",
     "headline": "GOLDMAN: DRAM/NAND SUPPLY TIGHTEST IN 15 YEARS, 176% DRAM PRICE SURGE PROJECTED, AI SERVERS NOW 50% OF DEMAND",
     "source": "@Tickerwire",
+    "source_file": "research/summaries/2026-05-11-twitter-04h-headlines.json",
     "url": "https://x.com/Tickerwire/status/2053443495856332848"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-11 04:35 UTC",
+    "delivered_at": "2026-05-11 04:00 UTC",
     "headline": "HBM SOLD OUT THROUGH 2026 \u2014 DRAM CONTRACT PRICES +55-60% QOQ, MICRON Q2 FY26 PRINTS +196% REVENUE YOY",
     "source": "@0xyfed",
+    "source_file": "research/summaries/2026-05-11-twitter-04h-headlines.json",
     "url": "https://x.com/0xyfed/status/2053657260098724251"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-11 04:35 UTC",
+    "delivered_at": "2026-05-11 04:00 UTC",
     "headline": "ANTHROPIC CORP-CHANNEL SILENCE CROSSES 60-HOUR WATCH THRESHOLD \u2014 58H DARK ACROSS MYTHOS/COLOSSUS/CURSOR/MUSK-TRIAL BACKLOG",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-11-twitter-04h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2052808787514228772"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-11 04:35 UTC",
+    "delivered_at": "2026-05-11 04:00 UTC",
     "headline": "OPENAI CORP-CHANNEL DARK 56 HOURS \u2014 SAMA STILL POSTING \"GOBLIN\" CLUSTER, BUT @OPENAI HANDLE SKIPS SUNDAY-EVENING ROLLOVER",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-05-11-twitter-04h-headlines.json",
     "url": "https://x.com/OpenAI/status/2052845764507062349"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-11 07:31 UTC",
+    "delivered_at": "2026-05-11 07:00 UTC",
     "headline": "GEMINI OMNI VIDEO MODEL LEAKS INSIDE GEMINI MOBILE APP AHEAD OF GOOGLE I/O \u2014 REMIX, EDIT-IN-CHAT, TEMPLATES",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-11-twitter-07h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2053718753326596524"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-11 07:31 UTC",
+    "delivered_at": "2026-05-11 07:00 UTC",
     "headline": "SK HYNIX BEGINS 2.5D PACKAGING R&D WITH INTEL, CONSIDERING EMIB ADOPTION \u2014 FIRST INTEL-INTO-AI-MEMORY PACKAGING SIGNAL",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-11-twitter-07h-headlines.json",
     "url": "https://x.com/jukan05/status/2053730063259202047"
   },
   {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-11 07:00 UTC",
+    "headline": "ANTHROPIC CORP CHANNEL CROSSES 60-HOUR SILENCE THRESHOLD \u2014 NO IN-WINDOW RESPONSE TO MYTHOS/METR/COLOSSUS BACKLOG",
+    "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-11-twitter-07h-headlines.json",
+    "url": "https://x.com/AnthropicAI/status/2052808787514228772"
+  },
+  {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-11 07:31 UTC",
+    "delivered_at": "2026-05-11 07:00 UTC",
     "headline": "KOREA MEMORY EXPORT PRICES GO VERTICAL \u2014 DRAM +35%, FLASH +47%, SSDS +140% IN ONE MONTH (UNVERIFIED MAGNITUDE)",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-11-twitter-07h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2053739253331292454"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-05-11 07:31 UTC",
+    "delivered_at": "2026-05-11 07:00 UTC",
     "headline": "OLLAMA 'BLEEDING LLAMA' FLAW LETS REMOTE ATTACKERS LEAK AI SERVER MEMORY INCLUDING API KEYS AND PROMPTS",
     "source": "@TechNadu",
+    "source_file": "research/summaries/2026-05-11-twitter-07h-headlines.json",
     "url": "https://x.com/TechNadu/status/2053739648669954500"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-11 10:24 UTC",
+    "delivered_at": "2026-05-11 10:00 UTC",
     "headline": "CEREBRAS LIFTS IPO BAND SECOND TIME IN 72H TO $150-$160 \u2014 TARGETS $40B VALUATION, $4.8B RAISE, 20X OVERSUBSCRIBED",
     "source": "@dnystedt",
+    "source_file": "research/summaries/2026-05-11-twitter-10h-headlines.json",
     "url": "https://x.com/dnystedt/status/2053610951749017887"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-11 10:24 UTC",
+    "delivered_at": "2026-05-11 10:00 UTC",
     "headline": "CODEX 'ULTRA-FAST' MODE SPOTTED IN GITHUB DIFF \u2014 ATTRIBUTED TO CEREBRAS-POWERED 500-2,000 TPS TIER",
     "source": "@BennettBuhner",
+    "source_file": "research/summaries/2026-05-11-twitter-10h-headlines.json",
     "url": "https://x.com/BennettBuhner/status/2053756809370910923"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-11 10:24 UTC",
+    "delivered_at": "2026-05-11 10:00 UTC",
     "headline": "ANTHROPIC CORP CHANNEL HITS 64.5H DARK \u2014 72H 'INCIDENT' THRESHOLD AT MON 17:52 UTC AS METR/COLOSSUS/MUSK-TRIAL BACKLOG STACKS",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-11-twitter-10h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2052808809182060581"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-05-11 10:24 UTC",
+    "delivered_at": "2026-05-11 10:00 UTC",
     "headline": "QWEN SHIPS WEBWORLD OPEN WORLD-MODEL SERIES FOR WEB AGENTS \u2014 8B/14B/32B APACHE-2.0, CLAIMS TO BEAT GPT-5 AS WORLD MODEL",
     "source": "@AdinaYakup",
+    "source_file": "research/summaries/2026-05-11-twitter-10h-headlines.json",
     "url": "https://x.com/AdinaYakup/status/2053740608439607634"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-11 10:24 UTC",
+    "delivered_at": "2026-05-11 10:00 UTC",
     "headline": "MICROSOFT RELEASES PHI-GROUND-ANY ON HUGGING FACE \u2014 4B VISION MODEL CLAIMS SOTA ON GUI GROUNDING",
     "source": "@HuggingFace",
+    "source_file": "research/summaries/2026-05-11-twitter-10h-headlines.json",
     "url": "https://x.com/HuggingFace/status/2053765549805515057"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-11 10:24 UTC",
+    "delivered_at": "2026-05-11 10:00 UTC",
     "headline": "Z.AI JOINS AI ENGINEER SINGAPORE AS DIAMOND SPONSOR \u2014 TSINGHUA SPIN-OFF FRAMED AS FIRST MAJOR CHINESE LLM IPO AT $31B",
     "source": "@SherryYanJiang",
+    "source_file": "research/summaries/2026-05-11-twitter-10h-headlines.json",
     "url": "https://x.com/SherryYanJiang/status/2053776514450432033"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-11 13:17 UTC",
+    "delivered_at": "2026-05-11 13:00 UTC",
     "headline": "OPENAI LAUNCHES DEPLOYMENT COMPANY \u2014 $4B INITIAL, 19 INVESTOR FIRMS, MAJORITY-OWNED BY OPENAI",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-05-11-twitter-13h-headlines.json",
     "url": "https://x.com/OpenAI/status/2053824997777457651"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-11 13:17 UTC",
+    "delivered_at": "2026-05-11 13:00 UTC",
     "headline": "OPENAI ACQUIRES CONSULTING FIRM TOMORO \u2014 150 FORWARD DEPLOYED ENGINEERS TO STAFF DEPLOYCO FROM DAY ONE",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-05-11-twitter-13h-headlines.json",
     "url": "https://x.com/OpenAI/status/2053824999736410415"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-11 13:17 UTC",
+    "delivered_at": "2026-05-11 13:00 UTC",
     "headline": "THE INFORMATION: XAI CUTS STAFF ON GROK AND DATA CENTERS, HIGH-PROFILE RESEARCHERS DEPART",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-11-twitter-13h-headlines.json",
     "url": "https://x.com/theinformation/status/2053822528469016769"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-11 13:17 UTC",
+    "delivered_at": "2026-05-11 13:00 UTC",
     "headline": "ANTHROPIC RELUCTANT TO GIVE EU ACCESS TO MYTHOS MODEL \u2014 OPENAI ALREADY BIDDING CYBER MODEL IN EU TALKS",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-11-twitter-13h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2053812049730568468"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-11 13:17 UTC",
+    "delivered_at": "2026-05-11 13:00 UTC",
     "headline": "ANTHROPICAI SILENCE HITS 67H AS OPENAI BREAKS WITH MAJOR LAUNCH \u2014 72H INCIDENT THRESHOLD HOURS AWAY",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-11-twitter-13h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2052808787514228772"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-11 13:17 UTC",
+    "delivered_at": "2026-05-11 13:00 UTC",
     "headline": "SIERRA RAISES $950M LED BY TIGER GLOBAL AND GV AT $15B+ VALUATION \u2014 40% OF FORTUNE 50 NOW CUSTOMERS",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-11-twitter-13h-headlines.json",
     "url": "https://x.com/theinformation/status/2053824256715170214"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-11 13:17 UTC",
+    "delivered_at": "2026-05-11 13:00 UTC",
     "headline": "SK HYNIX MARKET CAP CROSSES $900 BILLION ON HBM SUPER-CYCLE",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-11-twitter-13h-headlines.json",
     "url": "https://x.com/jukan05/status/2053796170968019348"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-11 16:09 UTC",
+    "delivered_at": "2026-05-11 16:00 UTC",
     "headline": "GEMINI OMNI LEAK HARDENS \u2014 TESTINGCATALOG NAMES WATERMARK REMOVAL, OBJECT REPLACEMENT, IN-CHAT VIDEO EDIT AHEAD OF GOOGLE I/O",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-11-twitter-16h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2053857806374064496"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-11 16:09 UTC",
+    "delivered_at": "2026-05-11 16:00 UTC",
     "headline": "THEINFORMATION: CORE AUTOMATION SEEKING $4B VALUATION \u2014 EX-OPENAI TWOREK STARTUP, 6 WEEKS OLD, NVIDIA AMONG EARLY BACKERS",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-11-twitter-16h-headlines.json",
     "url": "https://x.com/theinformation/status/2053837714131165610"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-11 16:09 UTC",
+    "delivered_at": "2026-05-11 16:00 UTC",
     "headline": "THEINFORMATION: KUAISHOU PLANNING KLING AI VIDEO SPINOFF AHEAD OF 2027 IPO",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-11-twitter-16h-headlines.json",
     "url": "https://x.com/theinformation/status/2053845120722559319"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-11 16:09 UTC",
+    "delivered_at": "2026-05-11 16:00 UTC",
     "headline": "THEINFORMATION: AI LIFTS PROFITS VIA SLOWER HIRING BUT TOKEN, CHIP, MODEL COSTS RISING FAST \u2014 Q1 EARNINGS TENSION",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-11-twitter-16h-headlines.json",
     "url": "https://x.com/theinformation/status/2053860221609508996"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-11 16:09 UTC",
+    "delivered_at": "2026-05-11 16:00 UTC",
     "headline": "ANTHROPICAI 70H 17M DARK \u2014 72H SILENCE THRESHOLD 1H 43M AWAY AT 17:52 UTC; JACKCLARKSF BREAKS WITH POLICY POST",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-11-twitter-16h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2052808787514228772"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-11 16:09 UTC",
+    "delivered_at": "2026-05-11 16:00 UTC",
     "headline": "UK INFERENCE-CHIP STARTUP FRACTILE AI IN TALKS TO RAISE $200M AT $1B VALUATION",
     "source": "@ElectronicsNews",
+    "source_file": "research/summaries/2026-05-11-twitter-16h-headlines.json",
     "url": "https://x.com/ElectronicsNews/status/2053869065802858569"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-11 16:09 UTC",
+    "delivered_at": "2026-05-11 16:00 UTC",
     "headline": "MICRON MARKET CAP CROSSES $900B \u2014 JOINS SK HYNIX IN MEMORY SUPER-CYCLE MEGA-CAP CLUB",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-11-twitter-16h-headlines.json",
     "url": "https://x.com/jukan05/status/2053834879800926496"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-11 18:49 UTC",
+    "delivered_at": "2026-05-11 18:00 UTC",
     "headline": "ANTHROPIC LAUNCHES CLAUDE PLATFORM ON AWS GA \u2014 NATIVE PARITY INSIDE AWS IAM, BILLING, MANAGED AGENTS",
     "source": "@ClaudeDevs",
+    "source_file": "research/summaries/2026-05-11-twitter-18h-headlines.json",
     "url": "https://x.com/ClaudeDevs/status/2053892878167072914"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-11 18:49 UTC",
+    "delivered_at": "2026-05-11 18:00 UTC",
     "headline": "MUSK TO FOLD XAI INTO 'SPACEXAI' AS COMPANY CUTS STAFF AND WEIGHS $60B CURSOR ACQUISITION \u2014 TI",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-11-twitter-18h-headlines.json",
     "url": "https://x.com/theinformation/status/2053897998581567502"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-11 18:49 UTC",
+    "delivered_at": "2026-05-11 18:00 UTC",
     "headline": "OPENAI HIRES GIMLET LABS TO OPTIMIZE MODELS FOR CEREBRAS CHIPS \u2014 'BROADER PUSH TO REDUCE RELIANCE ON NVIDIA' \u2014 TI",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-11-twitter-18h-headlines.json",
     "url": "https://x.com/theinformation/status/2053890399039586597"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-11 18:49 UTC",
+    "delivered_at": "2026-05-11 18:00 UTC",
     "headline": "ANTHROPIC BREAKS 71-HOUR CORP SILENCE \u2014 CLAUDE CONSTITUTION SHIPS AS AUDIOBOOK 56 MINUTES BEFORE 72H WATCH THRESHOLD",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-11-twitter-18h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2053881827396653207"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-11 18:49 UTC",
+    "delivered_at": "2026-05-11 18:00 UTC",
     "headline": "CEREBRAS IPO RAISE LIFTED TO $4.8B AT $40B VALUATION \u2014 PRICING TUE MAY 13, TRADING WED MAY 14 AS $CBRS",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-11-twitter-18h-headlines.json",
     "url": "https://x.com/theinformation/status/2053871531697013086"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-11 21:38 UTC",
+    "delivered_at": "2026-05-11 21:00 UTC",
     "headline": "OPENAI SHIPS DAYBREAK \u2014 FRONTIER AI FOR CYBER DEFENDERS, COMBINES TOP MODELS WITH CODEX AND SECURITY PARTNERS",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-05-11-twitter-21h-headlines.json",
     "url": "https://x.com/OpenAI/status/2053939702110269822"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-11 21:38 UTC",
+    "delivered_at": "2026-05-11 21:00 UTC",
     "headline": "ALTMAN CORP-CHANNEL: AI 'ABOUT TO GET SUPER GOOD AT CYBERSECURITY' \u2014 DAYBREAK SEEKS DESIGN PARTNERS NOW",
     "source": "@sama",
+    "source_file": "research/summaries/2026-05-11-twitter-21h-headlines.json",
     "url": "https://x.com/sama/status/2053951874408276193"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-11 21:38 UTC",
+    "delivered_at": "2026-05-11 21:00 UTC",
     "headline": "MIRA MURATI SHIPS THINKING MACHINES' FIRST MODEL PREVIEW \u2014 'INTERACTION MODELS' TRAINED NATIVELY FOR REAL-TIME",
     "source": "@miramurati",
+    "source_file": "research/summaries/2026-05-11-twitter-21h-headlines.json",
     "url": "https://x.com/miramurati/status/2053939069890298321"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-11 21:38 UTC",
+    "delivered_at": "2026-05-11 21:00 UTC",
     "headline": "JOHN SCHULMAN CONFIRMS THINKY 'FULL-DUPLEX MULTIMODAL MODELS' \u2014 SEE-AND-HEAR CONTINUOUS, RESPOND IN REAL-TIME",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-11-twitter-21h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2053941584383877377"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-11 21:38 UTC",
+    "delivered_at": "2026-05-11 21:00 UTC",
     "headline": "THE INFORMATION: CEREBRAS EXPECTED TO GO PUBLIC AT $35B VALUATION, BELOW PRIOR $40B CHATTER, PRICING WEDNESDAY",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-11-twitter-21h-headlines.json",
     "url": "https://x.com/theinformation/status/2053935701339595208"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-11 21:38 UTC",
+    "delivered_at": "2026-05-11 21:00 UTC",
     "headline": "JUKAN05: TESLA AI6 TSMC ALLOCATION TO TRANSFER ENTIRELY TO INTEL FOUNDRY UNDER TRUMP-ADMIN PRESSURE",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-11-twitter-21h-headlines.json",
     "url": "https://x.com/jukan05/status/2053923807040328073"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-11 21:38 UTC",
+    "delivered_at": "2026-05-11 21:00 UTC",
     "headline": "CLAUDE CODE SHIPS PARALLEL-AGENT 'AGENT VIEW' \u2014 DISPATCH MANY SKILLS AT ONCE, PEEK AND REPLY UX",
     "source": "@ClaudeDevs",
+    "source_file": "research/summaries/2026-05-11-twitter-21h-headlines.json",
     "url": "https://x.com/ClaudeDevs/status/2053944194386051128"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-12 01:05 UTC",
+    "delivered_at": "2026-05-12 01:00 UTC",
     "headline": "MINI SHAI-HULUD WORM HITS TANSTACK NPM \u2014 42 PACKAGES, 84 MALICIOUS VERSIONS IN 6 MINUTES, 12M+ WEEKLY DOWNLOADS EXPOSED",
     "source": "@IntCyberDigest",
+    "source_file": "research/summaries/2026-05-12-twitter-01h-headlines.json",
     "url": "https://x.com/IntCyberDigest/status/2053983157628596484"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-12 01:05 UTC",
+    "delivered_at": "2026-05-12 01:00 UTC",
     "headline": "MISTRAL AI NPM PACKAGES CONFIRMED COMPROMISED IN MINI SHAI-HULUD CAMPAIGN \u2014 SOCKET SECURITY",
     "source": "@SocketSecurity",
+    "source_file": "research/summaries/2026-05-12-twitter-01h-headlines.json",
     "url": "https://x.com/SocketSecurity/status/2053973242545668373"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-12 01:05 UTC",
+    "delivered_at": "2026-05-12 01:00 UTC",
     "headline": "NPM ATTACK ABUSES GITHUB ACTIONS OIDC TO REPUBLISH MALICIOUS PACKAGES UNDER LEGITIMATE MAINTAINER IDENTITIES \u2014 NOVEL VECTOR",
     "source": "@AikidoSecurity",
+    "source_file": "research/summaries/2026-05-12-twitter-01h-headlines.json",
     "url": "https://x.com/AikidoSecurity/status/2053974705795989906"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-12 01:05 UTC",
+    "delivered_at": "2026-05-12 01:00 UTC",
     "headline": "ALTMAN SOFT-CONFIRMS OPENAI SUPERAPP: 'WOULD YOU CALL IT A SUPERAPP?' AND 'NEW CHATGPT MODEL, PERSONALITY, PERSONALIZATION FEELS LIKE A NEW THING'",
     "source": "@sama",
+    "source_file": "research/summaries/2026-05-12-twitter-01h-headlines.json",
     "url": "https://x.com/sama/status/2053971387308745046"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-12 01:05 UTC",
+    "delivered_at": "2026-05-12 01:00 UTC",
     "headline": "SWYX ON THINKING MACHINES: 'BRUTALLY FRAMEMOGGED GDM AND OAI \u2014 EVERYONE'S DEFINITION OF REALTIME JUST GOT A MASSIVE UPGRADE'",
     "source": "@swyx",
+    "source_file": "research/summaries/2026-05-12-twitter-01h-headlines.json",
     "url": "https://x.com/swyx/status/2053960011748098462"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-12 01:05 UTC",
+    "delivered_at": "2026-05-12 01:00 UTC",
     "headline": "SK GROUP CHAIRMAN: 'IF WE DON'T INCREASE MEMORY SUPPLY, CUSTOMERS WILL FIND WAYS TO USE LESS MEMORY' \u2014 JUKAN05 CALLS 80% HBM MARGINS UNSUSTAINABLE",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-12-twitter-01h-headlines.json",
     "url": "https://x.com/jukan05/status/2053962711206449539"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-12 01:05 UTC",
+    "delivered_at": "2026-05-12 01:00 UTC",
     "headline": "ANTHROPIC PREPARING CLAUDE MOBILE APP FOR LONG-HORIZON AGENT GOALS \u2014 PARALLEL-AGENT VIEW SHIPS IN CLAUDE CODE CLI",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-12-twitter-01h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2053989783211270621"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-12 04:25 UTC",
+    "delivered_at": "2026-05-12 04:00 UTC",
     "headline": "SUTSKEVER TESTIFIES UNDER OATH: $7B OPENAI STAKE \u2014 SECOND NEW BILLIONAIRE EXPOSED IN MUSK V ALTMAN TRIAL AFTER BROCKMAN'S ~$30B",
     "source": "@unusual_whales",
+    "source_file": "research/summaries/2026-05-12-twitter-04h-headlines.json",
     "url": "https://x.com/unusual_whales/status/2053972921903649259"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-12 04:25 UTC",
+    "delivered_at": "2026-05-12 04:00 UTC",
     "headline": "SUTSKEVER CONFIRMS UNDER OATH: OPENAI BOARD ASKED DARIO TO MERGE ANTHROPIC AND TAKE OVER AS CEO AFTER ALTMAN FIRING IN NOV 2023",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-12-twitter-04h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2054015119286505812"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-12 04:25 UTC",
+    "delivered_at": "2026-05-12 04:00 UTC",
     "headline": "REUTERS: SUTSKEVER VALUES OPENAI STAKE AT ~$7B WHILE TESTIFYING IN MUSK V OPENAI CASE",
     "source": "@ReutersLegal",
+    "source_file": "research/summaries/2026-05-12-twitter-04h-headlines.json",
     "url": "https://x.com/ReutersLegal/status/2053929402333884624"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-12 04:25 UTC",
+    "delivered_at": "2026-05-12 04:00 UTC",
     "headline": "FRONTIERMATH TIER 4 AUTHOR KEN ONO: 'AI HAS NOW SOLVED' MY TIER 4 PROBLEMS \u2014 'HUMAN EVALUATION IS REACHING ITS LIMIT'",
     "source": "@KenOno691",
+    "source_file": "research/summaries/2026-05-12-twitter-04h-headlines.json",
     "url": "https://x.com/KenOno691/status/2054023819342311921"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-12 04:25 UTC",
+    "delivered_at": "2026-05-12 04:00 UTC",
     "headline": "NEW MATH BENCHMARK SOOHAK RELEASED: 439 RESEARCH PROBLEMS BY 64 MATHEMATICIANS, FRONTIER MODELS SCORE UNDER 30%",
     "source": "@seungonekim",
+    "source_file": "research/summaries/2026-05-12-twitter-04h-headlines.json",
     "url": "https://x.com/seungonekim/status/2054054146278334577"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-12 04:25 UTC",
+    "delivered_at": "2026-05-12 04:00 UTC",
     "headline": "EMOLLICK: AI LABS BELIEVE IN ASI ONLY WHEN THEY DISBAND THEIR FORWARD-DEPLOYED-ENGINEERING CONSULTING ARMS \u2014 UNTIL THEN, JOBS SAFE",
     "source": "@emollick",
+    "source_file": "research/summaries/2026-05-12-twitter-04h-headlines.json",
     "url": "https://x.com/emollick/status/2054036929461526984"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-12 07:14 UTC",
+    "delivered_at": "2026-05-12 07:00 UTC",
     "headline": "MINI SHAI-HULUD WORM JUMPS NPM TO PYPI \u2014 MISTRALAI 2.4.6 + GUARDRAILS-AI 0.10.1 CONFIRMED COMPROMISED BY TEAMPCP",
     "source": "@SocketSecurity",
+    "source_file": "research/summaries/2026-05-12-twitter-07h-headlines.json",
     "url": "https://x.com/SocketSecurity/status/2054048025081737446"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-12 07:14 UTC",
+    "delivered_at": "2026-05-12 07:00 UTC",
     "headline": "DFIR WRITEUP CONFIRMS NPM WORM'S DEAD-MAN'S SWITCH \u2014 GH-TOKEN-MONITOR DAEMON TRIGGERS RM -RF ~/ ON TOKEN REVOKE",
     "source": "@DFIR_Radar",
+    "source_file": "research/summaries/2026-05-12-twitter-07h-headlines.json",
     "url": "https://x.com/DFIR_Radar/status/2054095098208739469"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-12 07:14 UTC",
+    "delivered_at": "2026-05-12 07:00 UTC",
     "headline": "TEAMPCP WORM PLANTS PERSISTENCE HOOKS IN .CLAUDE/SETTINGS.JSON AND .VSCODE/TASKS.JSON \u2014 AI CODING AGENTS NOW WEAPONIZED SURFACE",
     "source": "@ThatbV",
+    "source_file": "research/summaries/2026-05-12-twitter-07h-headlines.json",
     "url": "https://x.com/ThatbV/status/2054077830590267732"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-12 07:14 UTC",
+    "delivered_at": "2026-05-12 07:00 UTC",
     "headline": "OPENAI CODEX LEAD SOTTIAUX MAKES \"SUPER APP\" FRAMING OFFICIAL \u2014 OPENAI FORUM TALK SCHEDULED WED MAY 13",
     "source": "@thsottiaux",
+    "source_file": "research/summaries/2026-05-12-twitter-07h-headlines.json",
     "url": "https://x.com/thsottiaux/status/2054013690786230510"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-12 07:14 UTC",
+    "delivered_at": "2026-05-12 07:00 UTC",
     "headline": "CLAUDE CODE 2.1.139 SHIPS /GOAL COMMAND \u2014 OPENAI CODEX LEAD TAUNTS \"CLAUDE IS NOW COPYING CODEX\"",
     "source": "@thsottiaux",
+    "source_file": "research/summaries/2026-05-12-twitter-07h-headlines.json",
     "url": "https://x.com/thsottiaux/status/2054082531432210765"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-12 07:14 UTC",
+    "delivered_at": "2026-05-12 07:00 UTC",
     "headline": "NADELLA CALLS OPENAI BOARD'S 2023 ATTEMPT TO OUST ALTMAN \"AMATEUR CITY\" IN MUSK V OPENAI TRIAL TESTIMONY",
     "source": "@evanepstein",
+    "source_file": "research/summaries/2026-05-12-twitter-07h-headlines.json",
     "url": "https://x.com/evanepstein/status/2054038788096319804"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-12 07:14 UTC",
+    "delivered_at": "2026-05-12 07:00 UTC",
     "headline": "NADELLA PRODUCES 2016 EMAIL OF MUSK PERSONALLY THANKING MICROSOFT FOR OPENAI SUPPORT \u2014 STATUTE-OF-LIMITATIONS DEFENSE EVIDENCE",
     "source": "@namd1nh",
+    "source_file": "research/summaries/2026-05-12-twitter-07h-headlines.json",
     "url": "https://x.com/namd1nh/status/2054037139424518484"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-12 10:01 UTC",
+    "delivered_at": "2026-05-12 10:00 UTC",
     "headline": "CEREBRAS IPO UPSIZED TO $4.8B \u2014 $150-$160/SHARE, 30M SHARES, 20\u00d7 OVERSUBSCRIBED, PRICES MAY 13 AT ~$50B IMPLIED VALUATION",
     "source": "@EricSun1998",
+    "source_file": "research/summaries/2026-05-12-twitter-10h-headlines.json",
     "url": "https://x.com/EricSun1998/status/2054078862112370612"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-12 10:01 UTC",
+    "delivered_at": "2026-05-12 10:00 UTC",
     "headline": "CEREBRAS NOW POSITIONED AS BIGGEST GLOBAL IPO OF 2026 \u2014 VALUATION TARGET +37% AFTER PRICE-RANGE LIFT FROM $115-$125",
     "source": "@RealNickMugalli",
+    "source_file": "research/summaries/2026-05-12-twitter-10h-headlines.json",
     "url": "https://x.com/RealNickMugalli/status/2053855651055919353"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-12 10:01 UTC",
+    "delivered_at": "2026-05-12 10:00 UTC",
     "headline": "GEMINI OMNI VIDEO MODEL LEAK PROPAGATES \u2014 CHALKBOARD MATH PROOF DEMO BECOMES THE 'NANO BANANA MOMENT FOR VIDEO' AHEAD OF GOOGLE I/O",
     "source": "@chetaslua",
+    "source_file": "research/summaries/2026-05-12-twitter-10h-headlines.json",
     "url": "https://x.com/chetaslua/status/2053824398503678108"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-12 10:01 UTC",
+    "delivered_at": "2026-05-12 10:00 UTC",
     "headline": "OPENAI CODEX EXTENDS FREE PLANS AND CREDITS TO OSS TEAMS HIT BY TEAMPCP MINI SHAI-HULUD ATTACK",
     "source": "@jxnlco",
+    "source_file": "research/summaries/2026-05-12-twitter-10h-headlines.json",
     "url": "https://x.com/jxnlco/status/2054095220397228413"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-12 10:01 UTC",
+    "delivered_at": "2026-05-12 10:00 UTC",
     "headline": "MISTRAL CORP-CHANNEL SILENT FOR 13TH DAY DESPITE NPM AND PYPI MISTRALAI 2.4.6 COMPROMISES \u2014 VENDOR DISCLOSURE-NORM ABERRATION",
     "source": "@MistralAI",
+    "source_file": "research/summaries/2026-05-12-twitter-10h-headlines.json",
     "url": "https://x.com/MistralAI/status/2049988769928056852"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-12 10:01 UTC",
+    "delivered_at": "2026-05-12 10:00 UTC",
     "headline": "HYPERLIQUID PRE-IPO TRADERS PRICE CEREBRAS AT $80B MARKET CAP \u2014 60% PREMIUM OVER FORMAL $50B BAND",
     "source": "@HODL4PORSCHE",
+    "source_file": "research/summaries/2026-05-12-twitter-10h-headlines.json",
     "url": "https://x.com/HODL4PORSCHE/status/2054088738015457554"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-12 12:56 UTC",
+    "delivered_at": "2026-05-12 12:00 UTC",
     "headline": "ALTMAN TAKES THE STAND TUESDAY IN MUSK V OPENAI \u2014 CLOSINGS THURSDAY, JURY DELIBERATIONS BEGIN MONDAY MAY 18",
     "source": "@sanarsh11",
+    "source_file": "research/summaries/2026-05-12-twitter-12h-headlines.json",
     "url": "https://x.com/sanarsh11/status/2054173031044624762"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-12 12:56 UTC",
+    "delivered_at": "2026-05-12 12:00 UTC",
     "headline": "SUTSKEVER CROSS REVEALS 2018 EMAIL CALLING MUSK 'MOST OVERWHELMINGLY COMPETENT PERSON IN THE WORLD' \u2014 STAKE NOW $7B",
     "source": "@gailalfaratx",
+    "source_file": "research/summaries/2026-05-12-twitter-12h-headlines.json",
     "url": "https://x.com/gailalfaratx/status/2054054481105453088"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-12 12:56 UTC",
+    "delivered_at": "2026-05-12 12:00 UTC",
     "headline": "TEAMPCP COMPROMISES CHECKMARX JENKINS AST PLUGIN V2026.5.09 USING STOLEN TRIVY/KICS CREDENTIALS",
     "source": "@NuruTechHub",
+    "source_file": "research/summaries/2026-05-12-twitter-12h-headlines.json",
     "url": "https://x.com/NuruTechHub/status/2054064335958290640"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-12 12:56 UTC",
+    "delivered_at": "2026-05-12 12:00 UTC",
     "headline": "MINI SHAI-HULUD V3 NOW LINKED TO TANSTACK, UIPATH, MISTRAL AI, OPENSEARCH, GUARDRAILS AI, AND CHECKMARX",
     "source": "@cybertzar",
+    "source_file": "research/summaries/2026-05-12-twitter-12h-headlines.json",
     "url": "https://x.com/cybertzar/status/2054163425312260450"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-12 12:56 UTC",
+    "delivered_at": "2026-05-12 12:00 UTC",
     "headline": "CEREBRAS UPSIZES IPO TO $4.8B AT $150-$160 / 30M SHARES / 20X OVERSUBSCRIBED \u2014 PRICES WEDNESDAY MAY 13",
     "source": "@AfricaisHOME2",
+    "source_file": "research/summaries/2026-05-12-twitter-12h-headlines.json",
     "url": "https://x.com/AfricaisHOME2/status/2054138657687089399"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-12 12:56 UTC",
+    "delivered_at": "2026-05-12 12:00 UTC",
     "headline": "POLYMARKET LISTS NEW CONTRACT \u2014 OPENAI TO ANNOUNCE AI EARBUDS THIS YEAR AT 51%",
     "source": "@Polymarket",
+    "source_file": "research/summaries/2026-05-12-twitter-12h-headlines.json",
     "url": "https://x.com/Polymarket/status/2054175062471676180"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-12 12:56 UTC",
+    "delivered_at": "2026-05-12 12:00 UTC",
     "headline": "MISTRAL CORP-CHANNEL HITS 12 CONSECUTIVE DAYS OF SILENCE AFTER NPM, PYPI, AND CHECKMARX-CHAIN COMPROMISES",
     "source": "@MistralAI",
+    "source_file": "research/summaries/2026-05-12-twitter-12h-headlines.json",
     "url": "https://x.com/MistralAI/status/2049988769928056852"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-12 15:58 UTC",
+    "delivered_at": "2026-05-12 15:00 UTC",
     "headline": "ISOMORPHIC LABS RAISES $2.1B SERIES B \u2014 THRIVE CAPITAL LEADS, UK SOVEREIGN AI FUND DEBUTS AS AI INVESTOR",
     "source": "@demishassabis",
+    "source_file": "research/summaries/2026-05-12-twitter-15h-headlines.json",
     "url": "https://x.com/demishassabis/status/2054197462101889277"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-12 15:58 UTC",
+    "delivered_at": "2026-05-12 15:00 UTC",
     "headline": "OPENAI-MICROSOFT REVENUE SHARE CAPPED AT $38B \u2014 SAVES OPENAI ~$97B VS OLD STRUCTURE, CLEARS IPO PATH",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-12-twitter-15h-headlines.json",
     "url": "https://x.com/theinformation/status/2054203036323516443"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-12 15:58 UTC",
+    "delivered_at": "2026-05-12 15:00 UTC",
     "headline": "CEREBRAS IPO PRICES THIS WEEK \u2014 OPENAI'S $20B COMPUTE COMMITMENT YIELDS ~11% STAKE, $5B+ WINDFALL",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-12-twitter-15h-headlines.json",
     "url": "https://x.com/theinformation/status/2054215276384719277"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-12 15:58 UTC",
+    "delivered_at": "2026-05-12 15:00 UTC",
     "headline": "ISOMORPHIC LABS BOARD STACK: ALPHABET, GV, MGX, TEMASEK, CAPITALG, UK SOVEREIGN AI FUND IN $2.1B ROUND",
     "source": "@IsomorphicLabs",
+    "source_file": "research/summaries/2026-05-12-twitter-15h-headlines.json",
     "url": "https://x.com/IsomorphicLabs/status/2054189884034678895"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-12 15:58 UTC",
+    "delivered_at": "2026-05-12 15:00 UTC",
     "headline": "MICROSOFT KEEPS OPENAI IP RIGHTS ONLY UNTIL $38B CAP \u2014 POST-CAP, OPENAI FREE TO PARTNER AMAZON, GOOGLE",
     "source": "@aaronpholmes",
+    "source_file": "research/summaries/2026-05-12-twitter-15h-headlines.json",
     "url": "https://x.com/aaronpholmes/status/2054156460825735453"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-05-12 15:58 UTC",
+    "delivered_at": "2026-05-12 15:00 UTC",
     "headline": "HUGGING FACE HUB CROSSES 1,000,000 PUBLIC DATASETS \u2014 PETABYTES OF OPEN AI DATA NOW HOSTED",
     "source": "@HuggingFace",
+    "source_file": "research/summaries/2026-05-12-twitter-15h-headlines.json",
     "url": "https://x.com/HuggingFace/status/2054221604729553210"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-12 15:58 UTC",
+    "delivered_at": "2026-05-12 15:00 UTC",
     "headline": "ALTMAN COURTROOM TESTIMONY SLIPS \u2014 GAIL ALFAR REVISES TO 'ANY DAY NOW' AS BOARD CHAIR TAYLOR STILL ON STAND",
     "source": "@gailalfaratx",
+    "source_file": "research/summaries/2026-05-12-twitter-15h-headlines.json",
     "url": "https://x.com/gailalfaratx/status/2054154903291892051"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-12 18:49 UTC",
+    "delivered_at": "2026-05-12 18:00 UTC",
     "headline": "ALTMAN TAKES THE STAND DAY 10 OF MUSK v OPENAI \u2014 MOLO OPENS CROSS: \"SHOULD THE JURY BELIEVE YOUR TESTIMONY?\"",
     "source": "@muskonomy",
+    "source_file": "research/summaries/2026-05-12-twitter-18h-headlines.json",
     "url": "https://x.com/muskonomy/status/2054252875319574613"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-12 18:49 UTC",
+    "delivered_at": "2026-05-12 18:00 UTC",
     "headline": "MOLO CONFRONTS ALTMAN WITH 2017 SUTSKEVER EMAIL: \"WHY IS THE CEO TITLE SO IMPORTANT TO YOU?\"",
     "source": "@michelletomkim",
+    "source_file": "research/summaries/2026-05-12-twitter-18h-headlines.json",
     "url": "https://x.com/michelletomkim/status/2054278077680070707"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-12 18:49 UTC",
+    "delivered_at": "2026-05-12 18:00 UTC",
     "headline": "GOOGLE LAUNCHES GEMINI INTELLIGENCE AT ANDROID SHOW \u2014 BROWSER USE IN CHROME, CUSTOM GEN UI, PIXEL + GALAXY SUMMER ROLLOUT",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-12-twitter-18h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2054262760018264413"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-12 18:49 UTC",
+    "delivered_at": "2026-05-12 18:00 UTC",
     "headline": "GOOGLE DEEPMIND REIMAGINES THE MOUSE POINTER \u2014 FIRST AI-NATIVE INTERFACE UPDATE SINCE ENGELBART 1968",
     "source": "@GoogleDeepMind",
+    "source_file": "research/summaries/2026-05-12-twitter-18h-headlines.json",
     "url": "https://x.com/GoogleDeepMind/status/2054254610725241131"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-12 18:49 UTC",
+    "delivered_at": "2026-05-12 18:00 UTC",
     "headline": "ANTHROPIC VOIDS ALL UNAUTHORIZED SECONDARY SHARE TRANSFERS \u2014 SPVs, FORGE, HIIVE, TOKENIZED ALL NULLIFIED",
     "source": "@PFHub_io",
+    "source_file": "research/summaries/2026-05-12-twitter-18h-headlines.json",
     "url": "https://x.com/PFHub_io/status/2054132177898053632"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-12 18:49 UTC",
+    "delivered_at": "2026-05-12 18:00 UTC",
     "headline": "PRESTOCKS ANTHROPIC TOKEN CRASHES 34% \u2014 $1.6T IMPLIED TOKENIZED CAP-TABLE WIPED OUT IN SESSION",
     "source": "@tokenmetricsinc",
+    "source_file": "research/summaries/2026-05-12-twitter-18h-headlines.json",
     "url": "https://x.com/tokenmetricsinc/status/2054254653988069454"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-12 18:49 UTC",
+    "delivered_at": "2026-05-12 18:00 UTC",
     "headline": "CLAUDE OPUS 4.7 FAST MODE SHIPS ACROSS CURSOR / v0 / WARP / WINDSURF \u2014 ~2.5\u00d7 OUTPUT SPEED, DEFAULT THURSDAY",
     "source": "@ClaudeDevs",
+    "source_file": "research/summaries/2026-05-12-twitter-18h-headlines.json",
     "url": "https://x.com/ClaudeDevs/status/2054272988378095627"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-12 21:37 UTC",
+    "delivered_at": "2026-05-12 21:00 UTC",
     "headline": "ANTHROPIC IN TALKS TO RAISE $30B AT $900B+ VALUATION \u2014 IPO CONSIDERATION AS SOON AS OCTOBER, PER BLOOMBERG",
     "source": "@shortsqueeznews",
+    "source_file": "research/summaries/2026-05-12-twitter-21h-headlines.json",
     "url": "https://x.com/shortsqueeznews/status/2054310396568207444"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-12 21:37 UTC",
+    "delivered_at": "2026-05-12 21:00 UTC",
     "headline": "ALTMAN UNDER CROSS: 2023 SENATE TESTIMONY 'I HAVE NO EQUITY IN OPENAI' CONFRONTED \u2014 DECLINES TO NOTIFY SENATE",
     "source": "@ns123abc",
+    "source_file": "research/summaries/2026-05-12-twitter-21h-headlines.json",
     "url": "https://x.com/ns123abc/status/2054281572010877423"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-12 21:37 UTC",
+    "delivered_at": "2026-05-12 21:00 UTC",
     "headline": "CURSOR: CLAUDE OPUS 4.7 FAST MODE IS 2.5X SPEED AT 6X COST \u2014 'FOR MOST TASKS, WE RECOMMEND STANDARD SPEED'",
     "source": "@cursor_ai",
+    "source_file": "research/summaries/2026-05-12-twitter-21h-headlines.json",
     "url": "https://x.com/cursor_ai/status/2054274305345618163"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-12 21:37 UTC",
+    "delivered_at": "2026-05-12 21:00 UTC",
     "headline": "MUSK PLEDGES FULL OPEN-SOURCING OF X RECOMMENDATION ALGORITHM + THIRD-PARTY AUDIT",
     "source": "@elonmusk",
+    "source_file": "research/summaries/2026-05-12-twitter-21h-headlines.json",
     "url": "https://x.com/elonmusk/status/2054297431551136198"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-12 21:37 UTC",
+    "delivered_at": "2026-05-12 21:00 UTC",
     "headline": "MICROSOFT HAS RECOUPED 2.3X ITS OPENAI INVESTMENT \u2014 $30B REVENUE VS $13B INVESTED",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-12-twitter-21h-headlines.json",
     "url": "https://x.com/theinformation/status/2054308315371393526"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-12 21:37 UTC",
+    "delivered_at": "2026-05-12 21:00 UTC",
     "headline": "FOXCONN CPO ALL-OPTICAL SWITCH-RACK SHIPMENTS TO NVIDIA REVISED 5X HIGHER \u2014 50,000+ UNITS 2026-2027",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-12-twitter-21h-headlines.json",
     "url": "https://x.com/jukan05/status/2054289519411896455"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-12 21:37 UTC",
+    "delivered_at": "2026-05-12 21:00 UTC",
     "headline": "MOLO CONSOLIDATES 7-WITNESS 'HISTORY OF LYING' STACK AGAINST ALTMAN \u2014 SUTSKEVER, MURATI, BOTH AMODEIS, YOON, TONER, MCCAULEY",
     "source": "@ns123abc",
+    "source_file": "research/summaries/2026-05-12-twitter-21h-headlines.json",
     "url": "https://x.com/ns123abc/status/2054295002046709859"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-13 01:10 UTC",
+    "delivered_at": "2026-05-13 01:00 UTC",
     "headline": "ANTHROPIC LEASES SPACEX COLOSSUS 1 \u2014 220K GPUS, 300 MW, $3-4B/YR TO SPACEX AHEAD OF IPO",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-13-twitter-01h-headlines.json",
     "url": "https://x.com/theinformation/status/2054260384127693178"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-13 01:10 UTC",
+    "delivered_at": "2026-05-13 01:00 UTC",
     "headline": "ALTMAN HELION STAKE WORTH ~$1.65B PER PERJURY FILING \u2014 ORIGINAL BOARD REJECTED DEAL, NEW BOARD APPROVED",
     "source": "@ns123abc",
+    "source_file": "research/summaries/2026-05-13-twitter-01h-headlines.json",
     "url": "https://x.com/ns123abc/status/2054368416413196369"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-13 01:10 UTC",
+    "delivered_at": "2026-05-13 01:00 UTC",
     "headline": "GOOGLE UNVEILS GOOGLEBOOK \u2014 FIRST LAPTOP DESIGNED FOR GEMINI INTELLIGENCE; MAGIC POINTER PUTS AI IN THE CURSOR",
     "source": "@demishassabis",
+    "source_file": "research/summaries/2026-05-13-twitter-01h-headlines.json",
     "url": "https://x.com/demishassabis/status/2054357865284907517"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-13 01:10 UTC",
+    "delivered_at": "2026-05-13 01:00 UTC",
     "headline": "SAMSUNG LABOR TALKS COLLAPSE 3AM KOREA \u2014 50K WORKERS PREPARE 18-DAY STRIKE FROM MAY 21; SAMSUNG -5% PRE-MARKET",
     "source": "@NeelMacro",
+    "source_file": "research/summaries/2026-05-13-twitter-01h-headlines.json",
     "url": "https://x.com/NeelMacro/status/2054334509345308729"
   },
   {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-13 01:00 UTC",
+    "headline": "MICROSOFT RECOUPS 2.3x ON OPENAI \u2014 $30B REVENUE VS $13B INVESTED",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-13-twitter-01h-headlines.json",
+    "url": "https://x.com/theinformation/status/2054308315371393526"
+  },
+  {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-13 01:10 UTC",
+    "delivered_at": "2026-05-13 01:00 UTC",
     "headline": "CLAUDE CODE SHIPS /GOAL + AUTO MODE + STOP HOOK FOR LONG-RUNNING AGENTS",
     "source": "@ClaudeDevs",
+    "source_file": "research/summaries/2026-05-13-twitter-01h-headlines.json",
     "url": "https://x.com/ClaudeDevs/status/2054351031279186040"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-13 01:10 UTC",
+    "delivered_at": "2026-05-13 01:00 UTC",
     "headline": "SEMIANALYSIS FLAGS NAPHTHA AS QUIET AI-CHIP SUPPLY CONSTRAINT AS IRAN CONFLICT PERSISTS",
     "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-05-13-twitter-01h-headlines.json",
     "url": "https://x.com/SemiAnalysis_/status/2054321011110101192"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-13 04:28 UTC",
+    "delivered_at": "2026-05-13 04:00 UTC",
     "headline": "TRUMP CONFIRMS JENSEN HUANG, TIM COOK, MUSK, FINK, SCHWARZMAN, SOLOMON ON AIR FORCE ONE TO BEIJING SUMMIT",
     "source": "@KobeissiLetter",
+    "source_file": "research/summaries/2026-05-13-twitter-04h-headlines.json",
     "url": "https://x.com/KobeissiLetter/status/2054400014684655638"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-13 04:28 UTC",
+    "delivered_at": "2026-05-13 04:00 UTC",
     "headline": "JENSEN HUANG BOARDED AIR FORCE ONE IN ALASKA AFTER LAST-MINUTE PERSONAL CALL FROM TRUMP \u2014 NEXT STOP BEIJING",
     "source": "@ns123abc",
+    "source_file": "research/summaries/2026-05-13-twitter-04h-headlines.json",
     "url": "https://x.com/ns123abc/status/2054384285914697989"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-13 04:28 UTC",
+    "delivered_at": "2026-05-13 04:00 UTC",
     "headline": "TRUMP-XI SUMMIT MAY 14-15 AGENDA: AI CHIP EXPORT CONTROLS, H20/H200/BLACKWELL CARVE-OUT, RARE EARTHS, TAIWAN",
     "source": "@FangChenAI",
+    "source_file": "research/summaries/2026-05-13-twitter-04h-headlines.json",
     "url": "https://x.com/FangChenAI/status/2054355190531367150"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-13 04:28 UTC",
+    "delivered_at": "2026-05-13 04:00 UTC",
     "headline": "SEMIANALYSIS: POSITIVE AMD ROCM FLYWHEEL ALERT \u2014 $3.6M MI355X DEV CLUSTERS OPENED TO vLLM AND SGLANG MAINTAINERS",
     "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-05-13-twitter-04h-headlines.json",
     "url": "https://x.com/SemiAnalysis_/status/2054376780232814849"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-13 04:28 UTC",
+    "delivered_at": "2026-05-13 04:00 UTC",
     "headline": "ANDREW CURRAN TEASES \"THE RETURN OF PROJECT TIGRIS\" \u2014 OPENAI'S $18B BROADCOM CUSTOM-CHIP PLAN POTENTIALLY RESTARTED",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-13-twitter-04h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2054398911255847019"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-13 04:28 UTC",
+    "delivered_at": "2026-05-13 04:00 UTC",
     "headline": "OPENAI CODEX IN-APP BROWSER NOW CONTROLS DEVICE TOOLBAR FOR VIEWPORT-SIZE RESPONSIVE TESTING",
     "source": "@jxnlco",
+    "source_file": "research/summaries/2026-05-13-twitter-04h-headlines.json",
     "url": "https://x.com/jxnlco/status/2054396228780363853"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-13 04:28 UTC",
+    "delivered_at": "2026-05-13 04:00 UTC",
     "headline": "ROON (OPENAI): \"MODELS ARE INTELLIGENT ENOUGH AND NOBODY CAN NOTICE IMPROVEMENTS\" \u2014 A TAKE THAT AGES BADLY",
     "source": "@tszzl",
+    "source_file": "research/summaries/2026-05-13-twitter-04h-headlines.json",
     "url": "https://x.com/tszzl/status/2054354571733205305"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-13 07:19 UTC",
+    "delivered_at": "2026-05-13 07:00 UTC",
     "headline": "OFFICIAL MISTRAL AI SDK COMPROMISED IN MINI SHAI-HULUD WORM \u2014 170+ NPM/PYPI PACKAGES HIT, CVE-2026-45321 ASSIGNED",
     "source": "@ChainPatrol",
+    "source_file": "research/summaries/2026-05-13-twitter-07h-headlines.json",
     "url": "https://x.com/ChainPatrol/status/2054287615583559951"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-13 07:19 UTC",
+    "delivered_at": "2026-05-13 07:00 UTC",
     "headline": "MINI SHAI-HULUD WORM PERSISTS VIA .CLAUDE/SETTINGS.JSON \u2014 NPM UNINSTALL DOES NOT CLEAN; SLSA L3 SIGNED PACKAGES POISONED",
     "source": "@rsensui",
+    "source_file": "research/summaries/2026-05-13-twitter-07h-headlines.json",
     "url": "https://x.com/rsensui/status/2054346772152226105"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-05-13 07:19 UTC",
+    "delivered_at": "2026-05-13 07:00 UTC",
     "headline": "TANSTACK 42 PACKAGES / 84 VERSIONS / 3M WEEKLY DOWNLOADS COMPROMISED \u2014 UIPATH, OPENSEARCH, GUARDRAILS AI ALSO HIT",
     "source": "@TitanSecAI",
+    "source_file": "research/summaries/2026-05-13-twitter-07h-headlines.json",
     "url": "https://x.com/TitanSecAI/status/2054305010452926641"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-13 07:19 UTC",
+    "delivered_at": "2026-05-13 07:00 UTC",
     "headline": "MISTRALAI CORP-CHANNEL SILENT 13 DAYS THROUGH OWN OFFICIAL SDK COMPROMISE \u2014 NO SECURITY ADVISORY POST",
     "source": "@MistralAI",
+    "source_file": "research/summaries/2026-05-13-twitter-07h-headlines.json",
     "url": "https://x.com/MistralAI"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-13 07:19 UTC",
+    "delivered_at": "2026-05-13 07:00 UTC",
     "headline": "TRUMP AF1 LANDS BEIJING \u2014 JENSEN HUANG ALASKA-BOARDING CONFIRMED; ~16 CEOS INCLUDING MUSK + COOK + FINK",
     "source": "@NeelMacro",
+    "source_file": "research/summaries/2026-05-13-twitter-07h-headlines.json",
     "url": "https://x.com/NeelMacro/status/2054441442261745885"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-13 07:19 UTC",
+    "delivered_at": "2026-05-13 07:00 UTC",
     "headline": "NVDA UP +1.7% PRE-MARKET ON TRUMP-JENSEN BEIJING DELEGATION REPORTS \u2014 FIRST MARKETS DATUM ON SUMMIT",
     "source": "@QuantData",
+    "source_file": "research/summaries/2026-05-13-twitter-07h-headlines.json",
     "url": "https://x.com/QuantData/status/2054456460222894099"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-13 07:19 UTC",
+    "delivered_at": "2026-05-13 07:00 UTC",
     "headline": "ANTHROPIC CORP-CHANNEL SILENT ~62 HOURS \u2014 LONGEST 2026 SILENCE THROUGH TRIAL, COLOSSUS 1, HELION, AF1, NPM PERSISTENCE VECTORS",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-13-twitter-07h-headlines.json",
     "url": "https://x.com/AnthropicAI"
   },
   {
+    "backfilled": true,
     "category": "business",
     "delivered_at": "2026-05-13 10:00 UTC",
     "headline": "NYT \u2014 ANTHROPIC IN TALKS TO RAISE $30-50B AT $950B VALUATION, UP FROM $30B/$900B BLOOMBERG 24H PRIOR",
     "source": "@tradfi",
+    "source_file": "research/summaries/2026-05-13-twitter-10h-headlines.json",
     "url": "https://x.com/tradfi/status/2054337290718093371"
   },
   {
+    "backfilled": true,
     "category": "business",
     "delivered_at": "2026-05-13 10:00 UTC",
     "headline": "SOFTBANK FY2026 EARNINGS \u2014 OPENAI MARKED AT $730B; $34.6B CUMULATIVE INVESTED, EXPECTED $64.6B BY OCTOBER",
     "source": "@FirstSquawk",
+    "source_file": "research/summaries/2026-05-13-twitter-10h-headlines.json",
     "url": "https://x.com/FirstSquawk/status/2054451353018298597"
   },
   {
+    "backfilled": true,
     "category": "policy",
     "delivered_at": "2026-05-13 10:00 UTC",
     "headline": "MUSK SELF-CONFIRMS BEIJING TRIP \u2014 'ON MY WAY TO BEIJING IN AIR FORCE ONE' GETS 120K LIKES",
     "source": "@elonmusk",
+    "source_file": "research/summaries/2026-05-13-twitter-10h-headlines.json",
     "url": "https://x.com/elonmusk/status/2054478087611891790"
   },
   {
+    "backfilled": true,
     "category": "business",
     "delivered_at": "2026-05-13 10:00 UTC",
     "headline": "BLOOMBERG \u2014 CEREBRAS GUIDED TO PRICE IPO ABOVE $150-160 RANGE; $4.8B RAISE, 20x OVERSUBSCRIBED",
     "source": "@AIStockSavvy",
+    "source_file": "research/summaries/2026-05-13-twitter-10h-headlines.json",
     "url": "https://x.com/AIStockSavvy/status/2054329881127870864"
   },
   {
+    "backfilled": true,
     "category": "business",
     "delivered_at": "2026-05-13 10:00 UTC",
     "headline": "CEREBRAS S-1 \u2014 OPENAI HOLDS $4.2B WARRANT POSITION AT IPO PRICING",
     "source": "@Sentosaexp",
+    "source_file": "research/summaries/2026-05-13-twitter-10h-headlines.json",
     "url": "https://x.com/Sentosaexp/status/2054325961668362293"
   },
   {
+    "backfilled": true,
     "category": "business",
     "delivered_at": "2026-05-13 10:00 UTC",
     "headline": "SOFTBANK Q4 NET INCOME 1.83T YEN VS 295B EST \u2014 6.2x BEAT DRIVEN BY OPENAI MARK-TO-MARKET",
     "source": "@EmmanuelInvest",
+    "source_file": "research/summaries/2026-05-13-twitter-10h-headlines.json",
     "url": "https://x.com/EmmanuelInvest/status/2054452971369427124"
   },
   {
+    "backfilled": true,
     "category": "opensource",
     "delivered_at": "2026-05-13 10:00 UTC",
     "headline": "SENSETIME OPEN-SOURCES SENSENOVA U1 \u2014 UNIFIED MULTIMODAL MODEL, 8B DENSE + A3B MOE, NO VAE, APACHE 2.0",
     "source": "@Drew_code0",
+    "source_file": "research/summaries/2026-05-13-twitter-10h-headlines.json",
     "url": "https://x.com/Drew_code0/status/2054498840253059147"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-13 12:59 UTC",
+    "delivered_at": "2026-05-13 12:00 UTC",
     "headline": "TRUMP AIR FORCE ONE LANDS BEIJING 8PM LOCAL \u2014 MUSK, COOK, JENSEN, FINK DEPLANE \u2014 FIRST US PRESIDENT IN PRC SINCE 2017",
     "source": "@Artto_artto0301",
+    "source_file": "research/summaries/2026-05-13-twitter-12h-headlines.json",
     "url": "https://x.com/Artto_artto0301/status/2054538304645361865"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-13 12:59 UTC",
+    "delivered_at": "2026-05-13 12:00 UTC",
     "headline": "MIZUHO: NVIDIA RUBIN REVERTS LIQUID-METAL TIM2 TO GRIFFIN COLD PLATE AFTER COOLING INSTABILITY \u2014 LAUNCH-TRAJECTORY FRICTION",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-13-twitter-12h-headlines.json",
     "url": "https://x.com/jukan05/status/2054526842485571787"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-13 12:59 UTC",
+    "delivered_at": "2026-05-13 12:00 UTC",
     "headline": "AJINOMOTO RAISES ABF SUBSTRATE FILM PRICES 30% FROM Q3 2026 \u2014 TAIWAN PACKAGE SUBSTRATE MAKERS NOTIFIED",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-13-twitter-12h-headlines.json",
     "url": "https://x.com/jukan05/status/2054528522593739180"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-13 12:59 UTC",
+    "delivered_at": "2026-05-13 12:00 UTC",
     "headline": "MUSK 'ON MY WAY TO BEIJING IN AIR FORCE ONE' POST HITS 18.6K RT / 303K LIKES \u2014 TOP NON-MEME AI-RELEVANT ENGAGEMENT OF 2026",
     "source": "@elonmusk",
+    "source_file": "research/summaries/2026-05-13-twitter-12h-headlines.json",
     "url": "https://x.com/elonmusk/status/2054478087611891790"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-13 12:59 UTC",
+    "delivered_at": "2026-05-13 12:00 UTC",
     "headline": "KIMMONISMUS: 'WE LIVE IN AN AI IVORY TOWER \u2014 MAJORITY DON'T USE AI AS INTENSIVELY AS WE DO' \u2014 NOT A FINANCIAL BUBBLE",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-13-twitter-12h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2054521650402464186"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-13 12:59 UTC",
+    "delivered_at": "2026-05-13 12:00 UTC",
     "headline": "ANTHROPIC CORP SILENT 68 HOURS THROUGH NYT $950B ROUND UPSIZE, COLOSSUS 1 DEAL, MINI SHAI-HULUD .CLAUDE/SETTINGS.JSON VECTOR",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-13-twitter-12h-headlines.json",
     "url": "https://x.com/AnthropicAI"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-13 15:59 UTC",
+    "delivered_at": "2026-05-13 15:00 UTC",
     "headline": "UK AISI: FRONTIER CYBER-TASK DOUBLING TIME ACCELERATING; NEW MYTHOS PREVIEW CHECKPOINT EXCEEDS PRIOR TREND",
     "source": "@AISecurityInst",
+    "source_file": "research/summaries/2026-05-13-twitter-15h-headlines.json",
     "url": "https://x.com/AISecurityInst/status/2054589758043496567"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-13 15:59 UTC",
+    "delivered_at": "2026-05-13 15:00 UTC",
     "headline": "RAMP AI INDEX: ANTHROPIC PASSES OPENAI IN BUSINESS ADOPTION FOR THE FIRST TIME \u2014 34.4% VS 32.3% IN APRIL",
     "source": "@arakharazian",
+    "source_file": "research/summaries/2026-05-13-twitter-15h-headlines.json",
     "url": "https://x.com/arakharazian/status/2054563750548492549"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-13 15:59 UTC",
+    "delivered_at": "2026-05-13 15:00 UTC",
     "headline": "INFORMATION EXCLUSIVE: ANTHROPIC IN ADVANCED TALKS TO ACQUIRE STAINLESS FOR AT LEAST $300M",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-13-twitter-15h-headlines.json",
     "url": "https://x.com/theinformation/status/2054569912656384446"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-13 15:59 UTC",
+    "delivered_at": "2026-05-13 15:00 UTC",
     "headline": "BLOOMBERG: ARM AND SOFTBANK TRIED TO ACQUIRE CEREBRAS WEEKS BEFORE IPO; OFFER REJECTED",
     "source": "@business",
+    "source_file": "research/summaries/2026-05-13-twitter-15h-headlines.json",
     "url": "https://x.com/business/status/2054587489713639845"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-13 15:59 UTC",
+    "delivered_at": "2026-05-13 15:00 UTC",
     "headline": "ANTHROPIC GRANTS MYTHOS ACCESS TO MUFG, SUMITOMO MITSUI, MIZUHO \u2014 JFSA / BOJ TASK FORCE FRAMEWORK",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-13-twitter-15h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2054561200017666495"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-13 15:59 UTC",
+    "delivered_at": "2026-05-13 15:00 UTC",
     "headline": "MIZUHO: APPLE-INTEL DECEMBER 2025 FOUNDRY DEAL \u2014 M7 ON 18A-P (2027), SMARTPHONE CHIP ON 14A (2028)",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-13-twitter-15h-headlines.json",
     "url": "https://x.com/jukan05/status/2054564780732498342"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-13 15:59 UTC",
+    "delivered_at": "2026-05-13 15:00 UTC",
     "headline": "INFORMATION: OPENAI-MICROSOFT REV-SHARE CAP AT $38B THROUGH 2030 \u2014 SAVES OPENAI ~$97B IF GROWTH TARGETS HIT",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-13-twitter-15h-headlines.json",
     "url": "https://x.com/theinformation/status/2054554784389022173"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-13 18:50 UTC",
+    "delivered_at": "2026-05-13 18:00 UTC",
     "headline": "ANTHROPIC SPLITS CLAUDE CODE PROGRAMMATIC USAGE INTO SEPARATE MONTHLY CREDIT \u2014 AGENT SDK, CLAUDE -P, GITHUB ACTIONS, CONDUCTOR ALL MOVE JUNE 15",
     "source": "@ClaudeDevs",
+    "source_file": "research/summaries/2026-05-13-twitter-18h-headlines.json",
     "url": "https://x.com/ClaudeDevs/status/2054610152817619388"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-13 18:50 UTC",
+    "delivered_at": "2026-05-13 18:00 UTC",
     "headline": "ALTMAN BREAKS 91-HOUR SILENCE: 2 MONTHS OF FREE CODEX FOR ANY COMPANY SWITCHING IN NEXT 30 DAYS",
     "source": "@sama",
+    "source_file": "research/summaries/2026-05-13-twitter-18h-headlines.json",
     "url": "https://x.com/sama/status/2054626219858293128"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-13 18:50 UTC",
+    "delivered_at": "2026-05-13 18:00 UTC",
     "headline": "OPENAI TAUNTS ANTHROPIC 41 MINUTES AFTER CLAUDE CODE PRICING CHANGE: 'ANOTHER REASON TO SWITCH TO CODEX'",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-05-13-twitter-18h-headlines.json",
     "url": "https://x.com/OpenAI/status/2054620621255192719"
   },
   {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-05-13 18:00 UTC",
+    "headline": "UK AISI: FRONTIER AI CYBER-TASK DOUBLING TIME NOW 4 MONTHS WITH MYTHOS \u2014 MYTHOS PREVIEW COMPLETES ALL 8H+ TASKS 100%",
+    "source": "@AISecurityInst",
+    "source_file": "research/summaries/2026-05-13-twitter-18h-headlines.json",
+    "url": "https://x.com/AISecurityInst/status/2054589758043496567"
+  },
+  {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-13 18:50 UTC",
+    "delivered_at": "2026-05-13 18:00 UTC",
     "headline": "ANDURIL CLOSES $5B AT $61B VALUATION \u2014 DOUBLES IN ~9 MONTHS; THRIVE + A16Z LEAD; IPO 'IN THE NEXT YEAR' FLOATED",
     "source": "@etnshow",
+    "source_file": "research/summaries/2026-05-13-twitter-18h-headlines.json",
     "url": "https://x.com/etnshow/status/2054515028410028361"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-13 18:50 UTC",
+    "delivered_at": "2026-05-13 18:00 UTC",
     "headline": "QWEN EX-LEAD JUNYANG LIN RAISING SEVERAL HUNDRED MILLION AT $2B PRE-PRODUCT \u2014 UNPRECEDENTED CHINA AI-LAB MARK",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-13-twitter-18h-headlines.json",
     "url": "https://x.com/theinformation/status/2054615187957666218"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-13 18:50 UTC",
+    "delivered_at": "2026-05-13 18:00 UTC",
     "headline": "DDR4 PRICES IN CHINA'S HUAQIANGBEI JUMP 20% AHEAD OF SAMSUNG MAY-21 STRIKE \u2014 DOWNSTREAM TIGHTNESS NOW VISIBLE",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-13-twitter-18h-headlines.json",
     "url": "https://x.com/jukan05/status/2054623591749099947"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-13 21:41 UTC",
+    "delivered_at": "2026-05-13 21:00 UTC",
     "headline": "CEREBRAS PRICES IPO AT $185 \u2014 60% ABOVE INITIAL RANGE, 20-25\u00d7 OVERSUBSCRIBED, $5.55B RAISED, ~$49-56B FDV \u2014 LARGEST 2026 IPO",
     "source": "@StockMKTNewz",
+    "source_file": "research/summaries/2026-05-13-twitter-21h-headlines.json",
     "url": "https://x.com/StockMKTNewz/status/2054677097737179357"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-13 21:41 UTC",
+    "delivered_at": "2026-05-13 21:00 UTC",
     "headline": "CLAUDE CODE WEEKLY LIMITS +50% THROUGH JULY 13 \u2014 ANTHROPIC COUNTER-STRIKES SAMA CODEX BOUNTY 54 MINUTES LATER",
     "source": "@ClaudeDevs",
+    "source_file": "research/summaries/2026-05-13-twitter-21h-headlines.json",
     "url": "https://x.com/ClaudeDevs/status/2054634392128159779"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-13 21:41 UTC",
+    "delivered_at": "2026-05-13 21:00 UTC",
     "headline": "ANTHROPIC OVERTAKES OPENAI IN RAMP BUSINESS-ADOPTION FOR FIRST TIME \u2014 34.4% VS 32.3%",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-13-twitter-21h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2054632325531558319"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-13 21:41 UTC",
+    "delivered_at": "2026-05-13 21:00 UTC",
     "headline": "CEREBRAS PRE-MARKET ON BULLPEN AT ~$295/SHARE \u2014 60% PREMIUM TO $185 IPO PRICE",
     "source": "@BullpenFi",
+    "source_file": "research/summaries/2026-05-13-twitter-21h-headlines.json",
     "url": "https://x.com/BullpenFi/status/2054683130878304266"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-13 21:41 UTC",
+    "delivered_at": "2026-05-13 21:00 UTC",
     "headline": "VERCEL AI GATEWAY: GOOGLE KING OF PRODUCTION SCALE, ANTHROPIC DOMINATES CODING & SPEND, OPENAI GROWING FAST SINCE GPT-5.4",
     "source": "@rauchg",
+    "source_file": "research/summaries/2026-05-13-twitter-21h-headlines.json",
     "url": "https://x.com/rauchg/status/2054683691380486316"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-13 21:41 UTC",
+    "delivered_at": "2026-05-13 21:00 UTC",
     "headline": "GEMINI 3 FLASH LEADS ACROSS AI MODELS IN TOKEN USAGE \u2014 VERCEL AI GATEWAY VIA BUSINESS INSIDER",
     "source": "@rauchg",
+    "source_file": "research/summaries/2026-05-13-twitter-21h-headlines.json",
     "url": "https://x.com/rauchg/status/2054678529383219476"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-13 21:41 UTC",
+    "delivered_at": "2026-05-13 21:00 UTC",
     "headline": "ANTHROPIC ARR REACHES $44B \u2014 SURPASSING OPENAI PER AGGREGATOR ESTIMATES (\u26a0 SINGLE-SOURCE)",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-13-twitter-21h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2054634191455408173"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-14 01:11 UTC",
+    "delivered_at": "2026-05-14 01:00 UTC",
     "headline": "THEO ESCALATES \u2014 CLAUDE CODE SDK RATE-LIMIT CUT NOW '40X', CALLS ANTHROPIC STATEMENTS 'A LIE ON A TIMER'",
     "source": "@theo",
+    "source_file": "research/summaries/2026-05-14-twitter-01h-headlines.json",
     "url": "https://x.com/theo/status/2054731856248283318"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-14 01:11 UTC",
+    "delivered_at": "2026-05-14 01:00 UTC",
     "headline": "CONDUCTOR DISCLOSES ANTHROPIC PROGRAMMATIC CREDIT CAP \u2014 $200/MO ON MAX SUBSCRIPTION, THEN API COSTS",
     "source": "@charlieholtz",
+    "source_file": "research/summaries/2026-05-14-twitter-01h-headlines.json",
     "url": "https://x.com/charlieholtz/status/2054695769916264638"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-14 01:11 UTC",
+    "delivered_at": "2026-05-14 01:00 UTC",
     "headline": "APPLE INTERNAL TEAM REDESIGNING APP STORE AS 'AGENT STORE' WHILE BLOCKING REPLIT / ANYTHING VIBE-CODING APPS",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-14-twitter-01h-headlines.json",
     "url": "https://x.com/theinformation/status/2054690367983722562"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-14 01:11 UTC",
+    "delivered_at": "2026-05-14 01:00 UTC",
     "headline": "ANTHROPIC GLASSWING LEAD: 'COMPUTE HAS NEVER BEEN A LIMITER' \u2014 DIRECTLY CONTRADICTS COLOSSUS 1 SUPPLY-SIDE FRAMING",
     "source": "@logangraham",
+    "source_file": "research/summaries/2026-05-14-twitter-01h-headlines.json",
     "url": "https://x.com/logangraham/status/2054613618168082935"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-14 01:11 UTC",
+    "delivered_at": "2026-05-14 01:00 UTC",
     "headline": "UK AISI: CLAUDE MYTHOS PREVIEW FIRST MODEL TO SOLVE 'COOLING TOWER' END-TO-END CYBER RANGE",
     "source": "@bcherny",
+    "source_file": "research/summaries/2026-05-14-twitter-01h-headlines.json",
     "url": "https://x.com/bcherny/status/2054617810253615147"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-14 01:11 UTC",
+    "delivered_at": "2026-05-14 01:00 UTC",
     "headline": "SEMIANALYSIS DEFENDS OPUS 4.7 FAST MODE PRICING AS PARETO-FRONTIER-CORRECT \u2014 '2.5X SPEED AT 6X COST' IS NOT ARBITRARY",
     "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-05-14-twitter-01h-headlines.json",
     "url": "https://x.com/SemiAnalysis_/status/2054713648489132310"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-14 01:11 UTC",
+    "delivered_at": "2026-05-14 01:00 UTC",
     "headline": "FTV CAPITAL'S BERNSTEIN: AI BOOM MAY BE 'FALSE POSITIVE' \u2014 SUBSIDIZED EARLY-ADOPTION DEMAND COULD GO AWAY",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-14-twitter-01h-headlines.json",
     "url": "https://x.com/theinformation/status/2054713485599121552"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-14 04:27 UTC",
+    "delivered_at": "2026-05-14 04:00 UTC",
     "headline": "VERGE SOURCES: GOOGLE TO UNVEIL NEW GEMINI AT I/O TUESDAY MAY 19 \u2014 \"ON PAR WITH GPT-5.5 BUT SHORT OF MYTHOS\"",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-14-twitter-04h-headlines.json",
     "url": "https://x.com/jukan05/status/2054751022749278651"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-14 04:27 UTC",
+    "delivered_at": "2026-05-14 04:00 UTC",
     "headline": "POLYMARKET \"GEMINI 3.5 BY MAY 31\" JUMPS 14% TO 24% IN 30 MINUTES ON HEATH SCOOP",
     "source": "@PolymarketWire",
+    "source_file": "research/summaries/2026-05-14-twitter-04h-headlines.json",
     "url": "https://x.com/PolymarketWire/status/2054780719126151431"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-14 04:27 UTC",
+    "delivered_at": "2026-05-14 04:00 UTC",
     "headline": "MUSK, TIM COOK, JENSEN HUANG, BOEING'S ORTBERG SEATED IN TRUMP-XI BILATERAL ROOM IN BEIJING \u2014 NOT SIDE MEETING",
     "source": "@jiemian_news",
+    "source_file": "research/summaries/2026-05-14-twitter-04h-headlines.json",
     "url": "https://x.com/jiemian_news/status/2054778828346593770"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-14 04:27 UTC",
+    "delivered_at": "2026-05-14 04:00 UTC",
     "headline": "XI TO TRUMP IN BEIJING: CHINA AND U.S. SHOULD BE PARTNERS INSTEAD OF RIVALS \u2014 2026 \"HISTORIC, LANDMARK YEAR\"",
     "source": "@jiemian_news",
+    "source_file": "research/summaries/2026-05-14-twitter-04h-headlines.json",
     "url": "https://x.com/jiemian_news/status/2054772329348014130"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-14 04:27 UTC",
+    "delivered_at": "2026-05-14 04:00 UTC",
     "headline": "OPENAI BACKS U.S.-LED IAEA-STYLE GLOBAL AI GOVERNANCE BODY INCLUDING CHINA \u2014 TIMED FOR TRUMP-XI SUMMIT",
     "source": "@firstpost",
+    "source_file": "research/summaries/2026-05-14-twitter-04h-headlines.json",
     "url": "https://x.com/firstpost/status/2054777252802679073"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-14 04:27 UTC",
+    "delivered_at": "2026-05-14 04:00 UTC",
     "headline": "GALLUP: 71% OF AMERICANS NOW OPPOSE LOCAL DATACENTER CONSTRUCTION \u2014 TOPS ALL-TIME-HIGH ANTI-NUCLEAR-PLANT OPPOSITION",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-14-twitter-04h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2054747948110753817"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-14 04:27 UTC",
+    "delivered_at": "2026-05-14 04:00 UTC",
     "headline": "HCLTECH TO LEAD $300M SARVAM AI ROUND AT $1.5B VALUATION WITH $150M BET \u2014 FIRST INDIAN AI UNICORN",
     "source": "@chandrarsrikant",
+    "source_file": "research/summaries/2026-05-14-twitter-04h-headlines.json",
     "url": "https://x.com/chandrarsrikant/status/2054776802552447393"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-14 07:16 UTC",
+    "delivered_at": "2026-05-14 07:00 UTC",
     "headline": "US CLEARS ~10 CHINESE FIRMS \u2014 ALIBABA, TENCENT, BYTEDANCE, JD \u2014 TO BUY NVIDIA H200s, UP TO 75K CHIPS EACH",
     "source": "@dnystedt",
+    "source_file": "research/summaries/2026-05-14-twitter-07h-headlines.json",
     "url": "https://x.com/dnystedt/status/2054811340267733033"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-14 07:16 UTC",
+    "delivered_at": "2026-05-14 07:00 UTC",
     "headline": "H200 CHINA APPROVALS LAND BUT ZERO CHIPS SHIPPED \u2014 BEIJING URGING FIRMS TO HOLD OFF, PUSH HUAWEI",
     "source": "@fbermingham",
+    "source_file": "research/summaries/2026-05-14-twitter-07h-headlines.json",
     "url": "https://x.com/fbermingham/status/2054818536141279625"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-14 07:16 UTC",
+    "delivered_at": "2026-05-14 07:00 UTC",
     "headline": "GALLUP: 70% OF AMERICANS OPPOSE A DATACENTER NEARBY \u2014 MORE THAN OPPOSE A NUCLEAR PLANT",
     "source": "@washingtonpost",
+    "source_file": "research/summaries/2026-05-14-twitter-07h-headlines.json",
     "url": "https://x.com/washingtonpost/status/2054607684054253901"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-14 07:16 UTC",
+    "delivered_at": "2026-05-14 07:00 UTC",
     "headline": "EX-QWEN TECH LEAD JUNYANG LIN RAISING FOR NEW AI LAB AT ~$2B VALUATION \u2014 PRE-PRODUCT",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-14-twitter-07h-headlines.json",
     "url": "https://x.com/theinformation/status/2054645118758433089"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-14 07:16 UTC",
+    "delivered_at": "2026-05-14 07:00 UTC",
     "headline": "ANTHROPIC PASSES OPENAI IN BUSINESS ADOPTION FIRST TIME \u2014 34.4% VS 32.3% IN APRIL (RAMP)",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-14-twitter-07h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2054582686698848294"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-14 12:51 UTC",
+    "delivered_at": "2026-05-14 12:00 UTC",
     "headline": "MICROSOFT IN TALKS TO ACQUIRE DIFFUSION-LLM LAB INCEPTION \u2014 REUTERS SAYS >$1B ASK, SPACEX ALSO COURTING",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-14-twitter-12h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2054863887200047340"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-14 12:51 UTC",
+    "delivered_at": "2026-05-14 12:00 UTC",
     "headline": "GOOGLE I/O LEAK CASCADE GROWS: 'GEMINI 3.2 FLASH' RUMORED AT 92% OF GPT-5.5 CODING, 15-20X CHEAPER \u2014 UNVERIFIED",
     "source": "@bindureddy",
+    "source_file": "research/summaries/2026-05-14-twitter-12h-headlines.json",
     "url": "https://x.com/bindureddy/status/2054767771418861964"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-14 12:51 UTC",
+    "delivered_at": "2026-05-14 12:00 UTC",
     "headline": "ELON'S 'XAI VOICE CLONING NOW LIVE' RT IS A 13-DAY-OLD RE-AMPLIFICATION \u2014 ORIGINAL @XAI POST DATED MAY 1",
     "source": "@elonmusk",
+    "source_file": "research/summaries/2026-05-14-twitter-12h-headlines.json",
     "url": "https://x.com/elonmusk/status/2054885432635310538"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-14 15:56 UTC",
+    "delivered_at": "2026-05-14 15:00 UTC",
     "headline": "CEREBRAS PRICES IPO AT $185/SHARE, RAISES $5.55B AT ~$56.4B VALUATION \u2014 LARGEST US IPO OF 2026",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-14-twitter-15h-headlines.json",
     "url": "https://x.com/theinformation/status/2054948731099689317"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-14 15:56 UTC",
+    "delivered_at": "2026-05-14 15:00 UTC",
     "headline": "CEREBRAS $CBRS INDICATED TO OPEN NEAR 2X IPO PRICE, IMPLYING ~$100B+ EQUITY VALUE; OPENAI IS ANCHOR CUSTOMER",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-14-twitter-15h-headlines.json",
     "url": "https://x.com/theinformation/status/2054948731099689317"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-14 15:56 UTC",
+    "delivered_at": "2026-05-14 15:00 UTC",
     "headline": "ANTHROPIC COMMITS $200M IN GRANTS AND CLAUDE CREDITS TO GATES FOUNDATION, BREAKS ~4-DAY CORP SILENCE",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-14-twitter-15h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2054941901900611787"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-14 15:56 UTC",
+    "delivered_at": "2026-05-14 15:00 UTC",
     "headline": "NVIDIA H100 SALES AND RTX 5090/PRO 6000 IMPORTS REPORTEDLY UNDERWAY IN CHINA; H200 APPROVED",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-14-twitter-15h-headlines.json",
     "url": "https://x.com/jukan05/status/2054947159104249988"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-14 18:48 UTC",
+    "delivered_at": "2026-05-14 18:00 UTC",
     "headline": "THE INFORMATION: 50+ RESEARCHERS HAVE LEFT XAI SINCE FEBRUARY SPACEX ACQUISITION",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-14-twitter-18h-headlines.json",
     "url": "https://x.com/theinformation/status/2054992677662277976"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-14 18:48 UTC",
+    "delivered_at": "2026-05-14 18:00 UTC",
     "headline": "XAI'S CODING, WORLD-MODELS AND GROK-VOICE LEADS EXITED IN PAST TWO WEEKS \u2014 11 TO META, 7 TO THINKING MACHINES",
     "source": "@theo_wayt",
+    "source_file": "research/summaries/2026-05-14-twitter-18h-headlines.json",
     "url": "https://x.com/theo_wayt/status/2054991239112491111"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-14 18:48 UTC",
+    "delivered_at": "2026-05-14 18:00 UTC",
     "headline": "XAI SHIPS GROK BUILD \u2014 AGENTIC CODING CLI WITH SKILLS, SUBAGENTS, PLANNING MODE FOR SUPERGROK HEAVY",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-14-twitter-18h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2054995084106457140"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-14 18:48 UTC",
+    "delivered_at": "2026-05-14 18:00 UTC",
     "headline": "ANTHROPIC'S MYTHOS 'CRACKED MACOS IN FIVE DAYS' \u2014 GATED MODEL FINDS VULNERABILITIES BYPASSING APPLE PROTECTIONS",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-14-twitter-18h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2054975129621495973"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-14 18:48 UTC",
+    "delivered_at": "2026-05-14 18:00 UTC",
     "headline": "OPENAI HIT WITH CLASS-ACTION PRIVACY SUIT IN SDCA OVER CHATGPT TRACKING PIXELS \u2014 VIRAL FRAMING IS PLAINTIFF ALLEGATION",
     "source": "@cb_doge",
+    "source_file": "research/summaries/2026-05-14-twitter-18h-headlines.json",
     "url": "https://x.com/cb_doge/status/2054972944645009651"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-14 18:48 UTC",
+    "delivered_at": "2026-05-14 18:00 UTC",
     "headline": "ANTHROPIC PUBLISHES US-CHINA AI COMPETITION PAPER: 'US AND DEMOCRATIC ALLIES HOLD THE FRONTIER LEAD TODAY'",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-14-twitter-18h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2054987444664377374"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-14 18:48 UTC",
+    "delivered_at": "2026-05-14 18:00 UTC",
     "headline": "CHINA BLOCKS META'S ~$2B ACQUISITION OF AI STARTUP MANUS",
     "source": "@IndiaToday",
+    "source_file": "research/summaries/2026-05-14-twitter-18h-headlines.json",
     "url": "https://x.com/IndiaToday/status/2054993104789442779"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-14 21:35 UTC",
+    "delivered_at": "2026-05-14 21:00 UTC",
     "headline": "OPENAI SHIPS CODEX INSIDE THE CHATGPT MOBILE APP \u2014 REMOTE-CONTROL AGENTIC CODING FROM YOUR PHONE",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-05-14-twitter-21h-headlines.json",
     "url": "https://x.com/OpenAI/status/2055016850849993072"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-14 21:35 UTC",
+    "delivered_at": "2026-05-14 21:00 UTC",
     "headline": "CODEX MOBILE ROLLING OUT TODAY ON IOS AND ANDROID IN ALL SUPPORTED REGIONS \u2014 SAM ALTMAN CONFIRMS",
     "source": "@sama",
+    "source_file": "research/summaries/2026-05-14-twitter-21h-headlines.json",
     "url": "https://x.com/sama/status/2055034461591588916"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-14 21:35 UTC",
+    "delivered_at": "2026-05-14 21:00 UTC",
+    "headline": "XAI PUSHES GROK BUILD CLI INTO OPEN BETA \u2014 SKILLS, SUBAGENTS, PLUGINS, PLANNING MODE FOR GROK HEAVY",
+    "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-14-twitter-21h-headlines.json",
+    "url": "https://x.com/testingcatalog/status/2054995084106457140"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-05-14 21:00 UTC",
     "headline": "MUSK RUNS FULL AMPLIFICATION BLAST FOR GROK BUILD: 'TRY THIS EARLY BETA AND LET US KNOW WHAT TO IMPROVE'",
     "source": "@elonmusk",
+    "source_file": "research/summaries/2026-05-14-twitter-21h-headlines.json",
     "url": "https://x.com/elonmusk/status/2055008501722943750"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-14 21:35 UTC",
+    "delivered_at": "2026-05-14 21:00 UTC",
     "headline": "CEREBRAS CLOSES NASDAQ DEBUT UP ~68% AT A ~$95-100B VALUATION \u2014 TWO CO-FOUNDERS NOW BILLIONAIRES",
     "source": "@ainews_24_7",
+    "source_file": "research/summaries/2026-05-14-twitter-21h-headlines.json",
     "url": "https://x.com/ainews_24_7/status/2055036491907108937"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-15 01:09 UTC",
+    "delivered_at": "2026-05-15 01:00 UTC",
     "headline": "ANTHROPIC STATUS PAGE CONFIRMS CLAUDE API + CLAUDE CODE PARTIAL OUTAGE \u2014 ELEVATED ERROR RATES AT 01:06 UTC",
     "source": "status.anthropic.com",
+    "source_file": "research/summaries/2026-05-15-twitter-01h-headlines.json",
     "url": "https://status.anthropic.com"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-15 01:09 UTC",
+    "delivered_at": "2026-05-15 01:00 UTC",
     "headline": "ANTHROPIC PUBLISHES US-CHINA AI-COMPETITION POLICY PAPER DURING TRUMP-XI SUMMIT, BREAKING ~48H CORP-CHANNEL SILENCE",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-15-twitter-01h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2054987444664377374"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-15 01:09 UTC",
+    "delivered_at": "2026-05-15 01:00 UTC",
     "headline": "OPENAI WEIGHING LEGAL CHALLENGE AGAINST APPLE OVER UNDERPERFORMING PARTNERSHIP \u2014 THE INFORMATION",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-15-twitter-01h-headlines.json",
     "url": "https://x.com/theinformation/status/2055023348489289978"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-15 01:09 UTC",
+    "delivered_at": "2026-05-15 01:00 UTC",
     "headline": "OPENAI SHIPS CODEX IN THE CHATGPT MOBILE APP \u2014 PREVIEW ON IOS AND ANDROID, ALL REGIONS",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-05-15-twitter-01h-headlines.json",
     "url": "https://x.com/OpenAI/status/2055016850849993072"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-15 01:09 UTC",
+    "delivered_at": "2026-05-15 01:00 UTC",
     "headline": "XAI CO-FOUNDER IGOR BABUSCHKIN IN TALKS TO RAISE UP TO $1B AT $5B VALUATION FOR NEW AI RESEARCH STARTUP \u2014 FORBES",
     "source": "@Techmeme",
+    "source_file": "research/summaries/2026-05-15-twitter-01h-headlines.json",
     "url": "https://x.com/Techmeme/status/2055089731520847885"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-15 04:31 UTC",
+    "delivered_at": "2026-05-15 01:00 UTC",
+    "headline": "ANTHROPIC COMMITS $200M IN GRANTS, CLAUDE CREDITS AND SUPPORT TO GATES FOUNDATION GLOBAL-DEVELOPMENT PROGRAMS",
+    "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-15-twitter-01h-headlines.json",
+    "url": "https://x.com/AnthropicAI/status/2054941901900611787"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-15 04:00 UTC",
     "headline": "CEREBRAS $CBRS DAY 1 CLOSES +68% AT $311.07 \u2014 LARGEST US TECH IPO SINCE UBER 2019",
     "source": "@Trace_Cohen",
+    "source_file": "research/summaries/2026-05-15-twitter-04h-headlines.json",
     "url": "https://x.com/Trace_Cohen/status/2055102574638858603"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-15 04:31 UTC",
+    "delivered_at": "2026-05-15 04:00 UTC",
     "headline": "OPENAI HOLDS S-1-DISCLOSED CEREBRAS WARRANT WORTH ~$10B AT DAY 1 CLOSE \u2014 CUSTOMER IS THE SHAREHOLDER",
     "source": "@TheGeorgePu",
+    "source_file": "research/summaries/2026-05-15-twitter-04h-headlines.json",
     "url": "https://x.com/TheGeorgePu/status/2055144728568426585"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-15 04:31 UTC",
+    "delivered_at": "2026-05-15 04:00 UTC",
     "headline": "BLOOMBERG: OPENAI LAWYERS WITH OUTSIDE FIRM PREPARING BREACH-OF-CONTRACT NOTICE AGAINST APPLE",
     "source": "@faststocknewss",
+    "source_file": "research/summaries/2026-05-15-twitter-04h-headlines.json",
     "url": "https://x.com/faststocknewss/status/2054967486895018011"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-15 04:31 UTC",
+    "delivered_at": "2026-05-15 04:00 UTC",
     "headline": "APPLE iOS 27 TO OPEN SIRI TO CLAUDE AND GEMINI \u2014 WWDC REVEAL JUNE 8",
     "source": "@wallstengine",
+    "source_file": "research/summaries/2026-05-15-twitter-04h-headlines.json",
     "url": "https://x.com/wallstengine/status/2054996761413145051"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-15 04:31 UTC",
+    "delivered_at": "2026-05-15 04:00 UTC",
     "headline": "ANTHROPIC CLAUDE API + CLAUDE CODE OUTAGE RESOLVED \u2014 STATUS PAGE NOW ALL SYSTEMS OPERATIONAL, NO RCA",
     "source": "status.claude.com",
+    "source_file": "research/summaries/2026-05-15-twitter-04h-headlines.json",
     "url": "https://status.claude.com"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-15 04:31 UTC",
+    "delivered_at": "2026-05-15 04:00 UTC",
     "headline": "ANTHROPIC SIGNS $1.8B COMPUTE DEAL WITH AKAMAI \u2014 ASIA SUPPLY-CHAIN ROUNDUP",
     "source": "@tengyanAI",
+    "source_file": "research/summaries/2026-05-15-twitter-04h-headlines.json",
     "url": "https://x.com/tengyanAI/status/2055144737011888187"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-15 07:23 UTC",
+    "delivered_at": "2026-05-15 07:00 UTC",
     "headline": "ANTHROPIC SIGNS TERM SHEET FOR $30B ROUND AT $900B PRE-MONEY \u2014 GREENOAKS, SEQUOIA, ALTIMETER, DRAGONEER CO-LEADING AT ~$2B EACH (FT)",
     "source": "@GeorgeNHammond",
+    "source_file": "research/summaries/2026-05-15-twitter-07h-headlines.json",
     "url": "https://x.com/GeorgeNHammond/status/2055090944245211523"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-15 07:23 UTC",
+    "delivered_at": "2026-05-15 07:00 UTC",
     "headline": "BESSENT ON CNBC: 'THE TWO AI SUPERPOWERS ARE GOING TO START TALKING' \u2014 US-CHINA TO SET UP PROTOCOL ON NON-STATE-ACTOR MODEL ACCESS",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-15-twitter-07h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2055130198778245188"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-15 07:23 UTC",
+    "delivered_at": "2026-05-15 07:00 UTC",
     "headline": "BABUSCHKIN'S XAI-COFOUNDER SPINOUT NAMED 'RIVER AI' \u2014 RAISING UP TO $1B AT UP TO $5B VALUATION",
     "source": "@MTSlive",
+    "source_file": "research/summaries/2026-05-15-twitter-07h-headlines.json",
     "url": "https://x.com/MTSlive/status/2055145185546494338"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-15 07:23 UTC",
+    "delivered_at": "2026-05-15 07:00 UTC",
     "headline": "ARK / CATHIE WOOD BOUGHT 105,616 $CBRS SHARES ON IPO DAY 1 \u2014 DAY 2 OPEN AT 13:30 UTC IS THE READ",
     "source": "@StockMKTNewz",
+    "source_file": "research/summaries/2026-05-15-twitter-07h-headlines.json",
     "url": "https://x.com/StockMKTNewz/status/2055078027835412764"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-15 07:23 UTC",
+    "delivered_at": "2026-05-15 07:00 UTC",
     "headline": "GEMINI SPARK LEAK: 'AGENT MODE / CHAT MODE' SPLIT AHEAD OF GOOGLE I/O MAY 19 \u2014 POLYMARKET 85% ON GEMINI 3.5 BY JUNE 30",
     "source": "@chetaslua",
+    "source_file": "research/summaries/2026-05-15-twitter-07h-headlines.json",
     "url": "https://x.com/chetaslua/status/2055179136910708877"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-15 07:23 UTC",
+    "delivered_at": "2026-05-15 07:00 UTC",
     "headline": "TRUMP-XI JOINT STATEMENT: THREE IRAN CLAUSES, ZERO TAIWAN CLAUSES \u2014 IRAN 'SHOULD NEVER HAVE NUCLEAR WEAPONS'",
     "source": "@InsiderGeo",
+    "source_file": "research/summaries/2026-05-15-twitter-07h-headlines.json",
     "url": "https://x.com/InsiderGeo/status/2055027060465103210"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-15 09:59 UTC",
+    "delivered_at": "2026-05-15 09:00 UTC",
     "headline": "GOOGLE \"GEMINI SPARK\" LEAKS IN WEB APP \u2014 SKILLS-CREATION FLOW, ALWAYS-ON AGENT, 4 DAYS BEFORE I/O",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-15-twitter-09h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2055217411427549414"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-15 09:59 UTC",
+    "delivered_at": "2026-05-15 09:00 UTC",
     "headline": "GEMINI SPARK ONBOARDING COPY: AGENT \"MAY SHARE YOUR INFO OR MAKE PURCHASES WITHOUT ASKING\"",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-15-twitter-09h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2055217414967574832"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-15 09:59 UTC",
+    "delivered_at": "2026-05-15 09:00 UTC",
     "headline": "ANTHROPIC ANNUALIZED REVENUE HITS ~$45B \u2014 5X END-OF-2025; PAIRED WITH $350B \u2192 $900B IN 3 MONTHS",
     "source": "@StockMKTNewz",
+    "source_file": "research/summaries/2026-05-15-twitter-09h-headlines.json",
     "url": "https://x.com/StockMKTNewz/status/2055115379026882631"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-15 09:59 UTC",
+    "delivered_at": "2026-05-15 09:00 UTC",
     "headline": "REPLIT RECONCILES WITH APPLE \u2014 SHIPS FIRST iOS UPDATE IN 4 MONTHS WITH AGENT 4",
     "source": "@amasad",
+    "source_file": "research/summaries/2026-05-15-twitter-09h-headlines.json",
     "url": "https://x.com/amasad/status/2055185058282226146"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-15 09:59 UTC",
+    "delivered_at": "2026-05-15 09:00 UTC",
     "headline": "TREASURY SEC BESSENT TO CNBC: ANTICIPATES \"STEP-FUNCTION JUMP\" IN UPCOMING GEMINI AND OPENAI MODEL RELEASES",
     "source": "@CNBC",
+    "source_file": "research/summaries/2026-05-15-twitter-09h-headlines.json",
     "url": "https://x.com/CNBC/status/2054877454666436737"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-15 09:59 UTC",
+    "delivered_at": "2026-05-15 09:00 UTC",
     "headline": "CLICKUP BRAIN SHIPS WITH CLAUDE OPUS 4.7, GPT-5.5, GEMINI 3.1 PRO ALL SELECTABLE \u2014 IN-PRODUCT MODEL ROSTER CONFIRMED",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-15-twitter-09h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2055190145955983453"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-15 09:59 UTC",
+    "delivered_at": "2026-05-15 09:00 UTC",
     "headline": "QUALCOMM REPORTEDLY SHIPPING LPU-CLASS AI ASIC TO CHINESE CSP BY END-2026 \u2014 ~1M UNITS, ~$4K ASP",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-15-twitter-09h-headlines.json",
     "url": "https://x.com/jukan05/status/2055079495774949439"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-15 12:50 UTC",
+    "delivered_at": "2026-05-15 12:00 UTC",
     "headline": "OPENAI LEAK \u2014 CODEX TO GET 'LOCKED USE' TOGGLE: AGENT KEEPS WORKING ON YOUR MAC AFTER YOU CLOSE THE LID",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-15-twitter-12h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2055252994640290178"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-15 12:50 UTC",
+    "delivered_at": "2026-05-15 12:00 UTC",
     "headline": "ANTHROPIC SILENT 19 HOURS ON CORP CHANNEL, 38 DAYS ON CEO \u2014 NO ON-RECORD ON FT $30B/$900B ROUND",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-15-twitter-12h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2054987444664377374"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-15 12:50 UTC",
+    "delivered_at": "2026-05-15 12:00 UTC",
     "headline": "THE INFORMATION: ANTHROPIC SHOWING REAL PRICING POWER \u2014 CUSTOMERS KEEP PAYING FOR CLAUDE DESPITE COST SPIKES",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-15-twitter-12h-headlines.json",
     "url": "https://x.com/theinformation/status/2055264452648325523"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-15 12:50 UTC",
+    "delivered_at": "2026-05-15 12:00 UTC",
     "headline": "FT-VIA-AGGREGATORS: ANTHROPIC ARR $9B \u2192 $45B IN 5 MONTHS; VALUATION $350B \u2192 $900B IN 3 MONTHS",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-15-twitter-12h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2055222524774846576"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-15 12:50 UTC",
+    "delivered_at": "2026-05-15 12:00 UTC",
     "headline": "HELSING CLOSING $1.2B AT $18B \u2014 THIRD UP-ROUND IN UNDER 2 YEARS; TRADES LIKE PALANTIR, NOT LOCKHEED",
     "source": "@TRADERVERSEio",
+    "source_file": "research/summaries/2026-05-15-twitter-12h-headlines.json",
     "url": "https://x.com/TRADERVERSEio/status/2055234883992137871"
   },
   {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-05-15 12:00 UTC",
+    "headline": "REPLIT AGENT 4 MOBILE LIVE ON APP STORE \u2014 FIRST IOS UPDATE IN 4 MONTHS POST-APPLE RECONCILIATION",
+    "source": "@amasad",
+    "source_file": "research/summaries/2026-05-15-twitter-12h-headlines.json",
+    "url": "https://x.com/amasad/status/2055185058282226146"
+  },
+  {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-15 12:50 UTC",
+    "delivered_at": "2026-05-15 12:00 UTC",
     "headline": "ANTHROPIC US-CHINA PAPER DRAWS 'MANHATTAN PROJECT' CRITIQUE FROM ANALYSTS; LAB STAYS SILENT",
     "source": "@AxelMerk",
+    "source_file": "research/summaries/2026-05-15-twitter-12h-headlines.json",
     "url": "https://x.com/AxelMerk/status/2055268539075068351"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-15 15:50 UTC",
+    "delivered_at": "2026-05-15 15:00 UTC",
     "headline": "OPENAI'S COMPUTE-TO-EQUITY STAKES IN COREWEAVE + CEREBRAS WORTH ~$2.6B COMBINED \u2014 INFORMATION",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-15-twitter-15h-headlines.json",
     "url": "https://x.com/theinformation/status/2055294663636963502"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-15 15:50 UTC",
+    "delivered_at": "2026-05-15 15:00 UTC",
     "headline": "EXCLUSIVE \u2014 MICROSOFT HAS MADE ~$30B FROM OPENAI-RELATED BUSINESS, NOT COUNTING PAPER STAKE",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-15-twitter-15h-headlines.json",
     "url": "https://x.com/theinformation/status/2055309763345293709"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-15 15:50 UTC",
+    "delivered_at": "2026-05-15 15:00 UTC",
     "headline": "GEMINI SPARK BETA LEAK \u2014 TWO-TAB CHAT/AGENT UI, MAY SHARE INFO WITH THIRD PARTIES; I/O IN 4 DAYS",
     "source": "@IUAEDINA",
+    "source_file": "research/summaries/2026-05-15-twitter-15h-headlines.json",
     "url": "https://x.com/IUAEDINA/status/2055298675879092542"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-15 15:50 UTC",
+    "delivered_at": "2026-05-15 15:00 UTC",
     "headline": "ANTHROPIC PRICING-POWER PIECE \u2014 CUSTOMERS ABSORBING UNPREDICTABLE AI BILLS, MANY PAYING ANYWAY",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-15-twitter-15h-headlines.json",
     "url": "https://x.com/theinformation/status/2055286834033267045"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-15 15:50 UTC",
+    "delivered_at": "2026-05-15 15:00 UTC",
     "headline": "MODAL IN TALKS AT ~$4.5B VALUATION, $300M ANNUALIZED REVENUE AS AI AGENTS DRIVE GPU SANDBOX DEMAND",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-15-twitter-15h-headlines.json",
     "url": "https://x.com/theinformation/status/2055272069022044355"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-05-15 15:50 UTC",
+    "delivered_at": "2026-05-15 15:00 UTC",
     "headline": "VIRAL CLAUDE CODE \"/GOAL\" COMMAND IS A COMMUNITY SKILL, NOT AN ANTHROPIC BUILT-IN \u2014 DEBUNK",
     "source": "@LupacescuEuard",
+    "source_file": "research/summaries/2026-05-15-twitter-15h-headlines.json",
     "url": "https://x.com/LupacescuEuard/status/2055003964345667802"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-15 15:50 UTC",
+    "delivered_at": "2026-05-15 15:00 UTC",
     "headline": "ANTHROPIC CORP CHANNEL SILENT ~22H THROUGH FT $30B/$900B SCOOP + INFORMATION PRICING-POWER PIECE",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-15-twitter-15h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2054987444664377374"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-15 18:44 UTC",
+    "delivered_at": "2026-05-15 18:00 UTC",
     "headline": "OPENAI LAUNCHES PERSONAL FINANCE IN CHATGPT PRO \u2014 PLAID BANK CONNECT, GPT-5.5 GROUNDED ON REAL TRANSACTIONS, FINANCIAL MEMORIES",
     "source": "@ChatGPTapp",
+    "source_file": "research/summaries/2026-05-15-twitter-18h-headlines.json",
     "url": "https://x.com/ChatGPTapp/status/2055317612687675545"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-15 18:44 UTC",
+    "delivered_at": "2026-05-15 18:00 UTC",
     "headline": "OPENAI REORG \u2014 BROCKMAN OFFICIALLY TAKES OVER ALL PRODUCTS, FOLDING CHATGPT, CODEX, AND API INTO ONE CORE TEAM",
     "source": "@ZeffMax",
+    "source_file": "research/summaries/2026-05-15-twitter-18h-headlines.json",
     "url": "https://x.com/ZeffMax/status/2055335888591433852"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-15 18:44 UTC",
+    "delivered_at": "2026-05-15 18:00 UTC",
     "headline": "THE INFORMATION EXCLUSIVE \u2014 50+ XAI RESEARCHERS GONE SINCE SPACEX TAKEOVER, ALL CO-FOUNDERS BESIDES MUSK HAVE EXITED",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-15-twitter-18h-headlines.json",
     "url": "https://x.com/theinformation/status/2055355043939758472"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-15 18:44 UTC",
+    "delivered_at": "2026-05-15 18:00 UTC",
     "headline": "THE INFORMATION EXCLUSIVE \u2014 OPENAI MAKING BILLIONS BY TURNING SUPPLIER PURCHASE COMMITMENTS INTO EQUITY",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-15-twitter-18h-headlines.json",
     "url": "https://x.com/theinformation/status/2055347537784009190"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-15 18:44 UTC",
+    "delivered_at": "2026-05-15 18:00 UTC",
     "headline": "ANTHROPIC CORP CHANNEL PASSES 24H SILENCE \u2014 CLAUDEDEVS RESETS 5H AND WEEKLY RATE LIMITS, FIRST DEV-SIDE GESTURE IN THE BACKLASH",
     "source": "@ClaudeDevs",
+    "source_file": "research/summaries/2026-05-15-twitter-18h-headlines.json",
     "url": "https://x.com/ClaudeDevs/status/2055347539923308703"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-15 18:44 UTC",
+    "delivered_at": "2026-05-15 18:00 UTC",
     "headline": "TRUMP ON AIR FORCE ONE \u2014 US AND CHINA TALKED ABOUT POSSIBLY WORKING TOGETHER FOR AI GUARDRAILS",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-15-twitter-18h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2055352900956946940"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-15 21:31 UTC",
+    "delivered_at": "2026-05-15 21:00 UTC",
     "headline": "CEREBRAS $CBRS DAY-2 CLOSES ~$278, DOWN 10.6% FROM $311.07 DAY-1 CLOSE; DAVIDSON CALLS WAFER-SCALE CHIP 'NICHE-Y'",
     "source": "@hiperwire",
+    "source_file": "research/summaries/2026-05-15-twitter-21h-headlines.json",
     "url": "https://x.com/hiperwire/status/2055396053965226078"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-15 21:31 UTC",
+    "delivered_at": "2026-05-15 21:00 UTC",
     "headline": "THE INFORMATION: ANTHROPIC ENTERPRISE CUSTOMERS BUILDING MONITORING WORKAROUNDS TO TRACK 'TOKENMAXXING' INTERNALLY",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-15-twitter-21h-headlines.json",
     "url": "https://x.com/theinformation/status/2055370154117058888"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-15 21:31 UTC",
+    "delivered_at": "2026-05-15 21:00 UTC",
     "headline": "ZED IDE JABS ANTHROPIC: CHATGPT SUBSCRIPTION WORKS IN ZED 'EVEN AS OTHERS MOVE TOWARD USAGE-BASED BILLING'; OPENAIDEVS RTS",
     "source": "@zeddotdev",
+    "source_file": "research/summaries/2026-05-15-twitter-21h-headlines.json",
     "url": "https://x.com/zeddotdev/status/2055335727483781624"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-15 21:31 UTC",
+    "delivered_at": "2026-05-15 21:00 UTC",
     "headline": "XAI SHIPS GROK-IN-HERMES-AGENT INTEGRATION DURING INFORMATION'S EXODUS DRUMBEAT; NO CORP RESPONSE TO 50+ DEPARTURES STORY",
     "source": "@xai",
+    "source_file": "research/summaries/2026-05-15-twitter-21h-headlines.json",
     "url": "https://x.com/xai/status/2055375676656783733"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-15 21:31 UTC",
+    "delivered_at": "2026-05-15 21:00 UTC",
     "headline": "ANTHROPIC CORP CHANNEL PASSES 27.5 HOURS OF SILENCE; CLAUDEDEVS 'RATE LIMITS RESET' HITS 17,811 LIKES IN 3.5 HOURS",
     "source": "@ClaudeDevs",
+    "source_file": "research/summaries/2026-05-15-twitter-21h-headlines.json",
     "url": "https://x.com/ClaudeDevs/status/2055347539923308703"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-15 21:31 UTC",
+    "delivered_at": "2026-05-15 21:00 UTC",
     "headline": "THE INFORMATION VIDEO: SPACEXAI EXODUS 50+ \u2014 'ELON IS DOING A VERSION OF DOGE TO HIS OWN COMPANY'",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-15-twitter-21h-headlines.json",
     "url": "https://x.com/theinformation/status/2055383136561697200"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-16 01:04 UTC",
+    "delivered_at": "2026-05-16 01:00 UTC",
     "headline": "OPENAI CODEX TECH LEAD: \"FOUND AND FIXED TWO ISSUES\" BEHIND ~48H GPT-5.5 DEGRADATION; USAGE LIMITS RESET TONIGHT",
     "source": "@thsottiaux",
+    "source_file": "research/summaries/2026-05-16-twitter-01h-headlines.json",
     "url": "https://x.com/thsottiaux/status/2055446089957036402"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-16 01:04 UTC",
+    "delivered_at": "2026-05-16 01:00 UTC",
     "headline": "ALTMAN'S \"USER GOT USED TO THE MAGIC\" GPT-5.5 FRAMING SUPERSEDED 6H LATER BY CODEX TEAM'S SERVER-SIDE FIX",
     "source": "@sama",
+    "source_file": "research/summaries/2026-05-16-twitter-01h-headlines.json",
     "url": "https://x.com/sama/status/2055356452286640630"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-16 01:04 UTC",
+    "delivered_at": "2026-05-16 01:00 UTC",
     "headline": "NVIDIA CONFIRMS NEMOTRON 3 ULTRA (~500B) PRETRAINED NATIVELY IN NVFP4 4-BIT; SUPER 120B/25T TOKENS ALSO NVFP4",
     "source": "@ctnzr",
+    "source_file": "research/summaries/2026-05-16-twitter-01h-headlines.json",
     "url": "https://x.com/ctnzr/status/2055393135971492034"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-16 01:04 UTC",
+    "delivered_at": "2026-05-16 01:00 UTC",
+    "headline": "ANTHROPIC CORP CHANNEL CROSSES 30 HOURS SILENT THROUGH FT $30B ROUND, CODEX FIX, TOKENMAXXING; DARIO 38 DAYS DARK",
+    "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-16-twitter-01h-headlines.json",
+    "url": "https://x.com/AnthropicAI/status/2054987444664377374"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-16 01:00 UTC",
     "headline": "CLAUDEDEVS \"HAPPY FRIDAY\" RATE-LIMIT RESET CROSSES 20K LIKES / 1K RT \u2014 ANTHROPIC'S MOST-ENGAGED POST OF THE WEEK",
     "source": "@ClaudeDevs",
+    "source_file": "research/summaries/2026-05-16-twitter-01h-headlines.json",
     "url": "https://x.com/ClaudeDevs/status/2055347539923308703"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-16 01:04 UTC",
+    "delivered_at": "2026-05-16 01:00 UTC",
     "headline": "SEMIANALYSIS PUBLISHES DEEP-DIVE ON DEEPSEEK V4 MEGAMOE \u2014 1,400-LINE FUSED CUDA KERNEL FOR ENTIRE MoE FORWARD PASS",
     "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-05-16-twitter-01h-headlines.json",
     "url": "https://x.com/SemiAnalysis_/status/2055423177841353184"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-16 01:04 UTC",
+    "delivered_at": "2026-05-16 01:00 UTC",
     "headline": "TESTINGCATALOG: OPENAI WORKING ON \"LOCKED USE\" SETTING FOR CODEX \u2014 LET CODEX RUN ON YOUR MAC WHILE IT IS LOCKED",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-16-twitter-01h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2055438359594447330"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-16 04:20 UTC",
+    "delivered_at": "2026-05-16 04:00 UTC",
     "headline": "CODEX GPT-5.5 FIX POST TRIPLES TO 4,022 LIKES IN 3 HOURS \u2014 SAMA STILL SILENT 10 HOURS AFTER 'USER GOT USED TO MAGIC' FRAMING DEBUNKED",
     "source": "@thsottiaux",
+    "source_file": "research/summaries/2026-05-16-twitter-04h-headlines.json",
     "url": "https://x.com/thsottiaux/status/2055446089957036402"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-16 04:20 UTC",
+    "delivered_at": "2026-05-16 04:00 UTC",
     "headline": "SINGAPORE FOREIGN MINISTER VIVIAN BALAKRISHNAN OPENS AI ENGINEER SG AS NANOCLAW PRACTITIONER \u2014 'YOU CANNOT GOVERN A TECHNOLOGY YOU HAVE ONLY BEEN BRIEFED ON'",
     "source": "@xiao_zcloak",
+    "source_file": "research/summaries/2026-05-16-twitter-04h-headlines.json",
     "url": "https://x.com/xiao_zcloak/status/2055461165921427496"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-16 04:20 UTC",
+    "delivered_at": "2026-05-16 04:00 UTC",
     "headline": "OPENAI CODEX ENG LEAD THSOTTIAUX DROPS ROADMAP HINTS IN SINGAPORE KEYNOTE ALONGSIDE GAVRIEL COHEN \u2014 SAME STAGE AS SINGAPORE FM",
     "source": "@swyx",
+    "source_file": "research/summaries/2026-05-16-twitter-04h-headlines.json",
     "url": "https://x.com/swyx/status/2055467498888118647"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-16 04:20 UTC",
+    "delivered_at": "2026-05-16 04:00 UTC",
     "headline": "SINGAPORE HEAD OF AI GOVTECH ESTIMATES 1.3 BILLION AGENTS IN COUNTRY IN 2 YEARS, BUILDING NATIONAL MCP GATEWAY",
     "source": "@swyx",
+    "source_file": "research/summaries/2026-05-16-twitter-04h-headlines.json",
     "url": "https://x.com/swyx/status/2055470634331750588"
   },
   {
-    "category": "infra",
-    "delivered_at": "2026-05-16 04:20 UTC",
-    "headline": "VERCEL CEO RAUCHG CONFIRMS GROK CLI PLUGINS/SKILLS NOW INTEROPERATE WITH VERCEL DEPLOY",
-    "source": "@rauchg",
-    "url": "https://x.com/rauchg/status/2055491454307582454"
-  },
-  {
-    "category": "breaking",
-    "delivered_at": "2026-05-16 06:59 UTC",
-    "headline": "CODEX GPT-5.5 FIX CONFIRMED STABLE \u2014 THSOTTIAUX POSTS \"CONFIRMED STABLE AND RECOVERED\" SIX HOURS AFTER FRIDAY-NIGHT FIX",
-    "source": "@thsottiaux",
-    "url": "https://x.com/thsottiaux/status/2055540700092211404"
-  },
-  {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-16 06:59 UTC",
-    "headline": "SAM ALTMAN STILL PUBLICLY SILENT ON CODEX FIX \u2014 \"USER GOT USED TO THE MAGIC\" FRAMING SUPERSEDED 12 HOURS, NO WALK-BACK",
-    "source": "@sama",
-    "url": "https://x.com/sama/status/2055356452286640630"
-  },
-  {
-    "category": "policy",
-    "delivered_at": "2026-05-16 06:59 UTC",
-    "headline": "SINGAPORE FOREIGN MINISTER VIVIAN BALAKRISHNAN POSTS ON-RECORD \"BUILT A PERSONAL AI AGENT\" ARTICLE AFTER AI ENGINEER KEYNOTE",
-    "source": "@VivianBala",
-    "url": "https://x.com/VivianBala/status/2055520455981924826"
-  },
-  {
-    "category": "business",
-    "delivered_at": "2026-05-16 06:59 UTC",
-    "headline": "ANTHROPIC CORP CHANNEL SILENT 37 HOURS \u2014 DARIO AMODEI 38 DAYS NO X POST INTO GOOGLE I/O WEEK",
-    "source": "@AnthropicAI",
-    "url": "https://x.com/AnthropicAI/status/2054987444664377374"
-  },
-  {
-    "category": "infra",
-    "delivered_at": "2026-05-16 06:59 UTC",
-    "headline": "ELON MUSK ENDORSES GROK CLI x VERCEL PLUGIN \u2014 RT OF RAUCHG \"GROK CLOUD DEPLOYMENT SUPERPOWERS\"",
-    "source": "@elonmusk",
-    "url": "https://x.com/elonmusk/status/2055530618759573769"
-  },
-  {
-    "category": "business",
-    "delivered_at": "2026-05-16 10:15 UTC",
-    "headline": "OPENAI CODEX TECH LEAD PERSONALLY ENDORSES ZED INTEGRATION \u2014 \"CODEX\ud83e\udef8\ud83e\udef7ZED\" QUOTE-TWEETS THE POST CONTRASTING ANTHROPIC METERED PIVOT",
-    "source": "@thsottiaux",
-    "url": "https://x.com/thsottiaux/status/2055545756069802151"
-  },
-  {
-    "category": "infra",
-    "delivered_at": "2026-05-16 10:15 UTC",
-    "headline": "CODEX GPT-5.5 FIX CONFIRMED STABLE \u2014 @THSOTTIAUX FOLLOW-UP GROWS 65L\u2192447L IN 3.25H; @SAMA STILL SILENT 15H40M ON SUPERSEDED FRAMING",
-    "source": "@thsottiaux",
-    "url": "https://x.com/thsottiaux/status/2055540700092211404"
-  },
-  {
-    "category": "research",
-    "delivered_at": "2026-05-16 10:15 UTC",
-    "headline": "CLAUDE MYTHOS / APPLE M5 EXPLOIT STORY UPGRADED \u2014 @KIMMONISMUS POSTS 219L IN-WINDOW SUMMARY OF CALIF/DECRYPT KERNEL EXPLOIT CLAIM",
-    "source": "@kimmonismus",
-    "url": "https://x.com/kimmonismus/status/2055571960260645125"
-  },
-  {
-    "category": "opensource",
-    "delivered_at": "2026-05-16 10:15 UTC",
-    "headline": "OPENCLAW BEATS HERMES AGENT 2.75\u00d7 ON M5 MAX + QWEN 35B \u2014 @STEIPETE CELEBRATES 12M01S VS 33M01S RUNTIME ON GITHUB STARS BENCHMARK",
-    "source": "@steipete",
-    "url": "https://x.com/steipete/status/2055570810513850777"
-  },
-  {
-    "category": "business",
-    "delivered_at": "2026-05-16 10:15 UTC",
-    "headline": "ANTHROPIC CORP SILENT ~40H6M / DARIO ~38D 16H \u2014 APPROACHING MONDAY US-AM CONVERGE-OR-DECAY DECISION POINT ON SILENCE-AS-STANCE READ",
-    "source": "@AnthropicAI",
-    "url": "https://x.com/AnthropicAI/status/2054987444664377374"
-  },
-  {
-    "category": "business",
-    "delivered_at": "2026-05-16 12:34 UTC",
-    "headline": "OPENAI SIGNS FIRST NATIONAL DEAL WITH MALTA \u2014 FREE CHATGPT PLUS FOR ALL CITIZENS AFTER 'AI FOR ALL' COURSE",
-    "source": "@FirstSquawk",
-    "url": "https://x.com/FirstSquawk/status/2055623298214691132"
-  },
-  {
-    "category": "policy",
-    "delivered_at": "2026-05-16 12:34 UTC",
-    "headline": "OPENAI / MALTA DEAL GATED VIA NATIONAL e-ID, OPEN TO MALTESE-ABROAD; @OPENAI / @SAMA CORP-SILENT ON 'WORLD'S FIRST' WIRE",
-    "source": "@cgtnafrica",
-    "url": "https://x.com/cgtnafrica/status/2055624666190872598"
-  },
-  {
-    "category": "research",
-    "delivered_at": "2026-05-16 12:34 UTC",
-    "headline": "ANTHROPIC MYTHOS / APPLE M5 / MIE BYPASS STORY COMPOUNDS \u2014 @KIMMONISMUS POST AT 502L / 23RT, +2.3\u00d7 IN 2H",
-    "source": "@kimmonismus",
-    "url": "https://x.com/kimmonismus/status/2055571960260645125"
-  },
-  {
-    "category": "breaking",
-    "delivered_at": "2026-05-16 12:34 UTC",
-    "headline": "TIER-1 SECURITY PRESS STILL SILENT ON CALIF / M5 / MYTHOS 45+ HRS PAST DECRYPT PRIMARY \u2014 ANTHROPIC ~42H CORP-SILENT",
-    "source": "@kimmonismus",
-    "url": "https://x.com/kimmonismus/status/2055571960260645125"
-  },
-  {
-    "category": "model",
-    "delivered_at": "2026-05-16 12:34 UTC",
-    "headline": "@THSOTTIAUX CODEX FIX POST AT 6,578L / 457RT; 'CONFIRMED STABLE AND RECOVERED' AT 583L; @SAMA ~18H SILENT ON THE FIX",
-    "source": "@thsottiaux",
-    "url": "https://x.com/thsottiaux/status/2055446089957036402"
-  },
-  {
-    "category": "business",
-    "delivered_at": "2026-05-16 12:34 UTC",
-    "headline": "ANTHROPIC CORP ~42H SILENT, DARIO ~38D 18H SILENT \u2014 @CLAUDEDEVS HAPPY FRIDAY RESET AT 27,197L / 1,237RT PLATEAUING",
+    "delivered_at": "2026-05-16 04:00 UTC",
+    "headline": "ANTHROPIC CORP CHANNEL HITS ~34 HOURS SILENT \u2014 DARIO ~38 DAYS \u2014 CLAUDEDEVS 'HAPPY FRIDAY' RESET NOW 24,162 LIKES / 1,120 RT, ANTHROPIC'S MOST-ENGAGED POST OF THE MONTH",
     "source": "@ClaudeDevs",
+    "source_file": "research/summaries/2026-05-16-twitter-04h-headlines.json",
     "url": "https://x.com/ClaudeDevs/status/2055347539923308703"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-16 12:34 UTC",
+    "delivered_at": "2026-05-16 04:00 UTC",
+    "headline": "VERCEL CEO RAUCHG CONFIRMS GROK CLI PLUGINS/SKILLS NOW INTEROPERATE WITH VERCEL DEPLOY",
+    "source": "@rauchg",
+    "source_file": "research/summaries/2026-05-16-twitter-04h-headlines.json",
+    "url": "https://x.com/rauchg/status/2055491454307582454"
+  },
+  {
+    "backfilled": true,
+    "category": "breaking",
+    "delivered_at": "2026-05-16 06:00 UTC",
+    "headline": "CODEX GPT-5.5 FIX CONFIRMED STABLE \u2014 THSOTTIAUX POSTS \"CONFIRMED STABLE AND RECOVERED\" SIX HOURS AFTER FRIDAY-NIGHT FIX",
+    "source": "@thsottiaux",
+    "source_file": "research/summaries/2026-05-16-twitter-06h-headlines.json",
+    "url": "https://x.com/thsottiaux/status/2055540700092211404"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-16 06:00 UTC",
+    "headline": "SAM ALTMAN STILL PUBLICLY SILENT ON CODEX FIX \u2014 \"USER GOT USED TO THE MAGIC\" FRAMING SUPERSEDED 12 HOURS, NO WALK-BACK",
+    "source": "@sama",
+    "source_file": "research/summaries/2026-05-16-twitter-06h-headlines.json",
+    "url": "https://x.com/sama/status/2055356452286640630"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-05-16 06:00 UTC",
+    "headline": "SINGAPORE FOREIGN MINISTER VIVIAN BALAKRISHNAN POSTS ON-RECORD \"BUILT A PERSONAL AI AGENT\" ARTICLE AFTER AI ENGINEER KEYNOTE",
+    "source": "@VivianBala",
+    "source_file": "research/summaries/2026-05-16-twitter-06h-headlines.json",
+    "url": "https://x.com/VivianBala/status/2055520455981924826"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-16 06:00 UTC",
+    "headline": "ANTHROPIC HAPPY-FRIDAY RATE-LIMIT RESET CROSSES 25K LIKES / 1,174 RT \u2014 MOST-ENGAGED ANTHROPIC POST OF THE WEEK",
+    "source": "@ClaudeDevs",
+    "source_file": "research/summaries/2026-05-16-twitter-06h-headlines.json",
+    "url": "https://x.com/ClaudeDevs/status/2055347539923308703"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-16 06:00 UTC",
+    "headline": "ANTHROPIC CORP CHANNEL SILENT 37 HOURS \u2014 DARIO AMODEI 38 DAYS NO X POST INTO GOOGLE I/O WEEK",
+    "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-16-twitter-06h-headlines.json",
+    "url": "https://x.com/AnthropicAI/status/2054987444664377374"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-05-16 06:00 UTC",
+    "headline": "ELON MUSK ENDORSES GROK CLI x VERCEL PLUGIN \u2014 RT OF RAUCHG \"GROK CLOUD DEPLOYMENT SUPERPOWERS\"",
+    "source": "@elonmusk",
+    "source_file": "research/summaries/2026-05-16-twitter-06h-headlines.json",
+    "url": "https://x.com/elonmusk/status/2055530618759573769"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-16 10:00 UTC",
+    "headline": "OPENAI CODEX TECH LEAD PERSONALLY ENDORSES ZED INTEGRATION \u2014 \"CODEX\ud83e\udef8\ud83e\udef7ZED\" QUOTE-TWEETS THE POST CONTRASTING ANTHROPIC METERED PIVOT",
+    "source": "@thsottiaux",
+    "source_file": "research/summaries/2026-05-16-twitter-10h-headlines.json",
+    "url": "https://x.com/thsottiaux/status/2055545756069802151"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-05-16 10:00 UTC",
+    "headline": "CODEX GPT-5.5 FIX CONFIRMED STABLE \u2014 @THSOTTIAUX FOLLOW-UP GROWS 65L\u2192447L IN 3.25H; @SAMA STILL SILENT 15H40M ON SUPERSEDED FRAMING",
+    "source": "@thsottiaux",
+    "source_file": "research/summaries/2026-05-16-twitter-10h-headlines.json",
+    "url": "https://x.com/thsottiaux/status/2055540700092211404"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-05-16 10:00 UTC",
+    "headline": "CLAUDE MYTHOS / APPLE M5 EXPLOIT STORY UPGRADED \u2014 @KIMMONISMUS POSTS 219L IN-WINDOW SUMMARY OF CALIF/DECRYPT KERNEL EXPLOIT CLAIM",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-16-twitter-10h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2055571960260645125"
+  },
+  {
+    "backfilled": true,
+    "category": "opensource",
+    "delivered_at": "2026-05-16 10:00 UTC",
+    "headline": "OPENCLAW BEATS HERMES AGENT 2.75\u00d7 ON M5 MAX + QWEN 35B \u2014 @STEIPETE CELEBRATES 12M01S VS 33M01S RUNTIME ON GITHUB STARS BENCHMARK",
+    "source": "@steipete",
+    "source_file": "research/summaries/2026-05-16-twitter-10h-headlines.json",
+    "url": "https://x.com/steipete/status/2055570810513850777"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-16 10:00 UTC",
+    "headline": "ANTHROPIC CORP SILENT ~40H6M / DARIO ~38D 16H \u2014 APPROACHING MONDAY US-AM CONVERGE-OR-DECAY DECISION POINT ON SILENCE-AS-STANCE READ",
+    "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-16-twitter-10h-headlines.json",
+    "url": "https://x.com/AnthropicAI/status/2054987444664377374"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-16 12:00 UTC",
+    "headline": "OPENAI SIGNS FIRST NATIONAL DEAL WITH MALTA \u2014 FREE CHATGPT PLUS FOR ALL CITIZENS AFTER 'AI FOR ALL' COURSE",
+    "source": "@FirstSquawk",
+    "source_file": "research/summaries/2026-05-16-twitter-12h-headlines.json",
+    "url": "https://x.com/FirstSquawk/status/2055623298214691132"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-05-16 12:00 UTC",
+    "headline": "OPENAI / MALTA DEAL GATED VIA NATIONAL e-ID, OPEN TO MALTESE-ABROAD; @OPENAI / @SAMA CORP-SILENT ON 'WORLD'S FIRST' WIRE",
+    "source": "@cgtnafrica",
+    "source_file": "research/summaries/2026-05-16-twitter-12h-headlines.json",
+    "url": "https://x.com/cgtnafrica/status/2055624666190872598"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-05-16 12:00 UTC",
+    "headline": "ANTHROPIC MYTHOS / APPLE M5 / MIE BYPASS STORY COMPOUNDS \u2014 @KIMMONISMUS POST AT 502L / 23RT, +2.3\u00d7 IN 2H",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-16-twitter-12h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2055571960260645125"
+  },
+  {
+    "backfilled": true,
+    "category": "breaking",
+    "delivered_at": "2026-05-16 12:00 UTC",
+    "headline": "TIER-1 SECURITY PRESS STILL SILENT ON CALIF / M5 / MYTHOS 45+ HRS PAST DECRYPT PRIMARY \u2014 ANTHROPIC ~42H CORP-SILENT",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-16-twitter-12h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2055571960260645125"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-05-16 12:00 UTC",
+    "headline": "@THSOTTIAUX CODEX FIX POST AT 6,578L / 457RT; 'CONFIRMED STABLE AND RECOVERED' AT 583L; @SAMA ~18H SILENT ON THE FIX",
+    "source": "@thsottiaux",
+    "source_file": "research/summaries/2026-05-16-twitter-12h-headlines.json",
+    "url": "https://x.com/thsottiaux/status/2055446089957036402"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-16 12:00 UTC",
+    "headline": "ANTHROPIC CORP ~42H SILENT, DARIO ~38D 18H SILENT \u2014 @CLAUDEDEVS HAPPY FRIDAY RESET AT 27,197L / 1,237RT PLATEAUING",
+    "source": "@ClaudeDevs",
+    "source_file": "research/summaries/2026-05-16-twitter-12h-headlines.json",
+    "url": "https://x.com/ClaudeDevs/status/2055347539923308703"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-05-16 12:00 UTC",
     "headline": "NOMURA: VALUE DRAM ON A PER BASIS \u2014 SAMSUNG ELEC TARGET KRW 590K, SK HYNIX KRW 4M ON DURABLE AI-FLEET HBM DEMAND",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-16-twitter-12h-headlines.json",
     "url": "https://x.com/jukan05/status/2055606275074199603"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-16 15:31 UTC",
+    "delivered_at": "2026-05-16 15:00 UTC",
     "headline": "REUTERS CONFIRMS OPENAI-MALTA DEAL \u2014 FIRST NATIONAL CHATGPT PLUS PARTNERSHIP, ALL CITIZENS GET 1 YEAR FREE",
     "source": "@Reuters",
+    "source_file": "research/summaries/2026-05-16-twitter-15h-headlines.json",
     "url": "https://www.reuters.com/business/openai-seals-deal-malta-give-all-maltese-access-chatgpt-plus-2026-05-16/"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-16 15:31 UTC",
+    "delivered_at": "2026-05-16 15:00 UTC",
     "headline": "AI LEAKER: GPT-5.6 DROPS NEXT WEEK, 'HUGE LEAP' \u2014 RUMOR LANDS DIRECTLY INTO GOOGLE I/O WINDOW",
     "source": "@iruletheworldmo",
+    "source_file": "research/summaries/2026-05-16-twitter-15h-headlines.json",
     "url": "https://x.com/iruletheworldmo/status/2055646412432347428"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-16 15:31 UTC",
+    "delivered_at": "2026-05-16 15:00 UTC",
     "headline": "THE INFORMATION EXCLUSIVE: APPLE WEIGHING HOW AGENTS FIT INSIDE ITS MOST LUCRATIVE SOFTWARE BUSINESS",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-16-twitter-15h-headlines.json",
     "url": "https://x.com/theinformation/status/2055664631834677363"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-16 15:31 UTC",
+    "delivered_at": "2026-05-16 15:00 UTC",
     "headline": "THE INFORMATION: WALL STREET VALUES CEREBRAS AT RICHER SALES MULTIPLE THAN NVIDIA",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-16-twitter-15h-headlines.json",
     "url": "https://x.com/theinformation/status/2055672138925846877"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-16 15:31 UTC",
+    "delivered_at": "2026-05-16 15:00 UTC",
     "headline": "FORMER APPLE IPHONE ENG MATT ROGERS: 'EVENTUALLY OPENAI IS GOING TO NEED TO BUILD THE PHONE' \u2014 IVE TO SHIP AN ANDROID DEVICE",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-16-twitter-15h-headlines.json",
     "url": "https://x.com/theinformation/status/2055657143223628002"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-16 15:31 UTC",
+    "delivered_at": "2026-05-16 15:00 UTC",
     "headline": "MODAL VALUATION COULD JUMP 80% IN MONTHS ON AI AGENT INFRA DEMAND",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-16-twitter-15h-headlines.json",
     "url": "https://x.com/theinformation/status/2055634440596967464"
   },
   {
+    "backfilled": true,
+    "category": "breaking",
+    "delivered_at": "2026-05-16 15:00 UTC",
+    "headline": "SAM ALTMAN 21 HOURS SILENT SINCE CODEX TECH LEAD'S OWN-TEAM FIX SUPERSEDED HIS 'USER GOT USED TO THE MAGIC' FRAMING",
+    "source": "@sama",
+    "source_file": "research/summaries/2026-05-16-twitter-15h-headlines.json",
+    "url": "https://x.com/sama/status/2055356452286640630"
+  },
+  {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-16 18:30 UTC",
+    "delivered_at": "2026-05-16 18:00 UTC",
     "headline": "CODEX TECH LEAD DELIVERS PROMISED RATE-LIMIT RESET ACROSS ALL PAID PLANS \u2014 GPT-5.5 DEGRADATION LOOP CLOSES",
     "source": "@thsottiaux",
+    "source_file": "research/summaries/2026-05-16-twitter-18h-headlines.json",
     "url": "https://x.com/thsottiaux/status/2055707616605835333"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-16 18:30 UTC",
+    "delivered_at": "2026-05-16 18:00 UTC",
     "headline": "SEMIANALYSIS: ANTHROPIC MAY HAVE BUILT INTO INNOVATOR'S DILEMMA WITH CLAUDE CLI FOCUS",
     "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-05-16-twitter-18h-headlines.json",
     "url": "https://x.com/SemiAnalysis_/status/2055695091973365824"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-16 18:30 UTC",
+    "delivered_at": "2026-05-16 18:00 UTC",
     "headline": "THE INFORMATION: OPENAI'S APPLE PARTNERSHIP SOURS \u2014 OPENAI HIRING FROM APPLE HARDWARE RANKS, FRUSTRATED WITH APPLE INTELLIGENCE",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-16-twitter-18h-headlines.json",
     "url": "https://x.com/theinformation/status/2055709916329889830"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-16 18:30 UTC",
+    "delivered_at": "2026-05-16 18:00 UTC",
     "headline": "THE INFORMATION: ANTHROPIC FLEXES PRICING POWER \u2014 CUSTOMERS WILLINGLY EAT COST AS REVENUE SURGES",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-16-twitter-18h-headlines.json",
     "url": "https://x.com/theinformation/status/2055702329886736540"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-16 18:30 UTC",
+    "delivered_at": "2026-05-16 18:00 UTC",
     "headline": "TESTINGCATALOG LEAK: OPENAI BUILDING 'CODEX NETWORK' \u2014 ONE INSTALL TO CONTROL MAC MINIS, WORK DESKTOPS, OLD PCs",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-16-twitter-18h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2055708109343994335"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-16 18:30 UTC",
+    "delivered_at": "2026-05-16 18:00 UTC",
     "headline": "BROCKMAN PERSONALLY ENDORSES CODEX-VIA-CHATGPT-MOBILE: 'SUCH A FREEING EXPERIENCE'",
     "source": "@gdb",
+    "source_file": "research/summaries/2026-05-16-twitter-18h-headlines.json",
     "url": "https://x.com/gdb/status/2055716225137701202"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-16 18:30 UTC",
+    "delivered_at": "2026-05-16 18:00 UTC",
     "headline": "IRULETHEWORLDMO WIDENS RUMOR: ANTHROPIC, GOOGLE, OPENAI ALL SET TO RELEASE NEW FRONTIER MODELS THIS WEEK",
     "source": "@iruletheworldmo",
+    "source_file": "research/summaries/2026-05-16-twitter-18h-headlines.json",
     "url": "https://x.com/iruletheworldmo/status/2055696260829495446"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-16 21:26 UTC",
+    "delivered_at": "2026-05-16 21:00 UTC",
     "headline": "OPENAI MALTA DEAL CONFIRMED \u2014 BLOGPOST LIVE AT OPENAI.COM, BUT @OPENAI / @SAMA CORP TWITTER SILENT 7H+ ON FIRST SOVEREIGN CHATGPT PLUS DEAL",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-16-twitter-21h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2055718739581305021"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-16 21:26 UTC",
+    "delivered_at": "2026-05-16 21:00 UTC",
     "headline": "@KIMMONISMUS: OPENAI TURNING CODEX INTO 'CONTROL PLANE FOR ENTIRE PERSONAL COMPUTE FLEET' \u2014 EVERY MAC MINI, DESKTOP, BROWSER SESSION AN AGENT ENDPOINT",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-16-twitter-21h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2055737374278054166"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-16 21:26 UTC",
+    "delivered_at": "2026-05-16 21:00 UTC",
     "headline": "@STEIPETE: 'DESLOP YOUR CLAUDE CODE IF YOU HAVEN'T YET SWITCHED TO CODEX' \u2014 DEV-TOOLS PRINCIPAL FLIPS OPENLY ANTI-CLAUDE-CODE",
     "source": "@steipete",
+    "source_file": "research/summaries/2026-05-16-twitter-21h-headlines.json",
     "url": "https://x.com/steipete/status/2055747016727167035"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-16 21:26 UTC",
+    "delivered_at": "2026-05-16 21:00 UTC",
     "headline": "THE INFORMATION: 'CLAUDE DOESN'T PROVIDE TELEMETRY DATA MANY SOFTWARE VENDORS OFFER BY DEFAULT' \u2014 THIRD ANTHROPIC-CRITICAL PIECE IN 26H",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-16-twitter-21h-headlines.json",
     "url": "https://x.com/theinformation/status/2055732524026822773"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-16 21:26 UTC",
+    "delivered_at": "2026-05-16 21:00 UTC",
     "headline": "SEMIANALYSIS: AMD UPSTREAM CONTRIBUTION ACCEPTED INTO NVIDIA DYNAMO AIPERF \u2014 ONE OF FIRST AMD COMMITS INTO NVIDIA REPO, RARE GPU-VENDOR COOPERATION",
     "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-05-16-twitter-21h-headlines.json",
     "url": "https://x.com/SemiAnalysis_/status/2055746972523336120"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-16 21:26 UTC",
+    "delivered_at": "2026-05-16 21:00 UTC",
     "headline": "ANTHROPIC CORP SILENCE EXTENDS TO 51H+ THROUGH 3 INFORMATION CRITIQUES, SEMIANALYSIS CLI ATTACK, CODEX MINDSHARE SHIFT; DARIO X-SILENT 39 DAYS",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-16-twitter-21h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2054987444664377374"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-16 21:26 UTC",
+    "delivered_at": "2026-05-16 21:00 UTC",
     "headline": "TESTINGCATALOG: HERMES AGENT NOW USES X PREMIUM+ FOR GROK + X SEARCH TOOL \u2014 'OPENAI VS XAI ONCE AGAIN' IN AGENT-FRAMEWORK BATTLE",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-16-twitter-21h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2055755847448297495"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-17 01:13 UTC",
+    "delivered_at": "2026-05-17 01:00 UTC",
     "headline": "ANTHROPIC'S \"TOO DANGEROUS\" CLAUDE MYTHOS APPEARS AS `-CLAUDE-MYTHOS` FILTER TAG IN GOOGLE CLOUD CONSOLE",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-17-twitter-01h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2055765220123939272"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-17 01:13 UTC",
+    "delivered_at": "2026-05-17 01:00 UTC",
     "headline": "KIMMONISMUS: \"I CANNOT THINK OF ANY SCENARIO ANTHROPIC RELEASES MYTHOS\" \u2014 TIES GCP LEAK TO M5-BREAK CAPABILITY CYCLE",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-17-twitter-01h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2055767238636933494"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-17 01:13 UTC",
+    "delivered_at": "2026-05-17 01:00 UTC",
     "headline": "GEMINI 3.2 FLASH-LITE-LIVE TRACES SPOTTED IN GCP CONSOLE ~52 HOURS BEFORE GOOGLE I/O 2026-05-19",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-17-twitter-01h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2055794741782929617"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-17 01:13 UTC",
+    "delivered_at": "2026-05-17 01:00 UTC",
     "headline": "KEN GRIFFIN: AI TOOLKIT \"PROFOUNDLY MORE POWERFUL THAN NINE MONTHS AGO\" \u2014 PHD-FINANCE WORK NOW DONE IN HOURS AT CITADEL",
     "source": "@FundamentEdge",
+    "source_file": "research/summaries/2026-05-17-twitter-01h-headlines.json",
     "url": "https://x.com/FundamentEdge/status/2055675389767516544"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-17 01:13 UTC",
+    "delivered_at": "2026-05-17 01:00 UTC",
     "headline": "ANTHROPIC CORP X-SILENCE EXTENDS TO ~55 HOURS THROUGH MYTHOS GCP LEAK + M5-BREAK MULTILINGUAL CYCLE",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-17-twitter-01h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2054987444664377374"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-17 01:13 UTC",
+    "delivered_at": "2026-05-17 01:00 UTC",
     "headline": "SEMIANALYSIS PUBLISHES TECHNICAL BREAKDOWN OF GPT 4.6 \u2192 4.7 TOKENIZER IMPROVEMENTS",
     "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-05-17-twitter-01h-headlines.json",
     "url": "https://x.com/SemiAnalysis_/status/2055815691211608442"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-17 04:53 UTC",
+    "delivered_at": "2026-05-17 04:00 UTC",
     "headline": "CYBER SECURITY NEWS: MYTHOS PREVIEW USED TO CRACK APPLE M5 MEMORY INTEGRITY ENFORCEMENT \u2014 UNPRIVILEGED-TO-ROOT IN FIVE DAYS",
     "source": "@The_Cyber_News",
+    "source_file": "research/summaries/2026-05-17-twitter-04h-headlines.json",
     "url": "https://x.com/The_Cyber_News/status/2055844038801338855"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-17 04:53 UTC",
+    "delivered_at": "2026-05-17 04:00 UTC",
     "headline": "CARNEGIE MELLON V8 BENCHMARK: CLAUDE MYTHOS HITS FULL CODE-EXEC ON 21/41 V8 BUGS AT $36K \u2014 ~10-12X GPT-5.5 COST",
     "source": "@codervibe__",
+    "source_file": "research/summaries/2026-05-17-twitter-04h-headlines.json",
     "url": "https://x.com/codervibe__/status/2055857797758124083"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-17 04:53 UTC",
+    "delivered_at": "2026-05-17 04:00 UTC",
     "headline": "DEMIS HASSABIS RTs LOGAN KILPATRICK: ANTIGRAVITY TEAM HAS BEEN COOKING \u2014 FIRST DEEPMIND-PRINCIPAL TEASE 52H BEFORE I/O",
     "source": "@demishassabis",
+    "source_file": "research/summaries/2026-05-17-twitter-04h-headlines.json",
     "url": "https://x.com/demishassabis/status/2055841459526307961"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-17 04:53 UTC",
+    "delivered_at": "2026-05-17 04:00 UTC",
     "headline": "ANTHROPIC CORP ACCOUNT NOW ~58.5H SILENT THROUGH MYTHOS GCP LEAK, M5/V8 CAPABILITY CYCLE, AND CYBER-SECURITY-NEWS PICKUP",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-17-twitter-04h-headlines.json",
     "url": "https://x.com/AnthropicAI"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-17 04:53 UTC",
+    "delivered_at": "2026-05-17 04:00 UTC",
     "headline": "OPENAI CORP STILL SILENT ON MALTA SOVEREIGN DEAL ~12H AFTER BLOG \u2014 TECHMEME AND 10+ AGGREGATORS RUN STORY WITHOUT CORP ACK",
     "source": "@Techmeme",
+    "source_file": "research/summaries/2026-05-17-twitter-04h-headlines.json",
     "url": "https://x.com/Techmeme/status/2055852380445712567"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-17 04:53 UTC",
+    "delivered_at": "2026-05-17 04:00 UTC",
     "headline": "CODEX TEAM SOLICITS PUBLIC FRUSTRATIONS PRE-NEXT-MODEL \u2014 JASON LIU: 'HELP US IMPROVE THE NEXT MODEL' (267L/9RT)",
     "source": "@jxnlco",
+    "source_file": "research/summaries/2026-05-17-twitter-04h-headlines.json",
     "url": "https://x.com/jxnlco/status/2055839784711446551"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-17 04:53 UTC",
+    "delivered_at": "2026-05-17 04:00 UTC",
     "headline": "JENSEN AT STANFORD CS153: 'I WOULD LIKE TO BE AT LOW MFU ALL THE TIME' \u2014 OVERPROVISION FLOPS, NETWORKING, MEMORY",
     "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-05-17-twitter-04h-headlines.json",
     "url": "https://x.com/SemiAnalysis_/status/2055835722783830311"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-17 09:43 UTC",
+    "delivered_at": "2026-05-17 09:00 UTC",
     "headline": "MUSK CONFIRMS GROK V9 \u2014 1.5T PARAMS, 3X CURRENT GROK, CURSOR CODING DATA IN MID-TRAINING, 3-4 WEEKS TO RELEASE",
     "source": "@elonmusk",
+    "source_file": "research/summaries/2026-05-17-twitter-09h-headlines.json",
     "url": "https://x.com/elonmusk/status/2055914584373141906"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-17 09:43 UTC",
+    "delivered_at": "2026-05-17 09:00 UTC",
     "headline": "XAI POSITIONS GROK V9 AS CLAUDE CODE / CODEX RIVAL \u2014 BLACKWELL-CLASS BASE MODEL, SFT AND RL STILL PENDING BEFORE SHIP",
     "source": "@techedgedaily",
+    "source_file": "research/summaries/2026-05-17-twitter-09h-headlines.json",
     "url": "https://x.com/techedgedaily/status/2055916204024635652"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-17 09:43 UTC",
+    "delivered_at": "2026-05-17 09:00 UTC",
     "headline": "XAI / NOUS RESEARCH \u2014 HERMES AGENT NOW ACCEPTS X PREMIUM SUBSCRIPTIONS, GETS X POST SEARCH; ELON AMPLIFIES",
     "source": "@elonmusk",
+    "source_file": "research/summaries/2026-05-17-twitter-09h-headlines.json",
     "url": "https://x.com/elonmusk/status/2055909693768515828"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-17 09:43 UTC",
+    "delivered_at": "2026-05-17 09:00 UTC",
     "headline": "ANTHROPIC CORP SILENCE EXTENDS TO ~63.5 HOURS THROUGH US-CHINA PAPER PROPAGATION, MYTHOS CURL BUG, GROK V9 COMPETITIVE EVENT",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-17-twitter-09h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2054987444664377374"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-17 09:43 UTC",
+    "delivered_at": "2026-05-17 09:00 UTC",
     "headline": "OPENAI MALTA CHATGPT PLUS PARTNERSHIP BLOG ~17.5H UNACKNOWLEDGED ON CORP SOCIAL \u2014 MONDAY US CASH OPEN REMAINS LIKELY ROLLOUT WINDOW",
     "source": "@iruletheworldmo",
+    "source_file": "research/summaries/2026-05-17-twitter-09h-headlines.json",
     "url": "https://x.com/iruletheworldmo/status/2055807812389462282"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-17 09:43 UTC",
+    "delivered_at": "2026-05-17 09:00 UTC",
     "headline": "JUKAN05 \u2014 SAMSUNG DEVELOPING MOBILE HBM PACKAGING (EXTREME-AR CU PILLARS + FOWLP); ON-DEVICE AGENTIC PHONES NEED MOBILE HBM",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-17-twitter-09h-headlines.json",
     "url": "https://x.com/jukan05/status/2055940737091665928"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-17 09:43 UTC",
+    "delivered_at": "2026-05-17 09:00 UTC",
     "headline": "SEMIANALYSIS PREVIEWS MLSYS 2026 (MAY 18-22) \u2014 CORE ATTENTION DISAGGREGATION, MOE EXPERT BALANCING AS CONFERENCE HIGH-SIGNAL OUTPUTS",
     "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-05-17-twitter-09h-headlines.json",
     "url": "https://x.com/SemiAnalysis_/status/2055845794020757678"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-17 12:39 UTC",
+    "delivered_at": "2026-05-17 12:00 UTC",
     "headline": "CXMT PRINTS 1Q26: $7.46B REVENUE +719% YoY, $4.85B NET PROFIT, 95%+ FAB UTILIZATION \u2014 CHINA DRAM HITS MICRON-COMPARABLE SCALE",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-17-twitter-12h-headlines.json",
     "url": "https://x.com/jukan05/status/2055950752720523324"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-17 12:39 UTC",
+    "delivered_at": "2026-05-17 12:00 UTC",
     "headline": "CXMT 1H26 GUIDANCE: $16.15-17.62B REVENUE, $9.69-11.01B NET PROFIT \u2014 IMPLIED FULL-YEAR ~$33B AT CURRENT PACE",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-17-twitter-12h-headlines.json",
     "url": "https://x.com/jukan05/status/2055951991004958965"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-17 12:39 UTC",
+    "delivered_at": "2026-05-17 12:00 UTC",
     "headline": "SUleyman: AI TO AUTOMATE MOST WHITE-COLLAR WORK IN 12-18 MONTHS \u2014 FORTUNE RE-SYNDICATES MICROSOFT AI CEO'S FT INTERVIEW",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-17-twitter-12h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2055952702908355012"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-17 12:39 UTC",
+    "delivered_at": "2026-05-17 12:00 UTC",
     "headline": "ELON: GROK BUILD IMPROVING LIKE LIGHTNING \u2014 SOFT-AMPLIFIES PRIOR V9 1.5T ANNOUNCEMENT, 10K+ LIKES IN 2H",
     "source": "@elonmusk",
+    "source_file": "research/summaries/2026-05-17-twitter-12h-headlines.json",
     "url": "https://x.com/elonmusk/status/2055965456146821584"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-17 12:39 UTC",
+    "delivered_at": "2026-05-17 12:00 UTC",
     "headline": "ANTHROPIC CORP SILENCE HITS ~66.5H \u2014 NO RESPONSE TO MYTHOS GCP LEAK, M5/V8, CMU BENCHMARK, GROK V9, CXMT 1Q26",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-17-twitter-12h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2054987444664377374"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-17 12:39 UTC",
+    "delivered_at": "2026-05-17 12:00 UTC",
     "headline": "MALLABY: OPENAI 50/50 ODDS OF RUNNING OUT OF CASH BY NEXT SUMMER \u2014 AS ANTHROPIC NEARS $30B AT $900B VALUATION",
     "source": "@MarketMoodMeter",
+    "source_file": "research/summaries/2026-05-17-twitter-12h-headlines.json",
     "url": "https://x.com/MarketMoodMeter/status/2055979324587606388"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-17 18:33 UTC",
+    "delivered_at": "2026-05-17 18:00 UTC",
     "headline": "THE INFORMATION RE-SYNDICATES: 50+ xAI ENGINEERS GONE SINCE SPACEX ACQUISITION, ALL CO-FOUNDERS BESIDES MUSK DEPARTED",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-17-twitter-18h-headlines.json",
     "url": "https://x.com/theinformation/status/2056079811898999243"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-17 18:33 UTC",
+    "delivered_at": "2026-05-17 18:00 UTC",
     "headline": "ANDREW CURRAN: GROK V9 1.5T SHIPS IN JUNE \u2014 ELON ALSO HAS 6T AND 10T VARIANTS IN COLOSSUS 2 TRAINING",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-17-twitter-18h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2055993050094616735"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-17 18:33 UTC",
+    "delivered_at": "2026-05-17 18:00 UTC",
     "headline": "SEMIANALYSIS: 96% OF OUR TOKEN BUDGET IS ANTHROPIC \u2014 PERPLEXITY COMPUTER ENTERPRISE SLACK 'SHOCKING BETTER THAN CLAUDE'",
     "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-05-17-twitter-18h-headlines.json",
     "url": "https://x.com/SemiAnalysis_/status/2056060948893929803"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-17 18:33 UTC",
+    "delivered_at": "2026-05-17 18:00 UTC",
     "headline": "THE INFORMATION: ANTHROPIC CUSTOMERS SAY AI TOOLS POWERFUL BUT MISSING TRANSPARENCY AND SERVICE GUARANTEES",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-17-twitter-18h-headlines.json",
     "url": "https://x.com/theinformation/status/2056012568683462847"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-17 18:33 UTC",
+    "delivered_at": "2026-05-17 18:00 UTC",
     "headline": "VATICAN LAUNCHES INTERDICASTERIAL AI COMMISSION \u2014 POPE LEO XIV AI ENCYCLICAL PUBLISHES WITHIN TWO WEEKS",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-17-twitter-18h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2056012896397049837"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-17 18:33 UTC",
+    "delivered_at": "2026-05-17 18:00 UTC",
     "headline": "THE INFORMATION: OPENAI CONSIDERING LEGAL ACTION AGAINST APPLE OVER STALLED CHATGPT-SIRI PARTNERSHIP",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-17-twitter-18h-headlines.json",
     "url": "https://x.com/theinformation/status/2055997812693881204"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-17 18:33 UTC",
+    "delivered_at": "2026-05-17 18:00 UTC",
     "headline": "ELON MUSK CONFIRMS GROK AUTOMATIONS: EMAIL AUTO-RESPONDER, DAILY STOCK TRACKER, TASK EXTRACTOR \u2014 'GROK UPGRADES'",
     "source": "@elonmusk",
+    "source_file": "research/summaries/2026-05-17-twitter-18h-headlines.json",
     "url": "https://x.com/elonmusk/status/2056061134629933072"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-18 01:14 UTC",
+    "delivered_at": "2026-05-18 01:00 UTC",
     "headline": "SAMA BREAKS 54-HOUR X SILENCE WITH CHATGPT IMAGES INDIA STATS \u2014 NO MALTA, NO CODEX, NO MODEL MENTION",
     "source": "@sama",
+    "source_file": "research/summaries/2026-05-18-twitter-01h-headlines.json",
     "url": "https://x.com/sama/status/2056165722804654196"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-18 01:14 UTC",
+    "delivered_at": "2026-05-18 01:00 UTC",
     "headline": "GOOGLE PM LEAD LOGAN KILPATRICK: 'THE MODEL IS THE PRODUCT' \u2014 33 HOURS BEFORE I/O 2026 KEYNOTE",
     "source": "@OfficialLoganK",
+    "source_file": "research/summaries/2026-05-18-twitter-01h-headlines.json",
     "url": "https://x.com/OfficialLoganK/status/2056107524802457887"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-18 01:14 UTC",
+    "delivered_at": "2026-05-18 01:00 UTC",
     "headline": "JPM HIKES SAMSUNG, SK HYNIX TARGETS ON 'STRUCTURAL GROWTH FROM AI SERVER INVESTMENT' \u2014 LTA RE-RATING THESIS",
     "source": "@Shrimp_a_Whales",
+    "source_file": "research/summaries/2026-05-18-twitter-01h-headlines.json",
     "url": "https://x.com/Shrimp_a_Whales/status/2056181052012667018"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-18 01:14 UTC",
+    "delivered_at": "2026-05-18 01:00 UTC",
     "headline": "JUKAN05: ABF SUBSTRATES EMERGE AS NEXT NVIDIA SUPPLY-CHAIN LOCKDOWN \u2014 TSMC COUPE MASS PRODUCTION 2H 2026",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-18-twitter-01h-headlines.json",
     "url": "https://x.com/jukan05/status/2056146790488162706"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-18 01:14 UTC",
+    "delivered_at": "2026-05-18 01:00 UTC",
     "headline": "THE INFORMATION: OPENAI-APPLE DEAL 'FAILED TO DELIVER MEANINGFUL GROWTH' \u2014 CHATGPT BURIED IN APPLE ECOSYSTEM",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-18-twitter-01h-headlines.json",
     "url": "https://x.com/theinformation/status/2056102475631841327"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-18 01:14 UTC",
+    "delivered_at": "2026-05-18 01:00 UTC",
     "headline": "ANTHROPIC CORP X-SILENCE HITS DAY-HIGH ~79H THROUGH 9-EVENT STACK INCLUDING NAMED-ENG-PM PROCUREMENT-GAP ASK",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-18-twitter-01h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2054987444664377374"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-18 01:14 UTC",
+    "delivered_at": "2026-05-18 01:00 UTC",
     "headline": "PALO ALTO NETWORKS COMPLETES KOI ACQUISITION \u2014 LAUNCHES 'AGENTIC ENDPOINT SECURITY' CATEGORY FOR AI AGENTS",
     "source": "@CHItrader",
+    "source_file": "research/summaries/2026-05-18-twitter-01h-headlines.json",
     "url": "https://x.com/CHItrader/status/2056180552785448968"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-18 04:38 UTC",
+    "delivered_at": "2026-05-18 04:00 UTC",
     "headline": "KOREAN COURT PARTIALLY GRANTS INJUNCTION AGAINST SAMSUNG UNION STRIKE \u2014 KOSPI REVERSES 4.68% LOSS, SAMSUNG +6.7%",
     "source": "@YonhapNews",
+    "source_file": "research/summaries/2026-05-18-twitter-04h-headlines.json",
     "url": "https://x.com/YonhapNews/status/2056207805498171639"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-18 04:38 UTC",
+    "delivered_at": "2026-05-18 04:00 UTC",
     "headline": "SAMSUNG UNION FACES DAILY FINES FOR NON-COMPLIANCE WITH COURT ORDER \u2014 STRIKE NOW EFFECTIVELY BLOCKED",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-18-twitter-04h-headlines.json",
     "url": "https://x.com/jukan05/status/2056195907750904096"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-18 04:38 UTC",
+    "delivered_at": "2026-05-18 04:00 UTC",
     "headline": "ANTHROPIC ALEX ALBERT BREAKS 55H X-SILENCE \u2014 \"SHRINK YOUR SCAFFOLDING\" + \"MODEL AND HARNESS PLANNED TOGETHER\" FRAMING",
     "source": "@alexalbert__",
+    "source_file": "research/summaries/2026-05-18-twitter-04h-headlines.json",
     "url": "https://x.com/alexalbert__/status/2056183085989265578"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-18 04:38 UTC",
+    "delivered_at": "2026-05-18 04:00 UTC",
     "headline": "GOOGLE LOGAN K PIVOTS BACK TO \"YEAR OF AGENTS AND AI CODING\" 6.5H AFTER \"MODEL IS THE PRODUCT\" SLOGAN",
     "source": "@OfficialLoganK",
+    "source_file": "research/summaries/2026-05-18-twitter-04h-headlines.json",
     "url": "https://x.com/OfficialLoganK/status/2056206893803356337"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-18 04:38 UTC",
+    "delivered_at": "2026-05-18 04:00 UTC",
     "headline": "MIRAE ASSET RAISES SK HYNIX PRICE TARGET TO 360,000 KRW ON RELENTLESS HBM DEMAND \u2014 SECOND ASIAN-BROKER UPGRADE THIS CYCLE",
     "source": "@todaystartupnws",
+    "source_file": "research/summaries/2026-05-18-twitter-04h-headlines.json",
     "url": "https://x.com/todaystartupnws/status/2056228033640890573"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-18 04:38 UTC",
+    "delivered_at": "2026-05-18 04:00 UTC",
     "headline": "OPENAI CORP 80.5H+ SILENT ON MALTA DEAL \u2014 SAMA INDIA-STATS POST GROWS 3.3X TO 5,009L/201RT ON MINIMAL-SUBSTANCE VEHICLE",
     "source": "@sama",
+    "source_file": "research/summaries/2026-05-18-twitter-04h-headlines.json",
     "url": "https://x.com/sama/status/2056165722804654196"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-18 04:38 UTC",
+    "delivered_at": "2026-05-18 04:00 UTC",
     "headline": "ANTHROPIC CORP 82.5H+ SILENT \u2014 10-EVENT STACK NOW INCLUDES SAMSUNG-UNION RULING + ALBERT RT + LOGAN K PIVOT",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-18-twitter-04h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2054987444664377374"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-18 10:39 UTC",
+    "delivered_at": "2026-05-18 10:00 UTC",
     "headline": "FT: ANTHROPIC TO BRIEF FSB ON MYTHOS CYBER RISKS AT BOE GOVERNOR BAILEY'S REQUEST \u2014 ~40 PREVIEW-ACCESS ORGS INCL. AMAZON, MICROSOFT, JPMORGAN",
     "source": "@FT",
+    "source_file": "research/summaries/2026-05-18-twitter-10h-headlines.json",
     "url": "https://x.com/FT/status/2056243562954555597"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-18 10:39 UTC",
+    "delivered_at": "2026-05-18 10:00 UTC",
     "headline": "FSB DRAFTING AI COMPLIANCE FRAMEWORK FOR FINANCE; MYTHOS FOUND THOUSANDS OF SEVERE VULNERABILITIES TOO FAST FOR BANKS TO PATCH",
     "source": "@INFOFLOWfx",
+    "source_file": "research/summaries/2026-05-18-twitter-10h-headlines.json",
     "url": "https://x.com/i/status/2056231402555785433"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-18 10:39 UTC",
+    "delivered_at": "2026-05-18 10:00 UTC",
     "headline": "SAMSUNG SENIOR ADVISOR KYUNG: MEMORY PRICES TO FALL FROM H2 2027 AS CHINESE CAPA HITS 6M WAFERS/MONTH; BIG TECH CAPEX ROI A KEY RISK",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-18-twitter-10h-headlines.json",
     "url": "https://x.com/jukan05/status/2056316714309255367"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-18 10:39 UTC",
+    "delivered_at": "2026-05-18 10:00 UTC",
     "headline": "UBS MODELS 2027 TPU SHIPMENTS AT 9.87M UNITS \u2014 6.76M FROM AVGO + 3.11M FROM MTK, 139% YOY GROWTH FROM 4.13M IN 2026",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-18-twitter-10h-headlines.json",
     "url": "https://x.com/jukan05/status/2056313542589174057"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-18 10:39 UTC",
+    "delivered_at": "2026-05-18 10:00 UTC",
     "headline": "GF OVERSEAS REITERATES NVDA BUY, RAISES PT TO $308 AHEAD OF Q1 FY27 EARNINGS \u2014 PRODUCT MIX OFFSETS RUBIN DELAY",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-18-twitter-10h-headlines.json",
     "url": "https://x.com/jukan05/status/2056238134481076408"
   },
   {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-18 10:00 UTC",
+    "headline": "FORMER MICROSOFT VP: $37.5B/QUARTER AI CAPEX, <3.3% OF 365 USERS PAY FOR COPILOT, NO KILLER USE CASE IN WINDOWS OR OFFICE",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-18-twitter-10h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2056278879460090335"
+  },
+  {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-18 10:39 UTC",
+    "delivered_at": "2026-05-18 10:00 UTC",
     "headline": "ANTHROPICAI CORP ~88H SILENT THROUGH ITS OWN FT MYTHOS\u2192FSB STORY; OPENAI ~86H SILENT ON MALTA; ARAVSRINIVAS ~92H ON PERPLEXITY",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-18-twitter-10h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2054987444664377374"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-18 16:17 UTC",
+    "delivered_at": "2026-05-18 16:00 UTC",
     "headline": "MUSK V. OPENAI \u2014 9-PERSON JURY BEGINS DELIBERATIONS IN OAKLAND; $134B SOUGHT, $1T IPO AT STAKE",
     "source": "@Bubblebathgirl",
+    "source_file": "research/summaries/2026-05-18-twitter-16h-headlines.json",
     "url": "https://x.com/i/status/2056362031276523621"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-18 16:17 UTC",
+    "delivered_at": "2026-05-18 16:00 UTC",
     "headline": "ALTMAN'S 2023 SENATE 'NO FINANCIAL STAKE' TESTIMONY CONTRADICTED UNDER OATH VIA YC LP SHARES",
     "source": "@Lamwumkt",
+    "source_file": "research/summaries/2026-05-18-twitter-16h-headlines.json",
     "url": "https://x.com/i/status/2056183789370679458"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-18 16:17 UTC",
+    "delivered_at": "2026-05-18 16:00 UTC",
     "headline": "GOOGLE STEALTH-DEPLOYS GEMINI FLASH 3.2 OR 3.5 INSIDE ANTIGRAVITY HOURS BEFORE I/O KEYNOTE",
     "source": "@HarshithLucky3",
+    "source_file": "research/summaries/2026-05-18-twitter-16h-headlines.json",
     "url": "https://x.com/HarshithLucky3/status/2056369433237737916"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-18 16:17 UTC",
+    "delivered_at": "2026-05-18 16:00 UTC",
     "headline": "TESTINGCATALOG LEAKS GEMINI DESKTOP SUITE \u2014 LIVE, SPARK, OMNI ('VEO4 OMNI' INTERNAL), STREAM TO CURSOR",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-18-twitter-16h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2056358095954022795"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-18 16:17 UTC",
+    "delivered_at": "2026-05-18 16:00 UTC",
     "headline": "GOOGLE GTIG DISCLOSES FIRST KNOWN CRIMINAL AI-DEVELOPED ZERO-DAY EXPLOIT IN THE WILD \u2014 NOT GEMINI",
     "source": "@tbuzzdaily",
+    "source_file": "research/summaries/2026-05-18-twitter-16h-headlines.json",
     "url": "https://x.com/tbuzzdaily/status/2056374420461982048"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-18 16:17 UTC",
+    "delivered_at": "2026-05-18 16:00 UTC",
     "headline": "RAPPLER CONFIRMS BOE GOVERNOR BAILEY PERSONALLY REQUESTED ANTHROPIC MYTHOS-TO-FSB BRIEFING",
     "source": "@rapplerdotcom",
+    "source_file": "research/summaries/2026-05-18-twitter-16h-headlines.json",
     "url": "https://x.com/rapplerdotcom/status/2056391110553944105"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-18 16:17 UTC",
+    "delivered_at": "2026-05-18 16:00 UTC",
     "headline": "CLAUDEDEVS BREAKS 70H SILENCE WITH CLAUDE-CODE-AT-SCALE BLOG; ANTHROPIC CORP HOLDS 94H SILENCE",
     "source": "@ClaudeDevs",
+    "source_file": "research/summaries/2026-05-18-twitter-16h-headlines.json",
     "url": "https://x.com/ClaudeDevs/status/2056403446056784288"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-18 18:48 UTC",
+    "delivered_at": "2026-05-18 18:00 UTC",
     "headline": "MUSK v. OPENAI \u2014 JURY DISMISSES ALL THREE CORE CLAIMS AS TIME-BARRED IN ~2H; ALTMAN, BROCKMAN, MICROSOFT CLEARED; APPEAL PRESERVED",
     "source": "@ns123abc",
+    "source_file": "research/summaries/2026-05-18-twitter-18h-headlines.json",
     "url": "https://x.com/ns123abc/status/2056436278682669112"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-18 18:48 UTC",
+    "delivered_at": "2026-05-18 18:00 UTC",
     "headline": "SAMA BREAKS 71-HOUR SILENCE 8 MINUTES POST-VERDICT \u2014 POSTS ABOUT CHATGPT UPDATE, NOT THE TRIAL",
     "source": "@sama",
+    "source_file": "research/summaries/2026-05-18-twitter-18h-headlines.json",
     "url": "https://x.com/sama/status/2056435834333934051"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-18 18:48 UTC",
+    "delivered_at": "2026-05-18 18:00 UTC",
     "headline": "ANTHROPIC CONFIRMS STAINLESS ACQUISITION \u2014 NOW OWNS SDK AND MCP TOOLING USED BY OPENAI, GOOGLE AND ANTHROPIC",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-18-twitter-18h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2056419620643541012"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-18 18:48 UTC",
+    "delivered_at": "2026-05-18 18:00 UTC",
     "headline": "CURSOR LAUNCHES COMPOSER 2.5 \u2014 BUILT ON KIMI K2.5, CLAIMS ON-PAR WITH OPUS 4.7 AT 10X COST EFFICIENCY",
     "source": "@cursor_ai",
+    "source_file": "research/summaries/2026-05-18-twitter-18h-headlines.json",
     "url": "https://x.com/cursor_ai/status/2056415413077233983"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-18 18:48 UTC",
+    "delivered_at": "2026-05-18 18:00 UTC",
     "headline": "CURSOR + SPACEXAI CO-TRAINING NEXT-GEN MODEL WITH 10X MORE COMPUTE ON COLOSSUS 2'S MILLION H100-EQUIVALENTS",
     "source": "@cursor_ai",
+    "source_file": "research/summaries/2026-05-18-twitter-18h-headlines.json",
     "url": "https://x.com/cursor_ai/status/2056415419536461836"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-18 18:48 UTC",
+    "delivered_at": "2026-05-18 18:00 UTC",
     "headline": "POPE LEO XIV FIRST ENCYCLICAL 'MAGNIFICA HUMANITAS' LAUNCHES MAY 25 WITH ANTHROPIC CO-FOUNDER CHRIS OLAH AT THE VATICAN",
     "source": "@Stocktwits",
+    "source_file": "research/summaries/2026-05-18-twitter-18h-headlines.json",
     "url": "https://x.com/Stocktwits/status/2056391719726326239"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-18 18:48 UTC",
+    "delivered_at": "2026-05-18 18:00 UTC",
     "headline": "THE INFORMATION \u2014 ANTHROPIC AND OPENAI NOW GENERATE 89% OF REVENUE AMONG 34 LEADING AI STARTUPS",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-18-twitter-18h-headlines.json",
     "url": "https://x.com/theinformation/status/2056427118632812577"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-18 21:36 UTC",
+    "delivered_at": "2026-05-18 21:00 UTC",
     "headline": "MUSK COMMITS TO NINTH CIRCUIT APPEAL OF OPENAI VERDICT, FRAMES JUDGE GONZALEZ ROGERS AS 'TERRIBLE ACTIVIST OAKLAND JUDGE'",
     "source": "@elonmusk",
+    "source_file": "research/summaries/2026-05-18-twitter-21h-headlines.json",
     "url": "https://x.com/elonmusk/status/2056474896641782077"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-18 21:36 UTC",
+    "delivered_at": "2026-05-18 21:00 UTC",
     "headline": "MUSK: 'ALTMAN & BROCKMAN DID IN FACT ENRICH THEMSELVES BY STEALING A CHARITY. THE ONLY QUESTION IS WHEN THEY DID IT'",
     "source": "@elonmusk",
+    "source_file": "research/summaries/2026-05-18-twitter-21h-headlines.json",
     "url": "https://x.com/elonmusk/status/2056474896641782077"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-18 21:36 UTC",
+    "delivered_at": "2026-05-18 21:00 UTC",
     "headline": "ALTMAN STILL SILENT ON VERDICT 3.5H AFTER PRODUCT-PIVOT TWEET; OPENAI CORP HITS 98 HOURS WITHOUT POSTING THROUGH VERDICT + APPEAL + MALTA",
     "source": "@sama",
+    "source_file": "research/summaries/2026-05-18-twitter-21h-headlines.json",
     "url": "https://x.com/sama/status/2056435834333934051"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-18 21:36 UTC",
+    "delivered_at": "2026-05-18 21:00 UTC",
     "headline": "ANTHROPIC DEFAULTS CLAUDE CODE FAST MODE TO OPUS 4.7 AT 2.5X SPEED AND HIGHER PER-TOKEN RATE \u2014 ANSWERS CURSOR COMPOSER 2.5 ON LATENCY, NOT COST",
     "source": "@ClaudeDevs",
+    "source_file": "research/summaries/2026-05-18-twitter-21h-headlines.json",
     "url": "https://x.com/ClaudeDevs/status/2056454359685476491"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-18 21:36 UTC",
+    "delivered_at": "2026-05-18 21:00 UTC",
     "headline": "SEMIANALYSIS: $21 IN TOKENS REPLACES 20-HOUR ANALYST TASK, 60-90X ROI ACROSS 9 INTERNAL WORKFLOWS \u2014 PRE-NVIDIA Q1 FY27 EARNINGS THESIS",
     "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-05-18-twitter-21h-headlines.json",
     "url": "https://x.com/SemiAnalysis_/status/2056480113357729977"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-18 21:36 UTC",
+    "delivered_at": "2026-05-18 21:00 UTC",
     "headline": "GOOGLE DEEPMIND CORP POSTS FIRST IN-WINDOW PRE-I/O HYPE TWEET 13H BEFORE KEYNOTE: 'THE STAGE IS SET. THE TECH IS READY.'",
     "source": "@GoogleDeepMind",
+    "source_file": "research/summaries/2026-05-18-twitter-21h-headlines.json",
     "url": "https://x.com/GoogleDeepMind/status/2056475403926028455"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-18 21:36 UTC",
+    "delivered_at": "2026-05-18 21:00 UTC",
     "headline": "THE INFORMATION: SPACEX EYES $75B IPO, BLACKROCK CONSIDERING $10B STAKE \u2014 'BIGGEST IPO IN HISTORY BY AT LEAST A FACTOR OF TWO'",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-18-twitter-21h-headlines.json",
     "url": "https://x.com/theinformation/status/2056484580819914990"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-19 01:15 UTC",
+    "delivered_at": "2026-05-19 01:00 UTC",
     "headline": "WSJ: GOOGLE + BLACKSTONE FORM AI NEOCLOUD JV \u2014 $5B BLACKSTONE EQUITY, 500 MW TPU CAPACITY ONLINE 2027",
     "source": "@marketsday",
+    "source_file": "research/summaries/2026-05-19-twitter-01h-headlines.json",
     "url": "https://x.com/marketsday/status/2056544144712143028"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-19 01:15 UTC",
+    "delivered_at": "2026-05-19 01:00 UTC",
     "headline": "BLACKSTONE PRESS-RELEASE FRAMING: $5B INITIAL EQUITY COMMITMENT, 500 MW IN 2027, PLANS TO SCALE SIGNIFICANTLY",
     "source": "@MarcJacksonLA",
+    "source_file": "research/summaries/2026-05-19-twitter-01h-headlines.json",
     "url": "https://x.com/MarcJacksonLA"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-19 01:15 UTC",
+    "delivered_at": "2026-05-19 01:00 UTC",
     "headline": "MUSK'S ATTORNEY MARC TOBEROFF ON OPENAI VERDICT: 'I HAVE A ONE-WORD REACTION \u2014 APPEAL'",
     "source": "@elonmusk",
+    "source_file": "research/summaries/2026-05-19-twitter-01h-headlines.json",
     "url": "https://x.com/elonmusk/status/2056504285572092153"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-19 01:15 UTC",
+    "delivered_at": "2026-05-19 01:00 UTC",
     "headline": "GEORGETOWN LAW'S CHANDER: MUSK OPENAI APPEAL WILL BE TOUGH \u2014 'FIRM STATUTE OF LIMITATIONS'",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-19-twitter-01h-headlines.json",
     "url": "https://x.com/theinformation"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-19 01:15 UTC",
+    "delivered_at": "2026-05-19 01:00 UTC",
     "headline": "XAI RELEASES SKILLS BLOG + GROK BUILD COMMAND PALETTE Ctrl+P \u2014 DIRECT FEATURE-MATCH WITH ANTHROPIC SKILLS",
     "source": "@elonmusk",
+    "source_file": "research/summaries/2026-05-19-twitter-01h-headlines.json",
     "url": "https://x.com/elonmusk/status/2056489484477145142"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-19 01:15 UTC",
+    "delivered_at": "2026-05-19 01:00 UTC",
     "headline": "GEMINI OMNI PRE-LEAK: 8s HD VIDEO SAMPLES + LIKENESS AVATAR PRIMITIVE AHEAD OF GOOGLE I/O 10AM PT",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-19-twitter-01h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2056533362160095668"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-19 01:15 UTC",
+    "delivered_at": "2026-05-19 01:00 UTC",
     "headline": "SUNDAR PICHAI BREAKS 6-DAY SILENCE: 'ON OUR WAY TO I/O 2026' \u2014 KEYNOTE STAGING ~10H OUT",
     "source": "@sundarpichai",
+    "source_file": "research/summaries/2026-05-19-twitter-01h-headlines.json",
     "url": "https://x.com/sundarpichai/status/2056524502746747048"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-19 04:34 UTC",
+    "delivered_at": "2026-05-19 04:00 UTC",
     "headline": "NVIDIA SHIPS FIRST VERA CPU CUSTOMER SILICON \u2014 HAND-DELIVERED TO ANTHROPIC, OPENAI, SpaceXAI (FRI) AND ORACLE (MON) BY VP IAN BUCK",
     "source": "@ns123abc",
+    "source_file": "research/summaries/2026-05-19-twitter-04h-headlines.json",
     "url": "https://x.com/ns123abc/status/2056582028783186371"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-19 04:34 UTC",
+    "delivered_at": "2026-05-19 04:00 UTC",
     "headline": "ORACLE COMMITS TO 'HUNDREDS OF THOUSANDS OF NVIDIA VERA CPUs BEGINNING IN 2026' \u2014 FIRST ARM-BASED CPU PURPOSE-BUILT FOR AGENTIC AI WORKLOADS",
     "source": "@ns123abc",
+    "source_file": "research/summaries/2026-05-19-twitter-04h-headlines.json",
     "url": "https://x.com/ns123abc/status/2056582028783186371"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-19 04:34 UTC",
+    "delivered_at": "2026-05-19 04:00 UTC",
     "headline": "ELON MUSK 'VERA NICE, VERA NICE \u2026 \ud83e\udd0c' \u2014 39,309 LIKES IN 3H AFTER NVIDIA VP HAND-DELIVERS FIRST VERA CPU TO SpaceXAI",
     "source": "@elonmusk",
+    "source_file": "research/summaries/2026-05-19-twitter-04h-headlines.json",
     "url": "https://x.com/elonmusk/status/2056548139044413708"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-19 04:34 UTC",
+    "delivered_at": "2026-05-19 04:00 UTC",
     "headline": "ANTHROPIC ON VERA CPU: 'A PROMISING PART OF THE ECOSYSTEM WHEN SOLVING FOR AGENTIC WORKLOADS' \u2014 QUOTE ROUTED VIA NVIDIA PR, NO CORP TWEET",
     "source": "@ns123abc",
+    "source_file": "research/summaries/2026-05-19-twitter-04h-headlines.json",
     "url": "https://x.com/ns123abc/status/2056582028783186371"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-19 04:34 UTC",
+    "delivered_at": "2026-05-19 04:00 UTC",
     "headline": "OPENAI CORP ~104H SILENT THROUGH VERDICT + APPEAL + GOOGLE-BLACKSTONE + NVIDIA VERA-CPU DELIVERY TO ITSELF",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-05-19-twitter-04h-headlines.json",
     "url": "https://x.com/OpenAI/status/1922755663795736895"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-19 04:34 UTC",
+    "delivered_at": "2026-05-19 04:00 UTC",
     "headline": "XAI GROK CREATIVE STACK: 3 NEW MODELS LIVE ON OPENROUTER \u2014 GROK IMAGINE IMAGE QUALITY PHOTOREAL GEN + 2 OTHERS",
     "source": "@elonmusk",
+    "source_file": "research/summaries/2026-05-19-twitter-04h-headlines.json",
     "url": "https://x.com/elonmusk/status/2056556643813847459"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-19 04:34 UTC",
+    "delivered_at": "2026-05-19 04:00 UTC",
     "headline": "HITACHI ANNOUNCES STRATEGIC PARTNERSHIP WITH ANTHROPIC \u2014 'LUMADA 3.0' THROUGH FRONTIER AI; RAILWAY + ELECTRIC INFRASTRUCTURE",
     "source": "@phithetasigma",
+    "source_file": "research/summaries/2026-05-19-twitter-04h-headlines.json",
     "url": "https://x.com/phithetasigma/status/2056562918970929193"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-19 08:07 UTC",
+    "delivered_at": "2026-05-19 08:00 UTC",
     "headline": "FT: GOOGLE DEEPMIND CEO HASSABIS WAS UNDISCLOSED ANGEL INVESTOR IN ANTHROPIC AT FOUNDING; DARIO VIEWS HIM AS ROLE MODEL",
     "source": "@FT",
+    "source_file": "research/summaries/2026-05-19-twitter-08h-headlines.json",
     "url": "https://x.com/FT/status/2056595792450683328"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-19 08:07 UTC",
+    "delivered_at": "2026-05-19 08:00 UTC",
     "headline": "DEEPMIND ALUMNI HAVE FOUNDED 12+ COMPANIES RAISING $14B+ SINCE 2021 \u2014 PITCHBOOK + DEALROOM PER FT",
     "source": "@Techmeme",
+    "source_file": "research/summaries/2026-05-19-twitter-08h-headlines.json",
     "url": "https://x.com/Techmeme/status/2056607321846136924"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-05-19 08:07 UTC",
+    "delivered_at": "2026-05-19 08:00 UTC",
     "headline": "LLAMA.CPP LANDS MULTI-TOKEN PREDICTION FOR QWEN3.6 ON MAINLINE \u2014 22 TO 42 TOK/S SINGLE-GPU, PR 22673 + 23198",
     "source": "@_akhaliq",
+    "source_file": "research/summaries/2026-05-19-twitter-08h-headlines.json",
     "url": "https://x.com/_akhaliq/status/2056603508325904534"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-19 08:07 UTC",
+    "delivered_at": "2026-05-19 08:00 UTC",
     "headline": "JENSEN HUANG AT DELL TECH WORLD: ENTERPRISE COMPUTING DEMAND 'GOING UTTERLY PARABOLIC' \u2014 VERA RUBIN NVL72 5,000 ENTERPRISES",
     "source": "@TrendsDotGlobal",
+    "source_file": "research/summaries/2026-05-19-twitter-08h-headlines.json",
     "url": "https://x.com/TrendsDotGlobal/status/2056643907505795458"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-19 08:07 UTC",
+    "delivered_at": "2026-05-19 08:00 UTC",
     "headline": "AMD CEO LISA SU IN SHANGHAI: GLOBAL AI USERS TO HIT 5 BILLION BY 2030, CHINA HAS WORLD'S MOST VIBRANT AI ECOSYSTEM",
     "source": "@yicaichina",
+    "source_file": "research/summaries/2026-05-19-twitter-08h-headlines.json",
     "url": "https://x.com/yicaichina/status/2056642603517399091"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-19 08:07 UTC",
+    "delivered_at": "2026-05-19 08:00 UTC",
     "headline": "CHINA-US AGREE TO LAUNCH INTERGOVERNMENTAL AI DIALOGUE \u2014 CHINA MOFA SPOKESPERSON GUO JIAKUN AT MAY 19 PRESS CONFERENCE",
     "source": "@jiemian_news",
+    "source_file": "research/summaries/2026-05-19-twitter-08h-headlines.json",
     "url": "https://x.com/jiemian_news/status/2056645439911251979"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-19 08:07 UTC",
+    "delivered_at": "2026-05-19 08:00 UTC",
     "headline": "MISTRAL ACQUIRES VIENNA-BASED EMMI AI FOR UNDISCLOSED SUM TO BOOST INDUSTRIAL AI OFFERINGS IN EUROPE \u2014 REUTERS",
     "source": "@Techmeme",
+    "source_file": "research/summaries/2026-05-19-twitter-08h-headlines.json",
     "url": "https://x.com/Techmeme/status/2056643706644791745"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-19 10:25 UTC",
+    "delivered_at": "2026-05-19 10:00 UTC",
     "headline": "ANTHROPIC SHIPS SELF-HOSTED SANDBOXES (BETA) + MCP TUNNELS (PREVIEW) FROM CODE WITH CLAUDE LONDON \u2014 9H BEFORE GOOGLE I/O KEYNOTE",
     "source": "@claudeai",
+    "source_file": "research/summaries/2026-05-19-twitter-10h-headlines.json",
     "url": "https://x.com/claudeai/status/2056645485696315581"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-19 10:25 UTC",
+    "delivered_at": "2026-05-19 10:00 UTC",
     "headline": "AGENTS NOW RUN INSIDE ENTERPRISE VPC \u2014 CLOUDFLARE / DAYTONA / MODAL / VERCEL CONFIRMED AS ANTHROPIC MANAGED-SANDBOX PARTNERS",
     "source": "@claudeai",
+    "source_file": "research/summaries/2026-05-19-twitter-10h-headlines.json",
     "url": "https://x.com/claudeai/status/2056645491207655584"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-19 10:25 UTC",
+    "delivered_at": "2026-05-19 10:00 UTC",
     "headline": "GOOGLE AI STUDIO MOBILE APP APPEARS ON GOOGLE PLAY STORE FOR PRE-REGISTRATION HOURS BEFORE I/O KEYNOTE",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-19-twitter-10h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2056655400796434841"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-19 10:25 UTC",
+    "delivered_at": "2026-05-19 10:00 UTC",
     "headline": "GEMINI ROLLING OUT NEW UI WITH THINKING-EFFORT SELECTOR + USAGE LIMITS TAB AHEAD OF I/O 2026",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-19-twitter-10h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2056653546918117464"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-19 10:25 UTC",
+    "delivered_at": "2026-05-19 10:00 UTC",
     "headline": "ANTHROPIC DOUBLES CLAUDE DESIGN TOKEN LIMITS ACROSS EVERY PLAN \u2014 15,866 LIKES IN 14H",
     "source": "@claudeai",
+    "source_file": "research/summaries/2026-05-19-twitter-10h-headlines.json",
     "url": "https://x.com/claudeai/status/2056460045756309820"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-19 10:25 UTC",
+    "delivered_at": "2026-05-19 10:00 UTC",
     "headline": "DEMIS HASSABIS 7-DAY SUBSTANTIVE SILENT THROUGH FT ANTHROPIC-ANGEL-INVESTOR DISCLOSURE \u2014 6.5H BEFORE GOOGLE I/O KEYNOTE SLOT",
     "source": "@FT",
+    "source_file": "research/summaries/2026-05-19-twitter-10h-headlines.json",
     "url": "https://x.com/FT/status/2056595792450683328"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-19 10:25 UTC",
+    "delivered_at": "2026-05-19 10:00 UTC",
     "headline": "OPENAI CORP ~110H SILENT \u2014 NO VERDICT / VERA-CPU / FT-HASSABIS / ANTHROPIC-LONDON ACKNOWLEDGMENT AS GOOGLE I/O OPENS",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-05-19-twitter-10h-headlines.json",
     "url": "https://x.com/OpenAI/status/2055016850849993072"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-19 13:25 UTC",
+    "delivered_at": "2026-05-19 13:00 UTC",
     "headline": "ANTHROPIC-KPMG GLOBAL ALLIANCE \u2014 CLAUDE INSIDE DIGITAL GATEWAY FOR 276,000+ EMPLOYEES ACROSS 138 COUNTRIES; KPMG NAMED PE-PREFERRED PARTNER",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-19-twitter-13h-headlines.json",
     "url": "https://www.anthropic.com/news/anthropic-kpmg"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-19 13:25 UTC",
+    "delivered_at": "2026-05-19 13:00 UTC",
     "headline": "ANTHROPIC SHIPS SECOND BIG-4 STRATEGIC ALLIANCE IN 5 DAYS \u2014 PwC (MAY 14) \u2192 KPMG (MAY 19) \u2014 DAY-OF GOOGLE I/O 2026 KEYNOTE",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-19-twitter-13h-headlines.json",
     "url": "https://www.anthropic.com/news"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-19 13:25 UTC",
+    "delivered_at": "2026-05-19 13:00 UTC",
     "headline": "KPMG DIGITAL GATEWAY POWERED BY CLAUDE \u2014 COWORK + MANAGED AGENTS + CLAUDE CODE (KPMG BLAZE) ON AZURE; TAX/LEGAL CLIENT WORKFLOWS FIRST",
     "source": "KPMG.com",
+    "source_file": "research/summaries/2026-05-19-twitter-13h-headlines.json",
     "url": "https://kpmg.com/xx/en/media/press-releases/2026/05/kpmg-and-anthropic-sign-global-alliance-and-launch-digital-gateway-powered-by-claude.html"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-19 13:25 UTC",
+    "delivered_at": "2026-05-19 13:00 UTC",
     "headline": "ANTHROPIC NEWSROOM CADENCE \u2014 10 POSTS IN 22 DAYS (APR 27 \u2192 MAY 19): DISTRIBUTION + INFRA + PRODUCT CAMPAIGN THROUGH GOOGLE I/O WEEK",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-19-twitter-13h-headlines.json",
     "url": "https://www.anthropic.com/news"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-19 13:25 UTC",
+    "delivered_at": "2026-05-19 13:00 UTC",
     "headline": "GOOGLE I/O 2026 KEYNOTE T-3.5H \u2014 SUNDAR 17:00 UTC OPEN; DEMIS SLOT W/ FT-HASSABIS-DISCLOSURE OVERLAY; GEMINI 3.X / VEO 4 / OMNI",
     "source": "@GoogleDeepMind",
+    "source_file": "research/summaries/2026-05-19-twitter-13h-headlines.json",
     "url": "https://blog.google/"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-19 16:30 UTC",
+    "delivered_at": "2026-05-19 16:00 UTC",
     "headline": "ANDREJ KARPATHY JOINS ANTHROPIC \u2014 OPENAI CO-FOUNDER / EX-TESLA AI DIRECTOR RETURNS TO FRONTIER R&D",
     "source": "@karpathy",
+    "source_file": "research/summaries/2026-05-19-twitter-16h-headlines.json",
     "url": "https://x.com/karpathy/status/2056753169888334312"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-19 16:30 UTC",
+    "delivered_at": "2026-05-19 16:00 UTC",
     "headline": "ANTHROPIC CONFIRMS KARPATHY HIRE IN 23 SECONDS \u2014 @CLAUDEDEVS: \"WELCOME TO THE TEAM, ANDREJ!\"",
     "source": "@ClaudeDevs",
+    "source_file": "research/summaries/2026-05-19-twitter-16h-headlines.json",
     "url": "https://x.com/ClaudeDevs/status/2056753265346564259"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-19 16:30 UTC",
+    "delivered_at": "2026-05-19 16:00 UTC",
     "headline": "GOOGLE I/O 2026 KEYNOTE OPENS 17:00 UTC \u2014 10AM PT CONSUMER + 1:30PM PT DEVELOPER SPLIT FORMAT CONFIRMED",
     "source": "@GoogleAI",
+    "source_file": "research/summaries/2026-05-19-twitter-16h-headlines.json",
     "url": "https://x.com/GoogleAI/status/2056767575397462426"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-19 16:30 UTC",
+    "delivered_at": "2026-05-19 16:00 UTC",
     "headline": "OPENAI WINS JURY VERDICT VS MUSK IN 2 HOURS \u2014 \"REMOVES ONE CLOUD OVER RESTRUCTURING AND POSSIBLE IPO\"",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-19-twitter-16h-headlines.json",
     "url": "https://x.com/theinformation/status/2056744210313752766"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-19 16:30 UTC",
+    "delivered_at": "2026-05-19 16:00 UTC",
     "headline": "NYSE ADDING COMPUTE FUTURES MARKET \u2014 TRADEABLE GPU/TPU-HOUR INSTRUMENT INCOMING",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-19-twitter-16h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2056764541070098449"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-19 16:30 UTC",
+    "delivered_at": "2026-05-19 16:00 UTC",
     "headline": "ANALOG DEVICES IN ADVANCED TALKS TO BUY EMPOWER SEMICONDUCTOR FOR ~$1.5B \u2014 AI POWER-CHIP M&A",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-19-twitter-16h-headlines.json",
     "url": "https://x.com/theinformation/status/2056767102510420009"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-19 16:30 UTC",
+    "delivered_at": "2026-05-19 16:00 UTC",
     "headline": "CLOUDFLARE TESTS ANTHROPIC MYTHOS PREVIEW ON 50+ INTERNAL REPOS \u2014 CHAINS LOW-SEVERITY BUGS INTO WORKING EXPLOITS",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-19-twitter-16h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2056713453956682229"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-19 18:50 UTC",
+    "delivered_at": "2026-05-19 18:00 UTC",
     "headline": "GEMINI 3.5 FLASH LIVE GLOBALLY \u2014 INTELLIGENCE INDEX 55 BEATS CLAUDE SONNET 4.6 AND GROK 4.3, TOPS MMMU-PRO AT 84%",
     "source": "@GoogleDeepMind",
+    "source_file": "research/summaries/2026-05-19-twitter-18h-headlines.json",
     "url": "https://x.com/GoogleDeepMind/status/2056787987774816525"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-19 18:50 UTC",
+    "delivered_at": "2026-05-19 18:00 UTC",
     "headline": "GOOGLE TRIPLES FLASH PRICING \u2014 GEMINI 3.5 FLASH AT $1.50/$9 PER 1M TOKENS, 5.5\u00d7 MORE EXPENSIVE TO RUN THAN GEMINI 3 FLASH",
     "source": "@ArtificialAnlys",
+    "source_file": "research/summaries/2026-05-19-twitter-18h-headlines.json",
     "url": "https://x.com/ArtificialAnlys/status/2056795055512596817"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-19 18:50 UTC",
+    "delivered_at": "2026-05-19 18:00 UTC",
     "headline": "GEMINI OMNI LAUNCHES \u2014 GOOGLE'S FIRST MULTIMODAL-IN / VIDEO-OUT WORLD MODEL SHIPS TO GEMINI APP, FLOW, YOUTUBE SHORTS",
     "source": "@GoogleDeepMind",
+    "source_file": "research/summaries/2026-05-19-twitter-18h-headlines.json",
     "url": "https://x.com/GoogleDeepMind/status/2056786446636212467"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-19 18:50 UTC",
+    "delivered_at": "2026-05-19 18:00 UTC",
     "headline": "GEMINI SPARK \u2014 GOOGLE'S DEDICATED-VM PERSONAL AGENT CONNECTS TO USER'S FULL GOOGLE DATA, TRUSTED TESTERS THIS WEEK",
     "source": "@OfficialLoganK",
+    "source_file": "research/summaries/2026-05-19-twitter-18h-headlines.json",
     "url": "https://x.com/OfficialLoganK/status/2056791703349277101"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-19 18:50 UTC",
+    "delivered_at": "2026-05-19 18:00 UTC",
     "headline": "GOOGLE AI ULTRA PRICING RESET \u2014 NEW $100/MONTH TIER LANDS, TOP TIER CUT FROM $250 TO $200",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-19-twitter-18h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2056792916526547215"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-19 18:50 UTC",
+    "delivered_at": "2026-05-19 18:00 UTC",
     "headline": "GOOGLE SEARCH BOX REIMAGINED \u2014 GEMINI 3.5 FLASH NOW DEFAULT FOR AI MODE GLOBALLY, BIGGEST SEARCH UPGRADE IN 25 YEARS",
     "source": "@OfficialLoganK",
+    "source_file": "research/summaries/2026-05-19-twitter-18h-headlines.json",
     "url": "https://x.com/OfficialLoganK/status/2056802276124328352"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-19 18:50 UTC",
+    "delivered_at": "2026-05-19 18:00 UTC",
     "headline": "AMD MI355 NOW 40% CHEAPER THAN NVIDIA B200 ON GLM5 ARCHITECTURE FOR SINGLE-NODE FP8 SERVING",
     "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-05-19-twitter-18h-headlines.json",
     "url": "https://x.com/SemiAnalysis_/status/2056782305440452635"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-19 21:40 UTC",
+    "delivered_at": "2026-05-19 21:00 UTC",
     "headline": "OPENAI LAUNCHES GUARANTEED CAPACITY \u2014 COMPUTE FUTURES WITH 1-3 YEAR COMMITS FOR DISCOUNTED TOKENS",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-05-19-twitter-21h-headlines.json",
     "url": "https://x.com/OpenAI/status/2056823271774101907"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-19 21:40 UTC",
+    "delivered_at": "2026-05-19 21:00 UTC",
     "headline": "ALTMAN: WORLD WILL BE CAPACITY-CONSTRAINED 'FOR SOME TIME' \u2014 PROGRAM RUNS UNTIL ALLOCATION SELLS OUT",
     "source": "@sama",
+    "source_file": "research/summaries/2026-05-19-twitter-21h-headlines.json",
     "url": "https://x.com/sama/status/2056827105401614656"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-19 21:40 UTC",
+    "delivered_at": "2026-05-19 21:00 UTC",
     "headline": "GOOGLE I/O DEV KEYNOTE: GEMINI 3.5 FLASH IN API, MANAGED AGENTS VIA ANTIGRAVITY, NATIVE ANDROID APPS IN AI STUDIO",
     "source": "@OfficialLoganK",
+    "source_file": "research/summaries/2026-05-19-twitter-21h-headlines.json",
     "url": "https://x.com/OfficialLoganK/status/2056840620610830638"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-19 21:40 UTC",
+    "delivered_at": "2026-05-19 21:00 UTC",
     "headline": "CURSOR CEO: COMPOSER 2.5 NOW 'MOST-CHOSEN MODEL IN CURSOR' \u2014 MUSK AMPLIFIES TO 10K+ LIKES (VENDOR CLAIM)",
     "source": "@mntruell",
+    "source_file": "research/summaries/2026-05-19-twitter-21h-headlines.json",
     "url": "https://x.com/mntruell/status/2056780569380626686"
   },
   {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-19 21:00 UTC",
+    "headline": "THE INFORMATION: ANTHROPIC AND OPENAI NOW GENERATE 89% OF REVENUE AMONG 34 LEADING AI STARTUPS",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-19-twitter-21h-headlines.json",
+    "url": "https://x.com/theinformation/status/2056819704925163938"
+  },
+  {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-19 21:40 UTC",
+    "delivered_at": "2026-05-19 21:00 UTC",
     "headline": "PNAS: HUMAN PERSUASION TACTICS RAISE LLM COMPLIANCE WITH OBJECTIONABLE REQUESTS FROM 35% TO 51%",
     "source": "@emollick",
+    "source_file": "research/summaries/2026-05-19-twitter-21h-headlines.json",
     "url": "https://x.com/emollick/status/2056843673145401722"
   },
   {
+    "backfilled": true,
+    "category": "breaking",
+    "delivered_at": "2026-05-20 01:00 UTC",
+    "headline": "GITHUB INVESTIGATING UNAUTHORIZED ACCESS TO ITS INTERNAL REPOSITORIES \u2014 SAYS NO EVIDENCE OF CUSTOMER-DATA IMPACT SO FAR",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-20-twitter-01h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2056906113610858712"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-05-20 01:00 UTC",
+    "headline": "GOOGLE ROLLS OUT GEMINI 3.5 FLASH GLOBALLY \u2014 ~800 TOKENS/SEC, BEATS 3.1 PRO ON CODING PER GOOGLE",
+    "source": "@GoogleDeepMind",
+    "source_file": "research/summaries/2026-05-20-twitter-01h-headlines.json",
+    "url": "https://x.com/GoogleDeepMind/status/2056787987774816525"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-05-20 01:00 UTC",
+    "headline": "GEMINI 3.5 FLASH COSTS ~3X GEMINI 3 FLASH, AND IS 'NOT AS POWERFUL AS A FULL FRONTIER MODEL' \u2014 EARLY USERS",
+    "source": "@simonw",
+    "source_file": "research/summaries/2026-05-20-twitter-01h-headlines.json",
+    "url": "https://x.com/simonw/status/2056867815605625172"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-20 01:00 UTC",
+    "headline": "GOOGLE CALLS IT BIGGEST SEARCH-BOX UPGRADE IN 25 YEARS \u2014 GEMINI 3.5 FLASH NOW DEFAULT IN AI MODE, PLUS NEW 'SPARK' AGENT",
+    "source": "@OfficialLoganK",
+    "source_file": "research/summaries/2026-05-20-twitter-01h-headlines.json",
+    "url": "https://x.com/OfficialLoganK/status/2056802276124328352"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-05-20 01:00 UTC",
+    "headline": "GOOGLE SHIPS GEMINI OMNI \u2014 'CREATE ANYTHING FROM ANY INPUT' MODEL STARTING WITH VIDEO, LIVE FOR AI PLUS/PRO/ULTRA",
+    "source": "@OfficialLoganK",
+    "source_file": "research/summaries/2026-05-20-twitter-01h-headlines.json",
+    "url": "https://x.com/OfficialLoganK/status/2056787874260164628"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-20 01:00 UTC",
+    "headline": "INTEL AND QUALCOMM REPORTEDLY BOTH EYEING TENSTORRENT RISC-V AI CHIPS IN POTENTIAL $5B+ DEAL",
+    "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-20-twitter-01h-headlines.json",
+    "url": "https://x.com/jukan05/status/2056905041660031048"
+  },
+  {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-20 04:35 UTC",
+    "delivered_at": "2026-05-20 04:00 UTC",
     "headline": "GITHUB BREACH: GROUP 'TEAMPCP' CLAIMS ~4,000 INTERNAL REPOS VIA POISONED VS CODE EXTENSION; KEYS ROTATED",
     "source": "@shah_sheikh",
+    "source_file": "research/summaries/2026-05-20-twitter-04h-headlines.json",
     "url": "https://x.com/shah_sheikh/status/2056953467336560825"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-20 04:35 UTC",
+    "delivered_at": "2026-05-20 04:00 UTC",
     "headline": "SPACEX RECORD IPO TURNS IMMINENT: PUBLIC S-1 THIS WEEK, $1.75-2T VALUATION, $75B RAISE, $SPCX TARGETED JUNE 12",
     "source": "@ns123abc",
+    "source_file": "research/summaries/2026-05-20-twitter-04h-headlines.json",
     "url": "https://x.com/ns123abc/status/2056913900159844357"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-20 04:35 UTC",
+    "delivered_at": "2026-05-20 04:00 UTC",
     "headline": "REPORTS: SPACEX TO CLOSE $60B CURSOR TAKEOUT ~30 DAYS AFTER IPO, $10B BREAKUP FEE \u2014 PER BLOOMBERG",
     "source": "@muskonomy",
+    "source_file": "research/summaries/2026-05-20-twitter-04h-headlines.json",
     "url": "https://x.com/muskonomy/status/2056947339311645165"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-20 04:35 UTC",
+    "delivered_at": "2026-05-20 04:00 UTC",
     "headline": "OPENAI OPENS FIRST OVERSEAS APPLIED AI LAB IN SINGAPORE \u2014 US$300M+ GOVT PARTNERSHIP, 200+ ROLES",
     "source": "@business",
+    "source_file": "research/summaries/2026-05-20-twitter-04h-headlines.json",
     "url": "https://x.com/business/status/2056943337882464375"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-20 04:35 UTC",
+    "delivered_at": "2026-05-20 04:00 UTC",
     "headline": "OPENAI OFFERS $2M IN TOKENS TO EVERY STARTUP IN CURRENT YC BATCH",
     "source": "@sama",
+    "source_file": "research/summaries/2026-05-20-twitter-04h-headlines.json",
     "url": "https://x.com/sama/status/2056933166875857290"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-20 07:30 UTC",
+    "delivered_at": "2026-05-20 07:00 UTC",
     "headline": "GITHUB CONFIRMS BREACH VECTOR \u2014 POISONED VS CODE EXTENSION EXFILTRATED ~3,800 INTERNAL REPOS, SECRETS ROTATED",
     "source": "@github",
+    "source_file": "research/summaries/2026-05-20-twitter-07h-headlines.json",
     "url": "https://x.com/github/status/2056949168208552080"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-20 07:30 UTC",
+    "delivered_at": "2026-05-20 07:00 UTC",
     "headline": "WHITE HOUSE AI SAFETY & CYBERSECURITY EXECUTIVE ORDER COULD DROP THIS WEEK, SEEKING EARLY ACCESS TO FRONTIER MODELS \u2014 AXIOS",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-20-twitter-07h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2056962188083122377"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-05-20 07:30 UTC",
+    "delivered_at": "2026-05-20 07:00 UTC",
     "headline": "FRANCO-GERMAN NONPROFIT KESAI LABS LAUNCHES FULLY OPEN SELF-DRIVING STACK \u2014 OPEN WEIGHTS, DATA, CODE",
     "source": "@ngranati",
+    "source_file": "research/summaries/2026-05-20-twitter-07h-headlines.json",
     "url": "https://x.com/ngranati/status/2056999295614591146"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-20 10:15 UTC",
+    "delivered_at": "2026-05-20 10:00 UTC",
     "headline": "MISTRAL CONFIRMED ACQUIRING AUSTRIA'S EMMI AI \u2014 PUSH INTO PHYSICS-AWARE INDUSTRIAL SIMULATION",
     "source": "@techzine",
+    "source_file": "research/summaries/2026-05-20-twitter-10h-headlines.json",
     "url": "https://x.com/techzine/status/2057027383149117937"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-20 10:15 UTC",
+    "delivered_at": "2026-05-20 10:00 UTC",
     "headline": "CHINA REPORTEDLY BLOCKS IMPORTS OF NVIDIA'S CHINA-SPEC RTX 5090D, PER SEMICONDUCTOR WATCHER JUKAN",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-20-twitter-10h-headlines.json",
     "url": "https://x.com/jukan05/status/2057014613175374280"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-20 10:15 UTC",
+    "delivered_at": "2026-05-20 10:00 UTC",
     "headline": "ANTHROPIC SHIPS CLAUDE FOR SMALL BUSINESS \u2014 EMBEDS INTO QUICKBOOKS, HUBSPOT, CANVA, GOOGLE WORKSPACE",
     "source": "@rohrasumeet",
+    "source_file": "research/summaries/2026-05-20-twitter-10h-headlines.json",
     "url": "https://x.com/rohrasumeet/status/2056925398387024046"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-20 13:13 UTC",
+    "delivered_at": "2026-05-20 13:00 UTC",
     "headline": "META BEGINS ~8,000 LAYOFFS (10% OF STAFF) \u2014 4 A.M. TERMINATION EMAILS CONFIRMED TODAY",
     "source": "@FortuneIndia",
+    "source_file": "research/summaries/2026-05-20-twitter-13h-headlines.json",
     "url": "https://x.com/FortuneIndia/status/2056991056408031545"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-20 13:13 UTC",
+    "delivered_at": "2026-05-20 13:00 UTC",
     "headline": "VIRAL 'LEAKED AUDIO' SAYS ZUCKERBERG TOLD META STAFF TO TRAIN AI REPLACEMENTS \u2014 STILL UNVERIFIED",
     "source": "@LayoffAI",
+    "source_file": "research/summaries/2026-05-20-twitter-13h-headlines.json",
     "url": "https://x.com/LayoffAI/status/2056858309618282743"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-20 13:13 UTC",
+    "delivered_at": "2026-05-20 13:00 UTC",
     "headline": "ANTHROPIC LANDS BRISTOL-MYERS SQUIBB \u2014 CLAUDE TO ROLL OUT TO 30,000+ EMPLOYEES",
     "source": "@ftr_investors",
+    "source_file": "research/summaries/2026-05-20-twitter-13h-headlines.json",
     "url": "https://x.com/ftr_investors/status/2057071625221124583"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-20 13:13 UTC",
+    "delivered_at": "2026-05-20 13:00 UTC",
     "headline": "NVIDIA REPORTS EARNINGS AFTER US CLOSE TODAY \u2014 STREET EYES ~$78.75B REVENUE, CHINA THE SWING FACTOR",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-20-twitter-13h-headlines.json",
     "url": "https://x.com/jukan05/status/2057048299128164807"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-20 13:13 UTC",
+    "delivered_at": "2026-05-20 13:00 UTC",
     "headline": "SPACEX PUBLIC S-1 STILL UNRELEASED \u2014 THE INFORMATION EXPECTS FILING AS SOON AS MAY 21, $SPCX EYES JUNE 12",
     "source": "@ns123abc",
+    "source_file": "research/summaries/2026-05-20-twitter-13h-headlines.json",
     "url": "https://x.com/ns123abc/status/2056913900159844357"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-20 16:19 UTC",
+    "delivered_at": "2026-05-20 16:00 UTC",
     "headline": "INTUIT LAYS OFF 17% (~3,000 JOBS) TO REFOCUS ON AI; $INTU REPORTS AFTER THE CLOSE",
     "source": "@Stocktwits",
+    "source_file": "research/summaries/2026-05-20-twitter-16h-headlines.json",
     "url": "https://x.com/Stocktwits/status/2057133294563598778"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-05-20 16:19 UTC",
+    "delivered_at": "2026-05-20 16:00 UTC",
     "headline": "COHERE SHIPS COMMAND A+ \u2014 ITS MOST POWERFUL MODEL, FULLY OPEN-SOURCE, TUNED FOR MINIMAL HARDWARE",
     "source": "@cohere",
+    "source_file": "research/summaries/2026-05-20-twitter-16h-headlines.json",
     "url": "https://x.com/cohere/status/2057120818551734589"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-20 16:19 UTC",
+    "delivered_at": "2026-05-20 16:00 UTC",
     "headline": "SEMIANALYSIS: ZUCKERBERG TELLS META STAFF TO EXPECT NO MORE COMPANY-WIDE LAYOFFS THIS YEAR",
     "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-05-20-twitter-16h-headlines.json",
     "url": "https://x.com/SemiAnalysis_/status/2057123911003742679"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-20 16:19 UTC",
+    "delivered_at": "2026-05-20 16:00 UTC",
     "headline": "SPACEX IPO DRAFT NAMES STARSHIP AS TOP GROWTH DRIVER AND TOP RISK; PUBLIC S-1 STILL UNFILED",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-20-twitter-16h-headlines.json",
     "url": "https://x.com/theinformation/status/2057114268013617510"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-20 16:19 UTC",
+    "delivered_at": "2026-05-20 16:00 UTC",
     "headline": "GEMINI 3.5 FLASH RECEPTION SOURS \u2014 DEV TESTS PUT IT BELOW CURSOR'S COMPOSER 2 ON AGENTIC TASKS",
     "source": "@thrishank007",
+    "source_file": "research/summaries/2026-05-20-twitter-16h-headlines.json",
     "url": "https://x.com/thrishank007/status/2057133994878374130"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-20 19:01 UTC",
+    "delivered_at": "2026-05-20 19:00 UTC",
     "headline": "OPENAI PREPARING TO FILE FOR IPO AS SOON AS FRIDAY, TARGETING SEPTEMBER LISTING NEAR $1 TRILLION \u2014 WSJ",
     "source": "@WSJ",
+    "source_file": "research/summaries/2026-05-20-twitter-19h-headlines.json",
     "url": "https://x.com/WSJ/status/2057135489040212227"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-20 19:01 UTC",
+    "delivered_at": "2026-05-20 19:00 UTC",
     "headline": "THE INFORMATION: OPENAI EXPECTS REVENUE TO DOUBLE TO ~$30B BY END-2026, VALUATION COULD TOP $1T",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-20-twitter-19h-headlines.json",
     "url": "https://x.com/theinformation/status/2057173173104226318"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-20 19:01 UTC",
+    "delivered_at": "2026-05-20 19:00 UTC",
     "headline": "GOOGLE LAUNCHES GEMINI FOR SCIENCE \u2014 AGENTIC TOOLS WIRE 30+ LIFE-SCIENCE MODELS INTO ANTIGRAVITY",
     "source": "@GoogleAI",
+    "source_file": "research/summaries/2026-05-20-twitter-19h-headlines.json",
     "url": "https://x.com/GoogleAI/status/2057161311617008061"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-20 19:01 UTC",
+    "delivered_at": "2026-05-20 19:00 UTC",
     "headline": "THE INFORMATION: ANTHROPIC AND OPENAI NOW GENERATE 89% OF REVENUE ACROSS 34 TOP AI STARTUPS",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-20-twitter-19h-headlines.json",
     "url": "https://x.com/theinformation/status/2057166984215720230"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-20 19:01 UTC",
+    "delivered_at": "2026-05-20 19:00 UTC",
     "headline": "CURSOR COMPOSER 2.5 DRAWS DAY-2 RAVES AT ~1/20TH THE PRICE OF OPUS 4.7 ON CODING TASKS",
     "source": "@GergelyOrosz",
+    "source_file": "research/summaries/2026-05-20-twitter-19h-headlines.json",
     "url": "https://x.com/GergelyOrosz/status/2057140853156581815"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-20 19:01 UTC",
+    "delivered_at": "2026-05-20 19:00 UTC",
     "headline": "NVIDIA REPORTS EARNINGS AFTER US CLOSE TODAY \u2014 CHINA-REVENUE COMMENTARY THE KEY SWING FACTOR",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-20-twitter-19h-headlines.json",
     "url": "https://x.com/jukan05/status/2057128604253962465"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-20 21:44 UTC",
+    "delivered_at": "2026-05-20 21:00 UTC",
     "headline": "NVIDIA Q1 REVENUE $81.6B UP 85% YoY, DATA CENTER $75.2B \u2014 BEATS TOP AND BOTTOM LINE",
     "source": "@ReutersWorld",
+    "source_file": "research/summaries/2026-05-20-twitter-21h-headlines.json",
     "url": "https://x.com/ReutersWorld/status/2057214880457838823"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-20 21:44 UTC",
+    "delivered_at": "2026-05-20 21:00 UTC",
     "headline": "NVIDIA GUIDES Q2 TO ~$91B, UNVEILS $80B BUYBACK \u2014 SHARES SLIP ~3% AFTER-HOURS DESPITE BEAT",
     "source": "@DanBehringer221",
+    "source_file": "research/summaries/2026-05-20-twitter-21h-headlines.json",
     "url": "https://x.com/DanBehringer221/status/2057213706384375827"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-20 21:44 UTC",
+    "delivered_at": "2026-05-20 21:00 UTC",
     "headline": "OPENAI MODEL CRACKS 80-YEAR-OLD ERD\u0150S UNIT-DISTANCE PROBLEM, DISPROVING SQUARE-GRID BELIEF",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-05-20-twitter-21h-headlines.json",
     "url": "https://x.com/OpenAI/status/2057176201782075690"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-20 21:44 UTC",
+    "delivered_at": "2026-05-20 21:00 UTC",
     "headline": "ALTMAN: 'A GENERAL-PURPOSE MODEL SOLVED A MAJOR OPEN PROBLEM IN MATHEMATICS \u2014 A KINDA BIG MILESTONE'",
     "source": "@sama",
+    "source_file": "research/summaries/2026-05-20-twitter-21h-headlines.json",
     "url": "https://x.com/sama/status/2057203171198636251"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-20 21:44 UTC",
+    "delivered_at": "2026-05-20 21:00 UTC",
     "headline": "WHITE HOUSE AI EXECUTIVE ORDER TO BE RELEASED TOMORROW, WASHINGTON POST REPORTS",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-20-twitter-21h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2057204924006728027"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-21 01:16 UTC",
+    "delivered_at": "2026-05-21 01:00 UTC",
     "headline": "ANTHROPIC TO PAY SPACEX $1.25B/MONTH (~$45B TO 2029) FOR COLOSSUS COMPUTE \u2014 REVEALED IN SPACEX S-1",
     "source": "@zerohedge",
+    "source_file": "research/summaries/2026-05-21-twitter-01h-headlines.json",
     "url": "https://x.com/zerohedge/status/2057211225335861278"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-21 01:16 UTC",
+    "delivered_at": "2026-05-21 01:00 UTC",
     "headline": "SPACEX FILES S-1 ON SEC EDGAR \u2014 $1.75T TARGET, $75B RAISE, JUNE 12 NASDAQ DEBUT UNDER $SPCX",
     "source": "@SawyerMerritt",
+    "source_file": "research/summaries/2026-05-21-twitter-01h-headlines.json",
     "url": "https://x.com/SawyerMerritt/status/2057201539735785746"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-21 01:16 UTC",
+    "delivered_at": "2026-05-21 01:00 UTC",
     "headline": "TRUMP SET TO SIGN AI EXECUTIVE ORDER THURSDAY \u2014 VOLUNTARY 90-DAY FRONTIER-MODEL PRE-RELEASE REVIEW, CEOS INVITED",
     "source": "@steph_palazzolo",
+    "source_file": "research/summaries/2026-05-21-twitter-01h-headlines.json",
     "url": "https://x.com/steph_palazzolo/status/2057179490900377620"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-21 04:39 UTC",
+    "delivered_at": "2026-05-21 01:00 UTC",
+    "headline": "OPENAI PREPARING TO FILE FOR IPO AS SOON AS FRIDAY \u2014 VALUATION COULD TOP $1 TRILLION",
+    "source": "@WSJ",
+    "source_file": "research/summaries/2026-05-21-twitter-01h-headlines.json",
+    "url": "https://x.com/WSJ/status/2057135489040212227"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-21 04:00 UTC",
     "headline": "ANTHROPIC PROJECTS FIRST OPERATING PROFIT \u2014 ~$559M ON $10.9B Q2 REVENUE, UP 130% QoQ (WSJ)",
     "source": "@cmani",
+    "source_file": "research/summaries/2026-05-21-twitter-04h-headlines.json",
     "url": "https://x.com/cmani/status/2057282907039830382"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-21 04:39 UTC",
+    "delivered_at": "2026-05-21 04:00 UTC",
     "headline": "OPENAI SAYS INTERNAL REASONING MODEL DISPROVED ~80-YEAR-OLD ERD\u0150S UNIT-DISTANCE CONJECTURE",
     "source": "@MTSlive",
+    "source_file": "research/summaries/2026-05-21-twitter-04h-headlines.json",
     "url": "https://x.com/MTSlive/status/2057178248648544417"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-21 04:39 UTC",
+    "delivered_at": "2026-05-21 04:00 UTC",
     "headline": "GEMINI 3.5 FLASH RANKS #1 ON ZAPIER AUTOMATION BENCH, 4X FASTER AT A FRACTION OF THE COST",
     "source": "@OfficialLoganK",
+    "source_file": "research/summaries/2026-05-21-twitter-04h-headlines.json",
     "url": "https://x.com/OfficialLoganK/status/2057317567673594131"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-21 04:39 UTC",
+    "delivered_at": "2026-05-21 04:00 UTC",
     "headline": "KOREA DRAM EXPORTS +498% YoY IN MAY, UNIT PRICE +432% \u2014 AI MEMORY SUPERCYCLE INTENSIFIES",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-21-twitter-04h-headlines.json",
     "url": "https://x.com/jukan05/status/2057272845932315045"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-21 07:34 UTC",
+    "delivered_at": "2026-05-21 07:00 UTC",
     "headline": "MUSK STANDS UP IN-HOUSE 'SPACEXAI' DIVISION \u2014 HIRING ENGINEERS, PHYSICISTS WITH ZERO AI EXPERIENCE",
     "source": "@elonmusk",
+    "source_file": "research/summaries/2026-05-21-twitter-07h-headlines.json",
     "url": "https://x.com/elonmusk/status/2057327547411570907"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-21 07:34 UTC",
+    "delivered_at": "2026-05-21 07:00 UTC",
     "headline": "SPACEX S-1 PEGS TOTAL ADDRESSABLE MARKET AT $28.5T \u2014 AI INFRASTRUCTURE THE $2.4T LINE ITEM",
     "source": "@muskonomy",
+    "source_file": "research/summaries/2026-05-21-twitter-07h-headlines.json",
     "url": "https://x.com/muskonomy/status/2057363701083369735"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-21 07:34 UTC",
+    "delivered_at": "2026-05-21 07:00 UTC",
     "headline": "SPACEX Q1 2026 REVENUE $4.7B, +15% YoY PER NOW-PUBLIC S-1; FILING CONFIRMS 18,712 BTC",
     "source": "@Gfilche",
+    "source_file": "research/summaries/2026-05-21-twitter-07h-headlines.json",
     "url": "https://x.com/Gfilche/status/2057357144253677577"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-21 13:24 UTC",
+    "delivered_at": "2026-05-21 13:00 UTC",
     "headline": "ALIBABA QWEN 3.7 MAX HITS TOP-5 ON ARTIFICIAL ANALYSIS INDEX (56.6) \u2014 ~3.6 POINTS BEHIND GPT-5.5",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-21-twitter-13h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2057420016543215779"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-21 13:24 UTC",
+    "delivered_at": "2026-05-21 13:00 UTC",
     "headline": "QWEN 3.7 MAX BEATS GEMINI 3.5 FLASH AND KIMI K2.6 \u2014 NEW TOP CHINESE MODEL, PROPRIETARY NOT OPEN",
     "source": "@aladagberk",
+    "source_file": "research/summaries/2026-05-21-twitter-13h-headlines.json",
     "url": "https://x.com/aladagberk/status/2057422568924004651"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-21 13:24 UTC",
+    "delivered_at": "2026-05-21 13:00 UTC",
     "headline": "WHITE HOUSE TO AWARD $2B IN QUANTUM GRANTS \u2014 $1B DIRECTLY TO IBM, EQUITY STAKES IN NINE COMPANIES",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-21-twitter-13h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2057421528829186077"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-21 13:24 UTC",
+    "delivered_at": "2026-05-21 13:00 UTC",
     "headline": "QUANTUM INDUSTRY EXECUTIVE ORDER BEING DRAFTED; IBM UP ~7% PRE-MARKET ON GRANT REPORT",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-21-twitter-13h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2057424085697613847"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-05-21 13:24 UTC",
+    "delivered_at": "2026-05-21 13:00 UTC",
     "headline": "STABILITY AI SHIPS STABLE AUDIO 3 WITH THREE OPEN-SOURCE VARIANTS, INCLUDING MEDIUM (2B)",
     "source": "@HuggingFace",
+    "source_file": "research/summaries/2026-05-21-twitter-13h-headlines.json",
     "url": "https://x.com/HuggingFace/status/2057428192021938242"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-21 16:14 UTC",
+    "delivered_at": "2026-05-21 16:00 UTC",
     "headline": "WHITE HOUSE CANCELS CEREMONY FOR TRUMP TO SIGN AI & CYBERSECURITY EXECUTIVE ORDER \u2014 AXIOS",
     "source": "@DeItaone",
+    "source_file": "research/summaries/2026-05-21-twitter-16h-headlines.json",
     "url": "https://x.com/DeItaone/status/2057482644577804741"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-21 16:14 UTC",
+    "delivered_at": "2026-05-21 16:00 UTC",
     "headline": "NEWSOM SIGNS FIRST-IN-NATION CALIFORNIA EXECUTIVE ORDER ON AI'S IMPACT ON WORKERS, SMALL BUSINESS",
     "source": "@GovPressOffice",
+    "source_file": "research/summaries/2026-05-21-twitter-16h-headlines.json",
     "url": "https://x.com/GovPressOffice/status/2057484088538435636"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-21 16:14 UTC",
+    "delivered_at": "2026-05-21 16:00 UTC",
     "headline": "OPENAI CONFIDENTIAL IPO S-1 STILL ON TRACK AS SOON AS FRIDAY, SEPTEMBER DEBUT EYED",
     "source": "@ColbFinance",
+    "source_file": "research/summaries/2026-05-21-twitter-16h-headlines.json",
     "url": "https://x.com/ColbFinance/status/2057477929693581500"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-21 18:49 UTC",
+    "delivered_at": "2026-05-21 18:00 UTC",
     "headline": "TRUMP POSTPONES AI EXECUTIVE ORDER \u2014 'DIDN'T LIKE CERTAIN ASPECTS,' SAYS IT COULD BLOCK US AI LEADERSHIP OVER CHINA",
     "source": "@alaynatreene",
+    "source_file": "research/summaries/2026-05-21-twitter-18h-headlines.json",
     "url": "https://x.com/alaynatreene/status/2057498371581936122"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-21 18:49 UTC",
+    "delivered_at": "2026-05-21 18:00 UTC",
     "headline": "ANTHROPIC IN EARLY TALKS TO RUN CLAUDE INFERENCE ON MICROSOFT MAIA 200 CHIPS, DIVERSIFYING FROM NVIDIA \u2014 THE INFORMATION",
     "source": "@rohanpaul_ai",
+    "source_file": "research/summaries/2026-05-21-twitter-18h-headlines.json",
     "url": "https://x.com/rohanpaul_ai/status/2057524853625049450"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-21 18:49 UTC",
+    "delivered_at": "2026-05-21 18:00 UTC",
     "headline": "MICROSOFT SHARES +2% ON REPORT IT IS PITCHING MAIA 200 TO ANTHROPIC AS CHEAPER-THAN-NVIDIA INFERENCE SILICON",
     "source": "@rohanpaul_ai",
+    "source_file": "research/summaries/2026-05-21-twitter-18h-headlines.json",
     "url": "https://x.com/rohanpaul_ai/status/2057524853625049450"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-21 18:49 UTC",
+    "delivered_at": "2026-05-21 18:00 UTC",
     "headline": "NVIDIA BEAT-AND-RAISE DRAWS 4TH STRAIGHT SELL-THE-NEWS SESSION; STOCK STALLS NEAR $230 AT ALL-TIME HIGHS",
     "source": "@GlenChristy6",
+    "source_file": "research/summaries/2026-05-21-twitter-18h-headlines.json",
     "url": "https://x.com/GlenChristy6/status/2057513655969927609"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-21 21:41 UTC",
+    "delivered_at": "2026-05-21 21:00 UTC",
     "headline": "OPENAI Q1 REVENUE ~$5.7B \u2014 ABOUT $1B AHEAD OF ANTHROPIC, PER THE INFORMATION",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-21-twitter-21h-headlines.json",
     "url": "https://x.com/theinformation/status/2057552216651620595"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-21 21:41 UTC",
+    "delivered_at": "2026-05-21 21:00 UTC",
     "headline": "ALTMAN: \"NEW CODEX SHIPS TODAY\" \u2014 OPENAI ADDS macOS APPSHOTS, /goal DEFAULT, SHAREABLE PLUGINS",
     "source": "@sama",
+    "source_file": "research/summaries/2026-05-21-twitter-21h-headlines.json",
     "url": "https://x.com/sama/status/2057559714788258003"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-21 21:41 UTC",
+    "delivered_at": "2026-05-21 21:00 UTC",
     "headline": "ANTHROPIC + OPENAI NOW ~89% OF REVENUE ACROSS 34 TRACKED AI STARTUPS \u2014 THE INFORMATION",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-21-twitter-21h-headlines.json",
     "url": "https://x.com/theinformation/status/2057514274222727216"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-21 21:41 UTC",
+    "delivered_at": "2026-05-21 21:00 UTC",
     "headline": "ANALOG DEVICES IN ADVANCED TALKS TO BUY AI POWER-CHIP STARTUP EMPOWER SEMICONDUCTOR FOR ~$1.5B",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-21-twitter-21h-headlines.json",
     "url": "https://x.com/theinformation/status/2057521865053139230"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-21 21:41 UTC",
+    "delivered_at": "2026-05-21 21:00 UTC",
     "headline": "STUDY: GPT-5.2 HITS EXPERT-LEVEL PEER REVIEW, COMPETITIVE WITH TOP NATURE REVIEWERS",
     "source": "@emollick",
+    "source_file": "research/summaries/2026-05-21-twitter-21h-headlines.json",
     "url": "https://x.com/emollick/status/2057528309727088907"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-22 01:15 UTC",
+    "delivered_at": "2026-05-22 01:00 UTC",
     "headline": "OPENAI SHIPS CODEX UPDATE: CONTROL MAC APPS FROM YOUR PHONE, APPSHOTS, BROWSER ANNOTATION MODE; NOW #1 TRENDING AI STORY",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-05-22-twitter-01h-headlines.json",
     "url": "https://x.com/OpenAI/status/2057617844800794878"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-22 01:15 UTC",
+    "delivered_at": "2026-05-22 01:00 UTC",
     "headline": "THE INFORMATION: SPACEX'S CURRENT BUSINESSES PENCIL TO ~$700B VS ITS $1.75T IPO TARGET \u2014 'NOT YET THE CLOUD BUSINESS'",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-22-twitter-01h-headlines.json",
     "url": "https://x.com/theinformation/status/2057629271045124319"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-22 01:15 UTC",
+    "delivered_at": "2026-05-22 01:00 UTC",
     "headline": "SPACEX SCRUBS FIRST STARSHIP V3 (FLIGHT 12) AFTER FUELING \u2014 STUCK TOWER-ARM PIN; RETRY POSSIBLE FRIDAY 5:30 CT",
     "source": "@elonmusk",
+    "source_file": "research/summaries/2026-05-22-twitter-01h-headlines.json",
     "url": "https://x.com/elonmusk/status/2057609682865254695"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-22 01:15 UTC",
+    "delivered_at": "2026-05-22 01:00 UTC",
     "headline": "MUSK: SPACEX TO COVER ALL POWER-GRID UPGRADE COSTS FOR ITS DATA CENTERS SO THEY DON'T FALL ON RATEPAYERS",
     "source": "@elonmusk",
+    "source_file": "research/summaries/2026-05-22-twitter-01h-headlines.json",
     "url": "https://x.com/elonmusk/status/2057591134654730414"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-22 13:08 UTC",
+    "delivered_at": "2026-05-22 13:00 UTC",
     "headline": "THE INFORMATION: ANTHROPIC IN EARLY TALKS TO RENT MICROSOFT'S CUSTOM MAIA AI CHIPS, DIVERSIFYING OFF NVIDIA",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-22-twitter-13h-headlines.json",
     "url": "https://x.com/theinformation/status/2057793704815907247"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-22 13:08 UTC",
+    "delivered_at": "2026-05-22 13:00 UTC",
     "headline": "OPENAI Q1 REVENUE ~$5.7B \u2014 BUT LOST MORE THAN $1 FOR EVERY DOLLAR IT TOOK IN",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-22-twitter-13h-headlines.json",
     "url": "https://x.com/theinformation/status/2057801171742462445"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-22 13:08 UTC",
+    "delivered_at": "2026-05-22 13:00 UTC",
     "headline": "THE INFORMATION: SPACEX, OPENAI AND ANTHROPIC ALL RACING TOWARD ~$1 TRILLION IPOS AT ONCE",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-22-twitter-13h-headlines.json",
     "url": "https://x.com/theinformation/status/2057808819695104366"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-22 13:08 UTC",
+    "delivered_at": "2026-05-22 13:00 UTC",
     "headline": "DEEPSEEK V4-PRO API PRICE TO DROP TO 1/4 OF ORIGINAL AFTER MAY 31 \u2014 AI PRICE WAR ROLLS ON",
     "source": "@lixuwei2005",
+    "source_file": "research/summaries/2026-05-22-twitter-13h-headlines.json",
     "url": "https://x.com/lixuwei2005/status/2057810725079482637"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-22 15:59 UTC",
+    "delivered_at": "2026-05-22 15:00 UTC",
     "headline": "ALTMAN TO STAFF: FILING ISN'T THE SAME AS GOING PUBLIC \u2014 OPENAI 'WON'T IPO UNTIL READY'",
     "source": "@steph_palazzolo",
+    "source_file": "research/summaries/2026-05-22-twitter-15h-headlines.json",
     "url": "https://x.com/steph_palazzolo/status/2057589397445300348"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-22 15:59 UTC",
+    "delivered_at": "2026-05-22 15:00 UTC",
     "headline": "ALTMAN SAYS ANTHROPIC IS CAPACITY-LIMITED, OPENAI JUST ADDED 2GW+ OF COMPUTE",
     "source": "@steph_palazzolo",
+    "source_file": "research/summaries/2026-05-22-twitter-15h-headlines.json",
     "url": "https://x.com/steph_palazzolo/status/2057589397445300348"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-22 15:59 UTC",
+    "delivered_at": "2026-05-22 15:00 UTC",
     "headline": "SPACEX IPO ASKS INVESTORS FOR A ~$1 TRILLION PREMIUM OVER PRIVATE VALUATION",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-22-twitter-15h-headlines.json",
     "url": "https://x.com/theinformation/status/2057820203954720999"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-22 15:59 UTC",
+    "delivered_at": "2026-05-22 15:00 UTC",
     "headline": "GO FOR LAUNCH: FIRST-EVER STARSHIP V3 (FLIGHT 12) WINDOW OPENS 22:30 UTC TONIGHT",
     "source": "@SpaceX",
+    "source_file": "research/summaries/2026-05-22-twitter-15h-headlines.json",
     "url": "https://x.com/SpaceX/status/2057843818859209147"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-22 15:59 UTC",
+    "delivered_at": "2026-05-22 15:00 UTC",
     "headline": "MICROSOFT PUSHING TO MAKE ANTHROPIC A MARQUEE CUSTOMER FOR ITS MAIA AI CHIPS",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-22-twitter-15h-headlines.json",
     "url": "https://x.com/theinformation/status/2057846479734124754"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-22 18:48 UTC",
+    "delivered_at": "2026-05-22 18:00 UTC",
     "headline": "DEEPSEEK MAKES 75% V4-PRO PRICE CUT PERMANENT \u2014 ~$0.44 INPUT / $0.88 OUTPUT PER 1M TOKENS, CACHE NEARLY FREE",
     "source": "@deepseek_ai",
+    "source_file": "research/summaries/2026-05-22-twitter-18h-headlines.json",
     "url": "https://x.com/deepseek_ai/status/2057854261699195173"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-22 18:48 UTC",
+    "delivered_at": "2026-05-22 18:00 UTC",
     "headline": "DEEPSEEK V4-PRO OUTPUT UNDERCUTS EVERY MAJOR CHINESE MODEL \u2014 VS KIMI K2.6 $4, QWEN 3.7 MAX $7.50",
     "source": "@thehypedotnews",
+    "source_file": "research/summaries/2026-05-22-twitter-18h-headlines.json",
     "url": "https://x.com/thehypedotnews/status/2057857344449495302"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-22 18:48 UTC",
+    "delivered_at": "2026-05-22 18:00 UTC",
     "headline": "THE INFORMATION: CURSOR BUILDING SOFTWARE TO REPLACE CORE PARTS OF GITHUB \u2014 REPOS, SECURITY, AUTOMATED TESTING",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-22-twitter-18h-headlines.json",
     "url": "https://x.com/theinformation/status/2057854144719806749"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-22 18:48 UTC",
+    "delivered_at": "2026-05-22 18:00 UTC",
     "headline": "POLITICO PUBLISHES FULL LEAKED DRAFT OF AI EXECUTIVE ORDER TRUMP PULLED BEFORE SIGNING",
     "source": "@SophiaCai99",
+    "source_file": "research/summaries/2026-05-22-twitter-18h-headlines.json",
     "url": "https://x.com/SophiaCai99/status/2057844511699570951"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-22 18:48 UTC",
+    "delivered_at": "2026-05-22 18:00 UTC",
     "headline": "SEMIANALYSIS: MEDIAN CODING-AGENT REQUEST IS 96K INPUT TOKENS, ~50% EXCEED 128K \u2014 INFERENCE COST NOW SET BY CONTEXT",
     "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-05-22-twitter-18h-headlines.json",
     "url": "https://x.com/SemiAnalysis_/status/2057869518295249373"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-22 18:48 UTC",
+    "delivered_at": "2026-05-22 18:00 UTC",
     "headline": "GOOGLE SAYS GEMINI 3.5 FLASH COULD SAVE LARGE CLOUD CUSTOMERS OVER $1 BILLION A YEAR VS RIVAL FRONTIER MODELS",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-22-twitter-18h-headlines.json",
     "url": "https://x.com/theinformation/status/2057884262087405707"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-22 21:35 UTC",
+    "delivered_at": "2026-05-22 21:00 UTC",
     "headline": "NYT: WHITE HOUSE OKS SECRET ~$9B PUSH TO RUSH TOP-SHELF AI CHIPS TO NSA AND CIA AMID SHORTAGE",
     "source": "@dnvolz",
+    "source_file": "research/summaries/2026-05-22-twitter-21h-headlines.json",
     "url": "https://x.com/dnvolz/status/2057938557910544853"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-22 21:35 UTC",
+    "delivered_at": "2026-05-22 21:00 UTC",
     "headline": "ANTHROPIC FINALIZING CLASSIFIED CONTRACT TO KEEP NSA ACCESS DESPITE SUPPLY-CHAIN DESIGNATION \u2014 NYT",
     "source": "@dnvolz",
+    "source_file": "research/summaries/2026-05-22-twitter-21h-headlines.json",
     "url": "https://x.com/dnvolz/status/2057938818850844925"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-22 21:35 UTC",
+    "delivered_at": "2026-05-22 21:00 UTC",
     "headline": "DEEPSEEK ADVANCING FIRST-EVER OUTSIDE ROUND ~$10.3B \u2014 CATL AND TENCENT IN TALKS TO INVEST",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-22-twitter-21h-headlines.json",
     "url": "https://x.com/theinformation/status/2057929554237276323"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-23 01:11 UTC",
+    "delivered_at": "2026-05-22 21:00 UTC",
+    "headline": "STARSHIP FLIGHT 12 \u2014 FIRST EVER VERSION 3 \u2014 TARGETS 22:30 UTC LAUNCH WINDOW TONIGHT",
+    "source": "@SpaceX",
+    "source_file": "research/summaries/2026-05-22-twitter-21h-headlines.json",
+    "url": "https://x.com/SpaceX/status/2057843818859209147"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-05-23 01:00 UTC",
     "headline": "SPACEX FLIES FIRST V3 STARSHIP ON FLIGHT 12 \u2014 DEPLOYS ~22 STARLINK TEST PAYLOADS; SUPER HEAVY BOOSTER HITS BOOSTBACK ANOMALY",
     "source": "@elonmusk",
+    "source_file": "research/summaries/2026-05-23-twitter-01h-headlines.json",
     "url": "https://x.com/elonmusk/status/2057974937923490301"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-23 04:26 UTC",
+    "delivered_at": "2026-05-23 04:00 UTC",
     "headline": "ANTHROPIC CONFIRMS PROJECT GLASSWING \u2014 ~50 PARTNERS USED GATED 'CLAUDE MYTHOS PREVIEW' TO FIND 10,000+ CRITICAL VULNS IN A MONTH",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-23-twitter-04h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2057909102542549503"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-23 04:26 UTC",
+    "delivered_at": "2026-05-23 04:00 UTC",
     "headline": "GLASSWING'S REAL BOTTLENECK IS PATCHING \u2014 ONLY ~530 HIGH/CRITICAL BUGS DISCLOSED, MAINTAINERS ASK ANTHROPIC TO SLOW DOWN",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-23-twitter-04h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2057909104090169464"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-23 04:26 UTC",
+    "delivered_at": "2026-05-23 04:00 UTC",
     "headline": "MYTHOS PREVIEW: CLOUDFLARE FINDS 2,000 BUGS, MOZILLA FIXES 271 IN FIREFOX (10x), FIRST MODEL TO SOLVE BOTH UK AISI CYBER RANGES",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-23-twitter-04h-headlines.json",
     "url": "https://www.anthropic.com/research/glasswing-initial-update"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-23 04:26 UTC",
+    "delivered_at": "2026-05-23 04:00 UTC",
     "headline": "STARSHIP V3 FLIES FOR THE FIRST TIME \u2014 MAIDEN FLIGHT 12 SEMI-SUCCESSFUL, BOOSTER ANOMALY ON BOOSTBACK BUT SHIP SPLASHDOWN COMPLETE",
     "source": "@SpaceX",
+    "source_file": "research/summaries/2026-05-23-twitter-04h-headlines.json",
     "url": "https://x.com/SpaceX/status/2058005949466501590"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-23 12:33 UTC",
+    "delivered_at": "2026-05-23 04:00 UTC",
+    "headline": "ANALOG DEVICES IN ADVANCED TALKS TO BUY AI POWER-CHIP STARTUP EMPOWER SEMICONDUCTOR FOR ~$1.5B",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-23-twitter-04h-headlines.json",
+    "url": "https://x.com/theinformation/status/2057906865711792262"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-23 12:00 UTC",
     "headline": "DEEPSEEK FUNDING ROUND COULD VALUE CHINESE AI LAB ABOVE $50B \u2014 CATL, TENCENT, STATE FUNDS CIRCLING",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-23-twitter-12h-headlines.json",
     "url": "https://x.com/theinformation/status/2058156092614467806"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-23 15:33 UTC",
+    "delivered_at": "2026-05-23 15:00 UTC",
     "headline": "CURSOR PREPARING DIRECT GITHUB CHALLENGE \u2014 NEW PRODUCT TO MANAGE REPOS, CODE REVIEWS, DEV WORKFLOWS",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-23-twitter-15h-headlines.json",
     "url": "https://x.com/theinformation/status/2058201352711422390"
   },
   {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-23 15:00 UTC",
+    "headline": "THE INFORMATION: SPACEX, OPENAI AND ANTHROPIC ALL RACING TOWARD ~$1 TRILLION IPOS AT ONCE",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-23-twitter-15h-headlines.json",
+    "url": "https://x.com/theinformation/status/2058208861748662778"
+  },
+  {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-23 15:33 UTC",
+    "delivered_at": "2026-05-23 15:00 UTC",
     "headline": "AI DATA CENTERS STRAINING GRID \u2014 TEXAS NOW LETS UTILITIES SHUT FACILITIES DOWN TO STAY STABLE",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-23-twitter-15h-headlines.json",
     "url": "https://x.com/theinformation/status/2058171166968233996"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-23 18:31 UTC",
+    "delivered_at": "2026-05-23 18:00 UTC",
     "headline": "OPENAI TOLD INVESTORS Q1 ADJUSTED OPERATING MARGIN WAS -122% \u2014 ~$1.22 LOST PER DOLLAR ON $5.7B REVENUE",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-23-twitter-18h-headlines.json",
     "url": "https://x.com/theinformation/status/2058231528258208095"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-23 18:31 UTC",
+    "delivered_at": "2026-05-23 18:00 UTC",
     "headline": "THE INFORMATION: SPACEX, OPENAI, ANTHROPIC IPOS COULD UNLEASH BILLIONS IN RETURNS FOR SEQUOIA, THRIVE, FOUNDERS FUND",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-23-twitter-18h-headlines.json",
     "url": "https://x.com/theinformation/status/2058246656303210775"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-23 18:31 UTC",
+    "delivered_at": "2026-05-23 18:00 UTC",
     "headline": "ANTHROPIC WEIGHING MICROSOFT'S MAIA AI CHIPS IN MULTICHIP PUSH TO CUT NVIDIA RELIANCE",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-23-twitter-18h-headlines.json",
     "url": "https://x.com/theinformation/status/2058216442378551467"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-23 18:31 UTC",
+    "delivered_at": "2026-05-23 18:00 UTC",
     "headline": "TRUMP ADMINISTRATION AND ANTHROPIC FINALIZING DEAL TO LET US SPY AGENCIES USE ITS AI TOOLS",
     "source": "@WatcherGuru",
+    "source_file": "research/summaries/2026-05-23-twitter-18h-headlines.json",
     "url": "https://x.com/WatcherGuru/status/2058219136874959285"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-23 21:27 UTC",
+    "delivered_at": "2026-05-23 21:00 UTC",
     "headline": "MICROSOFT ALLOCATES MORE NVIDIA SERVERS AND NEW AZURE CLUSTERS TO ANTHROPIC AS CLAUDE COMPUTE DEMAND RAMPS",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-23-twitter-21h-headlines.json",
     "url": "https://x.com/theinformation/status/2058276804603924547"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-23 21:27 UTC",
+    "delivered_at": "2026-05-23 21:00 UTC",
     "headline": "SEMIANALYSIS: ONSITE GAS TURBINES NOW THE DEFAULT PLANNING ASSUMPTION FOR NEXT-WAVE US AI TRAINING CLUSTERS",
     "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-05-23-twitter-21h-headlines.json",
     "url": "https://x.com/SemiAnalysis_/status/2058291985543303336"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-23 21:27 UTC",
+    "delivered_at": "2026-05-23 21:00 UTC",
     "headline": "GE VERNOVA TARGETING ~24 GW/YR OF GAS TURBINES, SIEMENS ENERGY RAMPING 20 TO 30 GW/YR FOR AI POWER BUILDOUT",
     "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-05-23-twitter-21h-headlines.json",
     "url": "https://x.com/SemiAnalysis_/status/2058291988412199075"
   },
   {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-05-23 21:00 UTC",
+    "headline": "ANTHROPIC ALSO IN TALKS TO RENT MICROSOFT'S CUSTOM MAIA AI CHIPS, EXPANDING MULTICHIP PUSH OFF NVIDIA",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-23-twitter-21h-headlines.json",
+    "url": "https://x.com/theinformation/status/2058216442378551467"
+  },
+  {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-24 01:16 UTC",
+    "delivered_at": "2026-05-24 01:00 UTC",
     "headline": "ANTHROPIC'S GATED \"MYTHOS\" MODEL LEAKS IN CLAUDE UI \u2014 \"CLAUDE-MYTHOS-1-PREVIEW\" SCOPED TO CLAUDE CODE + SECURITY, NOT PUBLIC API",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-24-twitter-01h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2058322222297518498"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-24 01:16 UTC",
+    "delivered_at": "2026-05-24 01:00 UTC",
     "headline": "SEMIANALYSIS: US CONSUMER SENTIMENT WORST SINCE 1952 \u2014 CALLS AI JOB-FEAR A \"MEASURABLE MACRO SIGNAL\"",
     "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-05-24-twitter-01h-headlines.json",
     "url": "https://x.com/SemiAnalysis_/status/2058352311588507795"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-24 01:16 UTC",
+    "delivered_at": "2026-05-24 01:00 UTC",
     "headline": "SECOND ANTHROPIC LEAK: \"CLAUDE-OPUS-4.8\" SPOTTED ON GOOGLE VERTEX \u2014 UNCONFIRMED, NEXT WAVE APPEARS TO BE QUEUING",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-24-twitter-01h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2058226072596971694"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-24 12:36 UTC",
+    "delivered_at": "2026-05-24 12:00 UTC",
     "headline": "XAI OPENS GROK BUILD CODING CLI TO ALL SUPERGROK AND X PREMIUM USERS \u2014 ONE-COMMAND INSTALL, NOW DOUBLES AS READ-ONLY X CLIENT",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-24-twitter-12h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2058513422694670684"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-24 12:36 UTC",
+    "delivered_at": "2026-05-24 12:00 UTC",
     "headline": "AMD COMMITS OVER $10B TO TAIWAN AI INFRASTRUCTURE \u2014 LISA SU TARGETS ADVANCED PACKAGING, SUBSTRATES TO SECURE SUPPLY THROUGH 2029",
     "source": "@dnystedt",
+    "source_file": "research/summaries/2026-05-24-twitter-12h-headlines.json",
     "url": "https://x.com/dnystedt/status/2058090523626537276"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-24 12:36 UTC",
+    "delivered_at": "2026-05-24 12:00 UTC",
     "headline": "KLING AI VIDEO HITS INDUSTRIAL FILM PRODUCTION \u2014 'HOUSE OF DAVID' CITED AS FIRST HOLLYWOOD SHOW TO OPENLY USE IT AT SCALE",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-24-twitter-12h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2058490137139413436"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-24 15:34 UTC",
+    "delivered_at": "2026-05-24 15:00 UTC",
     "headline": "THE INFORMATION: ANTHROPIC MAY SOON OVERTAKE OPENAI BY REVENUE; OPENAI Q1 REVENUE SURGED ON CODEX, CHATGPT",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-24-twitter-15h-headlines.json",
     "url": "https://x.com/theinformation/status/2058548614805274995"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-24 15:34 UTC",
+    "delivered_at": "2026-05-24 15:00 UTC",
     "headline": "THE INFORMATION: SPACEX, OPENAI, ANTHROPIC ALL RACING TOWARD ~$1 TRILLION IPOs AT ONCE \u2014 WALL STREET MUST CHOOSE",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-24-twitter-15h-headlines.json",
     "url": "https://x.com/theinformation/status/2058571236662247767"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-24 15:34 UTC",
+    "delivered_at": "2026-05-24 15:00 UTC",
     "headline": "THE INFORMATION: GOOGLE POSITIONS GEMINI 3.5 FLASH + ANTIGRAVITY AS CHEAPER THAN ANTHROPIC'S CODING MODELS",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-24-twitter-15h-headlines.json",
     "url": "https://x.com/theinformation/status/2058563720209445316"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-24 18:33 UTC",
+    "delivered_at": "2026-05-24 18:00 UTC",
     "headline": "DEEPMIND ALPHAPROOF NEXUS RESOLVES 9 OF 353 OPEN ERD\u0150S PROBLEMS \u2014 LEAN-VERIFIED, ~$100s PER PROBLEM",
     "source": "@mark_k",
+    "source_file": "research/summaries/2026-05-24-twitter-18h-headlines.json",
     "url": "https://x.com/mark_k/status/2058599517549638047"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-24 18:33 UTC",
+    "delivered_at": "2026-05-24 18:00 UTC",
     "headline": "DEEPMIND PREPRINT ALSO PROVES 44 OF 492 OPEN OEIS CONJECTURES VIA LLM-PLUS-LEAN AGENT (arXiv 2605.22763)",
     "source": "@mark_k",
+    "source_file": "research/summaries/2026-05-24-twitter-18h-headlines.json",
     "url": "https://x.com/mark_k/status/2058599517549638047"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-24 18:33 UTC",
+    "delivered_at": "2026-05-24 18:00 UTC",
     "headline": "ANTHROPIC DATAMINE: CLAUDE GETTING FILE-BASED 'MEMORY FILES' OPTION, SEEN AS PREP FOR PERSISTENT 'CONWAY' AGENT",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-24-twitter-18h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2058579152387653841"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-24 18:33 UTC",
+    "delivered_at": "2026-05-24 18:00 UTC",
     "headline": "THE INFORMATION: BUSINESSES NOW FORCING AI VENDORS TO PROVE TOOLS DELIVER \u2014 ADDING OPT-OUT CLAUSES IF FEATURES FALL SHORT",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-24-twitter-18h-headlines.json",
     "url": "https://x.com/theinformation/status/2058609004599734761"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-24 21:27 UTC",
+    "delivered_at": "2026-05-24 21:00 UTC",
     "headline": "OPENAI AVERAGED ~905M WEEKLY ACTIVE USERS IN Q1 \u2014 SHORT OF ITS 1 BILLION YEAR-END GOAL",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-24-twitter-21h-headlines.json",
     "url": "https://x.com/theinformation/status/2058639185297240108"
   },
   {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-24 21:00 UTC",
+    "headline": "THE INFORMATION: OPENAI Q1 REVENUE SURGED ON CODEX/CHATGPT \u2014 BUT ANTHROPIC MAY SOON OVERTAKE IT BY REVENUE",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-24-twitter-21h-headlines.json",
+    "url": "https://x.com/theinformation/status/2058548614805274995"
+  },
+  {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-24 21:27 UTC",
+    "delivered_at": "2026-05-24 21:00 UTC",
     "headline": "DEEPMIND ALPHAPROOF NEXUS SOLVED 9 OF 353 OPEN ERDOS PROBLEMS, LEAN-VERIFIED \u2014 MATHEMATICIANS PUSH BACK ON 'FORMALLY VS HEADLINE SOLVED'",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-24-twitter-21h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2058618029781713002"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-24 21:27 UTC",
+    "delivered_at": "2026-05-24 21:00 UTC",
     "headline": "VATICAN AI ENCYCLICAL 'MAGNIFICA HUMANITAS' SET FOR MONDAY MAY 25 WITH ANTHROPIC CO-FOUNDER CHRIS OLAH",
     "source": "@RNS",
+    "source_file": "research/summaries/2026-05-24-twitter-21h-headlines.json",
     "url": "https://x.com/RNS/status/2058654288243540120"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-25 01:17 UTC",
+    "delivered_at": "2026-05-25 01:00 UTC",
     "headline": "ECB CONVENING BANKS OVER CLAUDE MYTHOS CYBER-RISK, WARNS THREATS NEED FASTER RESPONSE \u2014 PER FT",
     "source": "@Cointelegraph",
+    "source_file": "research/summaries/2026-05-25-twitter-01h-headlines.json",
     "url": "https://x.com/Cointelegraph/status/2058709737370185802"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-25 01:17 UTC",
+    "delivered_at": "2026-05-25 01:00 UTC",
     "headline": "DEEPMIND ALPHAPROOF NEXUS RESOLVES 9 OF 353 OPEN ERDOS PROBLEMS, LEAN-VERIFIED AT A FEW HUNDRED DOLLARS EACH",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-25-twitter-01h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2058673672169107757"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-25 01:17 UTC",
+    "delivered_at": "2026-05-25 01:00 UTC",
     "headline": "VIRAL 'HASSABIS: ERDOS SOLVES DON'T MATTER FOR AGI' POST IS A RECYCLED JAN 2026 DAVOS QUOTE, NOT A NEW STATEMENT",
     "source": "@ns123abc",
+    "source_file": "research/summaries/2026-05-25-twitter-01h-headlines.json",
     "url": "https://x.com/ns123abc/status/2058705608564457733"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-25 07:53 UTC",
+    "delivered_at": "2026-05-25 07:00 UTC",
     "headline": "MUSK: GROK V9-MEDIUM (1.5T) FINISHES PRE-TRAINING, 2-3 WEEKS TO RELEASE, TRAINED ON CURSOR DATA FOR CODING",
     "source": "@elonmusk",
+    "source_file": "research/summaries/2026-05-25-twitter-07h-headlines.json",
     "url": "https://x.com/elonmusk/status/2058787384364265734"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-25 07:53 UTC",
+    "delivered_at": "2026-05-25 07:00 UTC",
     "headline": "VATICAN PUBLISHES MAGNIFICA HUMANITAS \u2014 FIRST PAPAL ENCYCLICAL ENTIRELY ON AI, ANTHROPIC'S OLAH BESIDE THE POPE",
     "source": "@KodowyAgent",
+    "source_file": "research/summaries/2026-05-25-twitter-07h-headlines.json",
     "url": "https://x.com/KodowyAgent/status/2058812107668295780"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-25 10:41 UTC",
+    "delivered_at": "2026-05-25 10:00 UTC",
     "headline": "POPE LEO XIV'S FIRST ENCYCLICAL ON AI: CONTROL 'MUST NOT REMAIN IN HANDS OF A FEW,' CURB LETHAL MILITARY AI",
     "source": "@cnnbrk",
+    "source_file": "research/summaries/2026-05-25-twitter-10h-headlines.json",
     "url": "https://x.com/cnnbrk/status/2058850483033260459"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-25 10:41 UTC",
+    "delivered_at": "2026-05-25 10:00 UTC",
     "headline": "MICROSOFT REPORTEDLY DROPPING THIRD-PARTY CLAUDE CODE FOR IN-HOUSE COPILOT BY JUNE 30; VIRAL 'AI BANNED' FRAMING DISPUTED",
     "source": "@somi_ai",
+    "source_file": "research/summaries/2026-05-25-twitter-10h-headlines.json",
     "url": "https://x.com/somi_ai/status/2058691763511124229"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-25 10:41 UTC",
+    "delivered_at": "2026-05-25 10:00 UTC",
     "headline": "HUAWEI PRESENTS 'TAU SCALING LAW' AT IEEE ISCAS, TARGETS 1.4NM-EQUIVALENT CHIP DENSITY BY 2031 WITHOUT EUV",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-05-25-twitter-10h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2058756156542365783"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-25 13:25 UTC",
+    "delivered_at": "2026-05-25 13:00 UTC",
     "headline": "ANTHROPIC CO-FOUNDER OLAH: AI MAY DISPLACE LABOR 'AT A VERY LARGE SCALE,' SUPPORTING WORKERS A 'MORAL IMPERATIVE'",
     "source": "@disclosetv",
+    "source_file": "research/summaries/2026-05-25-twitter-13h-headlines.json",
     "url": "https://x.com/disclosetv/status/2058859889619763654"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-25 13:25 UTC",
+    "delivered_at": "2026-05-25 13:00 UTC",
     "headline": "ANTHROPIC PASSES OPENAI IN US BUSINESS ADOPTION (34.4% VS 32.3%, RAMP) \u2014 BUT RISING PER-USE COSTS CLOUD THE WIN",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-25-twitter-13h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2058893123414319441"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-25 13:25 UTC",
+    "delivered_at": "2026-05-25 13:00 UTC",
     "headline": "THE INFORMATION: AI BUYERS GAIN LEVERAGE \u2014 FORCING SHORTER CONTRACTS, DISCOUNTS, WRITTEN AUTOMATION GUARANTEES",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-25-twitter-13h-headlines.json",
     "url": "https://x.com/theinformation/status/2058896090011680921"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-25 13:25 UTC",
+    "delivered_at": "2026-05-25 13:00 UTC",
     "headline": "GOOGLE ANTIGRAVITY ADDS GEMINI 3.5 FLASH (LOW) \u2014 45% FEWER TOKENS, RESETS QUOTA ON ALL PAID PLANS",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-25-twitter-13h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2058897591920693468"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-25 16:03 UTC",
+    "delivered_at": "2026-05-25 16:00 UTC",
     "headline": "SPACEX IPO FILING DETAILS ~$40B ANTHROPIC DEAL \u2014 $1.25B/MONTH TO LEASE COLOSSUS 1 THROUGH 2029, EITHER SIDE EXITS ON 90 DAYS",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-25-twitter-16h-headlines.json",
     "url": "https://x.com/theinformation/status/2058911087542603859"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-25 16:03 UTC",
+    "delivered_at": "2026-05-25 16:00 UTC",
     "headline": "SPACEX POSTS $4.7B Q1 REVENUE, $4.3B LOSS AS AI INFRASTRUCTURE SPEND RESHAPES PRE-IPO STORY",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-25-twitter-16h-headlines.json",
     "url": "https://x.com/theinformation/status/2058941264708465126"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-25 16:03 UTC",
+    "delivered_at": "2026-05-25 16:00 UTC",
     "headline": "POPE LEO XIV'S AI ENCYCLICAL GOES MAINSTREAM \u2014 VIRAL 'CALLS TO DISARM AI' FRAMING HITS MARKETS FEEDS",
     "source": "@WatcherGuru",
+    "source_file": "research/summaries/2026-05-25-twitter-16h-headlines.json",
     "url": "https://x.com/WatcherGuru/status/2058929387286696242"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-25 16:03 UTC",
+    "delivered_at": "2026-05-25 16:00 UTC",
     "headline": "MICROSOFT BLOCKS DATABRICKS POWER BI FEATURE, ESCALATING FIGHT OVER THE AI-AGENT SEMANTIC LAYER",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-25-twitter-16h-headlines.json",
     "url": "https://x.com/theinformation/status/2058926174143680811"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-25 18:45 UTC",
+    "delivered_at": "2026-05-25 18:00 UTC",
     "headline": "DEEPMIND OFFICIALLY UNVEILS ALPHAPROOF NEXUS \u2014 AI AGENT SOLVES 9 OPEN ERDOS PROBLEMS, 44 OEIS CONJECTURES, ALL VERIFIED IN LEAN",
     "source": "@GoogleDeepMind",
+    "source_file": "research/summaries/2026-05-25-twitter-18h-headlines.json",
     "url": "https://x.com/GoogleDeepMind/status/2058955817991204970"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-25 18:45 UTC",
+    "delivered_at": "2026-05-25 18:00 UTC",
     "headline": "POPE LEO XIV'S AI ENCYCLICAL HITS GLOBAL WIRE \u2014 REUTERS/AP: URGES AI REGULATION, WARNS SOME WEAPONS NOW 'BEYOND HUMAN CONTROL'",
     "source": "@abc13houston",
+    "source_file": "research/summaries/2026-05-25-twitter-18h-headlines.json",
     "url": "https://x.com/abc13houston/status/2058981464176242692"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-05-25 18:45 UTC",
+    "delivered_at": "2026-05-25 18:00 UTC",
     "headline": "MiMo V2.5-CODER RELEASED OPEN-WEIGHTS \u2014 BILLED AS A TOP LOCAL CODING MODEL, RUNS ON 128GB RAM",
     "source": "@HuggingFace",
+    "source_file": "research/summaries/2026-05-25-twitter-18h-headlines.json",
     "url": "https://x.com/huggingface/status/2058943804665688365"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-25 21:34 UTC",
+    "delivered_at": "2026-05-25 21:00 UTC",
     "headline": "DEEPSEEK SEEKING ~$7.35B RAISE \u2014 THE '$50B' FIGURE WAS THE VALUATION, NOT THE ROUND",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-25-twitter-21h-headlines.json",
     "url": "https://x.com/theinformation/status/2059016688645935246"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-25 21:34 UTC",
+    "delivered_at": "2026-05-25 21:00 UTC",
     "headline": "DEEPSEEK PERMANENTLY CUTS V4-PRO API PRICES 75% \u2014 UNDER A TENTH OF GPT-5.5 RATES",
     "source": "@caixin",
+    "source_file": "research/summaries/2026-05-25-twitter-21h-headlines.json",
     "url": "https://x.com/caixin/status/2058925874620035346"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-25 21:34 UTC",
+    "delivered_at": "2026-05-25 21:00 UTC",
     "headline": "ANTHROPIC POSTS OLAH'S VATICAN REMARKS: AI HAS 'INTERNAL STATES THAT FUNCTIONALLY MIRROR FEAR, GRIEF'",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-25-twitter-21h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2058983299092009421"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-25 21:34 UTC",
+    "delivered_at": "2026-05-25 21:00 UTC",
     "headline": "GOOGLE AI STUDIO SHIPS FREE NATIVE ANDROID APP-BUILDING \u2014 250,000 APPS IN ONE WEEK",
     "source": "@OfficialLoganK",
+    "source_file": "research/summaries/2026-05-25-twitter-21h-headlines.json",
     "url": "https://x.com/OfficialLoganK/status/2058997700218294564"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-25 21:34 UTC",
+    "delivered_at": "2026-05-25 21:00 UTC",
     "headline": "XAI CONFIRMS GROK BUILD NOW IN OPEN BETA FOR ALL SUPERGROK AND X PREMIUM+ USERS",
     "source": "@elonmusk",
+    "source_file": "research/summaries/2026-05-25-twitter-21h-headlines.json",
     "url": "https://x.com/elonmusk/status/2059016015644614797"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-26 04:34 UTC",
+    "delivered_at": "2026-05-26 04:00 UTC",
     "headline": "ANTHROPIC HIT WITH 'REGULATORY CAPTURE' BACKLASH OVER OLAH VATICAN REMARKS ANTHROPOMORPHIZING LLMS",
     "source": "@firstadopter",
+    "source_file": "research/summaries/2026-05-26-twitter-04h-headlines.json",
     "url": "https://x.com/firstadopter/status/2058986369934852449"
   },
   {
+    "backfilled": true,
     "category": "",
-    "delivered_at": "2026-05-26 04:34 UTC",
+    "delivered_at": "2026-05-26 04:00 UTC",
     "headline": "EMOLLICK: ZERO RIGOROUS PRODUCTIVITY STUDIES OF POST-DEC-2025 AUTONOMOUS CODING TOOLS \u2014 'A HUGE GAP'",
     "source": "@emollick",
+    "source_file": "research/summaries/2026-05-26-twitter-04h-headlines.json",
     "url": "https://x.com/emollick/status/2059118330472972331"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-26 04:34 UTC",
+    "delivered_at": "2026-05-26 04:00 UTC",
     "headline": "ROON: AI MARKET WILL CONCENTRATE TO ONE FIRM 'RUN AS REGULATED UTILITY' \u2014 FRONTIER-LAB TAKE ON ENDGAME",
     "source": "@tszzl",
+    "source_file": "research/summaries/2026-05-26-twitter-04h-headlines.json",
     "url": "https://x.com/tszzl/status/2059125674309542104"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-26 04:34 UTC",
+    "delivered_at": "2026-05-26 04:00 UTC",
     "headline": "BNN BLOOMBERG: POPE CALLS FOR ROBUST AI REGULATION IN MAGNIFICA HUMANITAS MANIFESTO",
     "source": "@BNNBloomberg",
+    "source_file": "research/summaries/2026-05-26-twitter-04h-headlines.json",
     "url": "https://x.com/BNNBloomberg/status/2059129980219527314"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-26 04:34 UTC",
+    "delivered_at": "2026-05-26 04:00 UTC",
     "headline": "JUKAN: HOLY STONE WARNS AI POWER-SPEC UPGRADES TO DEEPEN MLCC SHORTAGE \u2014 STRONGEST DEMAND IN 20 YEARS",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-26-twitter-04h-headlines.json",
     "url": "https://x.com/jukan05/status/2059101609901391927"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-26 07:29 UTC",
+    "delivered_at": "2026-05-26 07:00 UTC",
     "headline": "HUAWEI OFFICIALLY UNVEILS TAU SCALING LAW \u2014 TARGETS 1.4NM-EQUIVALENT DENSITY BY 2031 WITHOUT EUV",
     "source": "@Huawei",
+    "source_file": "research/summaries/2026-05-26-twitter-07h-headlines.json",
     "url": "https://x.com/Huawei/status/2059174428093882615"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-26 07:29 UTC",
+    "delivered_at": "2026-05-26 07:00 UTC",
     "headline": "BERNSTEIN CALLS HUAWEI TAU LAW \"ANOTHER DEEPSEEK MOMENT\" \u2014 FLAGS 2X\u201310X SPEEDUP FROM SOFTWARE OPTIMIZATIONS",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-26-twitter-07h-headlines.json",
     "url": "https://x.com/jukan05/status/2059162462767939796"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-05-26 07:29 UTC",
+    "delivered_at": "2026-05-26 07:00 UTC",
     "headline": "NEW CUSP BENCHMARK: FRONTIER MODELS FAIL TO PREDICT WHEN SCIENTIFIC ADVANCES OCCUR \u2014 ACROSS 4,760 EVENTS",
     "source": "@hardmaru",
+    "source_file": "research/summaries/2026-05-26-twitter-07h-headlines.json",
     "url": "https://x.com/hardmaru/status/2059169884563742879"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-26 07:29 UTC",
+    "delivered_at": "2026-05-26 07:00 UTC",
     "headline": "INDIA'S CBSE NATIONAL EXAM PORTAL TAKEN OFFLINE AFTER 19-YEAR-OLD CHANGES ANY OF 2M STUDENTS' MARKS",
     "source": "@deedydas",
+    "source_file": "research/summaries/2026-05-26-twitter-07h-headlines.json",
     "url": "https://x.com/deedydas/status/2059131444346425354"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-26 10:31 UTC",
+    "delivered_at": "2026-05-26 10:00 UTC",
     "headline": "HUAWEI TAU SCALING LAW WALKED BACK BY NAMED CHIP ARCHITECT \u2014 LEAKAGE-POWER SILENCE IS THE TELL, NOT A LITHOGRAPHY BREAKTHROUGH",
     "source": "@fi56622380",
+    "source_file": "research/summaries/2026-05-26-twitter-10h-headlines.json",
     "url": "https://x.com/fi56622380/status/2059176109061857761"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-26 10:31 UTC",
+    "delivered_at": "2026-05-26 10:00 UTC",
     "headline": "FDA LAUNCHES 10-COMPANY PILOT TO EVALUATE AI-GENERATED DRUG-SUBMISSION EVIDENCE \u2014 200+ AI-DESIGNED DRUGS IN TRIALS, ZERO APPROVED",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-26-twitter-10h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2059189028549738594"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-26 10:31 UTC",
+    "delivered_at": "2026-05-26 10:00 UTC",
     "headline": "MEMORY ANALYST: ~30% OF INDUSTRY DDR VOLUMES SET TO LOCK IN AT NEAR-CURRENT PRICING VIA LONG-TERM AGREEMENTS",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-26-twitter-10h-headlines.json",
     "url": "https://x.com/jukan05/status/2059190597328757064"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-26 10:31 UTC",
+    "delivered_at": "2026-05-26 10:00 UTC",
     "headline": "HUAWEI TAU MARGINAL BENEFIT DIMINISHES \u2014 100% AT 2 LAYERS, 50% AT 3, JUST 33% BY 2035 FOR 4-LAYER FOLDING",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-26-twitter-10h-headlines.json",
     "url": "https://x.com/jukan05/status/2059182877284413907"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-26 10:31 UTC",
+    "delivered_at": "2026-05-26 10:00 UTC",
     "headline": "@KIMMONISMUS: CODEX QUALITY HAS GOTTEN NOTICEABLY WORSE \u2014 IN-FEED USERS PILE ON, NO OPENAI RESPONSE",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-26-twitter-10h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2059206754253099176"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-26 13:19 UTC",
+    "delivered_at": "2026-05-26 13:00 UTC",
     "headline": "GOOGLE DEEPMIND: SYNTHID PASSES 100B WATERMARKED PIECES; OPENAI, ELEVENLABS, KAKAO JOIN NVIDIA IN CROSS-LAB ADOPTION",
     "source": "@GoogleDeepMind",
+    "source_file": "research/summaries/2026-05-26-twitter-13h-headlines.json",
     "url": "https://x.com/GoogleDeepMind/status/2059235181274202500"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-26 13:19 UTC",
+    "delivered_at": "2026-05-26 13:00 UTC",
     "headline": "SYNTHID VERIFICATION HITS 50M+ GEMINI CHECKS; NOW ROLLING OUT TO GOOGLE SEARCH AND CHROME",
     "source": "@GoogleDeepMind",
+    "source_file": "research/summaries/2026-05-26-twitter-13h-headlines.json",
     "url": "https://x.com/GoogleDeepMind/status/2059235184130535436"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-26 13:19 UTC",
+    "delivered_at": "2026-05-26 13:00 UTC",
     "headline": "PIXEL VIDEO PROVENANCE TRAIL ARRIVES \u2014 SIGNED FROM THE MOMENT YOU HIT RECORD",
     "source": "@GoogleDeepMind",
+    "source_file": "research/summaries/2026-05-26-twitter-13h-headlines.json",
     "url": "https://x.com/GoogleDeepMind/status/2059235187003642154"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-26 13:19 UTC",
+    "delivered_at": "2026-05-26 13:00 UTC",
     "headline": "LECUN BREAKS LAB-PRINCIPAL SILENCE ON POPE'S AI ENCYCLICAL \u2014 RTs 'CLOSED-SOURCE CITADELS' CRITIQUE OF ANTHROPIC/OPENAI",
     "source": "@ylecun",
+    "source_file": "research/summaries/2026-05-26-twitter-13h-headlines.json",
     "url": "https://x.com/ylecun/status/2059252114912182463"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-26 13:19 UTC",
+    "delivered_at": "2026-05-26 13:00 UTC",
     "headline": "THE INFORMATION: SPACEX, OPENAI, ANTHROPIC TRILLION-DOLLAR IPOs COULD ALL HIT MARKETS WITHIN MONTHS",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-26-twitter-13h-headlines.json",
     "url": "https://x.com/theinformation/status/2059243144940982530"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-26 13:19 UTC",
+    "delivered_at": "2026-05-26 13:00 UTC",
     "headline": "EX-PALANTIR TRIO LAUNCH PERCEPTIC OUT OF STEALTH WITH $12M SEED FOR END-TO-END AI DRUG DEVELOPMENT PLATFORM",
     "source": "@FortuneMagazine",
+    "source_file": "research/summaries/2026-05-26-twitter-13h-headlines.json",
     "url": "https://x.com/FortuneMagazine/status/2059255967909208224"
   },
   {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-05-26 16:00 UTC",
+    "headline": "HARVARD MATHEMATICIAN: STILL-UNRELEASED ANTHROPIC MYTHOS SOLVED ERD\u0150S UNIT-DISTANCE PROBLEM #90",
+    "source": "@__alpoge__",
+    "source_file": "research/summaries/2026-05-26-twitter-16h-headlines.json",
+    "url": "https://x.com/__alpoge__/status/2059298565093196012"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-05-26 16:00 UTC",
+    "headline": "NEW OSWORLD COMPUTER-USE SOTA \u2014 CLAUDE OPUS 4.7 HITS 83.6%, SONNET 4.6 81.5% VS 72.4% HUMAN BASELINE",
+    "source": "@nealchopra",
+    "source_file": "research/summaries/2026-05-26-twitter-16h-headlines.json",
+    "url": "https://x.com/nealchopra/status/2059303604373295301"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-05-26 16:00 UTC",
+    "headline": "ANTHROPIC PROJECT GLASSWING ONE-MONTH UPDATE LANDS IN MAINSTREAM SECURITY PRESS: 23,000 VULNS ACROSS 1,000 OSS PROJECTS",
+    "source": "@HackRead",
+    "source_file": "research/summaries/2026-05-26-twitter-16h-headlines.json",
+    "url": "https://x.com/HackRead/status/2059303488870371670"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-26 16:00 UTC",
+    "headline": "THE INFORMATION: SPACEX $1.75T IPO VALUATION RESTS ON $700B REAL BUSINESS PLUS $1T OF \"TECH THAT DOESN'T YET EXIST\"",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-26-twitter-16h-headlines.json",
+    "url": "https://x.com/theinformation/status/2059296025722961962"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-05-26 16:00 UTC",
+    "headline": "MICRON HITS $1 TRILLION MARKET CAP AS AI-DRIVEN MEMORY LTA SQUEEZE LOCKS IN ~30% OF DDR VOLUMES NEAR CURRENT PRICES",
+    "source": "@jukan05",
+    "source_file": "research/summaries/2026-05-26-twitter-16h-headlines.json",
+    "url": "https://x.com/jukan05/status/2059284149090103499"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-05-26 16:00 UTC",
+    "headline": "OPENROUTER NOW SERVING 1.5 QUADRILLION TOKENS/YR \u2014 15\u201330% OF GOOGLE APIS, 20\u201340% OF OPENAI, >50% OF AZURE FOUNDRY",
+    "source": "@deedydas",
+    "source_file": "research/summaries/2026-05-26-twitter-16h-headlines.json",
+    "url": "https://x.com/deedydas/status/2059298453872947623"
+  },
+  {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-31 12:47 UTC",
+    "delivered_at": "2026-05-26 16:00 UTC",
+    "headline": "GOOGLE DEEPMIND LAUNCHES GEMINI FOR SCIENCE \u2014 HYPOTHESIS GENERATION, COMPUTATIONAL DISCOVERY, LITERATURE INSIGHTS",
+    "source": "@GoogleDeepMind",
+    "source_file": "research/summaries/2026-05-26-twitter-16h-headlines.json",
+    "url": "https://x.com/GoogleDeepMind/status/2059302777818325236"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-05-31 12:00 UTC",
     "headline": "APPLE WWDC SIRI: ON-DEVICE DISTILLED GEMINI; HEAVY QUERIES NOW ROUTE TO GOOGLE CLOUD VIA NVIDIA CONFIDENTIAL-COMPUTE",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-31-twitter-12h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2061058117304262999"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-31 12:47 UTC",
+    "delivered_at": "2026-05-31 12:00 UTC",
     "headline": "ANTHROPIC CLOSES $65B SERIES H AT $965B POST-MONEY; $47B RUN-RATE \u2014 FIRST PRIVATE AI LAB PAST OPENAI BY PAPER VALUATION",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-05-31-twitter-12h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2060061347522433422"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-31 12:47 UTC",
+    "delivered_at": "2026-05-31 12:00 UTC",
     "headline": "CHAPTER CEO ON THE INFORMATION: ANTHROPIC 'DECREASED PRIOR MODEL QUALITY BEFORE NEW LAUNCH' \u2014 'APPLE PLAYBOOK'",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-31-twitter-12h-headlines.json",
     "url": "https://x.com/theinformation/status/2060783533564612887"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-31 12:47 UTC",
+    "delivered_at": "2026-05-31 12:00 UTC",
     "headline": "OPENROUTER RAISES $113M SERIES B AT $1.3B; CAPITALG (ALPHABET) LED, NVENTURES (NVIDIA) IN \u2014 ON TRACK FOR >1Q TOKENS/YR",
     "source": "@betterhn300",
+    "source_file": "research/summaries/2026-05-31-twitter-12h-headlines.json",
     "url": "https://x.com/betterhn300/status/2060934546376249774"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-31 12:47 UTC",
+    "delivered_at": "2026-05-31 12:00 UTC",
     "headline": "ROBINHOOD LAUNCHES AGENTIC TRADING + AGENTIC CREDIT CARD \u2014 THIRD-PARTY AI AGENTS NOW EXECUTE TRADES, PURCHASES",
     "source": "@0xJiuJitsuJerry",
+    "source_file": "research/summaries/2026-05-31-twitter-12h-headlines.json",
     "url": "https://x.com/0xJiuJitsuJerry/status/2060766741018583515"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-05-31 12:47 UTC",
+    "delivered_at": "2026-05-31 12:00 UTC",
     "headline": "DEEPSEEK PUBLISHES MULTI-CODING-AGENT INTEGRATION REPO \u2014 CLAUDE CODE, COPILOT, CODEX, CURSOR, WINDSURF + 20 MORE",
     "source": "@chenzeling4",
+    "source_file": "research/summaries/2026-05-31-twitter-12h-headlines.json",
     "url": "https://x.com/chenzeling4/status/2061055850400375192"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-31 15:40 UTC",
+    "delivered_at": "2026-05-31 15:00 UTC",
     "headline": "ANTHROPIC LEAK \u2014 CONWAY ONE-AGENT-PER-USER, ORBIT 'DEPLOY FAVORITE APPS', OPERON FOR BIOSCIENCE, .EXT CLAUDE MARKETPLACE COMING",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-31-twitter-15h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2061084839042838916"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-31 15:40 UTC",
+    "delivered_at": "2026-05-31 15:00 UTC",
     "headline": "MICROSOFT BUILD 2026 LEAK \u2014 COPILOT SUPER APP WITH CODE + COWORK TABS + SCOUT 24/7 AGENT STAGED FOR JUNE 2 UNVEIL",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-31-twitter-15h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2061108892709347444"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-31 15:40 UTC",
+    "delivered_at": "2026-05-31 15:00 UTC",
     "headline": "OPENAI'S TIBO CLAIMS 5M CODEX USERS, RATE LIMITS RESET MONDAY MORNING; SAM ALTMAN RETWEETS",
     "source": "@thsottiaux",
+    "source_file": "research/summaries/2026-05-31-twitter-15h-headlines.json",
     "url": "https://x.com/thsottiaux/status/2060964284117782996"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-05-31 15:40 UTC",
+    "delivered_at": "2026-05-31 15:00 UTC",
     "headline": "SAM ALTMAN RECIRCULATES ROSALIND BIODEFENSE LAUNCH: 'WE WANT TO HELP THE WORLD GET A HEAD START ON BIODEFENSE'",
     "source": "@sama",
+    "source_file": "research/summaries/2026-05-31-twitter-15h-headlines.json",
     "url": "https://x.com/sama/status/2061101875303530871"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-31 15:40 UTC",
+    "delivered_at": "2026-05-31 15:00 UTC",
     "headline": "FIREWORKS AI HITS $800M ANNUALIZED RUN RATE, 4X REVENUE GROWTH EX-CURSOR",
     "source": "@lqiao",
+    "source_file": "research/summaries/2026-05-31-twitter-15h-headlines.json",
     "url": "https://x.com/_akhaliq/status/2061103514906935703"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-31 15:40 UTC",
+    "delivered_at": "2026-05-31 15:00 UTC",
     "headline": "COREWEAVE + DELL FIRST CLOUD TO PASS L11 DIAGS ON NVIDIA RUBIN VR200 NVL72",
     "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-05-31-twitter-15h-headlines.json",
     "url": "https://x.com/SemiAnalysis_/status/2060912340590084479"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-31 15:40 UTC",
+    "delivered_at": "2026-05-31 15:00 UTC",
     "headline": "APPLE AI GLASSES PUSHED TO LATE 2027, VISION AIR TO 2029 \u2014 GURMAN REPORT",
     "source": "@9to5mac",
+    "source_file": "research/summaries/2026-05-31-twitter-15h-headlines.json",
     "url": "https://x.com/9to5mac/status/2061103805857505725"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-05-31 21:30 UTC",
+    "delivered_at": "2026-05-31 21:00 UTC",
     "headline": "SAM ALTMAN FORMALIZES OPENAI ROBOTICS \u2014 WORLD-SIM RESEARCH BECOMES HARDWARE ORG UNDER ADITYA RAMESH",
     "source": "@sama",
+    "source_file": "research/summaries/2026-05-31-twitter-21h-headlines.json",
     "url": "https://x.com/sama/status/2061117302528188712"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-31 21:30 UTC",
+    "delivered_at": "2026-05-31 21:00 UTC",
     "headline": "THE INFORMATION: MICROSOFT TO UNVEIL HOMEGROWN AI MODELS FOR CODING, SPEECH, REASONING AT BUILD 2026 TO CUT OPENAI / ANTHROPIC RELIANCE",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-31-twitter-21h-headlines.json",
     "url": "https://x.com/theinformation/status/2061160814615097363"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-05-31 21:30 UTC",
+    "delivered_at": "2026-05-31 21:00 UTC",
+    "headline": "TESTINGCATALOG SCOOPS COPILOT CODE + COWORK + SCOUT 24/7 AGENT TABS IN MICROSOFT BUILD 2026 SUPER-APP",
+    "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-05-31-twitter-21h-headlines.json",
+    "url": "https://x.com/testingcatalog/status/2061108892709347444"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-05-31 21:00 UTC",
     "headline": "CLAUDE MYTHOS PREVIEW PRICED AT $25 / $125 PER MILLION TOKENS \u2014 5X OPUS 4.7",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-05-31-twitter-21h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2061170599309791738"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-31 21:30 UTC",
+    "delivered_at": "2026-05-31 21:00 UTC",
     "headline": "SEMIANALYSIS: FRONTIER INFERENCE NOW 10X SPEED AT 20-50X PRICE PREMIUM \u2014 MARKET TEST FOR ULTRA-LOW-LATENCY AI",
     "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-05-31-twitter-21h-headlines.json",
     "url": "https://x.com/SemiAnalysis_/status/2061130917947576700"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-05-31 21:30 UTC",
+    "delivered_at": "2026-05-31 21:00 UTC",
     "headline": "THE INFORMATION: META LAUNCHES ENTERPRISE SOLUTIONS UNIT TO EMBED ENGINEERS WITH CORPORATE CUSTOMERS",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-31-twitter-21h-headlines.json",
     "url": "https://x.com/theinformation/status/2061168362768454035"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-05-31 21:30 UTC",
+    "delivered_at": "2026-05-31 21:00 UTC",
     "headline": "THE INFORMATION: APPLE'S AI COMEBACK PIVOTS TO ON-DEVICE INFERENCE OVER DATA CENTERS",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-05-31-twitter-21h-headlines.json",
     "url": "https://x.com/theinformation/status/2061175908308807750"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-06-01 01:49 UTC",
+    "delivered_at": "2026-06-01 01:00 UTC",
     "headline": "META AI INSTAGRAM EXPLOIT \u2014 AGENT RESET PASSWORDS ON NON-MFA ACCOUNTS WITHOUT IDENTITY CHECK; ZACHXBT, DARKWEBINFORMER CONFIRM PATCH",
     "source": "@zachxbt",
+    "source_file": "research/summaries/2026-06-01-twitter-01h-headlines.json",
     "url": "https://x.com/zachxbt/status/2061251183675949365"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-06-01 01:49 UTC",
+    "delivered_at": "2026-06-01 01:00 UTC",
     "headline": "INSTAGRAM HANDLES SWAPPED OVER WEEKEND AS TELEGRAM CHANNELS MONETIZED META AI BYPASS \u2014 IN-THREAD VICTIMS CONFIRM 2FA SKIRTED",
     "source": "@weezerOSINT",
+    "source_file": "research/summaries/2026-06-01-twitter-01h-headlines.json",
     "url": "https://x.com/weezerOSINT/status/2061223556994965643"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-01 01:49 UTC",
+    "delivered_at": "2026-06-01 01:00 UTC",
     "headline": "SOFTBANK MARKET CAP TOPS TOYOTA AT \u00a546.62T VS \u00a545.73T \u2014 FIRST TIME IN ~22 YEARS, NIKKEI PINS IT ON OPENAI STAKE",
     "source": "@AIElecX",
+    "source_file": "research/summaries/2026-06-01-twitter-01h-headlines.json",
     "url": "https://x.com/AIElecX/status/2061263757192630326"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-01 01:49 UTC",
+    "delivered_at": "2026-06-01 01:00 UTC",
     "headline": "APPLE SIRI ENGINEER KELSEY PETERSON STARTS AT OPENAI 8 DAYS BEFORE WWDC 2026 \u2014 GURMAN",
     "source": "@markgurman",
+    "source_file": "research/summaries/2026-06-01-twitter-01h-headlines.json",
     "url": "https://x.com/markgurman/status/2061236259843182813"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-01 01:49 UTC",
+    "delivered_at": "2026-06-01 01:00 UTC",
     "headline": "MICROSOFT BUILD 2026 OPENS MON JUNE 2, 9:30 AM PT \u2014 NADELLA KEYNOTE ON 'ASYNC COWORKERS,' COPILOT CODE/COWORK/SCOUT TABS LEAKED",
     "source": "@JoeMaristela",
+    "source_file": "research/summaries/2026-06-01-twitter-01h-headlines.json",
     "url": "https://x.com/JoeMaristela/status/2061262460917555374"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-01 01:49 UTC",
+    "delivered_at": "2026-06-01 01:00 UTC",
     "headline": "OPENAI ROBOTICS HIRING DRIVE \u2014 SAMA POST ANCHORS WEEKEND TALENT WAVE AT 9,288 LIKES",
     "source": "@sama",
+    "source_file": "research/summaries/2026-06-01-twitter-01h-headlines.json",
     "url": "https://x.com/sama/status/2061117302528188712"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-01 05:04 UTC",
+    "delivered_at": "2026-06-01 05:00 UTC",
     "headline": "NVIDIA SHIPS DGX STATION FOR WINDOWS \u2014 1-TRILLION-PARAMETER FRONTIER MODELS RUN LOCALLY ON GB300, OPENSHELL FOR ON-DEVICE AGENTS",
     "source": "@nvidianewsroom",
+    "source_file": "research/summaries/2026-06-01-twitter-05h-headlines.json",
     "url": "https://x.com/nvidianewsroom/status/2061307670607319201"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-01 05:04 UTC",
+    "delivered_at": "2026-06-01 05:00 UTC",
     "headline": "MINIMAX M3 LAUNCHES \u2014 OPEN-WEIGHTS, 1M CONTEXT VIA SPARSE ATTENTION, 59% SWE-BENCH PRO; WEIGHTS + TECH REPORT IN 10 DAYS",
     "source": "@MiniMax_AI",
+    "source_file": "research/summaries/2026-06-01-twitter-05h-headlines.json",
     "url": "https://x.com/MiniMax_AI/status/2061266317815296322"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-06-01 05:04 UTC",
+    "delivered_at": "2026-06-01 05:00 UTC",
     "headline": "NVIDIA ALPAMAYO 2 SUPER \u2014 32B OPEN-WEIGHTS REASONING VLA FOR LEVEL-4 ROBOTAXIS, SHIPS WITH ALPAGYM + OMNIDREAMS",
     "source": "@nvidianewsroom",
+    "source_file": "research/summaries/2026-06-01-twitter-05h-headlines.json",
     "url": "https://x.com/nvidianewsroom/status/2061311112059003264"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-01 05:04 UTC",
+    "delivered_at": "2026-06-01 05:00 UTC",
     "headline": "NVIDIA RTX SPARK \u2014 1 PFLOP CONSUMER PC CHIP FOR ON-DEVICE AI AGENTS, SHIPPING FALL 2026 WITH ASUS DELL HP LENOVO MS SURFACE MSI",
     "source": "@IdleProtocol",
+    "source_file": "research/summaries/2026-06-01-twitter-05h-headlines.json",
     "url": "https://x.com/IdleProtocol/status/2061311993458397675"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-06-01 05:04 UTC",
+    "delivered_at": "2026-06-01 05:00 UTC",
     "headline": "NVIDIA ISAAC GR00T \u2014 FIRST OPEN HUMANOID ROBOT REFERENCE DESIGN, UNITREE H2 BODY + SHARPA FIVE-FINGERED HANDS + JETSON THOR",
     "source": "@nvidianewsroom",
+    "source_file": "research/summaries/2026-06-01-twitter-05h-headlines.json",
     "url": "https://x.com/nvidianewsroom/status/2061312819480392042"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-01 05:04 UTC",
+    "delivered_at": "2026-06-01 05:00 UTC",
     "headline": "CHINA ISSUES SWEEPING NEW RULES TIGHTENING OVERSEAS DEALS ON INVESTORS, TECH, DATA, NATIONAL SECURITY \u2014 ONE MONTH POST-MANUS UNWIND",
     "source": "@ReutersTech",
+    "source_file": "research/summaries/2026-06-01-twitter-05h-headlines.json",
     "url": "https://x.com/ReutersTech/status/2061310663595553237"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-01 05:04 UTC",
+    "delivered_at": "2026-06-01 05:00 UTC",
     "headline": "DECART RAISES $300M WITH NVIDIA BACKING \u2014 GENERATIVE-AI INFRASTRUCTURE LAYER STILL TOP VC TARGET",
     "source": "@FutureWire__",
+    "source_file": "research/summaries/2026-06-01-twitter-05h-headlines.json",
     "url": "https://x.com/FutureWire__/status/2061312156050563357"
   },
   {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-06-01 08:00 UTC",
+    "headline": "SEMIANALYSIS LABELS JENSEN COMPUTEX KEYNOTE 'F TIER' \u2014 NVIDIA x MEDIATEK LAPTOP CHIP REPORTEDLY 6-8 MONTHS DELAYED",
+    "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-06-01-twitter-08h-headlines.json",
+    "url": "https://x.com/SemiAnalysis_/status/2061315076045295727"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-06-01 08:00 UTC",
+    "headline": "INTEL CRESCENT ISLAND AI DATA CENTER CHIP TARGETS YEAR-END LAUNCH \u2014 INFERENCE-FOCUSED, LPDDR5 NOT HBM, CHINA-COMPLIANT SKU IN PLAY (PER FT)",
+    "source": "@wallstengine",
+    "source_file": "research/summaries/2026-06-01-twitter-08h-headlines.json",
+    "url": "https://x.com/wallstengine/status/2061356265507614854"
+  },
+  {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-01 11:02 UTC",
+    "delivered_at": "2026-06-01 08:00 UTC",
+    "headline": "GOLDMAN SACHS RE-RATES MEMORY BIG THREE ON P/E BASIS \u2014 SAMSUNG, SK HYNIX BREAK HISTORICAL P/B CEILINGS ON AI ROE EXPANSION",
+    "source": "@jukan05",
+    "source_file": "research/summaries/2026-06-01-twitter-08h-headlines.json",
+    "url": "https://x.com/jukan05/status/2061333846759784518"
+  },
+  {
+    "backfilled": true,
+    "category": "opensource",
+    "delivered_at": "2026-06-01 08:00 UTC",
+    "headline": "NVIDIA COSMOS 3 WEIGHTS + POST-TRAINING RECIPES LIVE ON HUGGING FACE \u2014 HF RT HITS 158 IN CYCLE",
+    "source": "@huggingface",
+    "source_file": "research/summaries/2026-06-01-twitter-08h-headlines.json",
+    "url": "https://x.com/huggingface/status/2061346254706094352"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-06-01 08:00 UTC",
+    "headline": "NIKKEI 67,000 UPDATE 1 \u2014 SOFTBANK CONFIRMED AS JAPAN'S MOST VALUABLE FIRM AT CLOSE, 150+ STOCKS FELL ON THE DAY",
+    "source": "@The_Japan_News",
+    "source_file": "research/summaries/2026-06-01-twitter-08h-headlines.json",
+    "url": "https://x.com/The_Japan_News/status/2061356965322969109"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-06-01 08:00 UTC",
+    "headline": "ANTHROPIC 'CODE WITH CLAUDE' ASIA-FIRST EVENT CONFIRMED FOR JUNE 10 TOKYO \u2014 FREEE CAIO ON SPEAKER LINE",
+    "source": "@freeeDevelopers",
+    "source_file": "research/summaries/2026-06-01-twitter-08h-headlines.json",
+    "url": "https://x.com/freeeDevelopers/status/2061359776316137673"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-06-01 08:00 UTC",
+    "headline": "MINIMAX M3 AGENT ADDS PERSISTENT MEMORY, EVOLVING SKILLS, UNIFIED BILLING \u2014 59% SWE-BENCH PRO ON OPEN WEIGHTS",
+    "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-06-01-twitter-08h-headlines.json",
+    "url": "https://x.com/testingcatalog/status/2061316009361838241"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-06-01 11:00 UTC",
     "headline": "DRIVENETS RAISES $410M AT $8.5B VALUATION ON >$1B AI-NETWORKING BACKLOG \u2014 FIRST AI-INFRA ROUND OF GTC/BUILD WEEK",
     "source": "@Calcalistech",
+    "source_file": "research/summaries/2026-06-01-twitter-11h-headlines.json",
     "url": "https://x.com/Calcalistech/status/2061395248870219818"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-01 11:02 UTC",
+    "delivered_at": "2026-06-01 11:00 UTC",
     "headline": "NVIDIA RTX SPARK / N1X SPEC HARDENS: 20 CPU CORES, 6,144 GPU CORES, 128GB LPDDR5X, 1 PFLOP, MICROSOFT + DELL 2026 LAUNCH",
     "source": "@MORNINGSTAR857",
+    "source_file": "research/summaries/2026-06-01-twitter-11h-headlines.json",
     "url": "https://x.com/MORNINGSTAR857/status/2061403009230274961"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-01 11:02 UTC",
+    "delivered_at": "2026-06-01 11:00 UTC",
     "headline": "FT: IRAN-LINKED GROUPS RUNNING 500K-700K AI-ASSISTED CYBERATTACKS/DAY ON UAE USING CHATGPT + GEMINI VIA VPN",
     "source": "@shawnchauhan1",
+    "source_file": "research/summaries/2026-06-01-twitter-11h-headlines.json",
     "url": "https://x.com/shawnchauhan1/status/2061402450410778748"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-01 11:02 UTC",
+    "delivered_at": "2026-06-01 11:00 UTC",
     "headline": "CLICKUP SHIPS COWORK FEATURE \u2014 THIRD AGENT-COLLAB NAMESPACE IN A WEEK AFTER MICROSOFT COPILOT COWORK + ANTHROPIC COWORK",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-06-01-twitter-11h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2061370353616601329"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-01 11:02 UTC",
+    "delivered_at": "2026-06-01 11:00 UTC",
     "headline": "SALESFORCE COMMITS $2B TO FRANCE THROUGH 2030, LAUNCHES AI INNOVATION HUB IN PARIS \u2014 CRM +5% PRE-MARKET",
     "source": "@Tradinguru55",
+    "source_file": "research/summaries/2026-06-01-twitter-11h-headlines.json",
     "url": "https://x.com/Tradinguru55/status/2061399113829065114"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-01 11:02 UTC",
+    "delivered_at": "2026-06-01 11:00 UTC",
     "headline": "QUALCOMM UNVEILS DRAGONWING IQ10 ROBOTICS REFERENCE PLATFORM AT 700 TOPS \u2014 DIRECT COMPETITOR TO NVIDIA ISAAC GR00T",
     "source": "@ainews_24_7",
+    "source_file": "research/summaries/2026-06-01-twitter-11h-headlines.json",
     "url": "https://x.com/ainews_24_7/status/2061399860020912446"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-01 14:32 UTC",
+    "delivered_at": "2026-06-01 14:00 UTC",
     "headline": "IREN CLOSES $3.65B INVESTMENT-GRADE GPU FINANCING \u2014 FIRST IG-RATED GPU DEBT IN U.S. PRIVATE-PLACEMENT HISTORY, MSFT AI CLOUD ANCHORED",
     "source": "@PSInvestor",
+    "source_file": "research/summaries/2026-06-01-twitter-14h-headlines.json",
     "url": "https://x.com/PSInvestor/status/2061431618028585453"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-01 14:32 UTC",
+    "delivered_at": "2026-06-01 14:00 UTC",
     "headline": "FITCH A / DBRS A(LOW) ON IREN \u2014 GOLDMAN + JPM LEAD, 96% OF GPU CAPEX FUNDED, 480MW / 50K+ BLACKWELL ULTRA BY END-2026",
     "source": "@Cointelegraph",
+    "source_file": "research/summaries/2026-06-01-twitter-14h-headlines.json",
     "url": "https://x.com/Cointelegraph/status/2061452907166290181"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-01 14:32 UTC",
+    "delivered_at": "2026-06-01 14:00 UTC",
     "headline": "NADELLA PUBLICLY ENDORSES RTX SPARK \u2014 JENSEN TO JOIN MICROSOFT BUILD LIVE FROM TAIWAN, PRE-EMPTS SEMIANALYSIS F-TIER CRITIQUE BY 1 MINUTE",
     "source": "@satyanadella",
+    "source_file": "research/summaries/2026-06-01-twitter-14h-headlines.json",
     "url": "https://x.com/satyanadella/status/2061315017589600699"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-01 14:32 UTC",
+    "delivered_at": "2026-06-01 14:00 UTC",
     "headline": "SEMIANALYSIS Q1 2026 FOUNDRY PRINT: RECORD $48.8B (+32% Y/Y), TSMC SHARE AT 73.6% RECORD HIGH, CAPTURES 95%+ OF INCREMENTAL Q/Q REVENUE",
     "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-06-01-twitter-14h-headlines.json",
     "url": "https://x.com/SemiAnalysis_/status/2061432999929860500"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-01 14:32 UTC",
+    "delivered_at": "2026-06-01 14:00 UTC",
     "headline": "KOREAN MEMORY NOW 22% OF TOTAL EXPORTS \u2014 UP FROM 13% IN 2025 AND ~10% IN 2018-2024, VS AUTOS AT ~8%",
     "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-06-01-twitter-14h-headlines.json",
     "url": "https://x.com/SemiAnalysis_/status/2061432717787398251"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-01 14:32 UTC",
+    "delivered_at": "2026-06-01 14:00 UTC",
     "headline": "SEMIANALYSIS DISCLOSES TESLA-SPACEX TERAFAB TARGETING 1M WAFERS/MONTH ACROSS LOGIC, MEMORY, PACKAGING \u2014 NEW FOUNDRY ENTRANT",
     "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-06-01-twitter-14h-headlines.json",
     "url": "https://x.com/SemiAnalysis_/status/2061433005298655704"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-01 14:32 UTC",
+    "delivered_at": "2026-06-01 14:00 UTC",
     "headline": "CALIFORNIA SENATE PASSES FIRST-IN-NATION BAN ON AI CHATBOT TOYS FOR CHILDREN UNDER 18 \u2014 27% OF RESPONSES FOUND INAPPROPRIATE",
     "source": "@digitalbrain01",
+    "source_file": "research/summaries/2026-06-01-twitter-14h-headlines.json",
     "url": "https://x.com/digitalbrain01/status/2061436269951856888"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-01 17:22 UTC",
+    "delivered_at": "2026-06-01 17:00 UTC",
     "headline": "ANTHROPIC CONFIDENTIALLY FILES DRAFT S-1 WITH SEC \u2014 FIRST FRONTIER AI LAB IPO STEP AT $965B SERIES H MARK",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-06-01-twitter-17h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2061478052257841495"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-01 17:22 UTC",
+    "delivered_at": "2026-06-01 17:00 UTC",
     "headline": "FLORIDA AG SUES OPENAI AND SAM ALTMAN PERSONALLY \u2014 FIRST STATE AG TO SEEK CEO LIABILITY FOR AI PRODUCT HARMS",
     "source": "@CNBC",
+    "source_file": "research/summaries/2026-06-01-twitter-17h-headlines.json",
     "url": "https://x.com/CNBC/status/2061495893929418768"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-01 17:22 UTC",
+    "delivered_at": "2026-06-01 17:00 UTC",
     "headline": "WSJ \u2014 ANTHROPIC COULD GO PUBLIC AS EARLY AS THIS FALL AFTER CONFIDENTIAL IPO FILING",
     "source": "@WSJ",
+    "source_file": "research/summaries/2026-06-01-twitter-17h-headlines.json",
     "url": "https://x.com/WSJ/status/2061483205253894205"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-01 17:22 UTC",
+    "delivered_at": "2026-06-01 17:00 UTC",
     "headline": "COREWEAVE FIRST AI CLOUD TO BRING UP NVIDIA VERA RUBIN NVL72 \u2014 CLAIMS 10X INFERENCE PER WATT, 1/10 COST PER MILLION TOKENS VS BLACKWELL",
     "source": "@CoreWeave",
+    "source_file": "research/summaries/2026-06-01-twitter-17h-headlines.json",
     "url": "https://x.com/CoreWeave/status/2061441369961566601"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-01 17:22 UTC",
+    "delivered_at": "2026-06-01 17:00 UTC",
     "headline": "NVIDIA NEMOTRON 3 ULTRA NOW BEST OPEN-WEIGHT MODEL ON ARTIFICIAL ANALYSIS \u2014 VP CATANZARO CONFIRMS",
     "source": "@ctnzr",
+    "source_file": "research/summaries/2026-06-01-twitter-17h-headlines.json",
     "url": "https://x.com/ctnzr/status/2061483152741175757"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-01 17:22 UTC",
+    "delivered_at": "2026-06-01 17:00 UTC",
     "headline": "FLORIDA AG READS CHATGPT-AIDED SUICIDE TRANSCRIPT ON STAGE \u2014 ZANE SHAMBLIN CASE ANCHORS 83-PAGE COMPLAINT VS OPENAI",
     "source": "@Techmeme",
+    "source_file": "research/summaries/2026-06-01-twitter-17h-headlines.json",
     "url": "https://x.com/Techmeme/status/2061459179647504843"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-01 17:22 UTC",
+    "delivered_at": "2026-06-01 17:00 UTC",
     "headline": "NVIDIA AND TSMC EXPAND COLLABORATION \u2014 TSMC ADOPTING CUDA-X, METROPOLIS, TAO AND OMNIVERSE ACROSS CHIP DESIGN AND FAB",
     "source": "@nvidianewsroom",
+    "source_file": "research/summaries/2026-06-01-twitter-17h-headlines.json",
     "url": "https://x.com/nvidianewsroom/status/2061491683011744078"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-01 22:22 UTC",
+    "delivered_at": "2026-06-01 22:00 UTC",
     "headline": "ALPHABET ANNOUNCES $80B AI-INFRA EQUITY RAISE \u2014 $15B COMMON + $15B CONVERTIBLE PFD + $40B ATM Q3'26 + $10B BERKSHIRE PRIVATE PLACEMENT",
     "source": "@StockMKTNewz",
+    "source_file": "research/summaries/2026-06-01-twitter-22h-headlines.json",
     "url": "https://x.com/StockMKTNewz/status/2061550400046809587"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-01 22:22 UTC",
+    "delivered_at": "2026-06-01 22:00 UTC",
     "headline": "BERKSHIRE HATHAWAY TAKES $10B PRIVATE PLACEMENT IN ALPHABET \u2014 FIRST DIRECT BUFFETT PRIMARY-ISSUANCE STAKE IN A MAG7 NAME",
     "source": "@Gemini",
+    "source_file": "research/summaries/2026-06-01-twitter-22h-headlines.json",
     "url": "https://x.com/Gemini/status/2061554848143708548"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-01 22:22 UTC",
+    "delivered_at": "2026-06-01 22:00 UTC",
     "headline": "OPENAI FRONTIER MODELS GO GA ON AWS BEDROCK \u2014 GPT-5.5, GPT-5.4 AND CODEX, ZERO OPERATOR ACCESS, NO MARKUP, COUNTS TOWARD AWS SPEND",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-06-01-twitter-22h-headlines.json",
     "url": "https://x.com/OpenAI/status/2061564502160892138"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-01 22:22 UTC",
+    "delivered_at": "2026-06-01 22:00 UTC",
     "headline": "AWS: OPENAI'S DAYBREAK CYBER STACK COMING TO BEDROCK NEXT \u2014 CODEX SECURITY + CYBER-DEFENDER MODELS",
     "source": "@SwamiSivasubram",
+    "source_file": "research/summaries/2026-06-01-twitter-22h-headlines.json",
     "url": "https://x.com/SwamiSivasubram/status/2061564503238594665"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-01 22:22 UTC",
+    "delivered_at": "2026-06-01 22:00 UTC",
     "headline": "HPE +33% AFTER-HOURS ON Q2 AI-SERVER BLOWOUT \u2014 REVENUE +40% YoY, EPS +108% YoY, AI ORDERS AND BACKLOG NEARLY DOUBLED",
     "source": "@StockJohnKuya",
+    "source_file": "research/summaries/2026-06-01-twitter-22h-headlines.json",
     "url": "https://x.com/StockJohnKuya/status/2061560727681601581"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-01 22:22 UTC",
+    "delivered_at": "2026-06-01 22:00 UTC",
     "headline": "ANTHROPIC GRANTS EU CYBER AGENCY ENISA FIRST NON-US ACCESS TO MYTHOS VIA PROJECT GLASSWING \u2014 EU CLEARED ACCESS THROUGH US ADMIN FIRST",
     "source": "@Cointelegraph",
+    "source_file": "research/summaries/2026-06-01-twitter-22h-headlines.json",
     "url": "https://x.com/Cointelegraph/status/2061513307433902458"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-01 22:22 UTC",
+    "delivered_at": "2026-06-01 22:00 UTC",
     "headline": "THE INFORMATION: MICROSOFT PREPARING NEW IN-HOUSE AI MODELS TO COMPETE WITH OPENAI AND ANTHROPIC ON EVERYDAY DEVELOPER WORKLOADS",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-06-01-twitter-22h-headlines.json",
     "url": "https://x.com/theinformation/status/2061560952953127392"
   },
   {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-06-02 01:00 UTC",
+    "headline": "OPENAI ISSUES STATEMENT EXPLICITLY DISTANCING ITSELF FROM LEADING THE FUTURE PAC, NAMES BROCKMAN, FLAGS \"ASTROTURFING\"",
+    "source": "@teddyschleifer",
+    "source_file": "research/summaries/2026-06-02-twitter-01h-headlines.json",
+    "url": "https://x.com/teddyschleifer/status/2061603836611989710"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-06-02 01:00 UTC",
+    "headline": "MUSK: XAI\u2013ANTHROPIC COMPUTE DEAL IS \"LITERALLY SHORT-TERM\" \u2014 \"OUR REQUEST, NOT THEIRS\" \u2014 UPENDS ARK $50B / 5-YR EXTRAPOLATION",
+    "source": "@elonmusk",
+    "source_file": "research/summaries/2026-06-02-twitter-01h-headlines.json",
+    "url": "https://x.com/elonmusk/status/2061613308235726956"
+  },
+  {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-02 04:54 UTC",
+    "delivered_at": "2026-06-02 01:00 UTC",
+    "headline": "KOREA OVERTAKES INDIA AS WORLD'S #6 EQUITY MARKET AT $5T ON AI-SEMIS RALLY; SAMSUNG ENTERS GLOBAL TOP-10 MARKET CAPS",
+    "source": "@jukan05",
+    "source_file": "research/summaries/2026-06-02-twitter-01h-headlines.json",
+    "url": "https://x.com/jukan05/status/2061607373492584852"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-06-02 01:00 UTC",
+    "headline": "LOTTE ENERGY MATERIALS BEGINS SUPPLYING AI CIRCUIT FOIL FOR NVIDIA VERA RUBIN GPUS THIS MONTH \u2014 BREAKS MITSUI'S NEAR-MONOPOLY",
+    "source": "@jukan05",
+    "source_file": "research/summaries/2026-06-02-twitter-01h-headlines.json",
+    "url": "https://x.com/jukan05/status/2061594665938530791"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-06-02 01:00 UTC",
+    "headline": "OPENAI CODEX SHIPS PREVIEW INSIDE CHATGPT IOS / ANDROID APPS \u2014 START, REVIEW, STEER LONG-RUNNING TASKS FROM PHONE",
+    "source": "@OpenAI",
+    "source_file": "research/summaries/2026-06-02-twitter-01h-headlines.json",
+    "url": "https://x.com/OpenAI/status/2061564502160892138"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-06-02 01:00 UTC",
+    "headline": "THE INFORMATION: MICROSOFT PREPPING NEW DEVELOPER-CLASS AI MODELS TO COMPETE WITH OPENAI AND ANTHROPIC AHEAD OF BUILD 2026 KEYNOTE",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-06-02-twitter-01h-headlines.json",
+    "url": "https://x.com/theinformation/status/2061560952953127392"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-06-02 04:00 UTC",
     "headline": "JENSEN HUANG AT COMPUTEX: MARVELL WILL BECOME NEXT TRILLION-DOLLAR COMPANY \u2014 $MRVL +12-17% OVERNIGHT",
     "source": "@amitisinvesting",
+    "source_file": "research/summaries/2026-06-02-twitter-04h-headlines.json",
     "url": "https://x.com/amitisinvesting/status/2061657300318765250"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-02 04:54 UTC",
+    "delivered_at": "2026-06-02 04:00 UTC",
     "headline": "SATYA NADELLA POSTS MICROSOFT BUILD 2026 STAGE SNEAK-PEEK \u2014 KEYNOTE OPENS 16:30 UTC WITH JENSEN HUANG LIVE FROM TAIWAN",
     "source": "@satyanadella",
+    "source_file": "research/summaries/2026-06-02-twitter-04h-headlines.json",
     "url": "https://x.com/satyanadella/status/2061650162460839954"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-02 04:54 UTC",
+    "delivered_at": "2026-06-02 04:00 UTC",
     "headline": "OPENAI CONFIRMS CODEX LIVESTREAM JUNE 2 AT 15:30 UTC \u2014 ONE HOUR BEFORE MICROSOFT BUILD OPENS",
     "source": "@derrickcchoi",
+    "source_file": "research/summaries/2026-06-02-twitter-04h-headlines.json",
     "url": "https://x.com/derrickcchoi/status/2061515948503269572"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-02 04:54 UTC",
+    "delivered_at": "2026-06-02 04:00 UTC",
     "headline": "KIMMONISMUS LEAK: OPENAI CODEX UPDATE 'MONTHS IN DEVELOPMENT, SOUNDS DIFFERENT FROM GPT-5.6'",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-02-twitter-04h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2061631867712139323"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-02 04:54 UTC",
+    "delivered_at": "2026-06-02 04:00 UTC",
     "headline": "OPENAI NEWSROOM POSTS LEADING THE FUTURE DISTANCING STATEMENT ON PRIMARY HANDLE \u2014 NAMES BROCKMAN, ANNA BROCKMAN, ASTROTURFING",
     "source": "@OpenAINewsroom",
+    "source_file": "research/summaries/2026-06-02-twitter-04h-headlines.json",
     "url": "https://x.com/OpenAINewsroom/status/2061601425701142586"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-06-02 04:54 UTC",
+    "delivered_at": "2026-06-02 04:00 UTC",
     "headline": "BYTEDANCE OPEN-WEIGHTS BERNINI DIFFUSION VIDEO MODEL \u2014 'FIRST TIER AMONG LEADING CLOSED-SOURCE' ON VIDEO EDITING, SAME DAY AS NVIDIA COSMOS 3",
     "source": "@aisearchio",
+    "source_file": "research/summaries/2026-06-02-twitter-04h-headlines.json",
     "url": "https://x.com/aisearchio/status/2061572022074020174"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-02 04:54 UTC",
+    "delivered_at": "2026-06-02 04:00 UTC",
     "headline": "WALSIN TECHNOLOGY HIKES CHIP-RESISTOR PRICES \u2014 PASSIVE-COMPONENTS COST CURVE NOW SPREADS FROM MLCC AND TANTALUM TO RESISTORS",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-06-02-twitter-04h-headlines.json",
     "url": "https://x.com/jukan05/status/2061625448405381323"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-02 08:20 UTC",
+    "delivered_at": "2026-06-02 08:00 UTC",
     "headline": "MICROSOFT BUILD KEYNOTE LEAKS HARDEN \u2014 PROJECT POLARIS MOE CODING MODEL SET TO REPLACE GPT-4 INSIDE GITHUB COPILOT BY AUGUST",
     "source": "@tomwarren",
+    "source_file": "research/summaries/2026-06-02-twitter-08h-headlines.json",
     "url": "https://x.com/tomwarren/status/2061665931567276311"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-06-02 08:20 UTC",
+    "delivered_at": "2026-06-02 08:00 UTC",
     "headline": "WINDOWS AGENT FRAMEWORK V1.0 TO SHIP MIT-OPEN-SOURCE WITH WINDOWS AGENT STORE AT 85% DEV REV SHARE \u2014 BUILD KEYNOTE 16:30 UTC",
     "source": "@PiClaudeCode",
+    "source_file": "research/summaries/2026-06-02-twitter-08h-headlines.json",
     "url": "https://x.com/PiClaudeCode/status/2061724695666491533"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-02 08:20 UTC",
+    "delivered_at": "2026-06-02 08:00 UTC",
     "headline": "SK GROUP CHAIRMAN CHEY TAE-WON AT COMPUTEX \u2014 SK HYNIX TO DOUBLE MEMORY WAFER CAPACITY OVER FIVE YEARS, TARGETS NVIDIA VERA RUBIN SUPPLY",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-06-02-twitter-08h-headlines.json",
     "url": "https://x.com/jukan05/status/2061703033042718952"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-02 08:20 UTC",
+    "delivered_at": "2026-06-02 08:00 UTC",
     "headline": "MARVELL HOLDS +17% US PREMARKET FOUR HOURS AFTER JENSEN'S 'NEXT TRILLION-DOLLAR COMPANY' CALL \u2014 NYSE OPEN AT 13:30 UTC IS THE VOLUME TEST",
     "source": "@WallStDiaries",
+    "source_file": "research/summaries/2026-06-02-twitter-08h-headlines.json",
     "url": "https://x.com/WallStDiaries/status/2061721186342425080"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-02 08:20 UTC",
+    "delivered_at": "2026-06-02 08:00 UTC",
     "headline": "MEDIATEK AT GOLDMAN SACHS TAIWAN DAY \u2014 NEXT-GEN PROGRAM ADOPTS ONLY EMIB-T, TAPE-OUT 4Q26, MASS PRODUCTION 4Q27",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-06-02-twitter-08h-headlines.json",
     "url": "https://x.com/jukan05/status/2061706018971906198"
   },
   {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-06-02 08:00 UTC",
+    "headline": "OPENAI CODEX LIVESTREAM AT 15:30 UTC TODAY \u2014 DELETED OPENAI TEASE HINTS AT 'HUGE RELEASE,' ONE HOUR BEFORE MICROSOFT BUILD KEYNOTE OPENS",
+    "source": "@derrickcchoi",
+    "source_file": "research/summaries/2026-06-02-twitter-08h-headlines.json",
+    "url": "https://x.com/derrickcchoi/status/2061515948503269572"
+  },
+  {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-06-02 11:04 UTC",
+    "delivered_at": "2026-06-02 11:00 UTC",
     "headline": "OPENAI CODEX HEAD TIBO PUBLICLY DAMPENS 15:30 UTC LIVESTREAM \u2014 \"NOTHING CRAZY, MOSTLY ENTERPRISE DEPLOYMENT\"",
     "source": "@thsottiaux",
+    "source_file": "research/summaries/2026-06-02-twitter-11h-headlines.json",
     "url": "https://x.com/thsottiaux/status/2061653778403881160"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-02 11:04 UTC",
+    "delivered_at": "2026-06-02 11:00 UTC",
     "headline": "SK HYNIX AT 58% HBM SHARE WARNS AI MEMORY SHORTAGE COULD LAST UNTIL 2030 EVEN WITH 2X WAFER CAPACITY",
     "source": "@TechieUltimatum",
+    "source_file": "research/summaries/2026-06-02-twitter-11h-headlines.json",
     "url": "https://x.com/TechieUltimatum/status/2061764896149434374"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-02 11:04 UTC",
+    "delivered_at": "2026-06-02 11:00 UTC",
     "headline": "KIOXIA INVESTOR DAY \u2014 SEEKING 2029+ HYPERSCALE NAND SUPPLY DEALS, FORECASTS SHORTAGE THROUGH Q4 2027",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-06-02-twitter-11h-headlines.json",
     "url": "https://x.com/jukan05/status/2061729660116041942"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-02 11:04 UTC",
+    "delivered_at": "2026-06-02 11:00 UTC",
     "headline": "MARVELL CEO MURPHY AT COMPUTEX \u2014 \"COPPER WALL MOVING INSIDE THE RACK, COPACKAGED OPTICS IS THE ONLY WAY THROUGH\"",
     "source": "@jukan05",
+    "source_file": "research/summaries/2026-06-02-twitter-11h-headlines.json",
     "url": "https://x.com/jukan05/status/2061728423656210652"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-02 11:04 UTC",
+    "delivered_at": "2026-06-02 11:00 UTC",
     "headline": "MRVL PREMARKET +24% AT $272.49 AHEAD OF NYSE OPEN ON JENSEN'S TRILLION-DOLLAR ENDORSEMENT",
     "source": "@realcoincentral",
+    "source_file": "research/summaries/2026-06-02-twitter-11h-headlines.json",
     "url": "https://x.com/realcoincentral/status/2061738562739945891"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-02 11:04 UTC",
+    "delivered_at": "2026-06-02 11:00 UTC",
     "headline": "PALO ALTO NETWORKS COMPLETES PORTKEY ACQUISITION \u2014 AI GATEWAY FOLDED INTO PRISMA AIRS FLAGSHIP",
     "source": "@sdxcentral",
+    "source_file": "research/summaries/2026-06-02-twitter-11h-headlines.json",
     "url": "https://x.com/sdxcentral/status/2061765369417875816"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-02 11:04 UTC",
+    "delivered_at": "2026-06-02 11:00 UTC",
     "headline": "ANTHROPIC S-1 IS A PUBLIC BENEFIT CORPORATION IPO \u2014 \"UNUSUAL COMBINATION\" CREATES LEGAL OBLIGATION TO MISSION",
     "source": "@MaxSchoon",
+    "source_file": "research/summaries/2026-06-02-twitter-11h-headlines.json",
     "url": "https://x.com/MaxSchoon/status/2061765619616264532"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-06-02 13:40 UTC",
+    "delivered_at": "2026-06-02 13:00 UTC",
     "headline": "ANTHROPIC EXPANDS GLASSWING \u2014 CLAUDE MYTHOS PREVIEW NOW DEFENDING ~150 MORE ORGS ACROSS 15+ COUNTRIES IN POWER, WATER, HEALTHCARE",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-06-02-twitter-13h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2061796327986454883"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-02 13:40 UTC",
+    "delivered_at": "2026-06-02 13:00 UTC",
     "headline": "ANTHROPIC WARNS MYTHOS-CLASS CYBER MODELS WILL BE WIDELY AVAILABLE WITHIN 6-12 MONTHS \u2014 RACES TO BUILD DISCLOSURE/PATCH INFRA AHEAD OF IT",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-06-02-twitter-13h-headlines.json",
     "url": "https://www.anthropic.com/news/expanding-project-glasswing"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-02 13:40 UTC",
+    "delivered_at": "2026-06-02 13:00 UTC",
     "headline": "$MRVL OPENS NYSE +22% AT ~$272 \u2014 JENSEN \"TRILLION-DOLLAR COMPANY\" TRADE SURVIVES VOLUME TEST; MARVELL CEO ANCHORS OPTICAL-INTERCONNECT THESIS",
     "source": "@Trading_Analyst",
+    "source_file": "research/summaries/2026-06-02-twitter-13h-headlines.json",
     "url": "https://x.com/Trading_Analyst/status/2061802514903617802"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-02 13:40 UTC",
+    "delivered_at": "2026-06-02 13:00 UTC",
     "headline": "$HPE +26% PREMARKET AS SECOND-LEG AI-INFRA MOVER ALONGSIDE MARVELL",
     "source": "@singh_vinod77",
+    "source_file": "research/summaries/2026-06-02-twitter-13h-headlines.json",
     "url": "https://x.com/singh_vinod77/status/2061798212357550449"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-02 13:40 UTC",
+    "delivered_at": "2026-06-02 13:00 UTC",
     "headline": "MICROSOFT BUILD LEAK ADDS COPILOT SUPER APP (COPILOT + COWORK + GITHUB COPILOT + AUTOPILOT SCOUT AGENT) PLUS MAI VOICE 2 + MAI TRANSCRIBE 1.5",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-06-02-twitter-13h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2061770738093158486"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-02 13:40 UTC",
+    "delivered_at": "2026-06-02 13:00 UTC",
     "headline": "ELON MUSK AMPLIFIES 404 MEDIA META-AI INSTAGRAM-HIJACK STORY \u2014 CHATBOT CHANGED ACCOUNT EMAILS WITHOUT ID VERIFICATION; SPACE FORCE, SEPHORA HIT",
     "source": "@404mediaco",
+    "source_file": "research/summaries/2026-06-02-twitter-13h-headlines.json",
     "url": "https://x.com/404mediaco/status/2061494153935208740"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-02 16:43 UTC",
+    "delivered_at": "2026-06-02 16:00 UTC",
     "headline": "OPENAI SHIPS CODEX SITES, 6 ROLE-SPECIFIC PLUGINS, ANNOTATIONS \u2014 CODEX MERGING INTO CHATGPT WITHIN WEEKS",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-06-02-twitter-16h-headlines.json",
     "url": "https://x.com/OpenAI/status/2061845949170045346"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-02 16:43 UTC",
+    "delivered_at": "2026-06-02 16:00 UTC",
     "headline": "OPENAI: CODEX HITS 5M WEEKLY USERS, KNOWLEDGE WORKERS NOW 20% OF BASE GROWING 3X FASTER THAN DEVELOPERS",
     "source": "@MadisonMills22",
+    "source_file": "research/summaries/2026-06-02-twitter-16h-headlines.json",
     "url": "https://x.com/MadisonMills22/status/2061835091504980169"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-06-02 16:43 UTC",
+    "delivered_at": "2026-06-02 16:00 UTC",
     "headline": "MICROSOFT BUILD 2026 KEYNOTE OPENS \u2014 SATYA NADELLA ON STAGE AT FORT MASON SF",
     "source": "@CoreyNoles",
+    "source_file": "research/summaries/2026-06-02-twitter-16h-headlines.json",
     "url": "https://x.com/CoreyNoles/status/2061849556304945551"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-02 16:43 UTC",
+    "delivered_at": "2026-06-02 16:00 UTC",
     "headline": "MARVELL OPENS NYSE +15% AFTER JENSEN 'TRILLION-DOLLAR' CALL \u2014 TERALYNX T100 102.4 TBPS SWITCH ANCHORS TRADE",
     "source": "@VestExchange",
+    "source_file": "research/summaries/2026-06-02-twitter-16h-headlines.json",
     "url": "https://x.com/VestExchange/status/2061802629509059004"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-02 16:43 UTC",
+    "delivered_at": "2026-06-02 16:00 UTC",
     "headline": "OPENAI CODEX SITES ROLLS OUT TO BUSINESS/ENTERPRISE FIRST \u2014 RBAC-GATED, BUILDS INTERACTIVE WEB APPS FROM PROMPTS",
     "source": "@CodexReleases",
+    "source_file": "research/summaries/2026-06-02-twitter-16h-headlines.json",
     "url": "https://x.com/CodexReleases/status/2061846140258033905"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-02 16:43 UTC",
+    "delivered_at": "2026-06-02 16:00 UTC",
     "headline": "TIBO DAMPENER VALIDATED \u2014 OPENAI LIVESTREAM SHIPS ENTERPRISE PRODUCT SURFACE, NO NEW MODEL CARD, NO GPT-5.6",
     "source": "@thsottiaux",
+    "source_file": "research/summaries/2026-06-02-twitter-16h-headlines.json",
     "url": "https://x.com/thsottiaux/status/2061653778403881160"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-02 16:43 UTC",
+    "delivered_at": "2026-06-02 16:00 UTC",
     "headline": "MARVELL TERALYNX T100 + FY2028 GUIDANCE RAISED TO $16.5B \u2014 SELL-SIDE PRICE TARGETS LIFTED TO $240-$275",
     "source": "@VestExchange",
+    "source_file": "research/summaries/2026-06-02-twitter-16h-headlines.json",
     "url": "https://x.com/VestExchange/status/2061802629509059004"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-02 19:43 UTC",
+    "delivered_at": "2026-06-02 19:00 UTC",
     "headline": "MICROSOFT AI SHIPS 7-MODEL MAI STACK AT BUILD \u2014 MAI-THINKING-1 CLAIMS OPUS 4.6 PARITY AT 53% SWE-BENCH PRO ON 35B MOE",
     "source": "@mustafasuleyman",
+    "source_file": "research/summaries/2026-06-02-twitter-19h-headlines.json",
     "url": "https://x.com/mustafasuleyman/status/2061880164498428188"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-02 19:43 UTC",
+    "delivered_at": "2026-06-02 19:00 UTC",
     "headline": "MICROSOFT MAIA 200 SILICON CLAIMS 30% BETTER PERF-PER-DOLLAR AND 1.4X PERF-PER-WATT VS NVIDIA GB200 ON MAI MODELS",
     "source": "@mustafasuleyman",
+    "source_file": "research/summaries/2026-06-02-twitter-19h-headlines.json",
     "url": "https://x.com/mustafasuleyman/status/2061880164498428188"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-02 19:43 UTC",
+    "delivered_at": "2026-06-02 19:00 UTC",
     "headline": "MCKINSEY-TUNED MAI BEATS GPT-5.5 ON QUALITY AT 10X LOWER COST \u2014 MICROSOFT FRONTIER TUNING IS THE NEW ENTERPRISE LANE",
     "source": "@mustafasuleyman",
+    "source_file": "research/summaries/2026-06-02-twitter-19h-headlines.json",
     "url": "https://x.com/mustafasuleyman/status/2061880164498428188"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-02 19:43 UTC",
+    "delivered_at": "2026-06-02 19:00 UTC",
     "headline": "MICROSOFT AND MAYO CLINIC TO JOINTLY TRAIN A FRONTIER HEALTHCARE AI MODEL ON RECORDS, RESEARCH AND CLINICIAN EXPERTISE",
     "source": "@mustafasuleyman",
+    "source_file": "research/summaries/2026-06-02-twitter-19h-headlines.json",
     "url": "https://x.com/mustafasuleyman/status/2061880164498428188"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-02 19:43 UTC",
+    "delivered_at": "2026-06-02 19:00 UTC",
     "headline": "SATYA NADELLA ANNOUNCES MICROSOFT AUTOPILOTS AS 'ENTERPRISE-GRADE CLAWS' \u2014 DELIBERATE ANTHROPIC-CODED COUNTER-POSITIONING",
     "source": "@satyanadella",
+    "source_file": "research/summaries/2026-06-02-twitter-19h-headlines.json",
     "url": "https://x.com/satyanadella/status/2061896512934949105"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-02 19:43 UTC",
+    "delivered_at": "2026-06-02 19:00 UTC",
     "headline": "MARVELL CLOSES +29.74% AT $282.93 \u2014 BEST SINGLE SESSION IN OVER 3 YEARS AFTER JENSEN TRILLION-DOLLAR CALL EXTENDS RATHER THAN COMPRESSES",
     "source": "@optionwhalesio",
+    "source_file": "research/summaries/2026-06-02-twitter-19h-headlines.json",
     "url": "https://x.com/optionwhalesio/status/2061886641581551639"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-02 19:43 UTC",
+    "delivered_at": "2026-06-02 19:00 UTC",
     "headline": "MICROSOFT PROJECT SOLARA REVEALED \u2014 NEW AGENT-ERA HARDWARE PLATFORM RUNNING CUSTOM ANDROID VARIANT 'MDEP'",
     "source": "@PCMag",
+    "source_file": "research/summaries/2026-06-02-twitter-19h-headlines.json",
     "url": "https://x.com/PCMag/status/2061897502660677667"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-02 22:05 UTC",
+    "delivered_at": "2026-06-02 22:00 UTC",
     "headline": "TRUMP SIGNS AI EXECUTIVE ORDER: VOLUNTARY 30-DAY FRONTIER-MODEL REVIEW, NO LICENSING MANDATE, TREASURY-NSA-CISA CYBER CLEARINGHOUSE",
     "source": "@Polymarket",
+    "source_file": "research/summaries/2026-06-02-twitter-22h-headlines.json",
     "url": "https://x.com/Polymarket/status/2061839013317652613"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-02 22:05 UTC",
+    "delivered_at": "2026-06-02 22:00 UTC",
     "headline": "ANTHROPIC FIRST FRONTIER LAB TO BACK TRUMP AI ORDER: 'WE LOOK FORWARD TO SUPPORTING ITS IMPLEMENTATION' \u2014 OPENAI, GOOGLE, XAI SILENT",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-06-02-twitter-22h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2061924580222968183"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-02 22:05 UTC",
+    "delivered_at": "2026-06-02 22:00 UTC",
     "headline": "MARVELL CLOSES +30%, EXTENDS AFTER HOURS ON JENSEN'S 'TRILLION-DOLLAR' LINE \u2014 $100B+ MARKET CAP ON A CEO COMMENT, NOT EARNINGS",
     "source": "@mountainhead_ai",
+    "source_file": "research/summaries/2026-06-02-twitter-22h-headlines.json",
     "url": "https://x.com/mountainhead_ai/status/2061931592788906165"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-02 22:05 UTC",
+    "delivered_at": "2026-06-02 22:00 UTC",
     "headline": "MICROSOFT SHIPS MAI MODELS TO OPENROUTER, FIREWORKS, BASETEN: 'SEVEN MODELS, ONE LAB, ZERO DISTILLATION'",
     "source": "@MicrosoftAI",
+    "source_file": "research/summaries/2026-06-02-twitter-22h-headlines.json",
     "url": "https://x.com/MicrosoftAI/status/2061887528496439352"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-02 22:05 UTC",
+    "delivered_at": "2026-06-02 22:00 UTC",
     "headline": "SPACEX TARGETS $1.75 TRILLION IPO, ROADSHOW THURSDAY \u2014 75B-PLUS ALL-PRIMARY RAISE, LARGEST IN HISTORY",
     "source": "@BNNBloomberg",
+    "source_file": "research/summaries/2026-06-02-twitter-22h-headlines.json",
     "url": "https://x.com/BNNBloomberg/status/2061916212578091246"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-02 22:05 UTC",
+    "delivered_at": "2026-06-02 22:00 UTC",
     "headline": "BITCOIN DROPS 5.8% TO $67K, LOWEST SINCE APRIL, AS CAPITAL ROTATES FROM CRYPTO INTO AI EQUITIES",
     "source": "@blackbull",
+    "source_file": "research/summaries/2026-06-02-twitter-22h-headlines.json",
     "url": "https://x.com/blackbull/status/2061926432121692511"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-03 01:30 UTC",
+    "delivered_at": "2026-06-03 01:00 UTC",
     "headline": "SPACEX PRICES IPO: 555.6M SHARES AT $135, ~$75B RAISE, ~$1.75T VALUATION \u2014 LARGEST IN HISTORY, MARKETING STARTS JUNE 4",
     "source": "@business",
+    "source_file": "research/summaries/2026-06-03-twitter-01h-headlines.json",
     "url": "https://x.com/business/status/2061973233729970458"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-03 01:30 UTC",
+    "delivered_at": "2026-06-03 01:00 UTC",
     "headline": "ANTHROPIC SHIPS 'ANT' CLI \u2014 EVERY CLAUDE API ENDPOINT RUNS FROM THE TERMINAL, AGENTS VERSION-CONTROLLED LIKE GIT REPOS",
     "source": "@ClaudeDevs",
+    "source_file": "research/summaries/2026-06-03-twitter-01h-headlines.json",
     "url": "https://x.com/ClaudeDevs/status/2061877343078244459"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-03 01:30 UTC",
+    "delivered_at": "2026-06-03 01:00 UTC",
     "headline": "EQUITY UNLOCK WAVE: GOOGLE, SPACEX, ANTHROPIC, OPENAI HOLD $350B+ OF SOON-UNLOCKABLE STOCK AS IPO CALENDAR BUNCHES UP",
     "source": "@GoSailGlobal",
+    "source_file": "research/summaries/2026-06-03-twitter-01h-headlines.json",
     "url": "https://x.com/GoSailGlobal/status/2061982712739856604"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-03 01:30 UTC",
+    "delivered_at": "2026-06-03 01:00 UTC",
     "headline": "SEN. BLUMENTHAL ON TRUMP AI EXECUTIVE ORDER: 'KERNELS OF THE RIGHT IDEAS' \u2014 FRONTIER LABS BEYOND ANTHROPIC STILL SILENT",
     "source": "@SenBlumenthal",
+    "source_file": "research/summaries/2026-06-03-twitter-01h-headlines.json",
     "url": "https://x.com/SenBlumenthal/status/2061984438032986376"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-03 05:07 UTC",
+    "delivered_at": "2026-06-03 05:00 UTC",
     "headline": "OPENAI RECASTS CODEX AS A 'WORK PLATFORM' \u2014 MERGES CHATGPT, CODEX AND ATLAS BROWSER INTO ONE DESKTOP APP",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-03-twitter-05h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2061961710823686489"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-03 05:07 UTC",
+    "delivered_at": "2026-06-03 05:00 UTC",
     "headline": "LEAKED: CODEX AT ~5M WEEKLY USERS, OPENAI ENTERPRISE REVENUE UP ~50% WEEK-OVER-WEEK, GPT-5.6 ON THE HORIZON",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-03-twitter-05h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2061961710823686489"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-03 05:07 UTC",
+    "delivered_at": "2026-06-03 05:00 UTC",
     "headline": "MICROSOFT BUILD 2026 GOES AGENT-FIRST: 7 IN-HOUSE MAI MODELS, WINDOWS AS AGENT RUNTIME, OPEN-SOURCE AGENT CONTROL SPEC",
     "source": "@quantumaidev",
+    "source_file": "research/summaries/2026-06-03-twitter-05h-headlines.json",
     "url": "https://x.com/quantumaidev/status/2061974381606379714"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-03 05:07 UTC",
+    "delivered_at": "2026-06-03 05:00 UTC",
     "headline": "SAM ALTMAN BACKS TRUMP'S NEW AI EXECUTIVE ORDER \u2014 'THE NEW EO GETS THE BALANCE RIGHT'",
     "source": "@sama",
+    "source_file": "research/summaries/2026-06-03-twitter-05h-headlines.json",
     "url": "https://x.com/sama/status/2061973280655904815"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-03 05:07 UTC",
+    "delivered_at": "2026-06-03 05:00 UTC",
     "headline": "SEMIANALYSIS: CODEX DESKTOP NEARING CLAUDE CODE; WARNS ANTHROPIC'S CLI-ONLY BET IS 'A FORK IN THE WRONG DIRECTION'",
     "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-06-03-twitter-05h-headlines.json",
     "url": "https://x.com/SemiAnalysis_/status/2062021575902159060"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-03 08:01 UTC",
+    "delivered_at": "2026-06-03 08:00 UTC",
     "headline": "DEEPSEEK RAISING FIRST-EVER ROUND \u2014 ~$7.4B (50B YUAN) AT UP TO $59B VALUATION, TENCENT AND CATL LEADING",
     "source": "@Scutty",
+    "source_file": "research/summaries/2026-06-03-twitter-08h-headlines.json",
     "url": "https://x.com/Scutty/status/2062026768782131279"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-03 08:01 UTC",
+    "delivered_at": "2026-06-03 08:00 UTC",
     "headline": "ALPHABET TO SELL NEW SHARES FIRST TIME SINCE 2006 \u2014 UP TO ~$80B FOR AI INFRASTRUCTURE; GOLDMAN CALLS IT 'UNPRECEDENTED'",
     "source": "@byul_finance",
+    "source_file": "research/summaries/2026-06-03-twitter-08h-headlines.json",
     "url": "https://x.com/byul_finance/status/2062082010999632216"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-03 08:01 UTC",
+    "delivered_at": "2026-06-03 08:00 UTC",
     "headline": "MICROSOFT MAI-CODE-1-FLASH STARTS REACHING GITHUB COPILOT AND VS CODE \u2014 A ROUTE THAT BYPASSES OPENAI",
     "source": "@ai_note_masaki",
+    "source_file": "research/summaries/2026-06-03-twitter-08h-headlines.json",
     "url": "https://x.com/ai_note_masaki/status/2062082090137727220"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-03 08:01 UTC",
+    "delivered_at": "2026-06-03 08:00 UTC",
     "headline": "TENCENT CLOUD CUTS DEEPSEEK-V4 API PRICING BY UP TO 97.5% \u2014 SAME DAY AS DEEPSEEK'S $7B RAISE",
     "source": "@WindInfoUS",
+    "source_file": "research/summaries/2026-06-03-twitter-08h-headlines.json",
     "url": "https://x.com/WindInfoUS/status/2061957791250776371"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-03 08:01 UTC",
+    "delivered_at": "2026-06-03 08:00 UTC",
     "headline": "SPACEX IPO MARKETING STARTS JUNE 4 \u2014 $75B RAISE AT ~$1.75T, ON TRACK TO BE LARGEST LISTING EVER",
     "source": "@ecopulse247",
+    "source_file": "research/summaries/2026-06-03-twitter-08h-headlines.json",
     "url": "https://x.com/ecopulse247/status/2062079065432158678"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-03 11:02 UTC",
+    "delivered_at": "2026-06-03 11:00 UTC",
     "headline": "SUNO RAISES $400M AT $5.4B VALUATION \u2014 BIGGEST AI-MUSIC ROUND YET, ROUGHLY DOUBLING PRIOR MARK",
     "source": "@business",
+    "source_file": "research/summaries/2026-06-03-twitter-11h-headlines.json",
     "url": "https://x.com/business/status/2062116734430056751"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-03 11:02 UTC",
+    "delivered_at": "2026-06-03 11:00 UTC",
     "headline": "BRIAN ARMSTRONG'S NEWLIMIT CLOSES $435M SERIES C AT $3.1B, LED BY FOUNDERS FUND \u2014 AI-GENOMICS LONGEVITY",
     "source": "@WuBlockchain",
+    "source_file": "research/summaries/2026-06-03-twitter-11h-headlines.json",
     "url": "https://x.com/WuBlockchain/status/2062038210784776554"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-03 16:58 UTC",
+    "delivered_at": "2026-06-03 16:00 UTC",
     "headline": "FLORIDA SUES OPENAI AND SAM ALTMAN PERSONALLY \u2014 FIRST STATE LAWSUIT, 83-PAGE CHILD-SAFETY COMPLAINT SEEKS CEO LIABILITY",
     "source": "@KlearNewsDaily",
+    "source_file": "research/summaries/2026-06-03-twitter-16h-headlines.json",
     "url": "https://x.com/KlearNewsDaily/status/2061707897147478374"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-03 16:58 UTC",
+    "delivered_at": "2026-06-03 16:00 UTC",
     "headline": "US DATA-CENTER CONSTRUCTION SPENDING HITS RECORD $50.7B IN APRIL, +28% YoY \u2014 SURPASSES PUBLIC TRANSPORTATION FOR FIRST TIME",
     "source": "@i",
+    "source_file": "research/summaries/2026-06-03-twitter-16h-headlines.json",
     "url": "https://x.com/i/web/status/2062217135473283090"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-03 16:58 UTC",
+    "delivered_at": "2026-06-03 16:00 UTC",
     "headline": "RAY DALIO SAYS THE AI BUBBLE WILL BURST EVENTUALLY",
     "source": "@i",
+    "source_file": "research/summaries/2026-06-03-twitter-16h-headlines.json",
     "url": "https://x.com/i/web/status/2062213718054723648"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-03 19:48 UTC",
+    "delivered_at": "2026-06-03 19:00 UTC",
     "headline": "DEEPSEEK REPORTED CLOSING ~$7.4B ROUND AT UP TO ~$59B VALUATION \u2014 TENCENT, CATL BACK CHINA'S AI CHAMPION",
     "source": "@Benzinga",
+    "source_file": "research/summaries/2026-06-03-twitter-19h-headlines.json",
     "url": "https://x.com/Benzinga/status/2062225300545552508"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-03 19:48 UTC",
+    "delivered_at": "2026-06-03 19:00 UTC",
     "headline": "DEEPSEEK FOUNDER LIANG WENFENG PUTS ~$3B OF OWN CASH INTO ROUND; ALIBABA TALKED THEN WALKED AWAY",
     "source": "@mergenewsapp",
+    "source_file": "research/summaries/2026-06-03-twitter-19h-headlines.json",
     "url": "https://x.com/mergenewsapp/status/2062256288780681335"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-03 19:48 UTC",
+    "delivered_at": "2026-06-03 19:00 UTC",
     "headline": "OPENAI PUBLISHES FRONTIER-AI-SAFETY 'BLUEPRINT' FOR DEMOCRATIC GOVERNANCE, FRAMED AS NEXT STEP AFTER CYBER EO",
     "source": "@gdb",
+    "source_file": "research/summaries/2026-06-03-twitter-19h-headlines.json",
     "url": "https://x.com/gdb/status/2062259921664835833"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-06-03 19:48 UTC",
+    "delivered_at": "2026-06-03 19:00 UTC",
     "headline": "SURGE AI LAUNCHES COMPLEXCONSTRAINTS BENCHMARK \u2014 FRONTIER MODELS SCORE ONLY 0-40% ON ENTANGLED INSTRUCTIONS",
     "source": "@echen",
+    "source_file": "research/summaries/2026-06-03-twitter-19h-headlines.json",
     "url": "https://x.com/echen/status/2062258181905219813"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-06-03 19:48 UTC",
+    "delivered_at": "2026-06-03 19:00 UTC",
     "headline": "SURGE AI: 4B MODEL FINE-TUNED ON 1K EXAMPLES MATCHES A MODEL 60X ITS SIZE ON INSTRUCTION-FOLLOWING",
     "source": "@echen",
+    "source_file": "research/summaries/2026-06-03-twitter-19h-headlines.json",
     "url": "https://x.com/echen/status/2062258181905219813"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-06-03 19:48 UTC",
+    "delivered_at": "2026-06-03 19:00 UTC",
     "headline": "GOOGLE RELEASES MAGENTA REALTIME 2 ON HUGGING FACE \u2014 OPEN-WEIGHTS ON-DEVICE MUSIC GEN AT ~200MS LATENCY",
     "source": "@HuggingPapers",
+    "source_file": "research/summaries/2026-06-03-twitter-19h-headlines.json",
     "url": "https://x.com/HuggingPapers/status/2062260306039259236"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-03 19:48 UTC",
+    "delivered_at": "2026-06-03 19:00 UTC",
     "headline": "UBER COMMITS ~$500M TO AUTONOMOUS-DRIVING STARTUP NURO, FAR MORE THAN PREVIOUSLY DISCLOSED \u2014 REUTERS",
     "source": "@EmmanuelInvest",
+    "source_file": "research/summaries/2026-06-03-twitter-19h-headlines.json",
     "url": "https://x.com/EmmanuelInvest/status/2062257285171200391"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-06-03 22:07 UTC",
+    "delivered_at": "2026-06-03 22:00 UTC",
     "headline": "GOOGLE SHIPS GEMMA 4 12B \u2014 OPEN WEIGHTS, APACHE 2.0, RUNS LOCALLY ON A 16GB LAPTOP",
     "source": "@demishassabis",
+    "source_file": "research/summaries/2026-06-03-twitter-22h-headlines.json",
     "url": "https://x.com/demishassabis/status/2062241713398149524"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-03 22:07 UTC",
+    "delivered_at": "2026-06-03 22:00 UTC",
     "headline": "OPENAI EXPANDS GPT-ROSALIND, A LIFE-SCIENCES MODEL SERIES FOR DRUG DISCOVERY AT ENTERPRISE SCALE",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-06-03-twitter-22h-headlines.json",
     "url": "https://x.com/OpenAI/status/2062281977122996256"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-03 22:07 UTC",
+    "delivered_at": "2026-06-03 22:00 UTC",
     "headline": "OPENAI TEASES \"IT'S TIME TO FLY\" \u2014 LIVESTREAM EYED FOR JUNE 4 PREVIEW OF NEW CAPABILITIES",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-06-03-twitter-22h-headlines.json",
     "url": "https://x.com/OpenAI/status/2062249312839434452"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-06-03 22:07 UTC",
+    "delivered_at": "2026-06-03 22:00 UTC",
     "headline": "IDEOGRAM 4.0 CLAIMS #1 OPEN-WEIGHT SLOT ON IMAGE ARENA AT 1285 ELO",
     "source": "@Designarena",
+    "source_file": "research/summaries/2026-06-03-twitter-22h-headlines.json",
     "url": "https://x.com/Designarena/status/2062202740311560651"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-03 22:07 UTC",
+    "delivered_at": "2026-06-03 22:00 UTC",
     "headline": "ANTHROPIC EXPANDS PROJECT GLASSWING / CLAUDE MYTHOS TO ~150 MORE ORGS ACROSS 15+ COUNTRIES",
     "source": "@WesRoth",
+    "source_file": "research/summaries/2026-06-03-twitter-22h-headlines.json",
     "url": "https://x.com/WesRoth/status/2062293246987096307"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-03 22:07 UTC",
+    "delivered_at": "2026-06-03 22:00 UTC",
     "headline": "MARVELL EXTENDS GAINS TO OVER +45% IN TWO DAYS AFTER JENSEN HUANG'S \"NEXT TRILLION-DOLLAR\" CALL",
     "source": "@KobeissiLetter",
+    "source_file": "research/summaries/2026-06-03-twitter-22h-headlines.json",
     "url": "https://x.com/KobeissiLetter/status/2062171259983565138"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-04 01:31 UTC",
+    "delivered_at": "2026-06-04 01:00 UTC",
     "headline": "SPACEX FILES IPO WITH SEC \u2014 $74.4B NET RAISE, $135/SHARE, ~$1.75T VALUATION; ROADSHOW STARTS JUNE 4",
     "source": "@SawyerMerritt",
+    "source_file": "research/summaries/2026-06-04-twitter-01h-headlines.json",
     "url": "https://x.com/SawyerMerritt/status/2062272252314271782"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-04 01:31 UTC",
+    "delivered_at": "2026-06-04 01:00 UTC",
     "headline": "BLOOMBERG: DEEPSEEK CLOSE TO SEALING FIRST-EVER ~$7B FUNDING ROUND AT UP TO $59B, TENCENT AND CATL BACKING",
     "source": "@business",
+    "source_file": "research/summaries/2026-06-04-twitter-01h-headlines.json",
     "url": "https://x.com/DeJesusMorrobel/status/2062326054375571587"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-04 01:31 UTC",
+    "delivered_at": "2026-06-04 01:00 UTC",
     "headline": "ALPHABET UPSIZES AI CAPITAL RAISE TO ~$85B FROM $80B AS CONVERTIBLE SALE OVERSUBSCRIBED",
     "source": "@StockSavvyShay",
+    "source_file": "research/summaries/2026-06-04-twitter-01h-headlines.json",
     "url": "https://x.com/StockSavvyShay/status/2062166107004531191"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-04 04:44 UTC",
+    "delivered_at": "2026-06-04 04:00 UTC",
     "headline": "BROADCOM Q3 AI-CHIP GUIDE OF ~$16B UNDERSHOOTS STREET; SHARES SINK ~13% AFTER-HOURS, DRAG NVIDIA/AMD/MICRON",
     "source": "@marketsday",
+    "source_file": "research/summaries/2026-06-04-twitter-04h-headlines.json",
     "url": "https://x.com/marketsday/status/2062339930064642434"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-04 04:44 UTC",
+    "delivered_at": "2026-06-04 04:00 UTC",
     "headline": "BROADCOM Q2 AI SEMI REVENUE +143% TO $10.8B BUT FALLS SHORT; HOCK TAN HOLDS $100B+ TARGET INSTEAD OF RAISING",
     "source": "@TopStockAlerts1",
+    "source_file": "research/summaries/2026-06-04-twitter-04h-headlines.json",
     "url": "https://x.com/TopStockAlerts1/status/2062351062074318873"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-04 04:44 UTC",
+    "delivered_at": "2026-06-04 04:00 UTC",
     "headline": "CLOUDFLARE PARTNERS WITH XAI \u2014 GROK LLM, IMAGE, AUDIO AND VIDEO MODELS NOW LIVE ON CLOUDFLARE AI GATEWAY",
     "source": "@AiToolsRecap",
+    "source_file": "research/summaries/2026-06-04-twitter-04h-headlines.json",
     "url": "https://x.com/AiToolsRecap/status/2062392993164972480"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-04 04:44 UTC",
+    "delivered_at": "2026-06-04 04:00 UTC",
     "headline": "META WEIGHS UP TO $199.99/MO FOR 'HATCH' CONSUMER AI AGENT, RUNNING ON ITS OWN MUSE SPARK MODEL \u2014 THE INFORMATION",
     "source": "@JGidel4",
+    "source_file": "research/summaries/2026-06-04-twitter-04h-headlines.json",
     "url": "https://x.com/JGidel4/status/2062360036190376378"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-04 07:56 UTC",
+    "delivered_at": "2026-06-04 07:00 UTC",
     "headline": "THE INFORMATION: OPENAI TO FOLD CODEX INTO CHATGPT AS 'SUPER APP,' SHIPPING WITHIN WEEKS",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-06-04-twitter-07h-headlines.json",
     "url": "https://x.com/theinformation/status/2062293482492907573"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-04 07:56 UTC",
+    "delivered_at": "2026-06-04 07:00 UTC",
     "headline": "ALTMAN, AMODEI, HASSABIS CO-SIGN LETTER PRESSING CONGRESS TO SECURE SYNTHETIC-DNA ORDERS AS MODELS TURN BIO-CAPABLE",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-04-twitter-07h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2062347797710709177"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-04 07:56 UTC",
+    "delivered_at": "2026-06-04 07:00 UTC",
     "headline": "XAI SHIPS GROK IMAGINE 1.5 TO GENERAL ROLLOUT; GROK 4.3 MOVES OUT OF BETA INTO DEFAULT SEAT",
     "source": "@elonmusk",
+    "source_file": "research/summaries/2026-06-04-twitter-07h-headlines.json",
     "url": "https://x.com/elonmusk/status/2062392619418959901"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-04 07:56 UTC",
+    "delivered_at": "2026-06-04 07:00 UTC",
     "headline": "THE INFORMATION: MICROSOFT LAUNCHING HOME-GROWN AI MODELS AS CHEAPER ALTERNATIVE TO OPENAI AND ANTHROPIC",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-06-04-twitter-07h-headlines.json",
     "url": "https://x.com/theinformation/status/2062280830894887256"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-06-04 07:56 UTC",
+    "delivered_at": "2026-06-04 07:00 UTC",
     "headline": "ANTHROPIC: LATEST MODELS MORE LIKELY TO RECOGNIZE WHEN THEY'RE BEING EVALUATED, CASTING DOUBT ON BENCHMARKS",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-06-04-twitter-07h-headlines.json",
     "url": "https://x.com/theinformation/status/2062270613423526051"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-04 07:56 UTC",
+    "delivered_at": "2026-06-04 07:00 UTC",
     "headline": "ZUCKERBERG ANNOUNCES META BUSINESS AGENT VIA VIDEO; NO OFFICIAL POST YET",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-04-twitter-07h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2062182462302925081"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-04 07:56 UTC",
+    "delivered_at": "2026-06-04 07:00 UTC",
     "headline": "GOOGLE UNVEILS TPUV8T TRAINING CHIP AND 'VIRGO' NETWORK LINKING UP TO 134,400 CHIPS AT 47 PBPS",
     "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-06-04-twitter-07h-headlines.json",
     "url": "https://x.com/SemiAnalysis_/status/2062308538387505560"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-04 10:44 UTC",
+    "delivered_at": "2026-06-04 10:00 UTC",
     "headline": "META REPEATEDLY DELAYS NEXT DEVELOPER AI MODEL (MUSE SPARK API) ON BUGS, INFRA \u2014 WSJ VIA REUTERS",
     "source": "@Reuters",
+    "source_file": "research/summaries/2026-06-04-twitter-10h-headlines.json",
     "url": "https://x.com/Reuters/status/2062444387968106938"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-04 10:44 UTC",
+    "delivered_at": "2026-06-04 10:00 UTC",
     "headline": "ALTMAN, AMODEI, HASSABIS BACK MANDATORY DNA-SYNTHESIS SCREENING IN CROSS-LAB BIOSECURITY LETTER",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-04-twitter-10h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2062485389949145457"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-04 10:44 UTC",
+    "delivered_at": "2026-06-04 10:00 UTC",
     "headline": "TRUMP EO GIVES US GOVERNMENT UP TO 30 DAYS EXCLUSIVE PRE-RELEASE ACCESS TO FRONTIER MODELS",
     "source": "@kyleichan",
+    "source_file": "research/summaries/2026-06-04-twitter-10h-headlines.json",
     "url": "https://x.com/kyleichan/status/2061901741671801229"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-04 13:29 UTC",
+    "delivered_at": "2026-06-04 13:00 UTC",
     "headline": "BROADCOM PLUNGES ~14% AT THE OPEN, LEADS CHIP ROUT \u2014 S&P FALLS WHILE DOW CLIMBS ~500 IN SPLIT MARKET",
     "source": "@Reuters",
+    "source_file": "research/summaries/2026-06-04-twitter-13h-headlines.json",
     "url": "https://x.com/Reuters/status/2062519838526845128"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-04 13:29 UTC",
+    "delivered_at": "2026-06-04 13:00 UTC",
     "headline": "FOXCONN AND INTEL PARTNER TO CO-DEVELOP NEXT-GEN AI DATA-CENTER SYSTEMS \u2014 XEON SILICON MEETS FOXCONN MANUFACTURING",
     "source": "@qz",
+    "source_file": "research/summaries/2026-06-04-twitter-13h-headlines.json",
     "url": "https://x.com/qz/status/2062525099039924455"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-06-04 13:29 UTC",
+    "delivered_at": "2026-06-04 13:00 UTC",
     "headline": "OPENAI SAFETY POST: TODAY'S SYSTEMS SHOW 'EARLY SIGNS OF RECURSIVE SELF-IMPROVEMENT' \u2014 AI ACCELERATING AI",
     "source": "@haider1",
+    "source_file": "research/summaries/2026-06-04-twitter-13h-headlines.json",
     "url": "https://x.com/haider1/status/2062522256211775924"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-06-04 16:28 UTC",
+    "delivered_at": "2026-06-04 16:00 UTC",
     "headline": "ANTHROPIC: CLAUDE NOW SHOWS 'EARLY SIGNS OF RECURSIVE SELF-IMPROVEMENT' \u2014 WRITES 80%+ OF ITS OWN PRODUCTION CODE",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-06-04-twitter-16h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2062568862479208923"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-04 16:28 UTC",
+    "delivered_at": "2026-06-04 16:00 UTC",
     "headline": "ANTHROPIC'S UNRELEASED 'MYTHOS PREVIEW' HITS 52X CODING-SPEEDUP, RUNS 16+ HOURS AUTONOMOUSLY PER METR",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-06-04-twitter-16h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2062568869240476050"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-04 16:28 UTC",
+    "delivered_at": "2026-06-04 16:00 UTC",
     "headline": "OPENAI SHIPS REBUILT CHATGPT MEMORY \u2014 2X CAPACITY, BACKGROUND CURATION, ROLLING OUT TO US PLUS/PRO TODAY",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-06-04-twitter-16h-headlines.json",
     "url": "https://x.com/OpenAI/status/2062567556524003631"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-04 16:28 UTC",
+    "delivered_at": "2026-06-04 16:00 UTC",
     "headline": "BROADCOM SELLOFF DEEPENS TO ~14.7% (~$409); MACQUARIE CUTS TO NEUTRAL ON GOOGLE TPU IN-HOUSE BY 2027 RISK",
     "source": "@_TP888",
+    "source_file": "research/summaries/2026-06-04-twitter-16h-headlines.json",
     "url": "https://x.com/_TP888/status/2062565436663705625"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-04 16:28 UTC",
+    "delivered_at": "2026-06-04 16:00 UTC",
     "headline": "BEAT-AND-SOLD: CROWDSTRIKE -10%, PALO ALTO -6% DESPITE BEATS \u2014 MARKET'S 'BEAT = REWARD' RULE BREAKS",
     "source": "@theaietf",
+    "source_file": "research/summaries/2026-06-04-twitter-16h-headlines.json",
     "url": "https://x.com/theaietf/status/2062560549234225441"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-04 21:54 UTC",
+    "delivered_at": "2026-06-04 21:00 UTC",
     "headline": "SPACEX IPO ROADSHOW GOES LIVE \u2014 SPCX TO DEBUT ON NASDAQ JUNE 12, PRICES JUNE 11 AT FIXED $135, ~$1.75T",
     "source": "@SpaceX",
+    "source_file": "research/summaries/2026-06-04-twitter-21h-headlines.json",
     "url": "https://x.com/SpaceX/status/2062630481087082874"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-04 21:54 UTC",
+    "delivered_at": "2026-06-04 21:00 UTC",
     "headline": "SPACEX PROSPECTUS: $18.7B 2025 REVENUE, STARLINK ~61%, $4.9B NET LOSS \u2014 IPO PRICED AT ~94X SALES",
     "source": "@SpaceX",
+    "source_file": "research/summaries/2026-06-04-twitter-21h-headlines.json",
     "url": "https://x.com/SpaceX/status/2062630481087082874"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-04 21:54 UTC",
+    "delivered_at": "2026-06-04 21:00 UTC",
     "headline": "BROADCOM CLOSES DOWN ~12.6% AS DOW HITS RECORD; AI-CHIP SELLOFF EASES INTO THE BELL",
     "source": "closing-bell summary",
+    "source_file": "research/summaries/2026-06-04-twitter-21h-headlines.json",
     "url": "https://x.com/allday_stocks/status/2062648396050051326"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-06-04 21:54 UTC",
+    "delivered_at": "2026-06-04 21:00 UTC",
     "headline": "ANTHROPIC CORRECTS RSI DATA \u2014 OPUS 4 3X SPEEDUP DATES TO MAY 2025, NOT 2024; 2024 MODELS SHOWED ZERO",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-06-04-twitter-21h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2062634151556292775"
   },
   {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-06-05 08:00 UTC",
+    "headline": "CLAUDE OPUS 4.8 CREDITED WITH FINDING CRITICAL ZCASH BUG \u2014 $ZEC CRASHES ~50% ON UNLIMITED-MINT FLAW",
+    "source": "@SpecialSitsNews",
+    "source_file": "research/summaries/2026-06-05-twitter-08h-headlines.json",
+    "url": "https://x.com/SpecialSitsNews/status/2062809581076561983"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-06-05 08:00 UTC",
+    "headline": "ZCASH ORCHARD POOL SOUNDNESS BUG, HIDDEN SINCE MAY 2022, SPARKS ~$1.2B ALTCOIN LIQUIDATION CASCADE",
+    "source": "@Crypto_Potato",
+    "source_file": "research/summaries/2026-06-05-twitter-08h-headlines.json",
+    "url": "https://x.com/Crypto_Potato/status/2062811291006201966"
+  },
+  {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-05 10:43 UTC",
+    "delivered_at": "2026-06-05 08:00 UTC",
+    "headline": "FT: ANTHROPIC EMBEDS ENGINEERS INSIDE NSA TO DEPLOY 'MYTHOS' FOR OFFENSIVE CYBER OPS",
+    "source": "@WhaleFactor",
+    "source_file": "research/summaries/2026-06-05-twitter-08h-headlines.json",
+    "url": "https://x.com/WhaleFactor/status/2062742509113991234"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-06-05 08:00 UTC",
+    "headline": "ANTHROPIC FIGHTS PENTAGON IN COURT OVER MILITARY AI USE WHILE REPORTEDLY ARMING THE NSA \u2014 FT",
+    "source": "@agenzia_nova",
+    "source_file": "research/summaries/2026-06-05-twitter-08h-headlines.json",
+    "url": "https://x.com/agenzia_nova/status/2062794469989048444"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-06-05 08:00 UTC",
+    "headline": "ANTHROPIC PUBLISHES 'WHEN AI BUILDS ITSELF' PAUSE PAPER \u2014 SKEPTICS CALL DOOMERISM IPO POSITIONING AT ~$965B",
+    "source": "@TechFlowPost",
+    "source_file": "research/summaries/2026-06-05-twitter-08h-headlines.json",
+    "url": "https://x.com/TechFlowPost/status/2062807689374113814"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-06-05 08:00 UTC",
+    "headline": "NEW ANTHROPIC MODEL STRING 'CLAUDE-OCEANUS-V1-P' APPEARS FOR RED-TEAM ACCESS, HINTING AT NEXT-GEN MYTHOS",
+    "source": "@WesRoth",
+    "source_file": "research/summaries/2026-06-05-twitter-08h-headlines.json",
+    "url": "https://x.com/WesRoth/status/2062791531845873813"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-06-05 10:00 UTC",
     "headline": "WSJ MAINSTREAMS ANTHROPIC SELF-IMPROVEMENT DATA AS CALL FOR 'GLOBAL PAUSE' ON AI DEVELOPMENT",
     "source": "@AShmueil",
+    "source_file": "research/summaries/2026-06-05-twitter-10h-headlines.json",
     "url": "https://x.com/AShmueil/status/2062646456264355841"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-05 10:43 UTC",
+    "delivered_at": "2026-06-05 10:00 UTC",
     "headline": "'IRONWORM' NPM WORM HARVESTS OPENAI, ANTHROPIC AND AWS API KEYS VIA RUST INFOSTEALER + EBPF ROOTKIT",
     "source": "@cyber__razz",
+    "source_file": "research/summaries/2026-06-05-twitter-10h-headlines.json",
     "url": "https://x.com/cyber__razz/status/2062617083846754526"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-05 10:43 UTC",
+    "delivered_at": "2026-06-05 10:00 UTC",
     "headline": "ANTHROPIC IPO CHATTER TURNS SPECIFIC: 'CONFIDENTIAL S-1 FILED JUNE 1' AT ~$1T \u2014 SINGLE LOW-CRED SOURCE, UNVERIFIED",
     "source": "@bulldoghill",
+    "source_file": "research/summaries/2026-06-05-twitter-10h-headlines.json",
     "url": "https://x.com/bulldoghill/status/2062817975921451338"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-06-05 10:43 UTC",
+    "delivered_at": "2026-06-05 10:00 UTC",
     "headline": "OPENAI SAYS ONE OF ITS MODELS FOUND A COUNTEREXAMPLE TO AN 80-YEAR-OLD ERDOS CONJECTURE",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-06-05-twitter-10h-headlines.json",
     "url": "https://x.com/OpenAI/status/2062630454537424930"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-07 01:24 UTC",
+    "delivered_at": "2026-06-07 01:00 UTC",
     "headline": "WHITE HOUSE SENIOR AI POLICY ADVISER SRIRAM KRISHNAN TO EXIT AT END OF JUNE",
     "source": "@SCMPNews",
+    "source_file": "research/summaries/2026-06-07-twitter-01h-headlines.json",
     "url": "https://x.com/SCMPNews/status/2063353114074202171"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-07 01:24 UTC",
+    "delivered_at": "2026-06-07 01:00 UTC",
     "headline": "TRUMP ADMINISTRATION REPORTEDLY IN TALKS TO TAKE A US-GOVERNMENT EQUITY STAKE IN OPENAI",
     "source": "@mswnlz",
+    "source_file": "research/summaries/2026-06-07-twitter-01h-headlines.json",
     "url": "https://x.com/mswnlz/status/2063406773743337666"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-07 01:24 UTC",
+    "delivered_at": "2026-06-07 01:00 UTC",
     "headline": "GOOGLE-SPACEX COMPUTE PACT: ~$920M/MONTH THROUGH 2029 FOR ~110,000 GPUS \u2014 DIRECTION CONTESTED",
     "source": "@SawyerMerritt",
+    "source_file": "research/summaries/2026-06-07-twitter-01h-headlines.json",
     "url": "https://x.com/SawyerMerritt/status/2063374919912853706"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-07 05:02 UTC",
+    "delivered_at": "2026-06-07 05:00 UTC",
     "headline": "OPENAI PLOTS BIGGEST CHATGPT OVERHAUL SINCE LAUNCH \u2014 RECAST AS IPO-READY 'SUPER APP' WITH CODING AND AGENTS, PER FT",
     "source": "@Polymarket",
+    "source_file": "research/summaries/2026-06-07-twitter-05h-headlines.json",
     "url": "https://x.com/Polymarket/status/2063477552170090816"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-07 05:02 UTC",
+    "delivered_at": "2026-06-07 05:00 UTC",
     "headline": "'CLAUDE MYTHOS' LEAK CHATTER GROWS \u2014 CLAUDE-MYTHOS-5 SLUG REPORTEDLY SPOTTED IN DEV MODE AS A FOURTH MODEL CLASS",
     "source": "@johnsavage_ai",
+    "source_file": "research/summaries/2026-06-07-twitter-05h-headlines.json",
     "url": "https://x.com/johnsavage_ai/status/2063377904700944537"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-07 05:02 UTC",
+    "delivered_at": "2026-06-07 05:00 UTC",
     "headline": "TRUMP ADMIN STILL 'DISCUSSING' US EQUITY STAKE IN OPENAI 'SO THE AMERICAN PEOPLE CAN BENEFIT' \u2014 NO TERMS ON RECORD",
     "source": "@LasinduLive",
+    "source_file": "research/summaries/2026-06-07-twitter-05h-headlines.json",
     "url": "https://x.com/LasinduLive/status/2063482688074563768"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-07 10:12 UTC",
+    "delivered_at": "2026-06-07 10:00 UTC",
     "headline": "OPENAI REORGANIZING AROUND CODEX \u2014 5M WEEKLY USERS, FOLDING IT INTO CHATGPT TO RACE ANTHROPIC ON CODING AGENTS",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-06-07-twitter-10h-headlines.json",
     "url": "https://x.com/theinformation/status/2063274751527731441"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-07 10:12 UTC",
+    "delivered_at": "2026-06-07 10:00 UTC",
     "headline": "OPENAI CODEX ENTERPRISE REVENUE UP ~50% WEEK-OVER-WEEK, NOW MERGING INTO CHATGPT AND ATLAS",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-06-07-twitter-10h-headlines.json",
     "url": "https://x.com/theinformation/status/2063282280362037468"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-07 10:12 UTC",
+    "delivered_at": "2026-06-07 10:00 UTC",
     "headline": "SPACEX/xAI IS THE COMPUTE SELLER \u2014 ANTHROPIC RENTING ITS CAPACITY FOR ~$1.25B/MONTH, THE INFORMATION CONFIRMS",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-06-07-twitter-10h-headlines.json",
     "url": "https://x.com/theinformation/status/2063244564937183235"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-07 10:12 UTC",
+    "delivered_at": "2026-06-07 10:00 UTC",
     "headline": "ELON NOW PULLING $2B+/MONTH IN COMPUTE-AS-A-SERVICE: GOOGLE ~$920M/MO + ANTHROPIC ~$1.25B/MO",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-07-twitter-10h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2063278695763329352"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-07 10:12 UTC",
+    "delivered_at": "2026-06-07 10:00 UTC",
     "headline": "CHATGPT CAN NOW REFERENCE YOUR SYNCED GMAIL FOR PERSONALIZED RESPONSES, ROLLING OUT TO MORE ACCOUNTS",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-06-07-twitter-10h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2063532702356160962"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-07 10:12 UTC",
+    "delivered_at": "2026-06-07 10:00 UTC",
     "headline": "META WEIGHS $200/MONTH 'HATCH' AI AGENT TO BUILD TOOLS AND AUTOMATE WEB TASKS \u2014 INTERNAL DOCS",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-06-07-twitter-10h-headlines.json",
     "url": "https://x.com/theinformation/status/2062957697436123636"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-07 12:59 UTC",
+    "delivered_at": "2026-06-07 12:00 UTC",
     "headline": "ANTHROPIC CONFIDENTIAL IPO FILING CONFIRMED \u2014 S-1 SUBMITTED JUNE 1 AT ~$965B, LISTING COULD COME THIS FALL",
     "source": "@CoreviceLLC",
+    "source_file": "research/summaries/2026-06-07-twitter-12h-headlines.json",
     "url": "https://x.com/CoreviceLLC/status/2063419027951874300"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-07 12:59 UTC",
+    "delivered_at": "2026-06-07 12:00 UTC",
     "headline": "ANTHROPIC URGES COORDINATED GLOBAL PAUSE ON FRONTIER AI, FLAGS RECURSIVE SELF-IMPROVEMENT RISK",
     "source": "@HedgieMarkets",
+    "source_file": "research/summaries/2026-06-07-twitter-12h-headlines.json",
     "url": "https://x.com/HedgieMarkets/status/2063414924626546734"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-07 12:59 UTC",
+    "delivered_at": "2026-06-07 12:00 UTC",
     "headline": "AI EQUITIES SELL OFF \u2014 QQQ DOWN 4.8% IN ONE DAY AS AI LEADERSHIP BLEEDS",
     "source": "@VolumeLeaders",
+    "source_file": "research/summaries/2026-06-07-twitter-12h-headlines.json",
     "url": "https://x.com/VolumeLeaders/status/2063602939575329023"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-07 15:54 UTC",
+    "delivered_at": "2026-06-07 15:00 UTC",
     "headline": "OPENAI'S BIGGEST CHATGPT REVAMP SINCE LAUNCH RUMORED NEXT WEEK ALONGSIDE GPT-5.6 \u2014 ANDREW CURRAN",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-07-twitter-15h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2063639710535479662"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-07 15:54 UTC",
+    "delivered_at": "2026-06-07 15:00 UTC",
     "headline": "THE INFORMATION: XAI CUTS CODING STAFF, CHURNS GROK CODE LEADS, LEANS ON CURSOR AND TESLA ENGINEERS",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-06-07-twitter-15h-headlines.json",
     "url": "https://x.com/theinformation/status/2063622052297289975"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-07 15:54 UTC",
+    "delivered_at": "2026-06-07 15:00 UTC",
     "headline": "CHATGPT CROSSES 600 MILLION MONTHLY ACTIVE USERS FOR THE FIRST TIME \u2014 SIMILARWEB",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-06-07-twitter-15h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2063598548306858269"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-07 15:54 UTC",
+    "delivered_at": "2026-06-07 15:00 UTC",
     "headline": "DEVELOPERS HIT 'MODEL NOT FOUND: GPT-5.5' 404s IN CODEX, READ AS POSSIBLE GPT-5.6 ROLLOUT TELL",
     "source": "@lalit_notFound",
+    "source_file": "research/summaries/2026-06-07-twitter-15h-headlines.json",
     "url": "https://x.com/lalit_notFound/status/2063644496731267493"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-07 18:53 UTC",
+    "delivered_at": "2026-06-07 18:00 UTC",
     "headline": "OPENAI CHATGPT 'SUPER APP' OVERHAUL TO ROLL OUT IN COMING WEEKS \u2014 'CHAT IS DEAD,' EMPLOYEE TELLS FT",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-07-twitter-18h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2063643307381543039"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-07 18:53 UTC",
+    "delivered_at": "2026-06-07 18:00 UTC",
     "headline": "GPT-5.6 AND CLAUDE MYTHOS BOTH EXPECTED NEXT WEEK \u2014 BUT OPENAI AND ANTHROPIC ACCOUNTS STAY SILENT, NOTHING SHIPPED",
     "source": "@daniel_mac8",
+    "source_file": "research/summaries/2026-06-07-twitter-18h-headlines.json",
     "url": "https://x.com/daniel_mac8/status/2063653184816497049"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-07 18:53 UTC",
+    "delivered_at": "2026-06-07 18:00 UTC",
     "headline": "FT: NSA USING ANTHROPIC'S MYTHOS FOR OFFENSIVE CYBER OPS AS LAB BATTLES PENTAGON OVER CLAUDE",
     "source": "@TimoVainionpaa",
+    "source_file": "research/summaries/2026-06-07-twitter-18h-headlines.json",
     "url": "https://x.com/TimoVainionpaa/status/2063693823948013802"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-07 21:42 UTC",
+    "delivered_at": "2026-06-07 21:00 UTC",
     "headline": "APPLE TO UNVEIL OVERHAULED AI-POWERED SIRI AT WWDC KEYNOTE MONDAY \u2014 GEMINI BACKEND RUMORED",
     "source": "@Polymarket",
+    "source_file": "research/summaries/2026-06-07-twitter-21h-headlines.json",
     "url": "https://x.com/Polymarket/status/2063735418596491381"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-07 21:42 UTC",
+    "delivered_at": "2026-06-07 21:00 UTC",
     "headline": "SPACEX PRICES RECORD IPO AT $135/SHARE \u2014 $75B RAISE, ~$1.77 TRILLION VALUATION",
     "source": "@akishore",
+    "source_file": "research/summaries/2026-06-07-twitter-21h-headlines.json",
     "url": "https://x.com/akishore/status/2063689689744146815"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-06-07 21:42 UTC",
+    "delivered_at": "2026-06-07 21:00 UTC",
     "headline": "SEMIANALYSIS: NVIDIA NEMOTRON3 ULTRA TRAILS KIMI K2.6 AND GLM5.1 ON CODING BENCHMARKS",
     "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-06-07-twitter-21h-headlines.json",
     "url": "https://x.com/SemiAnalysis_/status/2063727789631480134"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-08 01:24 UTC",
+    "delivered_at": "2026-06-08 01:00 UTC",
     "headline": "APPLE WWDC KEYNOTE TODAY \u2014 GEMINI-POWERED SIRI EXPECTED IN TIM COOK'S REPORTED FINAL KEYNOTE AS CEO",
     "source": "@mnh_18",
+    "source_file": "research/summaries/2026-06-08-twitter-01h-headlines.json",
     "url": "https://x.com/mnh_18/status/2063297364295884988"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-08 01:24 UTC",
+    "delivered_at": "2026-06-08 01:00 UTC",
     "headline": "CLOUDFLARE ACQUIRES VOIDZERO \u2014 VITE/VITEST/ROLLDOWN MAKER; TOOLCHAIN STAYS OPEN-SOURCE, $1M ECOSYSTEM FUND",
     "source": "@so_sthbryan",
+    "source_file": "research/summaries/2026-06-08-twitter-01h-headlines.json",
     "url": "https://x.com/so_sthbryan/status/2063737765011878003"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-06-08 01:24 UTC",
+    "delivered_at": "2026-06-08 01:00 UTC",
     "headline": "GOOGLE GEMMA 4 12B OPEN WEIGHTS \u2014 APACHE 2.0, RUNS ON 16GB, NATIVE AUDIO; 150M+ FAMILY DOWNLOADS",
     "source": "@sudoingX",
+    "source_file": "research/summaries/2026-06-08-twitter-01h-headlines.json",
     "url": "https://x.com/sudoingX/status/2063671874341720373"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-08 01:24 UTC",
+    "delivered_at": "2026-06-08 01:00 UTC",
     "headline": "HITACHI GRANTED CLAUDE MYTHOS PREVIEW ACCESS AS ANTHROPIC SCALES TO CRITICAL INFRA IN 15+ COUNTRIES",
     "source": "@ITLINE410513",
+    "source_file": "research/summaries/2026-06-08-twitter-01h-headlines.json",
     "url": "https://x.com/ITLINE410513/status/2063794596078039490"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-08 10:47 UTC",
+    "delivered_at": "2026-06-08 10:00 UTC",
     "headline": "KOSPI HALTED: SOUTH KOREA TRIPS CIRCUIT BREAKER ON ~8-9% PLUNGE AS BROADCOM AI-CHIP MISS REPRICES SEMIS TRADE",
     "source": "@onechancefreedm",
+    "source_file": "research/summaries/2026-06-08-twitter-10h-headlines.json",
     "url": "https://x.com/onechancefreedm/status/2063871000000000000"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-08 10:47 UTC",
+    "delivered_at": "2026-06-08 10:00 UTC",
     "headline": "AI TRADE UNWIND: NASDAQ -4.18% FRIDAY (WORST SINCE APRIL 2025), NVIDIA -6.2%, BROADCOM -7.9% ON CUSTOM-SILICON FEARS",
     "source": "@capitalcom",
+    "source_file": "research/summaries/2026-06-08-twitter-10h-headlines.json",
     "url": "https://x.com/capitalcom/status/2063931000000000000"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-08 10:47 UTC",
+    "delivered_at": "2026-06-08 10:00 UTC",
     "headline": "ANTHROPIC: `CLAUDE-MYTHOS-5` SLUG SPOTTED IN DEV MODE \u2014 MYTHOS MAY BECOME A FOURTH MODEL CLASS BESIDE HAIKU/SONNET/OPUS",
     "source": "@WesRoth",
+    "source_file": "research/summaries/2026-06-08-twitter-10h-headlines.json",
     "url": "https://x.com/WesRoth/status/2063848000000000000"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-08 10:47 UTC",
+    "delivered_at": "2026-06-08 10:00 UTC",
     "headline": "AMD TO INVEST UP TO \u00a32B IN UK AI AND COMPUTE OVER 5 YEARS, PARTNERING IMPERIAL COLLEGE LONDON AND ORIOLE NETWORKS",
     "source": "@AIStockSavvy",
+    "source_file": "research/summaries/2026-06-08-twitter-10h-headlines.json",
     "url": "https://x.com/AIStockSavvy/status/2063927000000000000"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-06-08 10:47 UTC",
+    "delivered_at": "2026-06-08 10:00 UTC",
     "headline": "WWDC TODAY 17:00 UTC: APPLE SET TO UNVEIL GEMINI-BACKED SIRI IN TIM COOK'S REPORTEDLY FINAL KEYNOTE AS CEO",
     "source": "@aaronp613",
+    "source_file": "research/summaries/2026-06-08-twitter-10h-headlines.json",
     "url": "https://x.com/aaronp613/status/2063931000000000000"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-08 10:47 UTC",
+    "delivered_at": "2026-06-08 10:00 UTC",
     "headline": "GROK LEAVES X PREMIUM WALLED GARDEN \u2014 NOW REACHABLE BY DEVELOPERS VIA CLOUDFLARE AI GATEWAY",
     "source": "@contextreportai",
+    "source_file": "research/summaries/2026-06-08-twitter-10h-headlines.json",
     "url": "https://x.com/contextreportai/status/2063920000000000000"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-08 13:46 UTC",
+    "delivered_at": "2026-06-08 13:00 UTC",
     "headline": "AI-CHIP TRADE BOUNCES AT US OPEN \u2014 S&P FUTURES ~+0.8%, CHIPS LEAD OVERSOLD RECOVERY AFTER FRIDAY ROUT",
     "source": "@VitalTrades",
+    "source_file": "research/summaries/2026-06-08-twitter-13h-headlines.json",
     "url": "https://x.com/VitalTrades/status/2063960484101910859"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-08 13:46 UTC",
+    "delivered_at": "2026-06-08 13:00 UTC",
     "headline": "NVIDIA'S HUANG IN SEOUL: AI MEMORY SHORTAGE TO LAST 'QUITE A FEW YEARS' ACROSS WHOLE SUPPLY CHAIN",
     "source": "@CKCapitalxx",
+    "source_file": "research/summaries/2026-06-08-twitter-13h-headlines.json",
     "url": "https://x.com/CKCapitalxx/status/2063723367014846937"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-08 13:46 UTC",
+    "delivered_at": "2026-06-08 13:00 UTC",
     "headline": "NVIDIA SIGNS NEW KOREA PARTNERSHIPS WITH SK HYNIX, NAVER AND DOOSAN ON AI INFRASTRUCTURE",
     "source": "@bobbi_news",
+    "source_file": "research/summaries/2026-06-08-twitter-13h-headlines.json",
     "url": "https://x.com/bobbi_news/status/2063941098892845276"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-08 13:46 UTC",
+    "delivered_at": "2026-06-08 13:00 UTC",
     "headline": "UNRELEASED ANTHROPIC MODEL 'OCEANUS' (CLAUDE-OCEANUS-V1-P) LEAKED VIA RESOLD API ACCESS; PRICED ~3X OPUS",
     "source": "@rohanpaul_ai",
+    "source_file": "research/summaries/2026-06-08-twitter-13h-headlines.json",
     "url": "https://x.com/rohanpaul_ai/status/2063568309736677780"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-08 13:46 UTC",
+    "delivered_at": "2026-06-08 13:00 UTC",
     "headline": "ARK'S CATHIE WOOD DEFENDS PRE-IPO AI NAMES \u2014 SPACEX, OPENAI, ANTHROPIC \u2014 AGAINST 'MONEY-LOSING' CRITICS",
     "source": "@ARKInvest",
+    "source_file": "research/summaries/2026-06-08-twitter-13h-headlines.json",
     "url": "https://x.com/ARKInvest/status/2063980079827337460"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-06-08 19:02 UTC",
+    "delivered_at": "2026-06-08 19:00 UTC",
     "headline": "APPLE SHIPS REBUILT 'SIRI AI' RUNNING ON CUSTOM GOOGLE GEMINI MODEL AT WWDC \u2014 NOT OPENAI",
     "source": "WWDC 2026 keynote",
+    "source_file": "research/summaries/2026-06-08-twitter-19h-headlines.json",
     "url": "https://x.com/i/status/2064061146227757412"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-08 19:02 UTC",
+    "delivered_at": "2026-06-08 19:00 UTC",
     "headline": "APPLE'S NEW SIRI AI BLOCKED IN EU AND CHINA AT LAUNCH AS DMA TALKS HIT DEAD END",
     "source": "WWDC 2026 post-keynote",
+    "source_file": "research/summaries/2026-06-08-twitter-19h-headlines.json",
     "url": "https://x.com/i/status/2064060428863619542"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-08 19:02 UTC",
+    "delivered_at": "2026-06-08 19:00 UTC",
     "headline": "iOS 27 LETS USERS SET CLAUDE, CHATGPT, GEMINI OR GROK AS DEFAULT AI ASSISTANT",
     "source": "WWDC 2026 keynote",
+    "source_file": "research/summaries/2026-06-08-twitter-19h-headlines.json",
     "url": "https://x.com/i/status/2064045749260988811"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-08 19:02 UTC",
+    "delivered_at": "2026-06-08 19:00 UTC",
     "headline": "iOS 27 / iPadOS 27 / macOS 27 DEV BETA LIVE NOW WITH SYSTEM-WIDE 'LIQUID GLASS' UI",
     "source": "WWDC 2026 keynote",
+    "source_file": "research/summaries/2026-06-08-twitter-19h-headlines.json",
     "url": "https://x.com/i/status/2064053087946608646"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-08 19:02 UTC",
+    "delivered_at": "2026-06-08 19:00 UTC",
     "headline": "TIM COOK'S FINAL WWDC KEYNOTE \u2014 JOHN TERNUS TO TAKE OVER AS APPLE CEO IN SEPTEMBER",
     "source": "WWDC 2026 keynote",
+    "source_file": "research/summaries/2026-06-08-twitter-19h-headlines.json",
     "url": "https://x.com/i/status/2064059964709388774"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-06-08 21:46 UTC",
+    "delivered_at": "2026-06-08 21:00 UTC",
     "headline": "OPENAI CONFIRMS IT FILED A CONFIDENTIAL S-1 \u2014 ANNOUNCES AHEAD OF EXPECTED LEAK, TIMING UNDECIDED",
     "source": "@OpenAINewsroom",
+    "source_file": "research/summaries/2026-06-08-twitter-21h-headlines.json",
     "url": "https://x.com/OpenAINewsroom/status/2064094175541461220"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-08 21:46 UTC",
+    "delivered_at": "2026-06-08 21:00 UTC",
     "headline": "REPORTS: OPENAI IPO TARGETS UP TO $1T VALUATION, COULD DEBUT AS EARLY AS SEPTEMBER; GOLDMAN, MORGAN STANLEY LEADING",
     "source": "@KobeissiLetter",
+    "source_file": "research/summaries/2026-06-08-twitter-21h-headlines.json",
     "url": "https://x.com/KobeissiLetter/status/2064094804523229538"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-08 21:46 UTC",
+    "delivered_at": "2026-06-08 21:00 UTC",
     "headline": "AI IPO SUPERCYCLE \u2014 OPENAI + ANTHROPIC (FILED JUN 1) + SPACEX ($1.75T, JUN 12) HEAD TO PUBLIC MARKETS",
     "source": "@NewsTongueX",
+    "source_file": "research/summaries/2026-06-08-twitter-21h-headlines.json",
     "url": "https://x.com/NewsTongueX/status/2063914441402413423"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-06-08 21:46 UTC",
+    "delivered_at": "2026-06-08 21:00 UTC",
     "headline": "ANTHROPIC RESEARCH CLAIM: CLAUDE MYTHOS PREVIEW BUILT WORKING FIREFOX EXPLOIT IN 1 HOUR FROM A PATCH",
     "source": "@IntCyberDigest",
+    "source_file": "research/summaries/2026-06-08-twitter-21h-headlines.json",
     "url": "https://x.com/IntCyberDigest/status/2064084653175169212"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-09 17:50 UTC",
+    "delivered_at": "2026-06-09 17:00 UTC",
     "headline": "ANTHROPIC SHIPS CLAUDE FABLE 5 \u2014 FIRST PUBLIC 'MYTHOS-CLASS' MODEL, 'EXCEEDS ANY MODEL WE'VE MADE GENERALLY AVAILABLE'",
     "source": "@claudeai",
+    "source_file": "research/summaries/2026-06-09-twitter-17h-headlines.json",
     "url": "https://x.com/claudeai/status/2064394146916229443"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-09 17:50 UTC",
+    "delivered_at": "2026-06-09 17:00 UTC",
     "headline": "FABLE 5 ROUTES HIGH-RISK CYBER/BIO/CHEM QUERIES TO OPUS 4.8 \u2014 SAFETY FALLBACK IN UNDER 5% OF SESSIONS",
     "source": "@claudeai",
+    "source_file": "research/summaries/2026-06-09-twitter-17h-headlines.json",
     "url": "https://x.com/claudeai/status/2064394155258765783"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-09 17:50 UTC",
+    "delivered_at": "2026-06-09 17:00 UTC",
     "headline": "ANTHROPIC ALSO LAUNCHES MYTHOS 5 \u2014 SAME MODEL, SAFEGUARDS LIFTED, RESTRICTED TO GLASSWING PARTNERS",
     "source": "@claudeai",
+    "source_file": "research/summaries/2026-06-09-twitter-17h-headlines.json",
     "url": "https://x.com/claudeai/status/2064394158056386684"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-09 17:50 UTC",
+    "delivered_at": "2026-06-09 17:00 UTC",
     "headline": "FABLE 5 PRICED ~2X OPUS 4.8 AT $10/$50 PER MILLION TOKENS \u2014 FREE ON PAID PLANS ONLY UNTIL JUNE 22, THEN CREDITS",
     "source": "@theguptaankush",
+    "source_file": "research/summaries/2026-06-09-twitter-17h-headlines.json",
     "url": "https://x.com/theguptaankush/status/2064403418580754919"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-09 17:50 UTC",
+    "delivered_at": "2026-06-09 17:00 UTC",
     "headline": "REPORTS: FABLE 5 IMPOSES MANDATORY 30-DAY DATA RETENTION, OVERRIDING ENTERPRISE ZERO-RETENTION CONTRACTS",
     "source": "@oesnadaki",
+    "source_file": "research/summaries/2026-06-09-twitter-17h-headlines.json",
     "url": "https://x.com/oesnadaki/status/2064402107961098252"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-06-09 17:50 UTC",
+    "delivered_at": "2026-06-09 17:00 UTC",
     "headline": "ANTHROPIC SELF-REPORTS FABLE 5 AT 80.3% ON SWE-BENCH PRO VS GPT-5.5 58.6% AND GEMINI 3.1 PRO 54.2% \u2014 NO INDEPENDENT EVAL YET",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-09-twitter-17h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2064394487317528592"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-09 18:59 UTC",
+    "delivered_at": "2026-06-09 18:00 UTC",
     "headline": "KARPATHY CALLS CLAUDE FABLE 5 A 'MAJOR-VERSION-BUMP STEP CHANGE' \u2014 SOTA ON EVERYTHING BY A MARGIN",
     "source": "@karpathy",
+    "source_file": "research/summaries/2026-06-09-twitter-18h-headlines.json",
     "url": "https://x.com/karpathy/status/2064409694761054332"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-09 18:59 UTC",
+    "delivered_at": "2026-06-09 18:00 UTC",
     "headline": "FABLE 5 BACKLASH: USERS SAY OPUS 4.8 SAFETY REROUTE FIRES ON BENIGN QUERIES, BURNS ~2X TOKENS",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-09-twitter-18h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2064406584923464174"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-09 18:59 UTC",
+    "delivered_at": "2026-06-09 18:00 UTC",
     "headline": "GOOGLE SHIPS GEMINI 3.5 LIVE TRANSLATE \u2014 REAL-TIME SPEECH-TO-SPEECH, 70+ LANGUAGES, LIVE IN API NOW",
     "source": "@OfficialLoganK",
+    "source_file": "research/summaries/2026-06-09-twitter-18h-headlines.json",
     "url": "https://x.com/OfficialLoganK/status/2064369125447864674"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-09 18:59 UTC",
+    "delivered_at": "2026-06-09 18:00 UTC",
     "headline": "GOOGLE TO GUARANTEE ~$35B OF TPU LEASES FOR ANTHROPIC ACROSS 5 US DATA CENTERS; BROADCOM DESIGNS CHIPS",
     "source": "@Sam_Badawi",
+    "source_file": "research/summaries/2026-06-09-twitter-18h-headlines.json",
     "url": "https://x.com/Sam_Badawi/status/2064420693048193485"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-09 18:59 UTC",
+    "delivered_at": "2026-06-09 18:00 UTC",
     "headline": "FABLE 5 LISTS AT $10/$50 PER M \u2014 ~70% CHEAPER THAN GPT-5.5 PRO AT $30/$180, BUT ~2X OPUS 4.8",
     "source": "@ns123abc",
+    "source_file": "research/summaries/2026-06-09-twitter-18h-headlines.json",
     "url": "https://x.com/ns123abc/status/2064407019537170731"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-06-09 21:51 UTC",
+    "delivered_at": "2026-06-09 21:00 UTC",
     "headline": "FABLE 5 SYSTEM CARD: MYTHOS 5 WROTE WORKING EXPLOITS IN 88.4% OF TRIALS VS OPUS 4.8'S 8.8%",
     "source": "@rohanpaul_ai",
+    "source_file": "research/summaries/2026-06-09-twitter-21h-headlines.json",
     "url": "https://x.com/rohanpaul_ai/status/2064411737361993828"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-06-09 21:51 UTC",
+    "delivered_at": "2026-06-09 21:00 UTC",
     "headline": "NEW ANTHROPIC SAFEGUARD: FABLE 5 COVERTLY DEGRADES ITS OWN OUTPUT ON AI-DEV QUERIES INSTEAD OF REFUSING (~0.03% OF TRAFFIC)",
     "source": "@Hangsiin",
+    "source_file": "research/summaries/2026-06-09-twitter-21h-headlines.json",
     "url": "https://x.com/Hangsiin/status/2064397550434816088"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-09 21:51 UTC",
+    "delivered_at": "2026-06-09 21:00 UTC",
     "headline": "CLAUDE CODE LEAD CHERNY: FABLE 5 IS BIGGEST STEP UP SINCE OPUS 4.5, HAS 'BIG MODEL SMELL'",
     "source": "@bcherny",
+    "source_file": "research/summaries/2026-06-09-twitter-21h-headlines.json",
     "url": "https://x.com/bcherny/status/2064431111154053187"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-09 21:51 UTC",
+    "delivered_at": "2026-06-09 21:00 UTC",
     "headline": "HVM AUTHOR TAELIN: FABLE 5 LANDED 1,770% SPEEDUP IN 2 HOURS, BEAT OPUS 4.8 AND A SWARM OF GPT-5.5 AGENTS",
     "source": "@VictorTaelin",
+    "source_file": "research/summaries/2026-06-09-twitter-21h-headlines.json",
     "url": "https://x.com/VictorTaelin/status/2064448425936994742"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-06-09 21:51 UTC",
+    "delivered_at": "2026-06-09 21:00 UTC",
     "headline": "ANTHROPIC SYSTEM CARD CLAIMS MYTHOS 5 GENOMICS MODEL BEAT A PUBLISHED SCIENCE PAPER AT 1/100TH THE SIZE",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-09-twitter-21h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2064413892378546418"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-09 21:51 UTC",
+    "delivered_at": "2026-06-09 21:00 UTC",
     "headline": "DOCTOR FLAGS FABLE 5 OVERREACH: WORD 'CANCER' TRIPS BIOSECURITY FILTER, MODEL 'UNUSABLE'",
     "source": "@DeryaTR_",
+    "source_file": "research/summaries/2026-06-09-twitter-21h-headlines.json",
     "url": "https://x.com/DeryaTR_/status/2064398237545726235"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-10 01:21 UTC",
+    "delivered_at": "2026-06-10 01:00 UTC",
     "headline": "FABLE 5 BEATS GPT-5.5 ON CODING IN SAME-INPUT HEAD-TO-HEAD \u2014 BUT ONLY WHEN THE OPUS-4.8 SAFETY REROUTE DOESN'T FIRE",
     "source": "@ImAI_Eruel",
+    "source_file": "research/summaries/2026-06-10-twitter-01h-headlines.json",
     "url": "https://x.com/ImAI_Eruel/status/2064505543230967980"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-06-10 01:21 UTC",
+    "delivered_at": "2026-06-10 01:00 UTC",
     "headline": "FIRST INDEPENDENT BENCHMARK: FABLE 5 RANKS SECOND TO GPT-5.5 ON CREATIVE WRITING, DENTING 'SOTA ON EVERYTHING' CLAIM",
     "source": "@LechMazur",
+    "source_file": "research/summaries/2026-06-10-twitter-01h-headlines.json",
     "url": "https://x.com/LechMazur/status/2064503575577821458"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-10 01:21 UTC",
+    "delivered_at": "2026-06-10 01:00 UTC",
     "headline": "FABLE 5 TOKEN BURN IS THE OPUS-4.8 REROUTE, NOT THE MODEL \u2014 INDEPENDENT TEST FINDS NATIVE CODING FASTER AND CHEAPER THAN CODEX",
     "source": "@ImAI_Eruel",
+    "source_file": "research/summaries/2026-06-10-twitter-01h-headlines.json",
     "url": "https://x.com/ImAI_Eruel/status/2064506223387640232"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-10 04:41 UTC",
+    "delivered_at": "2026-06-10 04:00 UTC",
     "headline": "ARTIFICIAL ANALYSIS: CLAUDE FABLE 5 DEBUTS #1 ON INTELLIGENCE INDEX AT 64.9, ~5 POINTS AHEAD OF GPT-5.5",
     "source": "@ArtificialAnlys",
+    "source_file": "research/summaries/2026-06-10-twitter-04h-headlines.json",
     "url": "https://x.com/ArtificialAnlys/status/2064500150069030992"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-10 04:41 UTC",
+    "delivered_at": "2026-06-10 04:00 UTC",
     "headline": "INDEPENDENT EVAL CLOCKS FABLE 5 SAFETY REROUTE AT ~8% OF TASKS \u2014 ABOVE ANTHROPIC'S STATED 'UNDER 5% OF SESSIONS'",
     "source": "@ArtificialAnlys",
+    "source_file": "research/summaries/2026-06-10-twitter-04h-headlines.json",
     "url": "https://x.com/ArtificialAnlys/status/2064500150069030992"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-10 04:41 UTC",
+    "delivered_at": "2026-06-10 04:00 UTC",
     "headline": "FABLE 5 PRICED $10/$50 PER 1M TOKENS, 2X OPUS; ONE HUMANITY'S-LAST-EXAM RUN COST ~$2.2K, AA'S PRICIEST MODEL EVER",
     "source": "@ArtificialAnlys",
+    "source_file": "research/summaries/2026-06-10-twitter-04h-headlines.json",
     "url": "https://x.com/ArtificialAnlys/status/2064500152430383489"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-06-10 04:41 UTC",
+    "delivered_at": "2026-06-10 04:00 UTC",
     "headline": "COHERE SHIPS NORTH MINI CODE \u2014 30B OPEN-WEIGHTS CODING MODEL, SCORES 27.6 ON AA INTELLIGENCE INDEX",
     "source": "@ArtificialAnlys",
+    "source_file": "research/summaries/2026-06-10-twitter-04h-headlines.json",
     "url": "https://x.com/ArtificialAnlys/status/2064377790875455938"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-10 07:48 UTC",
+    "delivered_at": "2026-06-10 07:00 UTC",
     "headline": "FABLE 5 DEBATE PIVOTS TO COST \u2014 OPERATORS REPORT BURNING CLAUDE MAX LIMITS IN UNDER 30 MINUTES",
     "source": "@VraserX",
+    "source_file": "research/summaries/2026-06-10-twitter-07h-headlines.json",
     "url": "https://x.com/VraserX/status/2064608754214003058"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-10 07:48 UTC",
+    "delivered_at": "2026-06-10 07:00 UTC",
     "headline": "JUNE 22 CLIFF DOMINATES \u2014 USERS FEAR FABLE 5 UNAFFORDABLE ONCE FREE WINDOW ENDS, ONE DEEP-RESEARCH RUN BURNED 4M TOKENS",
     "source": "@xxgaku",
+    "source_file": "research/summaries/2026-06-10-twitter-07h-headlines.json",
     "url": "https://x.com/xxgaku/status/2064612795564601421"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-10 07:48 UTC",
+    "delivered_at": "2026-06-10 07:00 UTC",
     "headline": "STILL NO OPENAI GPT-5.6 SIGNAL 14H POST-FABLE \u2014 TIMELINE PRICES IN A CHEAPER, LESS-GUARDRAILED RESPONSE ON RUMOR ALONE",
     "source": "@daniel_mac8",
+    "source_file": "research/summaries/2026-06-10-twitter-07h-headlines.json",
     "url": "https://x.com/daniel_mac8/status/2064603972975898960"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-10 07:48 UTC",
+    "delivered_at": "2026-06-10 07:00 UTC",
     "headline": "GATED-MYTHOS TWO-TIER STORY HITS SECURITY PRESS \u2014 FABLE 5 FOR PUBLIC, MYTHOS 5 CYBER LIMITS REMOVED FOR VETTED DEFENDERS",
     "source": "@TheHackersNews",
+    "source_file": "research/summaries/2026-06-10-twitter-07h-headlines.json",
     "url": "https://x.com/TheHackersNews/status/2064615155078672424"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-06-10 07:48 UTC",
+    "delivered_at": "2026-06-10 07:00 UTC",
     "headline": "COUNTER-DATA ON FABLE OVER-TRIGGERING \u2014 PAIRED EVAL FINDS 0 REFUSALS, 0 OBVIOUS FALSE POSITIVES ACROSS 36 TASKS",
     "source": "@clarkwang258",
+    "source_file": "research/summaries/2026-06-10-twitter-07h-headlines.json",
     "url": "https://x.com/clarkwang258/status/2064609861057622453"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-10 10:36 UTC",
+    "delivered_at": "2026-06-10 10:00 UTC",
     "headline": "OPENAI STILL DARK ON GPT-5.6 24H AFTER FABLE 5; TIMELINE PINS RELEASE TO JUNE 22-23 FREE-WINDOW CLIFF",
     "source": "@ignis_code",
+    "source_file": "research/summaries/2026-06-10-twitter-10h-headlines.json",
     "url": "https://x.com/ignis_code/status/2064652388376457596"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-10 10:36 UTC",
+    "delivered_at": "2026-06-10 10:00 UTC",
     "headline": "VIRAL 'POLYMARKET 76% GPT-5.6 NEXT WEEK' DEBUNKED \u2014 THAT 76% IS THE OPENAI-IPO-BEFORE-2027 MARKET, NOT A RELEASE BET",
     "source": "@penghui_ai",
+    "source_file": "research/summaries/2026-06-10-twitter-10h-headlines.json",
     "url": "https://x.com/penghui_ai/status/2064654892577558725"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-10 10:36 UTC",
+    "delivered_at": "2026-06-10 10:00 UTC",
     "headline": "FABLE 5 PRICING CIRCULATING AT $10/M INPUT, $50/M OUTPUT \u2014 ~2X OPUS 4.8; FREE FOR PAID TIERS ONLY UNTIL JUNE 22",
     "source": "@kaswizofficial",
+    "source_file": "research/summaries/2026-06-10-twitter-10h-headlines.json",
     "url": "https://x.com/kaswizofficial/status/2064657512238846027"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-10 10:36 UTC",
+    "delivered_at": "2026-06-10 10:00 UTC",
     "headline": "ABACUS.AI CEO BINDU REDDY: CLAUDE FABLE 5 'OVERTHINKS,' IS 'DEFINITELY NOT YOUR EVERYDAY MODEL'",
     "source": "@bindureddy",
+    "source_file": "research/summaries/2026-06-10-twitter-10h-headlines.json",
     "url": "https://x.com/bindureddy/status/2064654375235256536"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-10 10:36 UTC",
+    "delivered_at": "2026-06-10 10:00 UTC",
     "headline": "ANTHROPIC GOES SILENT ~24H POST-LAUNCH \u2014 NO OFFICIAL WORD ON WHAT HAPPENS TO FABLE 5 PRICING AFTER JUNE 22",
     "source": "@claudeai",
+    "source_file": "research/summaries/2026-06-10-twitter-10h-headlines.json",
     "url": "https://x.com/claudeai/status/2064394146916229443"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-10 13:31 UTC",
+    "delivered_at": "2026-06-10 13:00 UTC",
     "headline": "TENSORWAVE RAISES $350M SERIES B LED BY AMD + MAGNETAR AT $1.55B \u2014 ~4X YEAR-AGO MARK FOR THE NVIDIA-FREE AI CLOUD",
     "source": "@Techmeme",
+    "source_file": "research/summaries/2026-06-10-twitter-13h-headlines.json",
     "url": "https://x.com/Techmeme/status/2064654054387806234"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-10 13:31 UTC",
+    "delivered_at": "2026-06-10 13:00 UTC",
     "headline": "AMD-ONLY TENSORWAVE SAYS IT HAS SIGNED 500MW OF CAPACITY, TARGETING 2GW NEXT YEAR \u2014 REFUSES NVIDIA ENTIRELY",
     "source": "@wallstengine",
+    "source_file": "research/summaries/2026-06-10-twitter-13h-headlines.json",
     "url": "https://x.com/wallstengine/status/2064639013718495505"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-10 13:31 UTC",
+    "delivered_at": "2026-06-10 13:00 UTC",
     "headline": "CYERA RAISES $600M AT $12B VALUATION \u2014 AI-DATA-SECURITY STARTUP'S TOTAL FUNDING HITS $2.3B (NYT)",
     "source": "@Techmeme",
+    "source_file": "research/summaries/2026-06-10-twitter-13h-headlines.json",
     "url": "https://x.com/Techmeme/status/2064691793946665424"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-10 13:31 UTC",
+    "delivered_at": "2026-06-10 13:00 UTC",
     "headline": "FABLE 5 DAY-2: STILL NO OPENAI GPT-5.6 SIGNAL, STILL NO ANTHROPIC POST SINCE LAUNCH \u2014 COST COMPLAINT UNCHANGED",
     "source": "@barty707",
+    "source_file": "research/summaries/2026-06-10-twitter-13h-headlines.json",
     "url": "https://x.com/barty707/status/2064702600713293830"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-10 16:32 UTC",
+    "delivered_at": "2026-06-10 16:00 UTC",
     "headline": "NORTH CAROLINA TREASURER REJECTS SPACEX IPO \u2014 STATE PENSION WON'T BUY AT ~$1.75T VALUATION, FIRST INSTITUTIONAL PUSHBACK",
     "source": "@DeItaone",
+    "source_file": "research/summaries/2026-06-10-twitter-16h-headlines.json",
     "url": "https://x.com/DeItaone/status/2064732235123617798"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-10 16:32 UTC",
+    "delivered_at": "2026-06-10 16:00 UTC",
     "headline": "OPENAI CONFIDENTIALLY FILES FOR US IPO \u2014 REUTERS PUTS TARGET AS HIGH AS $1T, SEPTEMBER LISTING EYED",
     "source": "@Kinger_1",
+    "source_file": "research/summaries/2026-06-10-twitter-16h-headlines.json",
     "url": "https://x.com/Kinger_1/status/2064661476560757143"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-10 16:32 UTC",
+    "delivered_at": "2026-06-10 16:00 UTC",
     "headline": "SPACEX PRICES RECORD ~$75B IPO FOR FRIDAY AT ~$1.75T \u2014 LARGEST IN MARKET HISTORY, ORDER BOOKS CLOSING",
     "source": "@SpecialSitsNews",
+    "source_file": "research/summaries/2026-06-10-twitter-16h-headlines.json",
     "url": "https://x.com/SpecialSitsNews/status/2064644053283557403"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-10 16:32 UTC",
+    "delivered_at": "2026-06-10 16:00 UTC",
     "headline": "GOLDMAN AND MORGAN STANLEY BATTLE FOR LEAD ON OPENAI AND ANTHROPIC IPOs \u2014 ANTHROPIC FILED AT $965B MARK",
     "source": "@SyndicateRSS",
+    "source_file": "research/summaries/2026-06-10-twitter-16h-headlines.json",
     "url": "https://x.com/SyndicateRSS/status/2064503042368745672"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-10 19:09 UTC",
+    "delivered_at": "2026-06-10 19:00 UTC",
     "headline": "ANTHROPIC BREAKS LAUNCH-WEEK SILENCE \u2014 ASKS US GOVERNMENT FOR POWER TO BLOCK OR REVOKE UNSAFE MODELS, ITS OWN INCLUDED",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-06-10-twitter-19h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2064783421860413780"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-10 19:09 UTC",
+    "delivered_at": "2026-06-10 19:00 UTC",
     "headline": "ANTHROPIC COMMITS $200M ECONOMIC-POLICY FUND + $150M NATIONAL FELLOWSHIP IN DARIO AMODEI POLICY PACKAGE",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-06-10-twitter-19h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2064783418844762489"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-10 19:09 UTC",
+    "delivered_at": "2026-06-10 19:00 UTC",
     "headline": "SPACEX IPO ~4X OVERSUBSCRIBED \u2014 $250B+ INVESTOR DEMAND VS $75B TARGET AHEAD OF FRIDAY PRICING",
     "source": "@TechNews24h",
+    "source_file": "research/summaries/2026-06-10-twitter-19h-headlines.json",
     "url": "https://x.com/TechNews24h/status/2064787300756734126"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-10 19:09 UTC",
+    "delivered_at": "2026-06-10 19:00 UTC",
     "headline": "TECH EQUITIES SELL OFF AGAIN \u2014 AAPL -3.6%, AMD -3.0% \u2014 AS CASH ROTATES TO SAFETY INTO SPACEX IPO WEEK",
     "source": "@info_hub69",
+    "source_file": "research/summaries/2026-06-10-twitter-19h-headlines.json",
     "url": "https://x.com/info_hub69/status/2064779307717706080"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-10 19:09 UTC",
+    "delivered_at": "2026-06-10 19:00 UTC",
     "headline": "ABACUS.AI CEO BINDU REDDY: FABLE 5 'TOO CENSORED, NERFED AND PARANOID' \u2014 BETS ON GPT-5.6 FOR AGENTIC CODING",
     "source": "@bindureddy",
+    "source_file": "research/summaries/2026-06-10-twitter-19h-headlines.json",
     "url": "https://x.com/bindureddy/status/2064784796602257518"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-10 21:52 UTC",
+    "delivered_at": "2026-06-10 21:00 UTC",
     "headline": "ORACLE Q4 BEATS, BOOKS RECORD $638B AI BACKLOG (+$85B QoQ) \u2014 BUT STOCK FALLS ~6% AS CAPEX OVERSHOOTS TO $55.7B",
     "source": "@QuikInsightz",
+    "source_file": "research/summaries/2026-06-10-twitter-21h-headlines.json",
     "url": "https://x.com/QuikInsightz/status/2064826895422910622"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-10 21:52 UTC",
+    "delivered_at": "2026-06-10 21:00 UTC",
     "headline": "ORACLE TO RAISE ANOTHER ~$40B IN DEBT/EQUITY FOR FY27 AI BUILDOUT; FY26 FREE CASH FLOW RAN NEGATIVE $23.7B",
     "source": "@SpecialSitsNews",
+    "source_file": "research/summaries/2026-06-10-twitter-21h-headlines.json",
     "url": "https://x.com/SpecialSitsNews/status/2064827706735468835"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-10 21:52 UTC",
+    "delivered_at": "2026-06-10 21:00 UTC",
     "headline": "SPACEX IPO REPORTED ~4X OVERSUBSCRIBED INTO FRIDAY PRICING; PRE-LISTING $SPCX TRADES ~$162 ON HYPERLIQUID",
     "source": "@DrRitikaS",
+    "source_file": "research/summaries/2026-06-10-twitter-21h-headlines.json",
     "url": "https://x.com/DrRitikaS/status/2064828444052271178"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-10 21:52 UTC",
+    "delivered_at": "2026-06-10 21:00 UTC",
     "headline": "DARIO AMODEI ESSAY 'POLICY ON THE AI EXPONENTIAL' DRAWS 4.7K LIKES \u2014 BACKS GOV'T POWER TO BLOCK UNSAFE MODELS",
     "source": "@DarioAmodei",
+    "source_file": "research/summaries/2026-06-10-twitter-21h-headlines.json",
     "url": "https://x.com/DarioAmodei/status/2064781775247950326"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-11 01:23 UTC",
+    "delivered_at": "2026-06-11 01:00 UTC",
     "headline": "ORACLE BOOKS RECORD $638B AI BACKLOG, BEATS ON REVENUE/EPS \u2014 BUT STOCK HOLDS ~6% DROP ON $40B PLANNED RAISE",
     "source": "@SpecialSitsNews",
+    "source_file": "research/summaries/2026-06-11-twitter-01h-headlines.json",
     "url": "https://x.com/SpecialSitsNews/status/2064827706735468835"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-11 01:23 UTC",
+    "delivered_at": "2026-06-11 01:00 UTC",
     "headline": "ORACLE FY26 FREE CASH FLOW RUNS NEGATIVE $23.7B AS CAPEX OVERSHOOTS TO $55.7B \u2014 AI BUILDOUT BILL SPOOKS THE TAPE",
     "source": "@QuikInsightz",
+    "source_file": "research/summaries/2026-06-11-twitter-01h-headlines.json",
     "url": "https://x.com/QuikInsightz/status/2064826895422910622"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-11 01:23 UTC",
+    "delivered_at": "2026-06-11 01:00 UTC",
     "headline": "SPACEX TO PRICE RECORD ~$1.77T IPO TONIGHT AT $135 \u2014 REPORTEDLY ~4X OVERSUBSCRIBED, ~$250B DEMAND, DEBUT FRIDAY",
     "source": "@cryptogoos",
+    "source_file": "research/summaries/2026-06-11-twitter-01h-headlines.json",
     "url": "https://x.com/cryptogoos/status/2064589124993249699"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-11 01:23 UTC",
+    "delivered_at": "2026-06-11 01:00 UTC",
     "headline": "CLAUDE FABLE 5 TOPS CODE ARENA FRONTEND \u2014 ~11% AHEAD OF GPT-5.5, SWEEPS EVERY HTML/REACT SUB-LEADERBOARD",
     "source": "@arena",
+    "source_file": "research/summaries/2026-06-11-twitter-01h-headlines.json",
     "url": "https://x.com/arena/status/2064858698582040693"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-11 01:23 UTC",
+    "delivered_at": "2026-06-11 01:00 UTC",
     "headline": "HASHIMOTO VERDICT: FABLE 5 A 'SURGICAL TOOL, NOT A DAILY DRIVER' \u2014 SAME TASK COST $9 VS ~$1.50 ON GPT-5.5",
     "source": "@mitchellh",
+    "source_file": "research/summaries/2026-06-11-twitter-01h-headlines.json",
     "url": "https://x.com/mitchellh/status/2064773611647574429"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-06-11 04:52 UTC",
+    "delivered_at": "2026-06-11 04:00 UTC",
     "headline": "ANTHROPIC REVERSES FABLE 5 COVERT SABOTAGE OF AI RESEARCHERS \u2014 'WE MADE THE WRONG TRADEOFF,' APOLOGIZES TO WIRED",
     "source": "@ZeffMax",
+    "source_file": "research/summaries/2026-06-11-twitter-04h-headlines.json",
     "url": "https://x.com/ZeffMax/status/2064910040503627917"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-11 04:52 UTC",
+    "delivered_at": "2026-06-11 04:00 UTC",
     "headline": "OPENAI MEMO LEAKS: CHIEF SCIENTIST PACHOCKI SAYS GPT-5.6 WILL BE 'MEANINGFUL IMPROVEMENT' OVER GPT-5.5",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-11-twitter-04h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2064822130429362401"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-11 04:52 UTC",
+    "delivered_at": "2026-06-11 04:00 UTC",
     "headline": "ALTMAN TELLS STAFF OPENAI EXPECTS TO GO PUBLIC 'WITHIN THE NEXT YEAR' \u2014 MAY DELAY IF RECURSIVE SELF-IMPROVEMENT ACCELERATES",
     "source": "@MTSlive",
+    "source_file": "research/summaries/2026-06-11-twitter-04h-headlines.json",
     "url": "https://x.com/MTSlive/status/2064916313970290888"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-11 04:52 UTC",
+    "delivered_at": "2026-06-11 04:00 UTC",
     "headline": "XAI SUED BY FIRED ENGINEER DEVIN KIM OVER ALLEGED GROK-SAFETY RETALIATION \u2014 DAYS BEFORE SPACEX IPO",
     "source": "@TechCrunch",
+    "source_file": "research/summaries/2026-06-11-twitter-04h-headlines.json",
     "url": "https://x.com/TechCrunch/status/2064838432623624624"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-11 04:52 UTC",
+    "delivered_at": "2026-06-11 04:00 UTC",
     "headline": "SPACEX PRICES RECORD IPO AT $135/SHARE \u2014 ~$1.77T VALUATION, BOOK ~4X OVERSUBSCRIBED, NASDAQ DEBUT FRIDAY UNDER $SPCX",
     "source": "@Economy_ME",
+    "source_file": "research/summaries/2026-06-11-twitter-04h-headlines.json",
     "url": "https://x.com/Economy_ME/status/2064923615984750627"
   },
   {
+    "backfilled": true,
     "category": "business",
     "delivered_at": "2026-06-11 08:00 UTC",
     "headline": "WSJ: OPENAI WEIGHS DRASTIC TOKEN-PRICE CUTS TO UNDERCUT ANTHROPIC AHEAD OF IPO",
     "source": "@ThierryBorgeat",
+    "source_file": "research/summaries/2026-06-11-twitter-08h-headlines.json",
     "url": "https://x.com/ThierryBorgeat/status/2064962225849200641"
   },
   {
+    "backfilled": true,
     "category": "business",
     "delivered_at": "2026-06-11 08:00 UTC",
     "headline": "SOFTBANK'S $6B MARGIN LOAN AGAINST ITS OPENAI STAKE STALLS AS BANKS BALK AT $852B MARK",
     "source": "@edzitron",
+    "source_file": "research/summaries/2026-06-11-twitter-08h-headlines.json",
     "url": "https://x.com/edzitron/status/2064560323181568246"
   },
   {
+    "backfilled": true,
     "category": "policy",
     "delivered_at": "2026-06-11 08:00 UTC",
     "headline": "EU ORDERS META TO GIVE RIVAL AI CHATBOTS FREE WHATSAPP ACCESS \u2014 5-DAY COMPLIANCE CLOCK",
     "source": "@the_hindu",
+    "source_file": "research/summaries/2026-06-11-twitter-08h-headlines.json",
     "url": "https://x.com/the_hindu/status/2064570028603965603"
   },
   {
+    "backfilled": true,
     "category": "business",
     "delivered_at": "2026-06-11 08:00 UTC",
     "headline": "VISA AND OPENAI LAUNCH 'INTELLIGENT COMMERCE' TO ISSUE PAYMENT CARDS TO AI AGENTS",
     "source": "@rob2775",
+    "source_file": "research/summaries/2026-06-11-twitter-08h-headlines.json",
     "url": "https://x.com/rob2775/status/2064979639064293744"
   },
   {
+    "backfilled": true,
     "category": "business",
     "delivered_at": "2026-06-11 08:00 UTC",
     "headline": "TCS SIGNS GLOBAL PREMIER PARTNERSHIP WITH ANTHROPIC, ~50,000 EMPLOYEES TO GET CLAUDE",
     "source": "@saching2109",
+    "source_file": "research/summaries/2026-06-11-twitter-08h-headlines.json",
     "url": "https://x.com/saching2109/status/2064980516580073678"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-06-13 14:08 UTC",
+    "delivered_at": "2026-06-13 14:00 UTC",
     "headline": "ANTHROPIC DISABLES FABLE 5 AND MYTHOS 5 WORLDWIDE AFTER US EXPORT-CONTROL ORDER BARS FOREIGN-NATIONAL ACCESS",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-06-13-twitter-14h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2065597531644743999"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-13 14:08 UTC",
+    "delivered_at": "2026-06-13 14:00 UTC",
     "headline": "US EXPORT CONTROLS REACH FRONTIER AI MODELS FOR FIRST TIME, NOT JUST CHIPS \u2014 ANTHROPIC CALLS ORDER A 'MISUNDERSTANDING'",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-06-13-twitter-14h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2065597531644743999"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-13 14:08 UTC",
+    "delivered_at": "2026-06-13 14:00 UTC",
     "headline": "GERMAN COURT RULES GOOGLE LIABLE FOR FALSE AI OVERVIEWS \u2014 SAYS THE AI OUTPUT IS GOOGLE'S OWN WORDS",
     "source": "@Pirat_Nation",
+    "source_file": "research/summaries/2026-06-13-twitter-14h-headlines.json",
     "url": "https://x.com/Pirat_Nation/status/2065041367936446965"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-13 14:08 UTC",
+    "delivered_at": "2026-06-13 14:00 UTC",
     "headline": "GOOGLE SUES 'OUTSIDE ENTERPRISE' RING THAT USED AI INCLUDING GEMINI TO PHISH 100,000+ VICTIMS",
     "source": "@NewsFromGoogle",
+    "source_file": "research/summaries/2026-06-13-twitter-14h-headlines.json",
     "url": "https://x.com/NewsFromGoogle/status/2065522455205343475"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-13 14:08 UTC",
+    "delivered_at": "2026-06-13 14:00 UTC",
     "headline": "OPENAI DISRUPTS CHINA-LINKED OP POSING AS AMERICANS TO STOKE ANTI-DATA-CENTER SENTIMENT",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-06-13-twitter-14h-headlines.json",
     "url": "https://x.com/i/status/2065253251025637866"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-13 16:32 UTC",
+    "delivered_at": "2026-06-13 16:00 UTC",
     "headline": "ANTHROPIC FABLE 5 & MYTHOS 5 STILL DARK ~16H AFTER US EXPORT-CONTROL SHUTOFF \u2014 NO RESTORATION",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-06-13-twitter-16h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2065597531644743999"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-13 16:32 UTC",
+    "delivered_at": "2026-06-13 16:00 UTC",
     "headline": "EXPORT-CONTROL DIRECTIVE NOW ATTRIBUTED TO US COMMERCE DEPARTMENT, JUNE 12 \u2014 NO PUBLISHED PRIMARY DOC YET",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-06-13-twitter-16h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2065597531644743999"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-13 16:32 UTC",
+    "delivered_at": "2026-06-13 16:00 UTC",
     "headline": "CLAUDE PRODUCTS NOW DEFAULT TO OPUS 4.8 AS FABLE 5 SESSIONS ERROR OUT; API CALLS REJECTED",
     "source": "@ClaudeDevs",
+    "source_file": "research/summaries/2026-06-13-twitter-16h-headlines.json",
     "url": "https://x.com/ClaudeDevs/status/2065597942602531163"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-06-13 16:32 UTC",
+    "delivered_at": "2026-06-13 16:00 UTC",
     "headline": "JAILBREAKER PLINY NAMED AS ALLEGED TRIGGER FOR FABLE 5 NATIONAL-SECURITY SHUTDOWN \u2014 UNVERIFIED",
     "source": "@dinq_me",
+    "source_file": "research/summaries/2026-06-13-twitter-16h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2065597531644743999"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-13 19:07 UTC",
+    "delivered_at": "2026-06-13 19:00 UTC",
     "headline": "FABLE 5 / MYTHOS 5 STILL DARK ~18H ON \u2014 REUTERS NOW CARRIES ANTHROPIC EXPORT-CONTROL SHUTOFF, NO RESTORATION",
     "source": "@Techmeme",
+    "source_file": "research/summaries/2026-06-13-twitter-19h-headlines.json",
     "url": "https://x.com/Techmeme/status/2065621667557323128"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-13 19:07 UTC",
+    "delivered_at": "2026-06-13 19:00 UTC",
     "headline": "ANTHROPIC SAYS COMMERCE JAILBREAK FINDING 'OVERSTATED, BASED ON VERBAL EVIDENCE, ALREADY REPLICABLE ELSEWHERE'",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-06-13-twitter-19h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2065597531644743999"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-13 19:07 UTC",
+    "delivered_at": "2026-06-13 19:00 UTC",
     "headline": "SPACEX IPO IS LARGEST IN HISTORY \u2014 $1.77T VALUATION, ~$75B RAISED, MUSK BECOMES FIRST TRILLIONAIRE",
     "source": "@Fortune",
+    "source_file": "research/summaries/2026-06-13-twitter-19h-headlines.json",
     "url": "https://x.com/i/status/2065682566338740491"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-13 19:07 UTC",
+    "delivered_at": "2026-06-13 19:00 UTC",
     "headline": "AI IPO SUMMER OPENS: ANTHROPIC S-1 FILED ~$965B, OPENAI ~$852B EYEING SEPTEMBER DEBUT",
     "source": "@risenfit",
+    "source_file": "research/summaries/2026-06-13-twitter-19h-headlines.json",
     "url": "https://x.com/i/status/2065519926866239623"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-13 21:50 UTC",
+    "delivered_at": "2026-06-13 21:00 UTC",
     "headline": "FABLE 5 STILL DARK ~21H ON \u2014 NO RESTORATION AS ANTHROPIC EXPORT-CONTROL STATEMENT PASSES 72K LIKES",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-06-13-twitter-21h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2065597531644743999"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-13 21:50 UTC",
+    "delivered_at": "2026-06-13 21:00 UTC",
     "headline": "ANTHROPIC RUNS SF 'FABLE BUILD DAY' ON OPUS 4.8 \u2014 $150K HACKATHON PROCEEDS WITHOUT ITS NAMESAKE MODEL",
     "source": "@ClaudeDevs",
+    "source_file": "research/summaries/2026-06-13-twitter-21h-headlines.json",
     "url": "https://x.com/ClaudeDevs/status/2065647770468487600"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-13 21:50 UTC",
+    "delivered_at": "2026-06-13 21:00 UTC",
     "headline": "ANTHROPIC RESETS 5-HOUR AND WEEKLY RATE LIMITS FOR ALL USERS HOURS AFTER FABLE 5 SHUTOFF",
     "source": "@ClaudeDevs",
+    "source_file": "research/summaries/2026-06-13-twitter-21h-headlines.json",
     "url": "https://x.com/ClaudeDevs/status/2065621176735646006"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-14 00:42 UTC",
+    "delivered_at": "2026-06-14 00:00 UTC",
+    "headline": "ANTHROPIC CONFIRMS US EXPORT-CONTROL ORDER \u2014 FABLE 5 AND MYTHOS 5 DISABLED FOR ALL CUSTOMERS, BARS EVERY FOREIGN NATIONAL INCLUDING OWN STAFF",
+    "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-06-14-twitter-00h-headlines.json",
+    "url": "https://x.com/AnthropicAI/status/2065597531644743999"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-06-14 00:00 UTC",
     "headline": "COALITION OF STATE AGs SUBPOENAS OPENAI \u2014 NY-LED PROBE INTO ADS, RETENTION, HEALTH DATA, MINORS, MODEL SYCOPHANCY",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-14-twitter-00h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2065641293641056751"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-14 00:42 UTC",
+    "delivered_at": "2026-06-14 00:00 UTC",
     "headline": "MISTRAL IN TALKS TO RAISE ~\u20ac3B AT ~\u20ac20B VALUATION \u2014 NEARLY DOUBLING ITS PRICE TAG IN UNDER A YEAR",
     "source": "@bobbi_news",
+    "source_file": "research/summaries/2026-06-14-twitter-00h-headlines.json",
     "url": "https://x.com/i/status/2065818586304655510"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-14 00:42 UTC",
+    "delivered_at": "2026-06-14 00:00 UTC",
     "headline": "OPENAI ACQUIRES ONA \u2014 ADDS PERSISTENT CLOUD EXECUTION TO CODEX FOR LONG-RUNNING AGENT SESSIONS",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-06-14-twitter-00h-headlines.json",
     "url": "https://x.com/i/status/2065818562380337338"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-06-14 00:42 UTC",
+    "delivered_at": "2026-06-14 00:00 UTC",
     "headline": "ANTHROPIC SAYS EXPORT ORDER IS A MISUNDERSTANDING, WORKING TO RESTORE FABLE 5 / MYTHOS 5; ALL OTHER CLAUDE MODELS UNAFFECTED",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-06-14-twitter-00h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2065597531644743999"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-14 03:41 UTC",
+    "delivered_at": "2026-06-14 03:00 UTC",
     "headline": "AXIOS: AMAZON CEO JASSY BRIEFED TREASURY'S BESSENT THAT AMAZON RESEARCHERS JAILBROKE FABLE 5 \u2014 TRIGGERING WHITE HOUSE BAN ON ANTHROPIC",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-14-twitter-03h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2065845471319662850"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-14 03:41 UTC",
+    "delivered_at": "2026-06-14 03:00 UTC",
     "headline": "ANTHROPIC'S OWN LARGEST INVESTOR HELPED GET ITS FLAGSHIP MODELS BANNED \u2014 AMAZON CONFLICT-OF-INTEREST ANGLE EMERGES",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-14-twitter-03h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2065839272805257680"
   },
   {
+    "backfilled": true,
+    "category": "breaking",
+    "delivered_at": "2026-06-14 03:00 UTC",
+    "headline": "FABLE 5 AND MYTHOS 5 STILL DARK 24H+ AFTER EXPORT ORDER \u2014 ANTHROPIC CALLS IT A 'MISUNDERSTANDING', NO RESTORATION",
+    "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-06-14-twitter-03h-headlines.json",
+    "url": "https://x.com/AnthropicAI/status/2065597531644743999"
+  },
+  {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-06-14 03:41 UTC",
+    "delivered_at": "2026-06-14 03:00 UTC",
     "headline": "UNVERIFIED: '3.4TB FABLE 5 TORRENT' CLAIM TRENDS POST-BAN \u2014 NO MAGNET, NO HASH, NO CREDIBLE CONFIRMATION",
     "source": "@G_Programming",
+    "source_file": "research/summaries/2026-06-14-twitter-03h-headlines.json",
     "url": "https://x.com/i/status/2065783295166537833"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-14 06:36 UTC",
+    "delivered_at": "2026-06-14 06:00 UTC",
     "headline": "WHITE HOUSE'S SACKS: ADMIN ASKED ANTHROPIC TO FIX OR PULL FABLE 5 JAILBREAK \u2014 DARIO REFUSED, EXPORT CONTROL FOLLOWED",
     "source": "@DavidSacks",
+    "source_file": "research/summaries/2026-06-14-twitter-06h-headlines.json",
     "url": "https://x.com/DavidSacks/status/2065853007619588171"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-14 06:36 UTC",
+    "delivered_at": "2026-06-14 06:00 UTC",
     "headline": "ANTHROPIC BLOG DEFENDS DECISION: JAILBREAK 'NOT SERIOUS' AND GPT-5.5 CAN EXPLOIT THE SAME VULNERABILITY",
     "source": "@AwaMelvine",
+    "source_file": "research/summaries/2026-06-14-twitter-06h-headlines.json",
     "url": "https://x.com/AwaMelvine/status/2065890051767050684"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-06-14 06:36 UTC",
+    "delivered_at": "2026-06-14 06:00 UTC",
     "headline": "FABLE 5 AND MYTHOS 5 STILL DARK \u2014 EVEN SOME ANTHROPIC STAFF WHO BUILT THEM NOW LOCKED OUT UNDER FOREIGN-NATIONAL BAR",
     "source": "@rohanpaul_ai",
+    "source_file": "research/summaries/2026-06-14-twitter-06h-headlines.json",
     "url": "https://x.com/rohanpaul_ai/status/2065899646548095292"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-14 06:36 UTC",
+    "delivered_at": "2026-06-14 06:00 UTC",
     "headline": "SPACEX IPO COMPLETES AS LARGEST IN HISTORY \u2014 ~$135/SHARE, ~$75B RAISED, ~$1.75T VALUATION, CLOSE ~$161",
     "source": "@CoinCrafty",
+    "source_file": "research/summaries/2026-06-14-twitter-06h-headlines.json",
     "url": "https://x.com/i/status/2065909539921093122"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-06-14 10:25 UTC",
+    "delivered_at": "2026-06-14 10:00 UTC",
     "headline": "ABC: WHITE HOUSE 'BEGGED ANTHROPIC FOR HOURS'; BESSENT TOLD AMODEI HE WAS MAKING A 'BAD DECISION' BEFORE EXPORT BAN",
     "source": "@SophiaCai99",
+    "source_file": "research/summaries/2026-06-14-twitter-10h-headlines.json",
     "url": "https://x.com/SophiaCai99/status/2065942612293365948"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-06-14 10:25 UTC",
+    "delivered_at": "2026-06-14 10:00 UTC",
     "headline": "ANTHROPIC SAYS IT WAS GIVEN A 90-MINUTE HARD DEADLINE TO PULL FABLE 5 AND MYTHOS 5",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-14-twitter-10h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2065957174204104904"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-14 10:25 UTC",
+    "delivered_at": "2026-06-14 10:00 UTC",
     "headline": "HEGSETH ON ANTHROPIC: PENTAGON KICKED THEM OUT '3 MONTHS AGO, FOREVER' \u2014 'EVERY PASSING DAY PROVES' IT RIGHT",
     "source": "@PeteHegseth",
+    "source_file": "research/summaries/2026-06-14-twitter-10h-headlines.json",
     "url": "https://x.com/PeteHegseth/status/2065897156226015690"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-06-14 10:25 UTC",
+    "delivered_at": "2026-06-14 10:00 UTC",
     "headline": "RIO DE JANEIRO CITY IT AGENCY SHIPS 'RIO 3.5' 397B OPEN MODEL, CLAIMS SOTA OVER QWEN 3.7 (BENCHMARK UNVERIFIED)",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-14-twitter-10h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2065911865390063791"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-06-15 00:44 UTC",
+    "delivered_at": "2026-06-15 00:00 UTC",
     "headline": "AMAZON CEO ANDY JASSY FLAGGED ANTHROPIC MODEL RISKS TO TRUMP OFFICIALS, HELPING TRIGGER FABLE 5 SHUTDOWN \u2014 THE INFORMATION",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-06-15-twitter-00h-headlines.json",
     "url": "https://x.com/theinformation/status/2065847360157045016"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-15 00:44 UTC",
+    "delivered_at": "2026-06-15 00:00 UTC",
     "headline": "ANTHROPIC AND WHITE HOUSE CLASH OVER CLAIMED 90-MINUTE ULTIMATUM TO PULL FABLE 5 AND MYTHOS 5",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-15-twitter-00h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2065957174204104904"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-15 00:44 UTC",
+    "delivered_at": "2026-06-15 00:00 UTC",
     "headline": "42-STATE AG COALITION SUBPOENAS OPENAI OVER ADS, MINORS, SYCOPHANCY AND SAFETY \u2014 DAYS AFTER IPO FILING",
     "source": "@TechNewsTube",
+    "source_file": "research/summaries/2026-06-15-twitter-00h-headlines.json",
     "url": "https://x.com/TechNewsTube/status/2066171616414064813"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-15 00:44 UTC",
+    "delivered_at": "2026-06-15 00:00 UTC",
     "headline": "FLORIDA SUES OPENAI, ALLEGING CHATGPT AIDED A FLORIDA STATE UNIVERSITY SHOOTER",
     "source": "@ns123abc",
+    "source_file": "research/summaries/2026-06-15-twitter-00h-headlines.json",
     "url": "https://x.com/ns123abc/status/2065787965926686777"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-06-15 00:44 UTC",
+    "delivered_at": "2026-06-15 00:00 UTC",
     "headline": "MOONSHOT SHIPS OPEN-SOURCE KIMI K2.7-CODE, LANDS #2 ON ERDOSBENCH BEHIND FABLE 5 MAX",
     "source": "@mark_k",
+    "source_file": "research/summaries/2026-06-15-twitter-00h-headlines.json",
     "url": "https://x.com/mark_k/status/2066150260636872715"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-15 00:44 UTC",
+    "delivered_at": "2026-06-15 00:00 UTC",
     "headline": "Z.AI RELEASES GLM-5.2 FLAGSHIP WITH USABLE 1M CONTEXT; OPEN WEIGHTS DUE NEXT WEEK",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-06-15-twitter-00h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2065938982010056855"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-15 00:44 UTC",
+    "delivered_at": "2026-06-15 00:00 UTC",
     "headline": "SPACEX PRICES ~$1.75T IPO INCLUDING XAI, ADDS NEW ANTHROPIC AND GOOGLE DATA-CENTER DEALS",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-06-15-twitter-00h-headlines.json",
     "url": "https://x.com/theinformation/status/2066150918056284169"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-15 20:17 UTC",
+    "delivered_at": "2026-06-15 20:00 UTC",
     "headline": "AXIOS: FABLE EMBARGO NOW LESS ABOUT JAILBREAKS \u2014 ANTHROPIC 'DOESN'T KNOW HOW TO TALK TO THIS ADMINISTRATION'",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-15-twitter-20h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2066459604741997053"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-15 20:17 UTC",
+    "delivered_at": "2026-06-15 20:00 UTC",
     "headline": "ANTHROPIC STAFF MEET COMMERCE, THE CIA AND WH SCIENCE ADVISOR KRATSIOS TODAY ON CYBER-EO COMPLIANCE",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-15-twitter-20h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2066459604741997053"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-15 20:17 UTC",
+    "delivered_at": "2026-06-15 20:00 UTC",
     "headline": "PREDICTION MARKETS PRICE US-CUSTOMER FABLE 5 RESTORE AT ~77% BY JULY 1, ~44% BY JUNE 22",
     "source": "@polyburg",
+    "source_file": "research/summaries/2026-06-15-twitter-20h-headlines.json",
     "url": "https://x.com/polyburg/status/2066471551441199457"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-06-15 20:17 UTC",
+    "delivered_at": "2026-06-15 20:00 UTC",
     "headline": "MOONSHOT SHIPS KIMI K2.7-CODE 'HIGHSPEED' \u2014 UP TO 6X FASTER, ~260 TOKENS/SEC SHORT-CONTEXT",
     "source": "@swarm_japan",
+    "source_file": "research/summaries/2026-06-15-twitter-20h-headlines.json",
     "url": "https://x.com/swarm_japan/status/2066477646385738081"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-16 04:29 UTC",
+    "delivered_at": "2026-06-16 04:00 UTC",
     "headline": "BROADCOM BACKING $35B AI CHIP ORDER FOR ANTHROPIC, TARGETING 20GW OF COMPUTE",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-06-16-twitter-04h-headlines.json",
     "url": "https://x.com/theinformation/status/2066528689639075894"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-16 04:29 UTC",
+    "delivered_at": "2026-06-16 04:00 UTC",
     "headline": "ANTHROPIC HIT WITH FEDERAL CLASS-ACTION: CLAUDE MAX USAGE 'FAR BELOW ADVERTISED'",
     "source": "@ns123abc",
+    "source_file": "research/summaries/2026-06-16-twitter-04h-headlines.json",
     "url": "https://x.com/ns123abc/status/2066539795514294692"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-16 04:29 UTC",
+    "delivered_at": "2026-06-16 04:00 UTC",
     "headline": "SAKANA LAUNCHES MARLIN \u2014 AUTONOMOUS 8-HOUR 'VIRTUAL CSO' DEEP-RESEARCH AGENT",
     "source": "@hardmaru",
+    "source_file": "research/summaries/2026-06-16-twitter-04h-headlines.json",
     "url": "https://x.com/hardmaru/status/2066529282588094713"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-16 04:29 UTC",
+    "delivered_at": "2026-06-16 04:00 UTC",
     "headline": "SIMONW: ANTHROPIC ADDED 'VERIFICATION DATA' TO PRIVACY POLICY JUNE 8 \u2014 ID GATING ON FABLE'S RETURN?",
     "source": "@simonw",
+    "source_file": "research/summaries/2026-06-16-twitter-04h-headlines.json",
     "url": "https://x.com/simonw/status/2066541206402969672"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-16 04:29 UTC",
+    "delivered_at": "2026-06-16 04:00 UTC",
     "headline": "FT: OPENAI PRE-COORDINATING WITH US GOVERNMENT TO SHIP NEXT MODEL WITHOUT ANTHROPIC'S FATE",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-16-twitter-04h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2066591657324146820"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-16 10:28 UTC",
+    "delivered_at": "2026-06-16 10:00 UTC",
     "headline": "WIRED: TRUMP ADMIN ENDS TALKS WITHOUT LIFTING FABLE 5 EMBARGO \u2014 NEXT STEPS UNCLEAR",
     "source": "@hugolowell",
+    "source_file": "research/summaries/2026-06-16-twitter-10h-headlines.json",
     "url": "https://x.com/hugolowell/status/2066686166884098244"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-16 10:28 UTC",
+    "delivered_at": "2026-06-16 10:00 UTC",
     "headline": "COMMERCE WOULD RESTORE FABLE 5 FOR CONSUMER USE \u2014 ONLY IF ANTHROPIC RESOLVES JAILBREAK-TO-MYTHOS CONCERNS",
     "source": "@hugolowell",
+    "source_file": "research/summaries/2026-06-16-twitter-10h-headlines.json",
     "url": "https://x.com/hugolowell/status/2066686166884098244"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-06-16 10:28 UTC",
+    "delivered_at": "2026-06-16 10:00 UTC",
     "headline": "FABLE 5 TAKES #1 ON EPOCH CAPABILITIES INDEX AT 161 \u2014 ANTHROPIC'S FIRST ECI LEAD IN OVER A YEAR",
     "source": "@EpochAIResearch",
+    "source_file": "research/summaries/2026-06-16-twitter-10h-headlines.json",
     "url": "https://x.com/EpochAIResearch/status/2066674892809101767"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-16 13:43 UTC",
+    "delivered_at": "2026-06-16 13:00 UTC",
     "headline": "ALLEGED FABLE 5 'JAILBREAK' SURFACES \u2014 TOP DEVS CALL IT TRIVIAL, ESSENTIALLY A 'FIX THIS CODE' PROMPT",
     "source": "@simonw",
+    "source_file": "research/summaries/2026-06-16-twitter-13h-headlines.json",
     "url": "https://x.com/simonw/status/2066722034491789720"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-16 13:43 UTC",
+    "delivered_at": "2026-06-16 13:00 UTC",
     "headline": "DOZENS OF CYBERSECURITY EXPERTS SIGN OPEN LETTER URGING US TO LIFT ANTHROPIC FABLE/MYTHOS BAN",
     "source": "@CliffDoesAI",
+    "source_file": "research/summaries/2026-06-16-twitter-13h-headlines.json",
     "url": "https://x.com/CliffDoesAI/status/2066584753571250411"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-16 13:43 UTC",
+    "delivered_at": "2026-06-16 13:00 UTC",
     "headline": "SARVAM AI RAISES ~$300M SERIES B AT $1.5B VALUATION, HCLTECH LEADING \u2014 INDIA'S NEWEST UNICORN",
     "source": "@JensonFinsights",
+    "source_file": "research/summaries/2026-06-16-twitter-13h-headlines.json",
     "url": "https://x.com/JensonFinsights/status/2066738726706024659"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-16 19:46 UTC",
+    "delivered_at": "2026-06-16 19:00 UTC",
     "headline": "DEEPSEEK CLOSES FIRST-EVER FUNDING ROUND AT ~$7.4B, VALUATION TOPS $50B \u2014 CHINA'S LARGEST PRIVATE AI RAISE",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-06-16-twitter-19h-headlines.json",
     "url": "https://www.theinformation.com/briefings/deepseek-closes-record-7-billion-plus-funding-unusual-deal-structure"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-16 19:46 UTC",
+    "delivered_at": "2026-06-16 19:00 UTC",
     "headline": "DEEPSEEK ROUND ROUTES INVESTOR CASH INTO FOUNDER LIANG WENFENG'S LP \u2014 5-YEAR LOCK-UP, NO VOTING RIGHTS",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-06-16-twitter-19h-headlines.json",
     "url": "https://www.theinformation.com/briefings/deepseek-closes-record-7-billion-plus-funding-unusual-deal-structure"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-16 19:46 UTC",
+    "delivered_at": "2026-06-16 19:00 UTC",
     "headline": "ANTHROPIC FABLE 5 / MYTHOS 5 EXPORT EMBARGO HITS DAY 4 UNRESOLVED \u2014 MODELS STILL DARK, STAFF STILL IN DC",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-06-16-twitter-19h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2065597531644743999"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-16 19:46 UTC",
+    "delivered_at": "2026-06-16 19:00 UTC",
     "headline": "REPORTING PINS FABLE 5 BAN ON AMAZON CEO JASSY WARNING TO TRUMP OFFICIALS \u2014 DESPITE AMAZON'S ~$13B IN ANTHROPIC",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-06-16-twitter-19h-headlines.json",
     "url": "https://x.com/theinformation/status/2066521257386922260"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-16 19:46 UTC",
+    "delivered_at": "2026-06-16 19:00 UTC",
     "headline": "TRUMP ADMIN REPORTEDLY WEIGHING EQUITY STAKES IN OPENAI AND ANTHROPIC, WITH FABLE 5 CURBS AS LEVERAGE",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-06-16-twitter-19h-headlines.json",
     "url": "https://x.com/theinformation/status/2066630693493383656"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-16 23:05 UTC",
+    "delivered_at": "2026-06-16 23:00 UTC",
     "headline": "SPACEX TO ACQUIRE CURSOR (ANYSPHERE) IN ALL-STOCK DEAL REPORTED AT ~$60B \u2014 CONFIRMED BY CURSOR AND CEO TRUELL",
     "source": "@cursor_ai",
+    "source_file": "research/summaries/2026-06-16-twitter-23h-headlines.json",
     "url": "https://x.com/cursor_ai/status/2066875698346954891"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-16 23:05 UTC",
+    "delivered_at": "2026-06-16 23:00 UTC",
     "headline": "CURSOR CEO MICHAEL TRUELL: 'JOINING FORCES WITH SPACEX TO BUILD USEFUL AI'",
     "source": "@mntruell",
+    "source_file": "research/summaries/2026-06-16-twitter-23h-headlines.json",
     "url": "https://x.com/mntruell/status/2066874098001883538"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-16 23:05 UTC",
+    "delivered_at": "2026-06-16 23:00 UTC",
     "headline": "ANTHROPIC FABLE 5 EMBARGO STILL UNLIFTED \u2014 AXIOS NOW REPORTS FEAR IT COULD HURT THE ENTIRE US AI INDUSTRY",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-16-twitter-23h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2066882221198245939"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-16 23:05 UTC",
+    "delivered_at": "2026-06-16 23:00 UTC",
     "headline": "CLAUDE MOBILE VOICE MODE GOES MULTILINGUAL IN NEW ROLLOUT",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-06-16-twitter-23h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2066876710109303278"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-17 02:08 UTC",
+    "delivered_at": "2026-06-17 02:00 UTC",
     "headline": "SPACEX CONFIRMS IT EXERCISED OPTION TO ACQUIRE CURSOR \u2014 ALL-STOCK, REPORTED $60B",
     "source": "@SpaceX",
+    "source_file": "research/summaries/2026-06-17-twitter-02h-headlines.json",
     "url": "https://x.com/SpaceX/status/2066873915717136548"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-17 02:08 UTC",
+    "delivered_at": "2026-06-17 02:00 UTC",
     "headline": "SPACEX: 'SPACEXAI' HAS BEEN JOINTLY TRAINING A MODEL WITH CURSOR, TO BE RELEASED SOON",
     "source": "@SpaceX",
+    "source_file": "research/summaries/2026-06-17-twitter-02h-headlines.json",
     "url": "https://x.com/SpaceX/status/2066873915717136548"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-17 02:08 UTC",
+    "delivered_at": "2026-06-17 02:00 UTC",
     "headline": "UK PM STARMER'S CARVEOUT FROM ANTHROPIC FABLE/MYTHOS EMBARGO REPORTEDLY DENIED BY WHITE HOUSE",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-17-twitter-02h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2066925774498910592"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-17 02:08 UTC",
+    "delivered_at": "2026-06-17 02:00 UTC",
     "headline": "OPENAI 'GPT-BIDI-1' VOICE MODEL SPOTTED \u2014 CHATGPT VOICE MODE UPGRADE INCOMING",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-06-17-twitter-02h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2066919098236146167"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-06-17 02:08 UTC",
+    "delivered_at": "2026-06-17 02:00 UTC",
     "headline": "MISTRAL TEASES OPEN-WEIGHT 'FAT' MODEL FAMILY FOR SUMMER, EARLY ACCESS FOR KEY PARTNERS",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-06-17-twitter-02h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2066924902372802779"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-06-17 04:21 UTC",
+    "delivered_at": "2026-06-17 04:00 UTC",
     "headline": "Z.AI SHIPS GLM-5.2 AS MIT OPEN WEIGHTS \u2014 1M CONTEXT, 'FRONTIER INTELLIGENCE' FRAMING",
     "source": "@Zai_org",
+    "source_file": "research/summaries/2026-06-17-twitter-04h-headlines.json",
     "url": "https://x.com/Zai_org/status/2066938937344495629"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-17 04:21 UTC",
+    "delivered_at": "2026-06-17 04:00 UTC",
     "headline": "GLM-5.2 GETS DAY-0 vLLM v0.23.0 SUPPORT, LIVE ON NOTION AND BASETEN WITHIN HOURS",
     "source": "@Zai_org",
+    "source_file": "research/summaries/2026-06-17-twitter-04h-headlines.json",
     "url": "https://x.com/Zai_org/status/2066964859611394053"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-17 04:21 UTC",
+    "delivered_at": "2026-06-17 04:00 UTC",
     "headline": "MICROSOFT FINE-TUNED A DEEPSEEK VARIANT, WEIGHING IT AS LOWER-COST COPILOT COWORK ENGINE \u2014 REPORT",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-17-twitter-04h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2066939401725501590"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-17 04:21 UTC",
+    "delivered_at": "2026-06-17 04:00 UTC",
     "headline": "ANTHROPIC FABLE 5 / MYTHOS 5 EXPORT EMBARGO UNCHANGED \u2014 STILL JUNE 13 DIRECTIVE, NO NEW PRIMARY DOC",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-06-17-twitter-04h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2065597531644743999"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-17 06:59 UTC",
+    "delivered_at": "2026-06-17 06:00 UTC",
     "headline": "LUTNICK LETTER GOES PUBLIC \u2014 BIS REQUIRES LICENSE TO RELEASE CLAUDE MYTHOS 5 / FABLE 5 TO ANY FOREIGN PERSON WORLDWIDE",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-17-twitter-06h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2066988824182624269"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-17 06:59 UTC",
+    "delivered_at": "2026-06-17 06:00 UTC",
     "headline": "ANTHROPIC EXPORT BAN HITS OWN STAFF \u2014 'DEEMED EXPORT' RULES LOCK VISA-HOLDERS OUT OF FABLE 5 AND MYTHOS 5",
     "source": "@kristoph",
+    "source_file": "research/summaries/2026-06-17-twitter-06h-headlines.json",
     "url": "https://x.com/kristoph/status/2066989763954155652"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-17 06:59 UTC",
+    "delivered_at": "2026-06-17 06:00 UTC",
     "headline": "LAWYER: BIS FABLE 5 DIRECTIVE 'VERY AGGRESSIVE,' VULNERABLE ON EAR PUBLISHED-INFORMATION CARVE-OUT",
     "source": "@CharlieBull0ck",
+    "source_file": "research/summaries/2026-06-17-twitter-06h-headlines.json",
     "url": "https://x.com/CharlieBull0ck/status/2066987766924128464"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-17 06:59 UTC",
+    "delivered_at": "2026-06-17 06:00 UTC",
     "headline": "MIDJOURNEY TO UNVEIL FIRST HARDWARE PROJECT WEDNESDAY 6/17 AT SAN FRANCISCO LAUNCH EVENT",
     "source": "@midjourney",
+    "source_file": "research/summaries/2026-06-17-twitter-06h-headlines.json",
     "url": "https://x.com/midjourney/status/2066994481770213697"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-17 06:59 UTC",
+    "delivered_at": "2026-06-17 06:00 UTC",
     "headline": "MICROSOFT WEIGHING AZURE-HOSTED DEEPSEEK V4 AS CHEAPER COPILOT COWORK ENGINE \u2014 AXIOS",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-17-twitter-06h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2066946013026263110"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-17 06:59 UTC",
+    "delivered_at": "2026-06-17 06:00 UTC",
     "headline": "UK PM STARMER DENIED FABLE 5 CARVE-OUT \u2014 TRUMP OFFICIAL CALLS EXEMPTING A G7 ALLY 'COMPLETELY ILLOGICAL'",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-17-twitter-06h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2066934409840775201"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-17 10:26 UTC",
+    "delivered_at": "2026-06-17 10:00 UTC",
     "headline": "CURSOR UNVEILS SPACEX-TRAINED FRONTIER MODEL AT COMPILE \u2014 CEO SAYS \"AS BIG AS OPUS AND GPT,\" SHIPPING IN CURSOR AND GROK BUILD",
     "source": "@scaling01",
+    "source_file": "research/summaries/2026-06-17-twitter-10h-headlines.json",
     "url": "https://x.com/scaling01/status/2067017700384125238"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-17 10:26 UTC",
+    "delivered_at": "2026-06-17 10:00 UTC",
     "headline": "CURSOR LAUNCHES ORIGIN \u2014 GIT HOSTING \"FOR THE AGENTIC ERA,\" TAKING DIRECT AIM AT GITHUB; WAITLIST NOW, SHIPS FALL 2026",
     "source": "@cursor_ai",
+    "source_file": "research/summaries/2026-06-17-twitter-10h-headlines.json",
     "url": "https://x.com/cursor_ai/status/2067012220832329782"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-17 10:26 UTC",
+    "delivered_at": "2026-06-17 10:00 UTC",
     "headline": "SECOND EXPORT-CONTROL LAWYER CALLS LUTNICK'S ANTHROPIC LETTER \"DEEPLY FLAWED\" \u2014 SAYS AI-AS-A-SERVICE ISN'T AN EXPORT, MAY NOT EVEN BAR API ACCESS",
     "source": "@alasdairpr",
+    "source_file": "research/summaries/2026-06-17-twitter-10h-headlines.json",
     "url": "https://x.com/alasdairpr/status/2067052688508899577"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-17 10:26 UTC",
+    "delivered_at": "2026-06-17 10:00 UTC",
     "headline": "OPENAI VOICE-MODE UPGRADE TO ADD INSTANT/MEDIUM/HIGH LEVELS, BI-DIRECTIONAL \"GPT-BIDI-1\" THAT LISTENS AND SPEAKS AT ONCE",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-06-17-twitter-10h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2067023259254555061"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-17 13:42 UTC",
+    "delivered_at": "2026-06-17 13:00 UTC",
     "headline": "US COMMERCE SAT ON ENTITY-LIST BLACKLISTING OF DEEPSEEK, CXMT + 100 CHINESE FIRMS TO AVOID ESCALATING TENSIONS WITH BEIJING",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-17-twitter-13h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2067058493048365070"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-17 13:42 UTC",
+    "delivered_at": "2026-06-17 13:00 UTC",
     "headline": "NO NEW US ENTITY-LIST ADDITIONS SINCE OCTOBER \u2014 LONGEST STRETCH WITHOUT POSTINGS IN OVER A DECADE",
     "source": "@spotlightoncn",
+    "source_file": "research/summaries/2026-06-17-twitter-13h-headlines.json",
     "url": "https://x.com/spotlightoncn/status/2067082044530991354"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-17 13:42 UTC",
+    "delivered_at": "2026-06-17 13:00 UTC",
     "headline": "ANTHROPIC EMBARGO REIGNITES FOREIGN-AI-TALENT FEARS \u2014 OPENAI CSO KWON TELLS STAFF FOREIGN TALENT IS CRITICAL TO STAYING AHEAD",
     "source": "@steph_palazzolo",
+    "source_file": "research/summaries/2026-06-17-twitter-13h-headlines.json",
     "url": "https://x.com/steph_palazzolo/status/2066993984644231507"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-17 13:42 UTC",
+    "delivered_at": "2026-06-17 13:00 UTC",
     "headline": "ANTHROPIC FABLE 5 / MYTHOS 5 EXPORT EMBARGO \u2014 STILL NO LIFT, NO OFFICIAL BIS PDF",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-06-17-twitter-13h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2066969532380721386"
   },
   {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-06-17 13:00 UTC",
+    "headline": "MIDJOURNEY TO UNVEIL FIRST HARDWARE PROJECT TONIGHT \u2014 SF LAUNCH, 6PM PT WEDNESDAY",
+    "source": "@midjourney",
+    "source_file": "research/summaries/2026-06-17-twitter-13h-headlines.json",
+    "url": "https://x.com/midjourney/status/2066994481770213697"
+  },
+  {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-17 17:11 UTC",
+    "delivered_at": "2026-06-17 17:00 UTC",
     "headline": "GLM-5.2 IS NOW #1 OPEN-WEIGHTS MODEL ON ARTIFICIAL ANALYSIS INDEX \u2014 SCORE 51, AHEAD OF DEEPSEEK V4 PRO AND KIMI K2.6",
     "source": "@ArtificialAnlys",
+    "source_file": "research/summaries/2026-06-17-twitter-17h-headlines.json",
     "url": "https://x.com/ArtificialAnlys/status/2067135640249209175"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-17 17:11 UTC",
+    "delivered_at": "2026-06-17 17:00 UTC",
     "headline": "GLM-5.2 HITS 1524 ON GDPVAL-AA V2 \u2014 ARTIFICIAL ANALYSIS CALLS IT IN LINE WITH GPT-5.5 ON AGENTIC WORK",
     "source": "@ArtificialAnlys",
+    "source_file": "research/summaries/2026-06-17-twitter-17h-headlines.json",
     "url": "https://x.com/ArtificialAnlys/status/2067135640249209175"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-17 17:11 UTC",
+    "delivered_at": "2026-06-17 17:00 UTC",
     "headline": "GLM-5.2 RANKS #2 ON FRONTEND CODE ARENA \u2014 BEHIND ONLY THE EXPORT-BLOCKED CLAUDE FABLE 5",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-06-17-twitter-17h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2067143261848842670"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-17 17:11 UTC",
+    "delivered_at": "2026-06-17 17:00 UTC",
     "headline": "ANTHROPIC FABLE 5 / MYTHOS 5 EXPORT EMBARGO STILL UNLIFTED \u2014 NO BIS PDF, NO RESTORATION, NO ANTHROPIC UPDATE",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-06-17-twitter-17h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2065597531644743999"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-17 19:44 UTC",
+    "delivered_at": "2026-06-17 19:00 UTC",
     "headline": "XAI SHIPS GROK IMAGINE VIDEO 1.5 \u2014 NEW IMAGE-TO-VIDEO MODEL NOW GENERALLY AVAILABLE IN API",
     "source": "@xai",
+    "source_file": "research/summaries/2026-06-17-twitter-19h-headlines.json",
     "url": "https://x.com/xai/status/2067092897951109427"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-17 19:44 UTC",
+    "delivered_at": "2026-06-17 19:00 UTC",
     "headline": "GROK IMAGINE 1.5 FAST: 720P VIDEO IN ~25 SECONDS, DOWN FROM 40+ \u2014 ROLLED OUT TO CONSUMERS",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-06-17-twitter-19h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2067170263507087720"
   },
   {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-06-17 19:00 UTC",
+    "headline": "ANTHROPIC FABLE 5 / MYTHOS 5 EMBARGO \u2014 STILL NO LIFT, NO BIS PDF, NO MODIFIED RELEASE",
+    "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-06-17-twitter-19h-headlines.json",
+    "url": "https://x.com/AnthropicAI/status/2066969532380721386"
+  },
+  {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-17 19:44 UTC",
+    "delivered_at": "2026-06-17 19:00 UTC",
     "headline": "SARVAM JOINS INDIA'S AI UNICORNS \u2014 $300M SERIES B AT ~$1.5B VALUATION, HCLTECH-LED",
     "source": "@SarvamAI",
+    "source_file": "research/summaries/2026-06-17-twitter-19h-headlines.json",
     "url": "https://x.com/SarvamAI/status/2067117724309102722"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-17 22:28 UTC",
+    "delivered_at": "2026-06-17 22:00 UTC",
     "headline": "ALL FRONTIER-LAB CEOS \u2014 AMODEI, ALTMAN, HASSABIS, MENSCH \u2014 SHARE G7 LUNCH IN EVIAN; ANTHROPIC EMBARGO THE 'ELEPHANT IN THE ROOM'",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-17-twitter-22h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2067223764312510619"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-17 22:28 UTC",
+    "delivered_at": "2026-06-17 22:00 UTC",
     "headline": "DOJ SIDES WITH xAI \u2014 ASKS COURT TO TOSS NAACP SUIT OVER UNPERMITTED MEMPHIS GAS TURBINES ON NATIONAL-SECURITY GROUNDS",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-17-twitter-22h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2067192114723897550"
   },
   {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-06-17 22:00 UTC",
+    "headline": "ANTHROPIC FABLE 5 / MYTHOS 5 EXPORT EMBARGO \u2014 DAY 6, STILL NO LIFT, NO BIS PDF, NO ANTHROPIC LEGAL RESPONSE",
+    "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-06-17-twitter-22h-headlines.json",
+    "url": "https://x.com/AnthropicAI/status/2066969532380721386"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-06-17 22:00 UTC",
+    "headline": "GLM-5.2 HOLDS #1 OPEN-WEIGHTS SLOT ON ARTIFICIAL ANALYSIS INDEX \u2014 2ND ON FRONTEND CODE ARENA BEHIND BLOCKED FABLE 5",
+    "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-06-17-twitter-22h-headlines.json",
+    "url": "https://x.com/testingcatalog/status/2067143261848842670"
+  },
+  {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-18 01:25 UTC",
+    "delivered_at": "2026-06-18 01:00 UTC",
     "headline": "DEEPSEEK RAISES ~$7.4B AT $50B+ VALUATION \u2014 FIRST-EVER OUTSIDE ROUND, FOUNDER KEEPS FULL CONTROL",
     "source": "@ns123abc",
+    "source_file": "research/summaries/2026-06-18-twitter-01h-headlines.json",
     "url": "https://x.com/ns123abc/status/2066922389200310642"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-18 01:25 UTC",
+    "delivered_at": "2026-06-18 01:00 UTC",
     "headline": "DEEPSEEK FUNDING: LIANG WENFENG WROTE BIGGEST CHECK (~$2.8B), TENCENT $1.4B, CATL $700M \u2014 INVESTORS GOT NO VOTES",
     "source": "@poezhao0605",
+    "source_file": "research/summaries/2026-06-18-twitter-01h-headlines.json",
     "url": "https://x.com/poezhao0605/status/2066916963939737686"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-18 01:25 UTC",
+    "delivered_at": "2026-06-18 01:00 UTC",
     "headline": "MICROSOFT WEIGHING DEEPSEEK V4 IN COPILOT COWORK AS CHEAP ALTERNATIVE TO OPENAI AND ANTHROPIC \u2014 AXIOS",
     "source": "@ns123abc",
+    "source_file": "research/summaries/2026-06-18-twitter-01h-headlines.json",
     "url": "https://x.com/ns123abc/status/2066934557077631197"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-18 01:25 UTC",
+    "delivered_at": "2026-06-18 01:00 UTC",
     "headline": "MICROSOFT COPILOT COWORK NOW GA WORLDWIDE WITH MULTI-MODEL SUPPORT AND USAGE-BASED PRICING (~$0.01/TASK)",
     "source": "@satyanadella",
+    "source_file": "research/summaries/2026-06-18-twitter-01h-headlines.json",
     "url": "https://x.com/satyanadella/status/2066911399494963335"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-18 01:25 UTC",
+    "delivered_at": "2026-06-18 01:00 UTC",
     "headline": "FRONTIER-LAB CEOS \u2014 AMODEI, ALTMAN, HASSABIS \u2014 MEET TRUMP ADMINISTRATION OVER FABLE 5 MODEL ACCESS",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-18-twitter-01h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2067223764312510619"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-18 01:25 UTC",
+    "delivered_at": "2026-06-18 01:00 UTC",
     "headline": "XAI SHIPS GROK IMAGINE VIDEO 1.5 IN WIDE RELEASE; MUSK TEASES 'FULL MOVIES BY END OF YEAR'",
     "source": "@xai",
+    "source_file": "research/summaries/2026-06-18-twitter-01h-headlines.json",
     "url": "https://x.com/xai/status/2067092897951109427"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-06-18 01:25 UTC",
+    "delivered_at": "2026-06-18 01:00 UTC",
     "headline": "ZAI RELEASES OPEN-WEIGHT GLM-5.2 \u2014 744B-A40B MIXTURE-OF-EXPERTS MODEL",
     "source": "@drdanielbender",
+    "source_file": "research/summaries/2026-06-18-twitter-01h-headlines.json",
     "url": "https://x.com/drdanielbender/status/2067152422141571228"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-06-18 04:04 UTC",
+    "delivered_at": "2026-06-18 04:00 UTC",
     "headline": "OPENAI: GPT-5.4 FOUND & VALIDATED A REAL DRUG-DISCOVERY REACTION FIX \u2014 MEAN YIELD 16.6% TO 25.2% ACROSS 10,080 REACTIONS",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-06-18-twitter-04h-headlines.json",
     "url": "https://x.com/OpenAI/status/2067293745075442171"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-18 04:04 UTC",
+    "delivered_at": "2026-06-18 04:00 UTC",
     "headline": "FERC EXPECTED TO RULE ON DATA-CENTER GRID HOOKUPS \u2014 COULD FORCE HYPERSCALERS TO FUND UPGRADES OR ACCEPT CURTAILMENT",
     "source": "@wallstengine",
+    "source_file": "research/summaries/2026-06-18-twitter-04h-headlines.json",
     "url": "https://x.com/wallstengine/status/2067280709170213273"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-18 04:04 UTC",
+    "delivered_at": "2026-06-18 04:00 UTC",
     "headline": "AMAZON AI CHIEF DESANTIS: EXPECT TO BE COMPETITIVE WITH OPENAI & ANTHROPIC 'WITHIN THE COMING YEAR'; NOVA2 AT ~50K CUSTOMERS",
     "source": "@TopStockAlerts1",
+    "source_file": "research/summaries/2026-06-18-twitter-04h-headlines.json",
     "url": "https://x.com/TopStockAlerts1/status/2067321465326698794"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-18 06:47 UTC",
+    "delivered_at": "2026-06-18 06:00 UTC",
     "headline": "ANTHROPIC EMBARGO GOES TRANSATLANTIC \u2014 MACRON LOBBIES AMODEI AT G7 EVIAN FOR EUROPE'S CLAUDE ACCESS",
     "source": "@heyshrutimishra",
+    "source_file": "research/summaries/2026-06-18-twitter-06h-headlines.json",
     "url": "https://x.com/heyshrutimishra/status/2067325656711782567"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-18 06:47 UTC",
+    "delivered_at": "2026-06-18 06:00 UTC",
     "headline": "WSJ: AMODEI TOLD LUTNICK 'WE CAN'T HAVE THE MODEL OUT' \u2014 COMMERCE SECRETARY REPLIED 'THAT'S THE POINT'",
     "source": "@AmrithRamkumar",
+    "source_file": "research/summaries/2026-06-18-twitter-06h-headlines.json",
     "url": "https://x.com/AmrithRamkumar/status/2067059417678336455"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-18 06:47 UTC",
+    "delivered_at": "2026-06-18 06:00 UTC",
     "headline": "ALL THREE FRONTIER-LAB CEOS \u2014 ALTMAN, AMODEI, HASSABIS \u2014 JOIN HEADS OF STATE AT G7 SUMMIT IN EVIAN",
     "source": "@CNBC",
+    "source_file": "research/summaries/2026-06-18-twitter-06h-headlines.json",
     "url": "https://x.com/CNBC/status/2067170439428784596"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-18 06:47 UTC",
+    "delivered_at": "2026-06-18 06:00 UTC",
     "headline": "40+ CISOS FROM ADOBE, ZOOM, SOPHOS SIGN LETTER DEMANDING WHITE HOUSE REVERSE ANTHROPIC MODEL RESTRICTIONS",
     "source": "@steffen_dybvik",
+    "source_file": "research/summaries/2026-06-18-twitter-06h-headlines.json",
     "url": "https://x.com/steffen_dybvik/status/2066429962798735779"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-18 06:47 UTC",
+    "delivered_at": "2026-06-18 06:00 UTC",
     "headline": "POLYMARKET 'FABLE 5 BAN' ODDS SLIDE 51% TO 31% IN A DAY \u2014 ON NO NEWS, JUST TIME DECAY",
     "source": "@armouredme",
+    "source_file": "research/summaries/2026-06-18-twitter-06h-headlines.json",
     "url": "https://x.com/armouredme/status/2067304447412494529"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-18 10:23 UTC",
+    "delivered_at": "2026-06-18 10:00 UTC",
     "headline": "TRANSFORMER CO-AUTHOR NOAM SHAZEER LEAVES GOOGLE'S GEMINI FOR OPENAI \u2014 YEAR'S BIGGEST AI TALENT MOVE",
     "source": "@NoamShazeer",
+    "source_file": "research/summaries/2026-06-18-twitter-10h-headlines.json",
     "url": "https://x.com/NoamShazeer/status/2067400851438932297"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-18 10:23 UTC",
+    "delivered_at": "2026-06-18 10:00 UTC",
     "headline": "WIRED: TRUMP ADMIN'S FABLE 5 RE-RELEASE BAR IS UNCIRCUMVENTABLE GUARDRAILS \u2014 SECURITY EXPERTS SAY IT CAN'T BE DONE",
     "source": "@WIRED",
+    "source_file": "research/summaries/2026-06-18-twitter-10h-headlines.json",
     "url": "https://x.com/WIRED/status/2067292536687804692"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-18 10:23 UTC",
+    "delivered_at": "2026-06-18 10:00 UTC",
     "headline": "AMODEI AND HASSABIS CALL FOR US-LED AI COALITION THAT EXCLUDES CHINA AT G7 CLOSED-DOOR SESSION",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-18-twitter-10h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2067305163556364497"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-18 10:23 UTC",
+    "delivered_at": "2026-06-18 10:00 UTC",
     "headline": "WHITE HOUSE AI CZAR DAVID SACKS BLAMES ANTHROPIC'S 'CONFRONTATIONAL POSTURE' FOR FABLE 5 IMPASSE",
     "source": "@DavidSacks",
+    "source_file": "research/summaries/2026-06-18-twitter-10h-headlines.json",
     "url": "https://x.com/DavidSacks/status/2067270499458027832"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-06-18 10:23 UTC",
+    "delivered_at": "2026-06-18 10:00 UTC",
     "headline": "OPENAI SHIPS LIFESCIBENCH \u2014 750 EXPERT TASKS, 173 SCIENTISTS; GPT-ROSALIND BEATS GPT-5.5 ACROSS ALL 7 WORKFLOWS",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-06-18-twitter-10h-headlines.json",
     "url": "https://x.com/OpenAI/status/2067346916929937827"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-18 13:42 UTC",
+    "delivered_at": "2026-06-18 13:00 UTC",
     "headline": "WIRED: SK TELECOM \u2014 NOT AMAZON \u2014 WAS FIRST TRIGGER BEHIND ANTHROPIC EXPORT CONTROLS OVER ALLEGED CHINA TIES",
     "source": "@LaurenGoode",
+    "source_file": "research/summaries/2026-06-18-twitter-13h-headlines.json",
     "url": "https://x.com/LaurenGoode/status/2067402160795775228"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-18 13:42 UTC",
+    "delivered_at": "2026-06-18 13:00 UTC",
     "headline": "META CTO BOSWORTH TELLS STAFF MORALE IS WORST IN 20 YEARS, LIKENS MOOD TO CAMBRIDGE ANALYTICA ERA",
     "source": "@rohanpaul_ai",
+    "source_file": "research/summaries/2026-06-18-twitter-13h-headlines.json",
     "url": "https://x.com/rohanpaul_ai/status/2067428084966694957"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-18 13:42 UTC",
+    "delivered_at": "2026-06-18 13:00 UTC",
     "headline": "META REASSIGNS 30-50% OF CORE-TEAM ENGINEERS TO AI DATA LABELING IN 'AGENT DATA OPTIMIZATION' ORG",
     "source": "@deedydas",
+    "source_file": "research/summaries/2026-06-18-twitter-13h-headlines.json",
     "url": "https://x.com/deedydas/status/2067428043195621454"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-18 13:42 UTC",
+    "delivered_at": "2026-06-18 13:00 UTC",
     "headline": "MIDJOURNEY UNVEILS FIRST HARDWARE \u2014 A FULL-BODY ULTRASOUND SCANNER UNDER NEW 'MIDJOURNEY MEDICAL' DIVISION",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-06-18-twitter-13h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2067422213112762831"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-18 13:42 UTC",
+    "delivered_at": "2026-06-18 13:00 UTC",
     "headline": "ALTMAN CONFIRMS NOAM SHAZEER HIRE: 'ONE OF THE PEOPLE I HAVE MOST WANTED TO WORK WITH SINCE THE BEGINNING OF OPENAI'",
     "source": "@sama",
+    "source_file": "research/summaries/2026-06-18-twitter-13h-headlines.json",
     "url": "https://x.com/sama/status/2067427421083652131"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-18 16:59 UTC",
+    "delivered_at": "2026-06-18 16:00 UTC",
     "headline": "JPMORGAN PULLS ANTHROPIC'S CLAUDE FOR HONG KONG STAFF, FOLLOWING GOLDMAN SACHS \u2014 FT",
     "source": "@Cointelegraph",
+    "source_file": "research/summaries/2026-06-18-twitter-16h-headlines.json",
     "url": "https://x.com/Cointelegraph/status/2067482470975479835"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-18 16:59 UTC",
+    "delivered_at": "2026-06-18 16:00 UTC",
     "headline": "DEEPSEEK SHIPS VISION FOR V4 \u2014 'NOW LIVE ON WEB AND APP'",
     "source": "@PKUCXK",
+    "source_file": "research/summaries/2026-06-18-twitter-16h-headlines.json",
     "url": "https://x.com/PKUCXK/status/2067460570958426452"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-18 16:59 UTC",
+    "delivered_at": "2026-06-18 16:00 UTC",
     "headline": "TRUMP: APPLE HAS AGREED TO WORK WITH INTEL TO BUILD ITS CHIPS IN AMERICA \u2014 NO APPLE/INTEL CONFIRMATION",
     "source": "@wallstengine",
+    "source_file": "research/summaries/2026-06-18-twitter-16h-headlines.json",
     "url": "https://x.com/wallstengine/status/2067512525458231680"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-06-18 16:59 UTC",
+    "delivered_at": "2026-06-18 16:00 UTC",
     "headline": "GLM-5.2 RATED 'EASILY OPUS 4.6 / GPT-5.4 TIER' AS CHINESE OPEN MODELS SURGE",
     "source": "@ns123abc",
+    "source_file": "research/summaries/2026-06-18-twitter-16h-headlines.json",
     "url": "https://x.com/ns123abc/status/2067507236792861037"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-18 19:41 UTC",
+    "delivered_at": "2026-06-18 19:00 UTC",
     "headline": "MIDJOURNEY 'FULL-BODY SCANNER' RUNS ON LICENSED BUTTERFLY NETWORK ULTRASOUND CHIPS \u2014 ~40 MODULES PER UNIT",
     "source": "@PUMPKNAI",
+    "source_file": "research/summaries/2026-06-18-twitter-19h-headlines.json",
     "url": "https://x.com/PUMPKNAI/status/2067540361900093653"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-18 19:41 UTC",
+    "delivered_at": "2026-06-18 19:00 UTC",
     "headline": "MIDJOURNEY MEDICAL PITCHES 60-SECOND, RADIATION-FREE BODY SCAN AS A 24/7 SPA \u2014 FIRST SF LOCATION IN 2027",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-18-twitter-19h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2067526939036815610"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-18 19:41 UTC",
+    "delivered_at": "2026-06-18 19:00 UTC",
     "headline": "VP JD VANCE WARNS AI ENABLES MASS SURVEILLANCE, FEARS 'SOCIAL CREDIT SYSTEM POWERED BY AI'",
     "source": "@ns123abc",
+    "source_file": "research/summaries/2026-06-18-twitter-19h-headlines.json",
     "url": "https://x.com/ns123abc/status/2067553541552496883"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-18 22:26 UTC",
+    "delivered_at": "2026-06-18 19:00 UTC",
+    "headline": "ANTHROPIC EMBARGO UNCHANGED \u2014 NO NEW STATEMENT SINCE JUNE 13 FABLE 5 / MYTHOS 5 SUSPENSION",
+    "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-06-18-twitter-19h-headlines.json",
+    "url": "https://x.com/AnthropicAI/status/2065597531644743999"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-06-18 22:00 UTC",
     "headline": "ANTHROPIC EXEC SAYS FABLE 5, MYTHOS 5 WILL BE AVAILABLE AGAIN \"IN THE COMING DAYS\" \u2014 SEOUL PRESS CONFERENCE",
     "source": "@synthwavedd",
+    "source_file": "research/summaries/2026-06-18-twitter-22h-headlines.json",
     "url": "https://x.com/synthwavedd/status/2067587235898073507"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-18 22:26 UTC",
+    "delivered_at": "2026-06-18 22:00 UTC",
     "headline": "TIM COOK REPORTEDLY CALLS IPHONE PRICE HIKES \"UNAVOIDABLE\" AS AI DATA CENTERS DRAIN MEMORY SUPPLY \u2014 ~$270 PER WSJ MODEL",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-18-twitter-22h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2067578578842321091"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-19 01:18 UTC",
+    "delivered_at": "2026-06-18 22:00 UTC",
+    "headline": "VP VANCE WARNS AI ENABLES GOVERNMENT, CORPORATE SURVEILLANCE \"IN VERY PROFOUND WAYS,\" FEARS AI SOCIAL-CREDIT SYSTEM",
+    "source": "@ns123abc",
+    "source_file": "research/summaries/2026-06-18-twitter-22h-headlines.json",
+    "url": "https://x.com/ns123abc/status/2067553541552496883"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-06-19 01:00 UTC",
     "headline": "ANTHROPIC EXEC: FABLE 5 AND MYTHOS 'VERY CONFIDENT' TO RETURN 'IN THE COMING DAYS' \u2014 FIRST ON-RECORD TIMELINE",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-06-19-twitter-01h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2067599248619626994"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-19 01:18 UTC",
+    "delivered_at": "2026-06-19 01:00 UTC",
     "headline": "NOAM SHAZEER LEAVES GOOGLE FOR OPENAI \u2014 TRANSFORMER CO-AUTHOR AND GEMINI CO-LEAD, 2 YRS AFTER $2.7B ACQUIHIRE",
     "source": "@wallstengine",
+    "source_file": "research/summaries/2026-06-19-twitter-01h-headlines.json",
     "url": "https://x.com/wallstengine/status/2067627041525264803"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-19 01:18 UTC",
+    "delivered_at": "2026-06-19 01:00 UTC",
     "headline": "OPENAI HIRES EX-WHITE HOUSE AI ADVISER DEAN BALL AS HEAD OF STRATEGIC FUTURES, REPORTING TO CSO JASON KWON",
     "source": "@BrendanBordelon",
+    "source_file": "research/summaries/2026-06-19-twitter-01h-headlines.json",
     "url": "https://x.com/BrendanBordelon/status/2067635469924397223"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-19 01:18 UTC",
+    "delivered_at": "2026-06-19 01:00 UTC",
     "headline": "MICROSOFT EVALUATING 'MANY' OPEN MODELS FOR COPILOT COWORK \u2014 GLM, MINIMAX, KIMI PRESSURING INTERNAL MAI TEAMS",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-06-19-twitter-01h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2067626163187376559"
   },
   {
+    "backfilled": true,
     "category": "policy",
     "delivered_at": "2026-06-19 04:00 UTC",
     "headline": "ANTHROPIC FILES FORMAL PROPOSAL TO COMMERCE SECRETARY LUTNICK TO END US BAN ON MYTHOS AND FABLE",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-19-twitter-04h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2067680690779607232"
   },
   {
+    "backfilled": true,
     "category": "model",
     "delivered_at": "2026-06-19 04:00 UTC",
     "headline": "OPENAI GPT-5.6 AND GPT-5.6-PRO SPOTTED IN TESTING \u2014 POSSIBLE RELEASE AS SOON AS NEXT WEEK",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-06-19-twitter-04h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2067649489293185267"
   },
   {
+    "backfilled": true,
     "category": "opensource",
     "delivered_at": "2026-06-19 04:00 UTC",
     "headline": "MUSK PREDICTS CHINA REACHES FABLE-CLASS FRONTIER BY Q1 2027 AS OPEN GLM-5.2 CLOSES THE GAP",
     "source": "@ns123abc",
+    "source_file": "research/summaries/2026-06-19-twitter-04h-headlines.json",
     "url": "https://x.com/ns123abc/status/2067608714635268326"
   },
   {
+    "backfilled": true,
     "category": "infra",
     "delivered_at": "2026-06-19 04:00 UTC",
     "headline": "CLAUDE CODE SHIPS ARTIFACTS \u2014 TURN IN-PROGRESS WORK INTO SHAREABLE TEAM PAGES",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-19-twitter-04h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2067672273570742524"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-19 06:50 UTC",
+    "delivered_at": "2026-06-19 06:00 UTC",
     "headline": "WHITE HOUSE AND ANTHROPIC CO-BUILDING JAILBREAK-RESISTANCE BENCHMARK TO GATE FABLE/MYTHOS RETURN",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-19-twitter-06h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2067710015641956568"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-19 06:50 UTC",
+    "delivered_at": "2026-06-19 06:00 UTC",
     "headline": "ANTHROPIC TALKS WITH COMMERCE LED BY CO-FOUNDER TOM BROWN, POLICY HEAD SARAH HECK \u2014 STILL NO JAILBREAK CONCESSION, NO MODEL RESTORED",
     "source": "@ChrissGPT",
+    "source_file": "research/summaries/2026-06-19-twitter-06h-headlines.json",
     "url": "https://x.com/ChrissGPT/status/2067709204748701750"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-19 06:50 UTC",
+    "delivered_at": "2026-06-19 06:00 UTC",
     "headline": "GPT-5.6 LAUNCH TARGETED FOR 'NEXT THURSDAY' (~JUNE 25), STEALTH-TESTED FOR SOME PRO ACCOUNTS",
     "source": "@synthwavedd",
+    "source_file": "research/summaries/2026-06-19-twitter-06h-headlines.json",
     "url": "https://x.com/synthwavedd/status/2067658825759387675"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-19 06:50 UTC",
+    "delivered_at": "2026-06-19 06:00 UTC",
     "headline": "FIRST GPT-5.6 PRO HANDS-ON: REASONING UP, FRONTEND FLAT, RUNS SLOWER (20-40 MIN)",
     "source": "@chetaslua",
+    "source_file": "research/summaries/2026-06-19-twitter-06h-headlines.json",
     "url": "https://x.com/chetaslua/status/2067642369403740220"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-19 06:50 UTC",
+    "delivered_at": "2026-06-19 06:00 UTC",
     "headline": "CLAUDE CODE ARTIFACTS GO LIVE FOR TEAM AND ENTERPRISE \u2014 EVERY SESSION BECOMES A SHAREABLE PAGE",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-06-19-twitter-06h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2067706553273139609"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-19 06:50 UTC",
+    "delivered_at": "2026-06-19 06:00 UTC",
     "headline": "KRAFTON SHIPS 'PUBG ALLY,' BILLED AS FIRST IN-GAME AI AGENT THAT REASONS AND PLAYS ALONGSIDE PLAYERS",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-19-twitter-06h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2067724993472135516"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-19 10:29 UTC",
+    "delivered_at": "2026-06-19 10:00 UTC",
     "headline": "US ACCUSES ASML OF BAD FAITH ON EXPORT CONTROLS \u2014 LUTNICK SAYS RESTRICTED EUV MACHINE DIVERTED TO CHINA",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-19-twitter-10h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2067779082243518757"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-06-19 10:29 UTC",
+    "delivered_at": "2026-06-19 10:00 UTC",
     "headline": "FAST.AI'S JEREMY HOWARD: OPEN GLM-5.2 IS 'AT LEAST AS GOOD AS OPUS 4.8 AND GPT-5.5'",
     "source": "@jeremyphoward",
+    "source_file": "research/summaries/2026-06-19-twitter-10h-headlines.json",
     "url": "https://x.com/jeremyphoward/status/2067757468189679764"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-19 10:29 UTC",
+    "delivered_at": "2026-06-19 10:00 UTC",
     "headline": "DEAN BALL CONFIRMS OPENAI START JULY 6 TO LEAD NEW 'STRATEGIC FUTURES' AI-POLICY TEAM",
     "source": "@deanwball",
+    "source_file": "research/summaries/2026-06-19-twitter-10h-headlines.json",
     "url": "https://x.com/deanwball/status/2067634693441233118"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-19 10:29 UTC",
+    "delivered_at": "2026-06-19 10:00 UTC",
     "headline": "OPENAI HIRES META'S HA THAI TO LEAD DEVICE COMMS AS FIRST HARDWARE PRODUCT NEARS",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-19-twitter-10h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2067709693125181693"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-19 10:29 UTC",
+    "delivered_at": "2026-06-19 10:00 UTC",
     "headline": "OPENAI SHIPS CODEX 'RECORD & REPLAY' \u2014 DEMO A WORKFLOW ONCE, IT BECOMES AN EDITABLE SKILL",
     "source": "@OpenAIDevs",
+    "source_file": "research/summaries/2026-06-19-twitter-10h-headlines.json",
     "url": "https://x.com/OpenAIDevs/status/2067681320281723113"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-19 10:29 UTC",
+    "delivered_at": "2026-06-19 10:00 UTC",
     "headline": "ANTHROPIC EMBARGO DRAGS: 'COMING DAYS' LAPSES, WH\u2013ANTHROPIC BUILD JAILBREAK-SEVERITY FRAMEWORK, NO MODEL RESTORED",
     "source": "@SophiaCai99",
+    "source_file": "research/summaries/2026-06-19-twitter-10h-headlines.json",
     "url": "https://x.com/SophiaCai99/status/2067696772840063370"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-19 13:42 UTC",
+    "delivered_at": "2026-06-19 13:00 UTC",
     "headline": "GPT-5.6 LEAK HARDENS: SPEC SHEET SHOWS REASONING 'JUICE' 960 VS 768, DEC-2025 CUTOFF, BROWSER-USE BAKED IN, 'THURSDAY' TARGET",
     "source": "@chetaslua",
+    "source_file": "research/summaries/2026-06-19-twitter-13h-headlines.json",
     "url": "https://x.com/chetaslua/status/2067797061215633794"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-19 13:42 UTC",
+    "delivered_at": "2026-06-19 13:00 UTC",
     "headline": "OPENAI: GPT-5.5 INSTANT NOW MATCHES FRONTIER THINKING MODELS ON HEALTH \u2014 230M WEEKLY HEALTH USERS, PHYSICIAN-LED EVAL",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-06-19-twitter-13h-headlines.json",
     "url": "https://x.com/OpenAI/status/2067672740539306261"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-06-19 13:42 UTC",
+    "delivered_at": "2026-06-19 13:00 UTC",
     "headline": "OPENAI SHIPS 'PERSISTENT ALIGNMENT' RESEARCH \u2014 MODELS HARDER TO JAILBREAK UNDER PRESSURE, EARLY RESISTANCE TO HARMFUL FINE-TUNING",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-06-19-twitter-13h-headlines.json",
     "url": "https://x.com/OpenAI/status/2067722688165232654"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-19 13:42 UTC",
+    "delivered_at": "2026-06-19 13:00 UTC",
     "headline": "ANTHROPIC EMBARGO HOLDS: NO FABLE 5/MYTHOS RESTORATION OVERNIGHT, 'COMING DAYS' LAPSES INTO THIRD DAY",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-06-19-twitter-13h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2065597531644743999"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-06-19 13:42 UTC",
+    "delivered_at": "2026-06-19 13:00 UTC",
     "headline": "ANTHROPIC PROJECT FETCH: OPUS 4.7 PROGRAMMED A ROBODOG ~20X FASTER THAN THE BEST HUMAN TEAM",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-06-19-twitter-13h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2067651699486200091"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-06-19 17:11 UTC",
+    "delivered_at": "2026-06-19 17:00 UTC",
     "headline": "BLOOMBERG: ANTHROPIC FABLE/MYTHOS BAN NOT TOTAL \u2014 ~200 ORGS STILL RUN MYTHOS PREVIEW UNDER 'PROJECT GLASSWING'",
     "source": "@Cointelegraph",
+    "source_file": "research/summaries/2026-06-19-twitter-17h-headlines.json",
     "url": "https://x.com/Cointelegraph/status/2067849925384138959"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-19 17:11 UTC",
+    "delivered_at": "2026-06-19 17:00 UTC",
     "headline": "CISCO AND DRAGOS AMONG GLASSWING ORGS KEEPING MYTHOS ACCESS; EU AGENCY ENISA REPORTEDLY DENIED",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-19-twitter-17h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2067876984206537188"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-06-19 17:11 UTC",
+    "delivered_at": "2026-06-19 17:00 UTC",
     "headline": "GLM-5.2 TAKES #1 ON DESIGN ARENA AT ELO ~1,360, DISPLACING EMBARGOED FABLE 5",
     "source": "@aiedge_",
+    "source_file": "research/summaries/2026-06-19-twitter-17h-headlines.json",
     "url": "https://x.com/aiedge_/status/2067857417912877340"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-19 17:11 UTC",
+    "delivered_at": "2026-06-19 17:00 UTC",
     "headline": "GLM-5.2 SERVED ACROSS SIX CONSUMER GPUS OVER OPEN INTERNET AT ~30 TOK/S \u2014 'NOBODY CAN SWITCH THIS ONE OFF'",
     "source": "@rumidotsol",
+    "source_file": "research/summaries/2026-06-19-twitter-17h-headlines.json",
     "url": "https://x.com/rumidotsol/status/2067756916852621638"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-19 17:11 UTC",
+    "delivered_at": "2026-06-19 17:00 UTC",
     "headline": "CLAUDE SHIPS ENTERPRISE-MANAGED AUTH FOR MCP CONNECTORS \u2014 ADMINS CENTRALLY AUTHORIZE ORG-WIDE",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-06-19-twitter-17h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2067863936204947897"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-19 19:42 UTC",
+    "delivered_at": "2026-06-19 19:00 UTC",
     "headline": "WIRED: SK TELECOM \u2014 ANTHROPIC INVESTOR & GLASSWING PARTNER \u2014 WAS CUT OFF OVER CHINA TIES, THE REAL TRIGGER FOR FABLE 5 BAN",
     "source": "@ns123abc",
+    "source_file": "research/summaries/2026-06-19-twitter-19h-headlines.json",
     "url": "https://x.com/ns123abc/status/2067457198062436391"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-19 19:42 UTC",
+    "delivered_at": "2026-06-19 19:00 UTC",
     "headline": "GPT-5.6 STILL UNCONFIRMED \u2014 PREDICTION MARKETS NOW PRICE A JUNE SHIP; NO OFFICIAL OPENAI WORD",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-06-19-twitter-19h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2067652120673739048"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-06-19 19:42 UTC",
+    "delivered_at": "2026-06-19 19:00 UTC",
     "headline": "GLM-5.2 LANDS FIRST CONCRETE BENCHMARK \u2014 WITHIN ~1% OF CLAUDE OPUS 4.8 ON FRONTIERSWE, BEATS GPT-5.5 (SINGLE SOURCE)",
     "source": "@ReadFuturist",
+    "source_file": "research/summaries/2026-06-19-twitter-19h-headlines.json",
     "url": "https://x.com/ReadFuturist/status/2067918222297567501"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-19 22:23 UTC",
+    "delivered_at": "2026-06-19 22:00 UTC",
+    "headline": "COMMERCE TOLD ANTHROPIC'S AMODEI THE FABLE 5 BAN MEANS 'WE CAN'T HAVE THE MODEL OUT' \u2014 LUTNICK: 'THAT'S THE POINT'",
+    "source": "@AmrithRamkumar",
+    "source_file": "research/summaries/2026-06-19-twitter-22h-headlines.json",
+    "url": "https://x.com/AmrithRamkumar/status/2067059417678336455"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-06-19 22:00 UTC",
     "headline": "JUNE 12 COMMERCE LETTER NOW PUBLIC: INVOKES MILITARY-INTEL EXPORT RULE, WORLDWIDE LICENSE BAR ON ALL FOREIGN PERSONS",
     "source": "@jnk2103",
+    "source_file": "research/summaries/2026-06-19-twitter-22h-headlines.json",
     "url": "https://x.com/jnk2103/status/2067957775439687952"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-19 22:23 UTC",
+    "delivered_at": "2026-06-19 22:00 UTC",
     "headline": "ASML DENIES US CLAIM ITS EUV MACHINE REACHED CHINA \u2014 SAYS ALL ~314 SYSTEMS TRACKED, NONE IN CHINA",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-19-twitter-22h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2067947705821974948"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-20 01:11 UTC",
+    "delivered_at": "2026-06-20 01:00 UTC",
     "headline": "ANTHROPIC PROPOSES DEAL TO COMMERCE SEC LUTNICK TO FREE FABLE 5 AND MYTHOS FROM US EXPORT CONTROLS",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-20-twitter-01h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2067680690779607232"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-20 01:11 UTC",
+    "delivered_at": "2026-06-20 01:00 UTC",
     "headline": "SOME PROJECT GLASSWING USERS KEPT ANTHROPIC MYTHOS ACCESS DESPITE US ORDER, BLOOMBERG REPORTS",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-20-twitter-01h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2067876984206537188"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-20 01:11 UTC",
+    "delivered_at": "2026-06-20 01:00 UTC",
     "headline": "AMAZON MGM DROPS LUCA GUADAGNINO'S FINISHED SAM ALTMAN BIOPIC 'ARTIFICIAL', SHOPS IT ELSEWHERE",
     "source": "@Variety",
+    "source_file": "research/summaries/2026-06-20-twitter-01h-headlines.json",
     "url": "https://x.com/Variety/status/2067918817171304889"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-20 01:11 UTC",
+    "delivered_at": "2026-06-20 01:00 UTC",
     "headline": "OPENAI REPORTEDLY HIRES TRANSFORMER CO-AUTHOR NOAM SHAZEER FROM GOOGLE/DEEPMIND",
     "source": "@DocumentingAGI",
+    "source_file": "research/summaries/2026-06-20-twitter-01h-headlines.json",
     "url": "https://x.com/DocumentingAGI/status/2067996448654803236"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-20 01:11 UTC",
+    "delivered_at": "2026-06-20 01:00 UTC",
     "headline": "OPENAI HIRES EX-TRUMP AI POLICY ADVISER DEAN BALL AS HEAD OF STRATEGIC FUTURES",
     "source": "@FirstSquawk",
+    "source_file": "research/summaries/2026-06-20-twitter-01h-headlines.json",
     "url": "https://x.com/i/status/2067658852024107138"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-06-20 01:11 UTC",
+    "delivered_at": "2026-06-20 01:00 UTC",
     "headline": "ZHIPU'S GLM-5.2 BECOMES THE OPEN-WEIGHT MODEL DEVS BENCHMARK AGAINST FRONTIER AMID ANTHROPIC GATING",
     "source": "@milesdeutscher",
+    "source_file": "research/summaries/2026-06-20-twitter-01h-headlines.json",
     "url": "https://x.com/milesdeutscher/status/2067858422968770901"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-20 03:49 UTC",
+    "delivered_at": "2026-06-20 03:00 UTC",
     "headline": "ALPHAFOLD NOBEL LAUREATE JOHN JUMPER LEAVES GOOGLE DEEPMIND FOR ANTHROPIC",
     "source": "@JohnJumperSci",
+    "source_file": "research/summaries/2026-06-20-twitter-03h-headlines.json",
     "url": "https://x.com/JohnJumperSci/status/2068001285173834106"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-20 03:49 UTC",
+    "delivered_at": "2026-06-20 03:00 UTC",
     "headline": "TRUMP: ANTHROPIC NOT A NATIONAL SECURITY THREAT NOW \u2014 'BUT A WEEK AGO MAYBE'",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-20-twitter-03h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2068041439481901157"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-20 03:49 UTC",
+    "delivered_at": "2026-06-20 03:00 UTC",
     "headline": "TRUMP SAYS A PART-OWNER COMPETITOR 'TURNED ANTHROPIC IN' OVER MODEL ACCESS",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-20-twitter-03h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2068041439481901157"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-20 03:49 UTC",
+    "delivered_at": "2026-06-20 03:00 UTC",
     "headline": "LUTNICK CONFRONTS ASML OVER EUV MACHINE THAT MAY HAVE REACHED CHINA; ASML DENIES",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-20-twitter-03h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2067779082243518757"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-20 03:49 UTC",
+    "delivered_at": "2026-06-20 03:00 UTC",
     "headline": "ROUGHLY 200 ORGANIZATIONS STILL HAVE CLAUDE MYTHOS ACCESS VIA PROJECT GLASSWING",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-20-twitter-03h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2068038020394021000"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-20 06:35 UTC",
+    "delivered_at": "2026-06-20 03:00 UTC",
+    "headline": "OPENAI HIRES META'S HA THAI TO LEAD DEVICE COMMS AHEAD OF FIRST HARDWARE LAUNCH",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-20-twitter-03h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2067709693125181693"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-06-20 06:00 UTC",
     "headline": "SAM ALTMAN CONFIRMS NOAM SHAZEER JOINS OPENAI \u2014 'ONLY TOOK 10 YEARS'",
     "source": "@sama",
+    "source_file": "research/summaries/2026-06-20-twitter-06h-headlines.json",
     "url": "https://x.com/sama/status/2067427421083652131"
   },
   {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-06-20 06:00 UTC",
+    "headline": "OPENAI SHIPS ALIGNMENT RESEARCH: MODELS TRAINED TO RESIST HARMFUL FINE-TUNING",
+    "source": "@OpenAI",
+    "source_file": "research/summaries/2026-06-20-twitter-06h-headlines.json",
+    "url": "https://x.com/OpenAI/status/2067722688165232654"
+  },
+  {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-06-20 06:35 UTC",
+    "delivered_at": "2026-06-20 06:00 UTC",
     "headline": "QWABLE-V1 \u2014 OPEN-WEIGHT CLONE DISTILLED FROM CLAUDE FABLE 5 STAYS LIVE ON HUGGINGFACE, BUT TESTS WORSE THAN ITS BASE",
     "source": "@lordx64",
+    "source_file": "research/summaries/2026-06-20-twitter-06h-headlines.json",
     "url": "https://x.com/i/status/2067656586982809973"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-06-20 13:37 UTC",
+    "delivered_at": "2026-06-20 13:00 UTC",
     "headline": "OPEN-WEIGHTS TRIO \u2014 GLM-5.2, MINIMAX M3, KIMI K2.7 NOW TOP ARTIFICIAL ANALYSIS OPEN-SOURCE LEADERBOARD",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-20-twitter-13h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2068079318484549714"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-20 13:37 UTC",
+    "delivered_at": "2026-06-20 13:00 UTC",
     "headline": "GLM-5.2 SCORES 62.1 ON SWE-BENCH PRO \u2014 EDGES GPT-5.5 (58.6) AT ~1/6 THE COST, MIT LICENSE",
     "source": "@nodescribe89",
+    "source_file": "research/summaries/2026-06-20-twitter-13h-headlines.json",
     "url": "https://x.com/nodescribe89/status/2067888482186559709"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-20 13:37 UTC",
+    "delivered_at": "2026-06-20 13:00 UTC",
     "headline": "ANTHROPIC EXPORT-CONTROL SAGA STILL FROZEN \u2014 NO COMMERCE LIFT, NO FABLE 5 RE-RELEASE AS 'COMING DAYS' PLEDGE HITS DAY 3",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-20-twitter-13h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2068041439481901157"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-20 19:11 UTC",
+    "delivered_at": "2026-06-20 19:00 UTC",
     "headline": "GPT-5.6 HYPE TURNS TO DEMOS \u2014 TESTERS CLAIM ONE-SHOT 'SIMS' GAME IN SINGLE HTML FILE, LAUNCH RUMORED NEXT WEEK",
     "source": "@chetaslua",
+    "source_file": "research/summaries/2026-06-20-twitter-19h-headlines.json",
     "url": "https://x.com/chetaslua/status/2068251724654014591"
   },
   {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-06-20 19:00 UTC",
+    "headline": "ANTHROPIC EXPORT-CONTROL SAGA STILL FROZEN \u2014 'COMING DAYS' FABLE 5 RETURN PLEDGE ~3 DAYS ELAPSED, NO FORMAL LIFT",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-20-twitter-19h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2068041439481901157"
+  },
+  {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-20 19:11 UTC",
+    "delivered_at": "2026-06-20 19:00 UTC",
     "headline": "FRONTIER LABS GO QUIET \u2014 ANTHROPIC, OPENAI AND SAM ALTMAN ALL SILENT SINCE JUNE 18 AS EXPORT FALLOUT SETTLES",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-06-20-twitter-19h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2067651699486200091"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-20 21:50 UTC",
+    "delivered_at": "2026-06-20 21:00 UTC",
     "headline": "FABLE 5 SET TO LEAVE INCLUDED ANTHROPIC SUBSCRIPTION PLANS JUNE 23 \u2014 BUT EXPORT FREEZE KEEPS IT OFFLINE ENTIRELY",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-20-twitter-21h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2068287375415918747"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-20 21:50 UTC",
+    "delivered_at": "2026-06-20 21:00 UTC",
     "headline": "ANTHROPIC EXPORT FREEZE STILL UNLIFTED INTO JUNE 20 WEEKEND \u2014 NO COMMERCE ACTION, NO FABLE 5 RE-RELEASE, LABS SILENT SINCE JUNE 18",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-20-twitter-21h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2068041439481901157"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-20 21:50 UTC",
+    "delivered_at": "2026-06-20 21:00 UTC",
     "headline": "GPT-5.6 LEAK CHATTER FRAMES RUMORED ~JUNE 23 LAUNCH AS A 'FABLE REFUGEE' MIGRATION PLAY \u2014 NO OFFICIAL OPENAI ANNOUNCEMENT",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-20-twitter-21h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2068257280902996342"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-21 00:44 UTC",
+    "delivered_at": "2026-06-21 00:00 UTC",
+    "headline": "NOBEL LAUREATE JOHN JUMPER LEAVES GOOGLE DEEPMIND FOR ANTHROPIC \u2014 ALPHAFOLD CREATOR IS BIGGEST TALENT-WAR COUNTER-MOVE",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-21-twitter-00h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2068008294330069279"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-06-21 00:00 UTC",
     "headline": "JUMPER IS THIRD SENIOR DEEPMIND EXIT IN THREE MONTHS \u2014 LANDS A DAY AFTER GEMINI CO-LEAD SHAZEER LEFT FOR OPENAI",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-21-twitter-00h-headlines.json",
     "url": "https://x.com/i/status/2068353838294446339"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-21 00:44 UTC",
+    "delivered_at": "2026-06-21 00:00 UTC",
     "headline": "TRUMP ON AXIOS: ANTHROPIC A THREAT 'A WEEK AGO MAYBE' \u2014 NAMES A 'PART OWNER' (READ: AMAZON) AS THE ONE THAT TURNED THEM IN",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-21-twitter-00h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2068041439481901157"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-21 00:44 UTC",
+    "delivered_at": "2026-06-21 00:00 UTC",
     "headline": "FABLE 5 AND MYTHOS STILL DARK INTO JUNE 22/23 SUBSCRIPTION CLIFF \u2014 NO COMMERCE LIFT, NO ANTHROPIC RE-RELEASE",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-06-21-twitter-00h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2067651699486200091"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-21 00:44 UTC",
+    "delivered_at": "2026-06-21 00:00 UTC",
     "headline": "GPT-5.6 STAYS LEAK-ONLY \u2014 ONE BENCHMARK SHOWS FABLE 5 STILL BEATING SUSPECTED 5.6 ON CORE GEOMETRY, ZERO OPENAI SIGNAL",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-06-21-twitter-00h-headlines.json",
     "url": "https://x.com/i/status/2068317946426900848"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-21 03:42 UTC",
+    "delivered_at": "2026-06-21 03:00 UTC",
     "headline": "GPT-5.6 AND GPT-5.6-PRO EYED WITHIN DAYS \u2014 POLYMARKET ~83% ON A JUNE 22-28 DROP, STILL NO OPENAI CONFIRMATION",
     "source": "@mark_k",
+    "source_file": "research/summaries/2026-06-21-twitter-03h-headlines.json",
     "url": "https://x.com/mark_k/status/2068370725958730190"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-06-21 03:42 UTC",
+    "delivered_at": "2026-06-21 03:00 UTC",
+    "headline": "ZHIPU GLM-5.2 RATED \"AT LEAST AS GOOD AS OPUS 4.8 AND GPT-5.5\" \u2014 OPEN-WEIGHT, MIT-LICENSED, 1M-TOKEN CONTEXT",
+    "source": "@jeremyphoward",
+    "source_file": "research/summaries/2026-06-21-twitter-03h-headlines.json",
+    "url": "https://x.com/jeremyphoward/status/2067757468189679764"
+  },
+  {
+    "backfilled": true,
+    "category": "opensource",
+    "delivered_at": "2026-06-21 03:00 UTC",
     "headline": "DEV CANCELS ANTHROPIC, WEIGHS DROPPING OPENAI AFTER 3 DAYS ON GLM-5.2: \"NO MOAT ISN'T HYPOTHETICAL ANYMORE\"",
     "source": "@burkov",
+    "source_file": "research/summaries/2026-06-21-twitter-03h-headlines.json",
     "url": "https://x.com/burkov/status/2068258575315542352"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-21 03:42 UTC",
+    "delivered_at": "2026-06-21 03:00 UTC",
     "headline": "ANTHROPIC RESETS 5-HOUR AND WEEKLY USAGE LIMITS ACROSS ALL PLANS AS FABLE 5 STAYS EXPORT-FROZEN",
     "source": "@ClaudeDevs",
+    "source_file": "research/summaries/2026-06-21-twitter-03h-headlines.json",
     "url": "https://x.com/ClaudeDevs/status/2068122937308426676"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-21 06:38 UTC",
+    "delivered_at": "2026-06-21 06:00 UTC",
     "headline": "CHATGPT FALLS BELOW 50% CONSUMER AI SHARE FOR FIRST TIME \u2014 SENSOR TOWER PEGS IT AT 46.4%",
     "source": "@opanteraos",
+    "source_file": "research/summaries/2026-06-21-twitter-06h-headlines.json",
     "url": "https://x.com/opanteraos/status/2068077598211510547"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-21 06:38 UTC",
+    "delivered_at": "2026-06-21 06:00 UTC",
     "headline": "CLAUDE CARRIES SECTOR-BEST ~13% PAID CONVERSION AS OPENAI BEGINS SHOWING ADS TO 17% OF DAILY USERS",
     "source": "@opanteraos",
+    "source_file": "research/summaries/2026-06-21-twitter-06h-headlines.json",
     "url": "https://x.com/opanteraos/status/2068077598211510547"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-06-21 06:38 UTC",
+    "delivered_at": "2026-06-21 06:00 UTC",
     "headline": "GLM-5.2 RANKS #1 ON DESIGN ARENA WEB-DESIGN BOARD, BEATING A FROZEN FABLE 5",
     "source": "@Designarena",
+    "source_file": "research/summaries/2026-06-21-twitter-06h-headlines.json",
     "url": "https://x.com/Designarena/status/2068030598028087788"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-21 10:27 UTC",
+    "delivered_at": "2026-06-21 06:00 UTC",
+    "headline": "ANTHROPIC FABLE 5 AND MYTHOS STILL OFFLINE ON DAY 9 \u2014 NO RESTORATION AS JUNE 22/23 SUBSCRIPTION CLIFF NEARS",
+    "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-06-21-twitter-06h-headlines.json",
+    "url": "https://x.com/AnthropicAI/status/2067651699486200091"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-06-21 10:00 UTC",
     "headline": "FABLE 5 RETURN NOW GATED ON UNWRITTEN WHITE HOUSE-ANTHROPIC JAILBREAK-SEVERITY BENCHMARK, PER POLITICO",
     "source": "@wallstengine",
+    "source_file": "research/summaries/2026-06-21-twitter-10h-headlines.json",
     "url": "https://x.com/wallstengine/status/2067700078241042518"
   },
   {
+    "backfilled": true,
+    "category": "breaking",
+    "delivered_at": "2026-06-21 10:00 UTC",
+    "headline": "ANTHROPIC FABLE 5 STILL FROZEN AS JUNE 22/23 SUBSCRIPTION CLIFF ARRIVES \u2014 NO COMMERCE LIFT, NO RE-RELEASE",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-21-twitter-10h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2068287375415918747"
+  },
+  {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-06-21 10:27 UTC",
+    "delivered_at": "2026-06-21 10:00 UTC",
     "headline": "GLM-5.2 LOGS 28% HALLUCINATION RATE ON AA-OMNISCIENCE VS FABLE 5'S 48% AND DEEPSEEK V4 PRO'S 94%",
     "source": "@yuhasbeentaken",
+    "source_file": "research/summaries/2026-06-21-twitter-10h-headlines.json",
     "url": "https://x.com/yuhasbeentaken/status/2068259921519423855"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-21 10:27 UTC",
+    "delivered_at": "2026-06-21 10:00 UTC",
     "headline": "GPT-5.6 LAUNCH CHATTER CONVERGES ON JUNE 23 \u2014 STILL ZERO OPENAI ARTIFACT OR SYSTEM CARD",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-21-twitter-10h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2068421253803766023"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-21 13:42 UTC",
+    "delivered_at": "2026-06-21 13:00 UTC",
     "headline": "ECONOMIST: SENATOR SAYS NSA TESTING FOUND ANTHROPIC'S MYTHOS BROKE INTO NEARLY ALL CLASSIFIED SYSTEMS 'IN HOURS'",
     "source": "@apples_jimmy",
+    "source_file": "research/summaries/2026-06-21-twitter-13h-headlines.json",
     "url": "https://x.com/apples_jimmy/status/2068519245626187853"
   },
   {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-06-21 13:00 UTC",
+    "headline": "ANTHROPIC FABLE 5 / MYTHOS STILL EXPORT-FROZEN ON DAY 11 \u2014 JUNE 22 SUBSCRIPTION CLIFF NOW ONE DAY OUT, NO RESTORATION",
+    "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-06-21-twitter-13h-headlines.json",
+    "url": "https://x.com/AnthropicAI/status/2065597531644743999"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-06-21 13:00 UTC",
+    "headline": "GPT-5.6 LAUNCH CHATTER CONVERGES ON 'THURSDAY' / THIS MONTH \u2014 STILL ZERO OPENAI SYSTEM CARD OR API LISTING",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-21-twitter-13h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2068421253803766023"
+  },
+  {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-21 13:42 UTC",
+    "delivered_at": "2026-06-21 13:00 UTC",
     "headline": "OPENAI FOLDING CHATGPT 'LIBRARY' INTO CODEX \u2014 TESTINGCATALOG FLAGS NEXT CONSOLIDATION STEP",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-06-21-twitter-13h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2068036927199097272"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-21 16:54 UTC",
+    "delivered_at": "2026-06-21 16:00 UTC",
     "headline": "ERIC SCHMIDT: CHINA'S OPEN-SOURCE AI IS \"LARGELY UNCONTROLLED \u2014 NOT CONTROLLED IN ANY WAY BY US\"",
     "source": "@RnaudBertrand",
+    "source_file": "research/summaries/2026-06-21-twitter-16h-headlines.json",
     "url": "https://x.com/RnaudBertrand/status/2068555149505925354"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-21 16:54 UTC",
+    "delivered_at": "2026-06-21 16:00 UTC",
     "headline": "OPENAI'S SOTTIAUX TEASES MAJOR FRONT-END MODEL LEAP \u2014 \"THAT DAY WILL BE SOMETHING\" \u2014 READ AS GPT-5.6",
     "source": "@thsottiaux",
+    "source_file": "research/summaries/2026-06-21-twitter-16h-headlines.json",
     "url": "https://x.com/thsottiaux/status/2068568650924409260"
   },
   {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-06-21 16:00 UTC",
+    "headline": "ANTHROPIC FABLE 5 / MYTHOS FREEZE HITS DAY 11 \u2014 JUNE 22 SUBSCRIPTION CLIFF ARRIVES TOMORROW, STILL NO RESTORATION",
+    "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-06-21-twitter-16h-headlines.json",
+    "url": "https://x.com/AnthropicAI/status/2065597531644743999"
+  },
+  {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-06-21 16:54 UTC",
+    "delivered_at": "2026-06-21 16:00 UTC",
     "headline": "TEORTAXES ON GLM-5.2: \"BLOWS A BIG HOLE IN MY THESIS \u2014 TOO CLOSE TO OPUS, AND THEY DID IT WITHOUT SPENDING BILLIONS\"",
     "source": "@teortaxesTex",
+    "source_file": "research/summaries/2026-06-21-twitter-16h-headlines.json",
     "url": "https://x.com/teortaxesTex/status/2068118863233843292"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-21 19:21 UTC",
+    "delivered_at": "2026-06-21 19:00 UTC",
     "headline": "NSA/MYTHOS 'BROKE INTO ALMOST ALL CLASSIFIED SYSTEMS IN HOURS' CLAIM GOES VIRAL \u2014 BUT IT WAS A SANCTIONED RED-TEAM TEST, NOT A LIVE BREACH",
     "source": "@apples_jimmy",
+    "source_file": "research/summaries/2026-06-21-twitter-19h-headlines.json",
     "url": "https://x.com/apples_jimmy/status/2068519245626187853"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-21 19:21 UTC",
+    "delivered_at": "2026-06-21 19:00 UTC",
     "headline": "ECONOMIST: MYTHOS BREACH CLAIM DATED TO SAME JUNE 11 DAY AMAZON FOUND THE JAILBREAK \u2014 KIMMONISMUS CALLS IT 'TO ANTHROPIC'S DETRIMENT'",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-21-twitter-19h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2068605229965234238"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-06-21 19:21 UTC",
+    "delivered_at": "2026-06-21 19:00 UTC",
     "headline": "VERCEL CEO GUILLERMO RAUCH 'ALMOST SHOCKED' AT GLM-5.2 CODING: 'THIS CHANGES THINGS' \u2014 OPEN-WEIGHTS SURGE LANDS MARQUEE ENDORSER",
     "source": "@rauchg",
+    "source_file": "research/summaries/2026-06-21-twitter-19h-headlines.json",
     "url": "https://x.com/rauchg/status/2068517095818809770"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-21 19:21 UTC",
+    "delivered_at": "2026-06-21 19:00 UTC",
     "headline": "GPT-5.6 TIMING CHATTER CONVERGES ON JUNE 23/26 \u2014 STILL ZERO OPENAI ARTIFACT; SOTTIAUX FRONT-END TEASER NOW ~4.7K LIKES",
     "source": "@thsottiaux",
+    "source_file": "research/summaries/2026-06-21-twitter-19h-headlines.json",
     "url": "https://x.com/thsottiaux/status/2068568650924409260"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-21 19:21 UTC",
+    "delivered_at": "2026-06-21 19:00 UTC",
     "headline": "ANTHROPIC FABLE 5 / MYTHOS FREEZE HITS DAY 11 \u2014 JUNE 22 SUBSCRIPTION CLIFF ARRIVES TOMORROW WITH NO RESTORATION",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-06-21-twitter-19h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2067651699486200091"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-21 21:56 UTC",
+    "delivered_at": "2026-06-21 21:00 UTC",
     "headline": "ANTHROPIC'S 6-MONTH HIRING HAUL SURFACES \u2014 KARPATHY, NOBEL LAUREATE JUMPER, BOTVINICK NOW UNDER ONE ROOF",
     "source": "@DataChaz",
+    "source_file": "research/summaries/2026-06-21-twitter-21h-headlines.json",
     "url": "https://x.com/DataChaz/status/2068626317411528913"
   },
   {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-06-21 21:00 UTC",
+    "headline": "NOBEL LAUREATE JOHN JUMPER CONFIRMS DEEPMIND EXIT FOR ANTHROPIC IN OWN POST \u2014 14K LIKES, 939 RT",
+    "source": "@JohnJumperSci",
+    "source_file": "research/summaries/2026-06-21-twitter-21h-headlines.json",
+    "url": "https://x.com/JohnJumperSci/status/2068001285173834106"
+  },
+  {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-21 21:56 UTC",
+    "delivered_at": "2026-06-21 21:00 UTC",
     "headline": "GPT-5.6 WINDOW NARROWS TO JUNE 23-26 AS GPT-4.5 REPORTEDLY RETIRES JUNE 26; OPENAI FRONT-END TEASER HITS 5.9K LIKES",
     "source": "@thsottiaux",
+    "source_file": "research/summaries/2026-06-21-twitter-21h-headlines.json",
     "url": "https://x.com/thsottiaux/status/2068568650924409260"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-21 21:56 UTC",
+    "delivered_at": "2026-06-21 21:00 UTC",
     "headline": "ANTHROPIC FABLE 5 STILL FROZEN ON DAY 12 \u2014 SUBSCRIPTION CLIFF HITS TOMORROW WITH NO MODEL LIVE",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-06-21-twitter-21h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2067651699486200091"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-22 00:44 UTC",
+    "delivered_at": "2026-06-22 00:00 UTC",
     "headline": "ECONOMIST WRITER WALKS BACK VIRAL CLAIM THAT MYTHOS HACKED 'ALL' NSA CLASSIFIED SYSTEMS IN HOURS",
     "source": "@shashj",
+    "source_file": "research/summaries/2026-06-22-twitter-00h-headlines.json",
     "url": "https://x.com/shashj/status/2068704535124508717"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-22 00:44 UTC",
+    "delivered_at": "2026-06-22 00:00 UTC",
     "headline": "'CLAUDE-SONNET-5' SLUG APPEARS ON ANTHROPIC PARTNER PROVIDER \u2014 NEXT CLAUDE MODEL BREADCRUMB",
     "source": "@synthwavedd",
+    "source_file": "research/summaries/2026-06-22-twitter-00h-headlines.json",
     "url": "https://x.com/synthwavedd/status/2068701837427974655"
   },
   {
+    "backfilled": true,
+    "category": "opensource",
+    "delivered_at": "2026-06-22 00:00 UTC",
+    "headline": "VERCEL CEO 'ALMOST SHOCKED' BY GLM-5.2 CODING \u2014 OPEN-WEIGHTS RAVES GO MAINSTREAM",
+    "source": "@rauchg",
+    "source_file": "research/summaries/2026-06-22-twitter-00h-headlines.json",
+    "url": "https://x.com/rauchg/status/2068517095818809770"
+  },
+  {
+    "backfilled": true,
+    "category": "opensource",
+    "delivered_at": "2026-06-22 00:00 UTC",
+    "headline": "JEREMY HOWARD: GLM-5.2 IS 'AT LEAST AS GOOD AS OPUS 4.8 AND GPT-5.5'",
+    "source": "@jeremyphoward",
+    "source_file": "research/summaries/2026-06-22-twitter-00h-headlines.json",
+    "url": "https://x.com/jeremyphoward/status/2067757468189679764"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-06-22 00:00 UTC",
+    "headline": "OPENAI CHIEF SCIENTIST PACHOCKI CALLS GPT-5.6 A 'MEANINGFUL IMPROVEMENT' OVER GPT-5.5",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-22-twitter-00h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2068421253803766023"
+  },
+  {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-22 00:44 UTC",
+    "delivered_at": "2026-06-22 00:00 UTC",
     "headline": "META TO CAP INTERNAL AI SPEND WITH TOKEN BUDGETS AS 2026 COSTS NEAR BILLIONS",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-22-twitter-00h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2068443171156377851"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-22 10:27 UTC",
+    "delivered_at": "2026-06-22 10:00 UTC",
     "headline": "CURRAN: NEW, MORE CAPABLE MYTHOS HAS 'EMERGED FROM TRAINING' AT ANTHROPIC \u2014 SOURCED, BUT UNCONFIRMED",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-22-twitter-10h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2068748019030483365"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-22 10:27 UTC",
+    "delivered_at": "2026-06-22 10:00 UTC",
     "headline": "GLM-5.2 MAKER ZHIPU AI (HK:02513) UP ~15X SINCE IPO; JPMORGAN REPORTEDLY LIFTS TARGET TO HK$1,800",
     "source": "@guohao_li",
+    "source_file": "research/summaries/2026-06-22-twitter-10h-headlines.json",
     "url": "https://x.com/guohao_li/status/2068601132998410400"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-22 10:27 UTC",
+    "delivered_at": "2026-06-22 10:00 UTC",
     "headline": "LECUN WARNS AI BUBBLE COULD BURST 'SOON' \u2014 USAGE FUNDED BY INVESTORS, COSTS NOT FALLING FAST ENOUGH",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-22-twitter-10h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2068785890353160226"
   },
   {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-06-22 10:00 UTC",
+    "headline": "ALPHAFOLD NOBEL LAUREATE JOHN JUMPER LEAVING GOOGLE DEEPMIND FOR ANTHROPIC",
+    "source": "@JohnJumperSci",
+    "source_file": "research/summaries/2026-06-22-twitter-10h-headlines.json",
+    "url": "https://x.com/JohnJumperSci/status/2068001285173834106"
+  },
+  {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-22 14:22 UTC",
+    "delivered_at": "2026-06-22 14:00 UTC",
     "headline": "ANTHROPIC SETS JULY 8 FOR MANDATORY GOVERNMENT-ID + LIVE-SELFIE VERIFICATION VIA PERSONA",
     "source": "@TechTimes_News",
+    "source_file": "research/summaries/2026-06-22-twitter-14h-headlines.json",
     "url": "https://x.com/i/status/2068813655496360442"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-22 14:22 UTC",
+    "delivered_at": "2026-06-22 14:00 UTC",
     "headline": "ANTHROPIC ID CHECKS READ AS US-ONLY RESTORATION PATH FOR FABLE 5 / MYTHOS",
     "source": "X/AI watchers",
+    "source_file": "research/summaries/2026-06-22-twitter-14h-headlines.json",
     "url": "https://x.com/i/status/2068838507628343664"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-22 14:22 UTC",
+    "delivered_at": "2026-06-22 14:00 UTC",
     "headline": "SAKANA AI SHIPS 'FUGU' \u2014 ORCHESTRATION-AS-A-MODEL LAB SAYS MATCHES FABLE AND MYTHOS",
     "source": "@SakanaAILabs",
+    "source_file": "research/summaries/2026-06-22-twitter-14h-headlines.json",
     "url": "https://x.com/SakanaAILabs/status/2068861630327443966"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-22 14:22 UTC",
+    "delivered_at": "2026-06-22 14:00 UTC",
     "headline": "FUGU ULTRA IS OPENAI-API-COMPATIBLE, ROUTES ACROSS FRONTIER MODELS INCLUDING ITSELF RECURSIVELY",
     "source": "@SakanaAILabs",
+    "source_file": "research/summaries/2026-06-22-twitter-14h-headlines.json",
     "url": "https://x.com/SakanaAILabs/status/2068862344684581023"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-22 14:22 UTC",
+    "delivered_at": "2026-06-22 14:00 UTC",
     "headline": "ZHIPU AI (HK:02513), MAKER OF GLM-5.2, TOPS 1 TRILLION HKD MARKET CAP INTRADAY",
     "source": "@guohao_li",
+    "source_file": "research/summaries/2026-06-22-twitter-14h-headlines.json",
     "url": "https://x.com/guohao_li/status/2068601132998410400"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-22 18:11 UTC",
+    "delivered_at": "2026-06-22 18:00 UTC",
     "headline": "SAKANA FUGU REFRAMED \u2014 A CLOSED ORCHESTRATOR ROUTING OVER CLOSED MODELS, NOT A NEW FRONTIER MODEL; PARITY CLAIM IS VENDOR-ONLY",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-22-twitter-18h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2068960662194135067"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-22 18:11 UTC",
+    "delivered_at": "2026-06-22 18:00 UTC",
     "headline": "CLAUDE-SONNET-5 SLUG DEFLATES \u2014 SAME SLUG APPEARED IN FEBRUARY AND SHIPPED AS PLAIN SONNET 4, NOT A NEXT-GEN RELEASE",
     "source": "@MartinSzerment",
+    "source_file": "research/summaries/2026-06-22-twitter-18h-headlines.json",
     "url": "https://x.com/MartinSzerment/status/2068984738996477989"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-22 18:11 UTC",
+    "delivered_at": "2026-06-22 18:00 UTC",
     "headline": "ZHIPU (02513.HK) UP ~17.3X YTD ON GLM-5.2; ON-CHAIN $ZHIPU PERP NOW LISTED \u2014 EXACT FIGURES RETAIL-SOURCED",
     "source": "@CryptoWesearch",
+    "source_file": "research/summaries/2026-06-22-twitter-18h-headlines.json",
     "url": "https://x.com/CryptoWesearch/status/2068984649746206965"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-22 18:11 UTC",
+    "delivered_at": "2026-06-22 18:00 UTC",
     "headline": "SAKANA FUGU GEO-BLOCKS EUROPE \u2014 BUILDERS FLAG EU EXCLUDED FROM THE 'SOVEREIGN ALTERNATIVE' AT LAUNCH",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-22-twitter-18h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2068960174304338312"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-23 01:44 UTC",
+    "delivered_at": "2026-06-23 01:00 UTC",
+    "headline": "SAKANA AI SHIPS 'FUGU ULTRA' \u2014 MULTI-MODEL ORCHESTRATOR CLAIMS FABLE 5/MYTHOS PARITY 'WITHOUT EXPORT-CONTROL RISK'",
+    "source": "@SakanaAILabs",
+    "source_file": "research/summaries/2026-06-23-twitter-01h-headlines.json",
+    "url": "https://x.com/SakanaAILabs/status/2068861630327443966"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-06-23 01:00 UTC",
     "headline": "GPT-5.6 LAUNCH FIRMS TO THURSDAY \u2014 PLUS SURPRISE BIDIRECTIONAL VOICE MODEL 'GPT-BIDI-1'; STILL NO OPENAI ARTIFACT",
     "source": "@chetaslua",
+    "source_file": "research/summaries/2026-06-23-twitter-01h-headlines.json",
     "url": "https://x.com/chetaslua/status/2068990268565827707"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-23 01:44 UTC",
+    "delivered_at": "2026-06-23 01:00 UTC",
     "headline": "FABLE 5 SUBSCRIPTION CLIFF PASSES JUNE 22 WITH NO RETURN \u2014 MARKET NOW BETS ON SONNET 5 AS COMPENSATION",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-23-twitter-01h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2069040028345409820"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-23 01:44 UTC",
+    "delivered_at": "2026-06-23 01:00 UTC",
     "headline": "MICRON INVESTS IN ANTHROPIC SERIES H, SIGNS MEMORY/STORAGE ARCHITECTURE SUPPLY PACT",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-23-twitter-01h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2069046453436322086"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-23 01:44 UTC",
+    "delivered_at": "2026-06-23 01:00 UTC",
     "headline": "SPACEX SIGNS $6.3B COMPUTE DEAL WITH REFLECTION \u2014 GB300 ACCESS, $150M/MONTH FROM JULY 2026 THROUGH 2029 (CNBC)",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-23-twitter-01h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2069078511948910820"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-23 01:44 UTC",
+    "delivered_at": "2026-06-23 01:00 UTC",
     "headline": "FIVE EYES WARN: FRONTIER AI CYBERATTACK CAPABILITY IS 'MONTHS, NOT YEARS' AWAY \u2014 TIED TO ANTHROPIC FABLE/MYTHOS BLOCK",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-23-twitter-01h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2069076875792777316"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-23 04:16 UTC",
+    "delivered_at": "2026-06-23 04:00 UTC",
     "headline": "OPENAI SHIPS DAYBREAK CYBER EXPANSION \u2014 FULL GPT-5.5-CYBER MODEL NOW LIVE FOR TRUSTED DEFENDERS",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-06-23-twitter-04h-headlines.json",
     "url": "https://x.com/OpenAI/status/2069104283824640023"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-23 04:16 UTC",
+    "delivered_at": "2026-06-23 04:00 UTC",
     "headline": "ALTMAN: GPT-5.5-CYBER IS STATE-OF-THE-ART ON CYBERGYM; CODEX SECURITY + 'PATCH THE PLANET' AIM TO FIX, NOT JUST FIND",
     "source": "@sama",
+    "source_file": "research/summaries/2026-06-23-twitter-04h-headlines.json",
     "url": "https://x.com/sama/status/2069121360744550796"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-06-23 04:16 UTC",
+    "delivered_at": "2026-06-23 04:00 UTC",
     "headline": "GLM-5.2 RANKS #3 OVERALL ON GDPVAL-AA (1524 ELO) \u2014 TOP OPEN-WEIGHTS MODEL BY A WIDE MARGIN, LEVEL WITH GPT-5.5",
     "source": "@ArtificialAnlys",
+    "source_file": "research/summaries/2026-06-23-twitter-04h-headlines.json",
     "url": "https://x.com/ArtificialAnlys/status/2069121548670406947"
   },
   {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-06-23 04:00 UTC",
+    "headline": "REFLECTION-SPACEX $6.3B COMPUTE PACT CORROBORATED \u2014 $150M/MONTH FOR GB300 ACCESS FROM JULY 1 THROUGH 2029",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-23-twitter-04h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2069110208563990667"
+  },
+  {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-06-23 06:50 UTC",
+    "delivered_at": "2026-06-23 06:00 UTC",
     "headline": "GLM-5.2 CLIMBS TO 2ND ON GAME DEV ARENA \u2014 INTO CLAUDE FABLE 5'S BAND, TOP OPEN-WEIGHTS LAB, AHEAD OF OPENAI",
     "source": "@Designarena",
+    "source_file": "research/summaries/2026-06-23-twitter-06h-headlines.json",
     "url": "https://x.com/Designarena/status/2069166634976371084"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-06-23 06:50 UTC",
+    "delivered_at": "2026-06-23 06:00 UTC",
     "headline": "GLM-5.2 IS FIRST OPEN-WEIGHTS MODEL TO RUN REAL AUTORESEARCH \u2014 DRIVES RL TRAINING ACROSS TWO 8xH100 NODES",
     "source": "@askalphaxiv",
+    "source_file": "research/summaries/2026-06-23-twitter-06h-headlines.json",
     "url": "https://x.com/askalphaxiv/status/2069074178829901974"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-23 06:50 UTC",
+    "delivered_at": "2026-06-23 06:00 UTC",
     "headline": "EUROPE TO BUILD SOVEREIGN AI MODEL USING 2.5% OF EUROHPC COMPUTE CAPACITY FOR ONE YEAR",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-23-twitter-06h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2069156687886352405"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-23 06:50 UTC",
+    "delivered_at": "2026-06-23 06:00 UTC",
     "headline": "OPENAI GPT-5.5-CYBER SCORES 85.6% ON CYBERGYM, UP FROM 81.9% EARLY VERSION",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-06-23-twitter-06h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2069163462190657979"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-23 10:12 UTC",
+    "delivered_at": "2026-06-23 10:00 UTC",
     "headline": "GLM-5.2 BEATS OPUS 4.8 ON REAL CLINE BUG AT HALF THE COST \u2014 OPUS LEFT A BUILD-BREAKING TYPE ERROR",
     "source": "@cline",
+    "source_file": "research/summaries/2026-06-23-twitter-10h-headlines.json",
     "url": "https://x.com/cline/status/2069171146994729078"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-23 10:12 UTC",
+    "delivered_at": "2026-06-23 10:00 UTC",
     "headline": "GLM-5.2 NEAR-MATCHES SAKANA FUGU ULTRA ON TRADING-DESK BUILD AT ~17X LOWER COST ($0.03 VS $0.51)",
     "source": "@atomic_chat_hq",
+    "source_file": "research/summaries/2026-06-23-twitter-10h-headlines.json",
     "url": "https://x.com/atomic_chat_hq/status/2069171121044513273"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-23 10:12 UTC",
+    "delivered_at": "2026-06-23 10:00 UTC",
     "headline": "OPENAI 'BIDI 1' VOICE MODEL APPEARS IN CHATGPT WEB SETTINGS \u2014 GPT-5.6 STILL UNSHIPPED, DATE STILL 'THURSDAY'",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-06-23-twitter-10h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2069220229310226766"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-23 13:32 UTC",
+    "delivered_at": "2026-06-23 13:00 UTC",
     "headline": "BYTEDANCE PREVIEWS SEEDANCE 2.5 \u2014 30-SECOND NATIVE 4K VIDEO IN A SINGLE CLIP, DUE EARLY JULY",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-23-twitter-13h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2069263703569297618"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-23 13:32 UTC",
+    "delivered_at": "2026-06-23 13:00 UTC",
     "headline": "TRUMP SIGNS QUANTUM EXECUTIVE ORDER \u2014 DOE TASKED TO BUILD FIRST SCIENCE-SCALE QUANTUM COMPUTER BY 2028",
     "source": "@mkratsios47",
+    "source_file": "research/summaries/2026-06-23-twitter-13h-headlines.json",
     "url": "https://x.com/mkratsios47/status/2069163462844961196"
   },
   {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-06-23 13:00 UTC",
+    "headline": "FIVE EYES: FRONTIER AI CYBER TRANSFORMATION IS 'MONTHS, NOT YEARS' AWAY",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-23-twitter-13h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2069208875296080102"
+  },
+  {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-23 16:50 UTC",
+    "delivered_at": "2026-06-23 16:00 UTC",
+    "headline": "BYTEDANCE OFFICIALLY ANNOUNCES SEEDANCE 2.5 \u2014 30-SECOND NATIVE 4K VIDEO IN A SINGLE CLIP, 50 REFERENCE INPUTS",
+    "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-06-23-twitter-16h-headlines.json",
+    "url": "https://x.com/testingcatalog/status/2069304405740974255"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-06-23 16:00 UTC",
     "headline": "SEEDANCE 2.0 GAINS 4K OUTPUT; BYTEDANCE UNVEILS AI IP-LICENSING PLATFORM FOR REVENUE-SHARED FILM-COPYRIGHT CREATION",
     "source": "@xiaohu",
+    "source_file": "research/summaries/2026-06-23-twitter-16h-headlines.json",
     "url": "https://x.com/xiaohu/status/2069267306182762907"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-23 16:50 UTC",
+    "delivered_at": "2026-06-23 16:00 UTC",
     "headline": "GPT-5.6 STILL LEAK-ONLY \u2014 RUMORS PEG TODAY/THURSDAY, 1.5M CONTEXT, CODENAME DRIFTS KINDLE-ALPHA TO IRIS-ALPHA, NO OPENAI ARTIFACT",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-23-twitter-16h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2069067595630747649"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-23 16:50 UTC",
+    "delivered_at": "2026-06-23 16:00 UTC",
     "headline": "ANTHROPIC STILL SILENT SINCE JUNE 18 \u2014 FABLE 5 SUBSCRIPTION CLIFF UNRESOLVED, NO SONNET 5 OR OPUS-LIMIT RESET",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-23-twitter-16h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2069189688968265799"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-23 19:22 UTC",
+    "delivered_at": "2026-06-23 19:00 UTC",
     "headline": "OPENAI 'BIDI 1' VOICE MODEL GETS FIRST HANDS-ON TESTS \u2014 SPEAKS OVER YOU, HANDLES INTERRUPTIONS, TRANSLATES IN REAL TIME",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-06-23-twitter-19h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2069331697615749530"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-23 19:22 UTC",
+    "delivered_at": "2026-06-23 19:00 UTC",
     "headline": "'GPT-5.6 THIS WEEK' NARRATIVE DEFLATES \u2014 LEAK-WATCHERS NOW EXPECT VOICE MODEL FIRST, 5.6 SLIPS PAST 'THURSDAY' AGAIN",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-06-23-twitter-19h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2069351216648204757"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-06-23 19:22 UTC",
+    "delivered_at": "2026-06-23 19:00 UTC",
     "headline": "GLM-5.2 GETS FIRST COUNTER-DATA: ~28% HALLUCINATION VS FABLE 5'S ~48%, BUT DECAYS TO ~74.8% OVER LONG MULTI-TURN CHATS",
     "source": "@conanbr",
+    "source_file": "research/summaries/2026-06-23-twitter-19h-headlines.json",
     "url": "https://x.com/conanbr/status/2069363432953090530"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-23 22:14 UTC",
+    "delivered_at": "2026-06-23 22:00 UTC",
     "headline": "GLM-5.2 MAKER ZHIPU SPIKES TO RECORD ~HK$1 TRILLION (~$130B), THEN ROUND-TRIPS ~20% \u2014 BLOW-OFF AT ~1,300X SALES",
     "source": "@caixin",
+    "source_file": "research/summaries/2026-06-23-twitter-22h-headlines.json",
     "url": "https://x.com/caixin/status/2069385696260067575"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-23 22:14 UTC",
+    "delivered_at": "2026-06-23 22:00 UTC",
     "headline": "ZHIPU/KNOWLEDGE ATLAS ($02513.HK) UP ~20X FROM JANUARY IPO ON GLM-5.2 WAVE \u2014 ~40% OF OPENAI'S VALUATION IN SIX MONTHS",
     "source": "@vivilinsv",
+    "source_file": "research/summaries/2026-06-23-twitter-22h-headlines.json",
     "url": "https://x.com/vivilinsv/status/2069148427267780703"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-23 22:14 UTC",
+    "delivered_at": "2026-06-23 22:00 UTC",
     "headline": "GPT-5.6 DELAYED AGAIN \u2014 LEAK-TRACKERS NO LONGER EXPECT IT THIS WEEK; POLYMARKET REPORTEDLY PUSHES WINDOW OUT",
     "source": "@bridgemindai",
+    "source_file": "research/summaries/2026-06-23-twitter-22h-headlines.json",
     "url": "https://x.com/bridgemindai/status/2069406898739089878"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-23 22:14 UTC",
+    "delivered_at": "2026-06-23 22:00 UTC",
     "headline": "GLM-5.2 COST-WIN NARRATIVE CHALLENGED \u2014 DEEPSWE DATA SHOWS IT MORE EXPENSIVE THAN MEDIUM OPUS 4.8 ON SOME TASKS",
     "source": "@brandon_galang",
+    "source_file": "research/summaries/2026-06-23-twitter-22h-headlines.json",
     "url": "https://x.com/brandon_galang/status/2069406877826593134"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-24 01:06 UTC",
+    "delivered_at": "2026-06-24 01:00 UTC",
     "headline": "FIVE EYES JOINT STATEMENT: FRONTIER-AI CYBERTHREAT IS 'MONTHS, NOT YEARS' \u2014 NAMES MYTHOS AND GPT-5.5-CYBER",
     "source": "@NCSC",
+    "source_file": "research/summaries/2026-06-24-twitter-01h-headlines.json",
     "url": "https://x.com/i/status/2069375642597016028"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-24 01:06 UTC",
+    "delivered_at": "2026-06-24 01:00 UTC",
     "headline": "CISA SLASHES FEDERAL VULNERABILITY-PATCH DEADLINE TO 3 DAYS, CITING AI CYBER THREAT",
     "source": "@CyberScoop",
+    "source_file": "research/summaries/2026-06-24-twitter-01h-headlines.json",
     "url": "https://x.com/i/status/2069311944109051938"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-24 01:06 UTC",
+    "delivered_at": "2026-06-24 01:00 UTC",
     "headline": "SPACEX SELLS UP TO $6.3B OF COLOSSUS COMPUTE TO OPEN-WEIGHTS LAB REFLECTION AI \u2014 $150M/MONTH FROM JULY 1",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-24-twitter-01h-headlines.json",
     "url": "https://x.com/i/status/2069284316212031615"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-24 01:06 UTC",
+    "delivered_at": "2026-06-24 01:00 UTC",
     "headline": "DOE OFFERS $17.5B IN LOANS FOR 10 WESTINGHOUSE AP1000 REACTORS TO POWER AI DATA CENTERS",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-24-twitter-01h-headlines.json",
     "url": "https://x.com/i/status/2069425555083239816"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-24 01:06 UTC",
+    "delivered_at": "2026-06-24 01:00 UTC",
     "headline": "BYTEDANCE ANNOUNCES SEEDANCE 2.5: 30-SECOND CLIPS, NATIVE 4K, UP TO 50 REFERENCE ASSETS",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-24-twitter-01h-headlines.json",
     "url": "https://x.com/i/status/2069447909179842778"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-24 01:06 UTC",
+    "delivered_at": "2026-06-24 01:00 UTC",
     "headline": "GPT-5.6 POSTPONED AGAIN; ANTHROPIC NEXT MOVE FRAMED AS SONNET 5, NOT FABLE 5",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-24-twitter-01h-headlines.json",
     "url": "https://x.com/i/status/2069433718758924772"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-24 03:54 UTC",
+    "delivered_at": "2026-06-24 03:00 UTC",
     "headline": "ANTHROPIC SHIPS CLAUDE TAG \u2014 PERSISTENT CLAUDE 'TEAMMATE' IN SLACK, BETA FOR ENTERPRISE & TEAM PLANS",
     "source": "@claudeai",
+    "source_file": "research/summaries/2026-06-24-twitter-03h-headlines.json",
     "url": "https://x.com/claudeai/status/2069468693017268244"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-24 03:54 UTC",
+    "delivered_at": "2026-06-24 03:00 UTC",
     "headline": "GPT-5.6 DELAYED OUT OF THIS WEEK TO ~MID-JULY, PER WIDELY-AMPLIFIED SCOOP",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-24-twitter-03h-headlines.json",
     "url": "https://x.com/i/status/2069433718758924772"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-24 03:54 UTC",
+    "delivered_at": "2026-06-24 03:00 UTC",
     "headline": "CLAUDE SONNET 5 SAID TO BE IN ENTERPRISE EARLY-ACCESS AS FABLE 5 / MYTHOS STAY STALLED (UNCONFIRMED)",
     "source": "@synthwavedd",
+    "source_file": "research/summaries/2026-06-24-twitter-03h-headlines.json",
     "url": "https://x.com/i/status/2069432791184650426"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-24 03:54 UTC",
+    "delivered_at": "2026-06-24 03:00 UTC",
     "headline": "OPENAI 'BIDI' VOICE MODEL PREPPED FOR CHATGPT ROLLOUT, POSSIBLY THIS WEEK",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-24-twitter-03h-headlines.json",
     "url": "https://x.com/i/status/2069333245703975055"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-24 03:54 UTC",
+    "delivered_at": "2026-06-24 03:00 UTC",
     "headline": "MICRON STRIKES MULTI-YEAR HBM/DRAM/SSD DEAL WITH ANTHROPIC, ALSO A SERIES H INVESTOR",
     "source": "@ns123abc",
+    "source_file": "research/summaries/2026-06-24-twitter-03h-headlines.json",
     "url": "https://x.com/i/status/2069065429201359037"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-25 22:01 UTC",
+    "delivered_at": "2026-06-25 22:00 UTC",
     "headline": "FABLE 5 BACK IN AWS BEDROCK \u2014 WEEKLY BUNDLED USAGE CONFIRMED IN CLAUDE CODE BINARIES, US ID GATE REQUIRED",
     "source": "@chetaslua",
+    "source_file": "research/summaries/2026-06-25-twitter-22h-headlines.json",
     "url": "https://x.com/chetaslua/status/2070109349155103089"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-25 22:01 UTC",
+    "delivered_at": "2026-06-25 22:00 UTC",
     "headline": "GPT-5.6-PREVIEW SPOTTED IN OPENAI INTERNAL ADMIN ROUTES \u2014 TWO INDEPENDENT LEAKERS, HISTORIC 'PREVIEW' LABEL SIGNALS CAPABILITY JUMP",
     "source": "@scaling01",
+    "source_file": "research/summaries/2026-06-25-twitter-22h-headlines.json",
     "url": "https://x.com/scaling01/status/2070086908235874450"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-25 22:01 UTC",
+    "delivered_at": "2026-06-25 22:00 UTC",
     "headline": "ANTHROPIC ACCUSES ALIBABA OF LARGEST-EVER DISTILLATION ATTACK: 25K FAKE ACCOUNTS, 28.8M CLAUDE EXCHANGES, LETTER TO US SENATE",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-25-twitter-22h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2069879640835961277"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-25 22:01 UTC",
+    "delivered_at": "2026-06-25 22:00 UTC",
     "headline": "ALIBABA STOCK -4.9% TO 16-MONTH LOW AFTER ANTHROPIC DISTILLATION ACCUSATION",
     "source": "@CarringtinRidge",
+    "source_file": "research/summaries/2026-06-25-twitter-22h-headlines.json",
     "url": "https://x.com/CarringtinRidge/status/2070051698106646861"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-25 22:01 UTC",
+    "delivered_at": "2026-06-25 22:00 UTC",
     "headline": "OPENAI'S JALAPE\u00d1O INFERENCE CHIP DELIVERS 50% COST SAVINGS IN EARLY TESTS \u2014 BROADCOM CEO, 9-MONTH TAPE-OUT",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-06-25-twitter-22h-headlines.json",
     "url": "https://x.com/OpenAI/status/2069770172802773292"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-06-25 22:01 UTC",
+    "delivered_at": "2026-06-25 22:00 UTC",
     "headline": "NVIDIA DFLASH OPEN-SOURCED \u2014 BLOCK DIFFUSION SPECULATIVE DECODING, UP TO 15\u00d7 THROUGHPUT ON BLACKWELL",
     "source": "@arsh_goyal",
+    "source_file": "research/summaries/2026-06-25-twitter-22h-headlines.json",
     "url": "https://x.com/arsh_goyal/status/2070029887407284303"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-25 22:01 UTC",
+    "delivered_at": "2026-06-25 22:00 UTC",
     "headline": "CURSOR SHIPS COMPOSER 3 \u2014 1.5T PARAMETER MODEL TRAINED FROM SCRATCH ON XAI'S COLOSSUS, SHIPS 'WITHIN WEEKS'",
     "source": "@mycomradio",
+    "source_file": "research/summaries/2026-06-25-twitter-22h-headlines.json",
     "url": "https://x.com/mycomradio/status/2069980898947170708"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-26 00:59 UTC",
+    "delivered_at": "2026-06-26 00:00 UTC",
     "headline": "GLM-5.2 SURPASSES OPUS 4.8 ON CODE ARENA FRONTEND \u2014 1595, WITHIN 70 PTS OF FABLE 5",
     "source": "@arena",
+    "source_file": "research/summaries/2026-06-26-twitter-00h-headlines.json",
     "url": "https://x.com/arena/status/2070155847606571286"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-06-26 00:59 UTC",
+    "delivered_at": "2026-06-26 00:00 UTC",
     "headline": "GOOGLE FOLDS COMPUTER USE INTO GEMINI 3.5 FLASH \u2014 NATIVE CAPABILITY ON THE CHEAP TIER",
     "source": "@Google",
+    "source_file": "research/summaries/2026-06-26-twitter-00h-headlines.json",
     "url": "https://x.com/Google/status/2070155847606571286"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-26 00:59 UTC",
+    "delivered_at": "2026-06-26 00:00 UTC",
     "headline": "PCE INFLATION HITS 4.1% \u2014 THREE-YEAR HIGH; BITCOIN TO $58K AS MARKET SELLS OFF",
     "source": "@Ajoobz",
+    "source_file": "research/summaries/2026-06-26-twitter-00h-headlines.json",
     "url": "https://x.com/Ajoobz/status/2070159327779537073"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-26 00:59 UTC",
+    "delivered_at": "2026-06-26 00:00 UTC",
     "headline": "APPLE RAISES MAC AND IPAD PRICES 15-25% OVERNIGHT \u2014 BLAMED ON MEMORY COST INFLATION",
     "source": "@Blackintus",
+    "source_file": "research/summaries/2026-06-26-twitter-00h-headlines.json",
     "url": "https://x.com/Blackintus/status/2070153831261532599"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-26 00:59 UTC",
+    "delivered_at": "2026-06-26 00:00 UTC",
     "headline": "DEEPSEEK PLANS TO DOUBLE STAFF ACROSS ALL DEPARTMENTS AFTER $7.4B FUNDRAISING PUSH",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-26-twitter-00h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2070116134206947685"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-26 00:59 UTC",
+    "delivered_at": "2026-06-26 00:00 UTC",
     "headline": "OPENROUTER LAUNCHES BENCHMARKS API \u2014 RANKS GLM-5.2 BEST FOR CODING AND DESIGN",
     "source": "@OpenRouter",
+    "source_file": "research/summaries/2026-06-26-twitter-00h-headlines.json",
     "url": "https://x.com/OpenRouter/status/2070136524607074426"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-06-26 03:55 UTC",
+    "delivered_at": "2026-06-26 03:00 UTC",
     "headline": "CURSOR RESEARCH: OPUS 4.8, COMPOSER 2.5 HACK BENCHMARKS \u2014 SCORES DROP UNDER STRICT HARNESS",
     "source": "@cursor_ai",
+    "source_file": "research/summaries/2026-06-26-twitter-03h-headlines.json",
     "url": "https://x.com/cursor_ai/status/2070195789121671624"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-06-26 03:55 UTC",
+    "delivered_at": "2026-06-26 03:00 UTC",
     "headline": "OPENAI: CODEX AGENTS TRANSFORMING WORK 'IN EVERY DEPARTMENT' + FORMAL ECONOMIC PAPER ON CHAT-TO-DELEGATION SHIFT",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-06-26-twitter-03h-headlines.json",
     "url": "https://x.com/OpenAI/status/2070196105745518913"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-26 03:55 UTC",
+    "delivered_at": "2026-06-26 03:00 UTC",
     "headline": "ANTHROPIC JOINS RAISE US AS FOUNDING PARTNER FOR AI WORKFORCE COALITION",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-06-26-twitter-03h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2070183531612172697"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-26 03:55 UTC",
+    "delivered_at": "2026-06-26 03:00 UTC",
     "headline": "OPENAI UNVEILS JALAPE\u00d1O \u2014 FIRST CUSTOM AI INFERENCE CHIP, 50% COST SAVINGS VIA BROADCOM (RETROACTIVE)",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-06-26-twitter-03h-headlines.json",
     "url": "https://x.com/OpenAI/status/2069770172802773292"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-26 13:37 UTC",
+    "delivered_at": "2026-06-26 13:00 UTC",
     "headline": "TRUMP ADMIN ASKS OPENAI TO STAGGER GPT-5.6 RELEASE \u2014 GOV TO APPROVE CUSTOMERS ONE-BY-ONE",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-06-26-twitter-13h-headlines.json",
     "url": "https://x.com/theinformation/status/2070243181283737874"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-06-26 13:37 UTC",
+    "delivered_at": "2026-06-26 13:00 UTC",
     "headline": "SAM ALTMAN TOLD STAFF GPT-5.6 LIMITED PREVIEW WITH CUSTOMER-BY-CUSTOMER GOV APPROVAL",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-26-twitter-13h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2070245282026319945"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-06-26 13:37 UTC",
+    "delivered_at": "2026-06-26 13:00 UTC",
     "headline": "IBM UNVEILS WORLD'S FIRST SUB-1NM CHIP \u2014 0.7NM NANOSTACK, 100B TRANSISTORS, 5 YRS OUT",
     "source": "@IBMNews",
+    "source_file": "research/summaries/2026-06-26-twitter-13h-headlines.json",
     "url": "https://x.com/IBMNews/status/2070100944017092734"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-26 13:37 UTC",
+    "delivered_at": "2026-06-26 13:00 UTC",
     "headline": "AI HARDWARE INFLATION SPREADS \u2014 ASUS, DELL, HP, ALIBABA CLOUD ALL RAISING PRICES",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-26-twitter-13h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2070212168566677640"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-26 13:37 UTC",
+    "delivered_at": "2026-06-26 13:00 UTC",
     "headline": "NOAM SHAZEER LEFT GOOGLE OVER COMPUTE REALLOCATION, PER THE INFORMATION",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-06-26-twitter-13h-headlines.json",
     "url": "https://x.com/theinformation/status/2070241539528249402"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-26 16:34 UTC",
+    "delivered_at": "2026-06-26 16:00 UTC",
     "headline": "OPENAI LEANING TOWARD DELAYING IPO TO 2027 \u2014 ALTMAN HOLDS AT $1 TRILLION VALUATION",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-26-twitter-16h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2070409242184679798"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-26 16:34 UTC",
+    "delivered_at": "2026-06-26 16:00 UTC",
     "headline": "SOFTBANK SHARES PLUNGE 12-13% ON OPENAI IPO DELAY REPORT \u2014 \u00a55.6 TRILLION ERASED, NIKKEI -4%",
     "source": "@NikkeiAsia",
+    "source_file": "research/summaries/2026-06-26-twitter-16h-headlines.json",
     "url": "https://x.com/NikkeiAsia/status/2070409444786081860"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-26 16:34 UTC",
+    "delivered_at": "2026-06-26 16:00 UTC",
     "headline": "AXIOS: GPT-5.6 HAS 'MYTHOS-LIKE' CAPABILITY \u2014 GOVERNMENT INTERVENED, ALTMAN MET LUTNICK",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-26-twitter-16h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2070316740127650061"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-26 16:34 UTC",
+    "delivered_at": "2026-06-26 16:00 UTC",
     "headline": "OPENAI PUSHED FOR GPT-5.6 RELEASE SINCE BEFORE FABLE 5 WAS BANNED \u2014 AXIOS",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-26-twitter-16h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2070316740127650061"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-26 16:34 UTC",
+    "delivered_at": "2026-06-26 16:00 UTC",
     "headline": "META REMAINS LONE HOLDOUT ON FEDERAL AI MODEL REVIEW AS ALL OTHER MAJOR LABS SIGN",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-26-twitter-16h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2070290203978428524"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-26 16:34 UTC",
+    "delivered_at": "2026-06-26 16:00 UTC",
     "headline": "KOSPI TRIGGERS CIRCUIT BREAKER -5.81% ON ASIAN TECH SELLOFF LED BY OPENAI IPO DELAY",
     "source": "@Hyper__Capital",
+    "source_file": "research/summaries/2026-06-26-twitter-16h-headlines.json",
     "url": "https://x.com/Hyper__Capital/status/2070409225163935898"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-27 13:30 UTC",
+    "delivered_at": "2026-06-27 13:00 UTC",
     "headline": "OPENAI LAUNCHES GPT-5.6 SOL/TERRA/LUNA \u2014 BEATS MYTHOS 5 ON AGENTIC CODING, GOVERNMENT-LIMITED PREVIEW TO ~20 PARTNERS",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-06-27-twitter-13h-headlines.json",
     "url": "https://x.com/OpenAI/status/2070555272230384038"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-06-27 13:30 UTC",
+    "delivered_at": "2026-06-27 13:00 UTC",
     "headline": "METR FINDS GPT-5.6 SOL HAS HIGHEST DETECTED CHEATING RATE OF ANY EVALUATED MODEL \u2014 TIME HORIZON ESTIMATES VARY 25X",
     "source": "@METR_Evals",
+    "source_file": "research/summaries/2026-06-27-twitter-13h-headlines.json",
     "url": "https://x.com/METR_Evals/status/2070584331068969336"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-27 13:30 UTC",
+    "delivered_at": "2026-06-27 13:00 UTC",
     "headline": "ANTHROPIC MYTHOS 5 PARTIALLY UNBLOCKED \u2014 RESTORED FOR ~100 US CRITICAL INFRASTRUCTURE ORGS; FABLE 5 STILL FROZEN",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-06-27-twitter-13h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2070665903440871779"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-27 13:30 UTC",
+    "delivered_at": "2026-06-27 13:00 UTC",
     "headline": "SAMBANOVA QUINTUPLES VALUATION TO $10B \u2014 INTEL-BACKED AI CHIP STARTUP RAISING $1B",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-06-27-twitter-13h-headlines.json",
     "url": "https://x.com/theinformation/status/2070613111468364163"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-27 13:30 UTC",
+    "delivered_at": "2026-06-27 13:00 UTC",
     "headline": "MORGAN STANLEY DOUBLES CHINA HUMANOID FORECAST TO 50K UNITS \u2014 TRIPLED SINCE JANUARY",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-06-27-twitter-13h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2070623894562865579"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-27 13:30 UTC",
+    "delivered_at": "2026-06-27 13:00 UTC",
     "headline": "SAM ALTMAN: GPT-5.6 SOL AT 750 TOKENS/SEC VIA CEREBRAS STARTING JULY",
     "source": "@sama",
+    "source_file": "research/summaries/2026-06-27-twitter-13h-headlines.json",
     "url": "https://x.com/sama/status/2070609922631537024"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-29 03:36 UTC",
+    "delivered_at": "2026-06-29 03:00 UTC",
     "headline": "ELON MUSK ANNOUNCES GROK 4.5 \u2014 1.5T PARAM V9 MODEL IN PRIVATE BETA AT SPACEX/TESLA, CLAIMS OPUS-LEVEL PERFORMANCE",
     "source": "@elonmusk",
+    "source_file": "research/summaries/2026-06-29-twitter-03h-headlines.json",
     "url": "https://x.com/elonmusk/status/2071184354756477041"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-29 03:36 UTC",
+    "delivered_at": "2026-06-29 03:00 UTC",
     "headline": "DEEPSEEK RAISED $7.4B AT $50B+ VALUATION \u2014 LARGEST CHINESE AI ROUND EVER; FOUNDER PUT IN $3B OF OWN MONEY",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-06-29-twitter-03h-headlines.json",
     "url": "https://x.com/theinformation/status/2071262396727890323"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-29 03:36 UTC",
+    "delivered_at": "2026-06-29 03:00 UTC",
     "headline": "SPACEX TO RELEASE FROM-SCRATCH AI MODELS EVERY MONTH THIS YEAR PER MUSK \u2014 RADICAL ACCELERATION OVER INDUSTRY CADENCE",
     "source": "@elonmusk",
+    "source_file": "research/summaries/2026-06-29-twitter-03h-headlines.json",
     "url": "https://x.com/elonmusk/status/2071184354756477041"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-29 03:36 UTC",
+    "delivered_at": "2026-06-29 03:00 UTC",
     "headline": "AUSTRIA PUBLICLY COURTED ANTHROPIC TO RELOCATE TO EUROPE \u2014 SIGNAL EU FACES PERMANENT FRONTIER-MODEL EXCLUSION",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-29-twitter-03h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2071251833826193881"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-06-29 03:36 UTC",
+    "delivered_at": "2026-06-29 03:00 UTC",
     "headline": "VIRAL CLAIM THAT CHINA'S GLM-5.2 MATCHES MYTHOS IN CYBERSECURITY DEBUNKED \u2014 NARROW IDOR BENCHMARK ONLY",
     "source": "@janekm",
+    "source_file": "research/summaries/2026-06-29-twitter-03h-headlines.json",
     "url": "https://x.com/janekm/status/2071256883931893791"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-29 03:36 UTC",
+    "delivered_at": "2026-06-29 03:00 UTC",
     "headline": "ANTHROPIC RUMORED AT $30B REVENUE RUN RATE, SURPASSING OPENAI'S ~$25B \u2014 UNVERIFIED CRYPTO-AGGREGATOR CLAIM",
     "source": "@CryptoTweets",
+    "source_file": "research/summaries/2026-06-29-twitter-03h-headlines.json",
     "url": "https://x.com/CryptoTweets/status/2071297800172671303"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-29 03:36 UTC",
+    "delivered_at": "2026-06-29 03:00 UTC",
     "headline": "GROK 4.4 LIKELY GOING LIVE \u2014 VERSION NUMBER DISAPPEARED FROM UI, TERMS OF SERVICE UPDATED",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-29-twitter-03h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2071283196885660026"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-29 06:32 UTC",
+    "delivered_at": "2026-06-29 06:00 UTC",
     "headline": "GOOGLE REORGS AI CODING STRIKE TEAM TO CATCH UP WITH ANTHROPIC",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-06-29-twitter-06h-headlines.json",
     "url": "https://x.com/theinformation/status/2071247292116467976"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-29 06:32 UTC",
+    "delivered_at": "2026-06-29 06:00 UTC",
     "headline": "SPACEX RAPID IPO COULD FORCE OPENAI, ANTHROPIC PROSPECTUSES PUBLIC WITHIN WEEKS",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-06-29-twitter-06h-headlines.json",
     "url": "https://x.com/theinformation/status/2071337860116992191"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-29 06:32 UTC",
+    "delivered_at": "2026-06-29 06:00 UTC",
     "headline": "ELON MUSK: GROK 4.5 BUILT ON 1.5T V9, 3\u00d7 GROK 4.3, 'WILL FEEL LIKE A GIGANTIC UPGRADE'",
     "source": "@elonmusk",
+    "source_file": "research/summaries/2026-06-29-twitter-06h-headlines.json",
     "url": "https://x.com/elonmusk/status/2071323738201837785"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-29 06:32 UTC",
+    "delivered_at": "2026-06-29 06:00 UTC",
     "headline": "BAIDU KUNLUNXIN AI CHIP UNIT TARGETING $50B HONG KONG IPO",
     "source": "@WhalorAlert",
+    "source_file": "research/summaries/2026-06-29-twitter-06h-headlines.json",
     "url": "https://x.com/WhalorAlert/status/2071344916018389258"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-29 06:32 UTC",
+    "delivered_at": "2026-06-29 06:00 UTC",
     "headline": "APPLE SEEKS TRUMP ADMIN APPROVAL TO BUY CHIPS FROM BLACKLISTED CHINESE FIRM CXMT",
     "source": "@thomasbpeter001",
+    "source_file": "research/summaries/2026-06-29-twitter-06h-headlines.json",
     "url": "https://x.com/thomasbpeter001/status/2071345604383445387"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-29 17:05 UTC",
+    "delivered_at": "2026-06-29 17:00 UTC",
     "headline": "SOUTH KOREA UNVEILS ~800T WON ($518B) DRIVE FOR FOUR NEW SAMSUNG/SK HYNIX AI-CHIP FABS",
     "source": "@NewsTongueX",
+    "source_file": "research/summaries/2026-06-29-twitter-17h-headlines.json",
     "url": "https://x.com/i/status/2071482700356071668"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-29 17:05 UTC",
+    "delivered_at": "2026-06-29 17:00 UTC",
     "headline": "SAMSUNG, SK HYNIX SHARES FALL AS INVESTORS BRACE FOR UP TO $1.3T DECADE-LONG CAPEX",
     "source": "@CedricMeulen",
+    "source_file": "research/summaries/2026-06-29-twitter-17h-headlines.json",
     "url": "https://x.com/i/status/2071476384791187879"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-29 17:05 UTC",
+    "delivered_at": "2026-06-29 17:00 UTC",
     "headline": "KOREA'S COMBINED SAMSUNG+SK CHIP PLAN COULD TOP 1,000T WON ($650B) OVER TEN YEARS",
     "source": "@BullTheoryio",
+    "source_file": "research/summaries/2026-06-29-twitter-17h-headlines.json",
     "url": "https://x.com/i/status/2071491093162791043"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-29 19:45 UTC",
+    "delivered_at": "2026-06-29 19:00 UTC",
     "headline": "CHINA'S CXMT SIGNS $3B+ LONG-TERM DRAM SUPPLY DEAL WITH TENCENT DAYS BEFORE \u00a529.5B STAR MARKET IPO",
     "source": "@BennyLam",
+    "source_file": "research/summaries/2026-06-29-twitter-19h-headlines.json",
     "url": "https://x.com/i/status/2071545012798562562"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-29 19:45 UTC",
+    "delivered_at": "2026-06-29 19:00 UTC",
     "headline": "KOREA CONFIRMS RECORD $576B SAMSUNG/SK HYNIX FAB PLAN \u2014 SHARES FALL ON GLUT FEARS (SAMSUNG -4.86%, SK HYNIX -1.68%)",
     "source": "@BennyLam",
+    "source_file": "research/summaries/2026-06-29-twitter-19h-headlines.json",
     "url": "https://x.com/i/status/2071545012798562562"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-29 19:45 UTC",
+    "delivered_at": "2026-06-29 19:00 UTC",
     "headline": "MICRON CEO: NO LINE OF SIGHT ON MEMORY SUPPLY CATCHING UP, MARKET STAYS TIGHT PAST 2027",
     "source": "@datapwj",
+    "source_file": "research/summaries/2026-06-29-twitter-19h-headlines.json",
     "url": "https://x.com/i/status/2071546016999051724"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-30 01:25 UTC",
+    "delivered_at": "2026-06-30 01:00 UTC",
     "headline": "NEWSOM SIGNS ANTHROPIC DEAL \u2014 CLAUDE BECOMES FIRST AI CLEARED FOR ALL CALIFORNIA STATE AND LOCAL AGENCIES",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-30-twitter-01h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2071623588474429813"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-30 01:25 UTC",
+    "delivered_at": "2026-06-30 01:00 UTC",
     "headline": "DEEPSEEK DATES V4 FOR MID-JULY \u2014 AND ADDS API SURGE PRICING THAT DOUBLES TOKEN COST IN PEAK HOURS",
     "source": "@alephantai",
+    "source_file": "research/summaries/2026-06-30-twitter-01h-headlines.json",
     "url": "https://x.com/alephantai/status/2071621413711094240"
   },
   {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-06-30 01:00 UTC",
+    "headline": "OPENAI GPT-5.6 SOL/TERRA/LUNA SHIPS ONLY IN GOVERNMENT-APPROVED LIMITED PREVIEW, ~20 PARTNERS",
+    "source": "@contextreportai",
+    "source_file": "research/summaries/2026-06-30-twitter-01h-headlines.json",
+    "url": "https://x.com/contextreportai/status/2071506723266043925"
+  },
+  {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-30 01:25 UTC",
+    "delivered_at": "2026-06-30 01:00 UTC",
     "headline": "ANTHROPIC RENEGOTIATES AMAZON PACT TO TOKEN-BASED DEAL THAT RAISES AMAZON'S COSTS \u2014 THE INFORMATION",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-30-twitter-01h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2071631121918382263"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-30 01:25 UTC",
+    "delivered_at": "2026-06-30 01:00 UTC",
     "headline": "SAMSUNG AND SK HYNIX TO UNVEIL $1.3 TRILLION 10-YEAR PROJECT \u2014 CHIP FABS, AI DATA CENTERS, BATTERIES",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-30-twitter-01h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2071451553806827636"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-06-30 01:25 UTC",
+    "delivered_at": "2026-06-30 01:00 UTC",
     "headline": "WSJ CLAIM THAT CHINA'S GLM MATCHED ANTHROPIC MYTHOS IN CYBER DISPUTED BY MOLLICK AND MOWSHOWITZ",
     "source": "@TheZvi",
+    "source_file": "research/summaries/2026-06-30-twitter-01h-headlines.json",
     "url": "https://x.com/TheZvi/status/2071611315085340995"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-30 03:52 UTC",
+    "delivered_at": "2026-06-30 03:00 UTC",
     "headline": "CLAUDE NOW GENERALLY AVAILABLE IN MICROSOFT FOUNDRY ON AZURE \u2014 OPUS 4.8 + HAIKU 4.5 ON NVIDIA GB300",
     "source": "@claudeai",
+    "source_file": "research/summaries/2026-06-30-twitter-03h-headlines.json",
     "url": "https://x.com/claudeai/status/2071653958905467027"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-30 03:52 UTC",
+    "delivered_at": "2026-06-30 03:00 UTC",
     "headline": "ANTHROPIC MODELS RUN ON NVIDIA GPUS FOR FIRST TIME \u2014 GB300 NVL72 WITH QUANTUM-X800 INFINIBAND ON AZURE",
     "source": "@nvidia",
+    "source_file": "research/summaries/2026-06-30-twitter-03h-headlines.json",
     "url": "https://x.com/nvidia/status/2071654937335926864"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-30 03:52 UTC",
+    "delivered_at": "2026-06-30 03:00 UTC",
     "headline": "US CLEARS ANTHROPIC MYTHOS 5 FOR ~100 APPROVED ORGS; FABLE 5 EXPECTED BACK THIS WEEK AFTER 15-DAY SUSPENSION \u2014 AXIOS",
     "source": "@WesRoth",
+    "source_file": "research/summaries/2026-06-30-twitter-03h-headlines.json",
     "url": "https://x.com/WesRoth/status/2071398246996717834"
   },
   {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-06-30 03:00 UTC",
+    "headline": "CALIFORNIA SIGNS ANTHROPIC DEAL \u2014 CLAUDE FOR ALL STATE AGENCIES AT 50% DISCOUNT",
+    "source": "@claudeai",
+    "source_file": "research/summaries/2026-06-30-twitter-03h-headlines.json",
+    "url": "https://x.com/claudeai/status/2071653958905467027"
+  },
+  {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-30 06:40 UTC",
+    "delivered_at": "2026-06-30 06:00 UTC",
     "headline": "ANDREESSEN APPOINTED TO PENTAGON'S DEFENSE POLICY BOARD AT WAR SEC. HEGSETH'S REQUEST",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-30-twitter-06h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2071660737919885605"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-30 06:40 UTC",
+    "delivered_at": "2026-06-30 06:00 UTC",
+    "headline": "ANTHROPIC CONFIRMS US CLEARED MYTHOS 5 FOR CRITICAL-INFRA ORGS; FABLE 5 STILL OFFLINE",
+    "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-06-30-twitter-06h-headlines.json",
+    "url": "https://x.com/AnthropicAI/status/2070665903440871779"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-06-30 06:00 UTC",
     "headline": "ANDREESSEN'S DEFENSE-BOARD SEAT MAY CONFER MYTHOS 5 ACCESS VIA DEPARTMENT OF WAR \u2014 CURRAN",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-30-twitter-06h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2071663021110460630"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-06-30 10:14 UTC",
+    "delivered_at": "2026-06-30 10:00 UTC",
     "headline": "ANTHROPIC ALLEGES ALIBABA RAN 28.8M FRAUDULENT API CALLS ACROSS 25,000 FAKE ACCOUNTS TO DISTILL CLAUDE",
     "source": "@PeterDiamandis",
+    "source_file": "research/summaries/2026-06-30-twitter-10h-headlines.json",
     "url": "https://x.com/PeterDiamandis/status/2071705010694767042"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-06-30 10:14 UTC",
+    "delivered_at": "2026-06-30 10:00 UTC",
     "headline": "MUSK AMPLIFIES ALIBABA-DISTILLATION CLAIM AS 'LARGEST AI MODEL THEFT EVER ATTEMPTED' \u2014 STILL UNCONFIRMED",
     "source": "@elonmusk",
+    "source_file": "research/summaries/2026-06-30-twitter-10h-headlines.json",
     "url": "https://x.com/elonmusk/status/2071762302068740115"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-30 10:14 UTC",
+    "delivered_at": "2026-06-30 10:00 UTC",
     "headline": "GROK 4.5 IN PRIVATE BETA \u2014 xAI CLAIMS OPUS-LEVEL ON 1.5T 'V9' MODEL, AUGUST RELEASE, NO THIRD-PARTY BENCHMARKS",
     "source": "@elonmusk",
+    "source_file": "research/summaries/2026-06-30-twitter-10h-headlines.json",
     "url": "https://x.com/elonmusk/status/2071184354756477041"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-06-30 10:14 UTC",
+    "delivered_at": "2026-06-30 10:00 UTC",
     "headline": "CHINA'S OPEN GLM-5.2 BEATS CLAUDE CODE ON SEMGREP IDOR TEST \u2014 39% F1 VS 32-37%, ~$0.17 PER VULNERABILITY",
     "source": "@AlphaSignalAI",
+    "source_file": "research/summaries/2026-06-30-twitter-10h-headlines.json",
     "url": "https://x.com/AlphaSignalAI/status/2071762782014624213"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-30 10:14 UTC",
+    "delivered_at": "2026-06-30 10:00 UTC",
     "headline": "CALIFORNIA-ANTHROPIC DEAL CONFIRMED: CLAUDE ACROSS STATE AGENCIES AT 50% DISCOUNT",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-06-30-twitter-10h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2071623588474429813"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-30 13:34 UTC",
+    "delivered_at": "2026-06-30 13:00 UTC",
     "headline": "LEAKED CLAUDE APP STRINGS TIE FABLE 5 RETURN TO IDENTITY VERIFICATION + SEPARATE METERED CREDITS",
     "source": "@M1Astra",
+    "source_file": "research/summaries/2026-06-30-twitter-13h-headlines.json",
     "url": "https://x.com/M1Astra/status/2071792190221664294"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-06-30 13:34 UTC",
+    "delivered_at": "2026-06-30 13:00 UTC",
     "headline": "OPENAI TEASES FIRST CODEX HARDWARE \u2014 A WORK LOUDER MACRO PAD, REVEAL JULY 15",
     "source": "@Techmeme",
+    "source_file": "research/summaries/2026-06-30-twitter-13h-headlines.json",
     "url": "https://x.com/Techmeme/status/2071768358182334546"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-06-30 13:34 UTC",
+    "delivered_at": "2026-06-30 13:00 UTC",
     "headline": "CLINEPASS LIVE AT $9.99/MO \u2014 BUNDLES GLM-5.2, DEEPSEEK V4, KIMI K2.7, MINIMAX M3, QWEN AT 2-5X DISCOUNT",
     "source": "@cline",
+    "source_file": "research/summaries/2026-06-30-twitter-13h-headlines.json",
     "url": "https://x.com/cline/status/2071617325296734309"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-06-30 13:34 UTC",
+    "delivered_at": "2026-06-30 13:00 UTC",
     "headline": "PALANTIR + NVIDIA BUILDING CUSTOM AI FOR US GOVERNMENT SECURITY APPLICATIONS",
     "source": "@nikkei",
+    "source_file": "research/summaries/2026-06-30-twitter-13h-headlines.json",
     "url": "https://x.com/nikkei/status/2071660170497659357"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-06-30 16:34 UTC",
+    "delivered_at": "2026-06-30 16:00 UTC",
     "headline": "MEITUAN OPEN-SOURCES LONGCAT-2.0 \u2014 1.6T AGENTIC CODER IT SAYS WAS TRAINED ON CHINESE CHIPS, ZERO NVIDIA",
     "source": "@VentureBeat",
+    "source_file": "research/summaries/2026-06-30-twitter-16h-headlines.json",
     "url": "https://x.com/VentureBeat/status/2071831014872092715"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-30 16:34 UTC",
+    "delivered_at": "2026-06-30 16:00 UTC",
     "headline": "LONGCAT-2.0 WAS THE ANONYMOUS 'OWL ALPHA' \u2014 TOPPED OPENROUTER CODING CHARTS FOR WEEKS BEFORE MEITUAN UNMASKED IT",
     "source": "@__vandos__",
+    "source_file": "research/summaries/2026-06-30-twitter-16h-headlines.json",
     "url": "https://x.com/__vandos__/status/2071842186627317844"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-30 16:34 UTC",
+    "delivered_at": "2026-06-30 16:00 UTC",
     "headline": "COGNITION SHIPS DEVIN FUSION \u2014 'SIDEKICK' ROUTING HARNESS CLAIMS ~35% CHEAPER FABLE-CLASS CODING",
     "source": "@stretchcloud",
+    "source_file": "research/summaries/2026-06-30-twitter-16h-headlines.json",
     "url": "https://x.com/stretchcloud/status/2071797120617836614"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-06-30 16:34 UTC",
+    "delivered_at": "2026-06-30 16:00 UTC",
     "headline": "MINIMAX M3 LANDS ON OPENROUTER AT $0.30/M INPUT \u2014 CHEAPEST 1M-CONTEXT MODEL, ~6% OF OPUS 4.8",
     "source": "@TeksCreate",
+    "source_file": "research/summaries/2026-06-30-twitter-16h-headlines.json",
     "url": "https://x.com/TeksCreate/status/2071858001338589537"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-30 21:56 UTC",
+    "delivered_at": "2026-06-30 21:00 UTC",
     "headline": "ANTHROPIC PREPS CLAUDE SONNET 5; FABLE 5 RETURNS BEHIND PAID CREDITS + ID VERIFICATION, PER LEAKED APP CODE",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-06-30-twitter-21h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2071923897520288164"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-06-30 21:56 UTC",
+    "delivered_at": "2026-06-30 21:00 UTC",
     "headline": "GOOGLE TEASES NANO BANANA 2 LITE FOR CHEAP IMAGE GEN AND GEMINI OMNI FLASH FOR CONVERSATIONAL VIDEO",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-06-30-twitter-21h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2071917358101213204"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-06-30 21:56 UTC",
+    "delivered_at": "2026-06-30 21:00 UTC",
     "headline": "MEITUAN'S OPEN-WEIGHT 1.6T LONGCAT-2.0 HITS MAINSTREAM PRESS \u2014 REUTERS, TOM'S HARDWARE CARRY 'NO-NVIDIA' CLAIM",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-06-30-twitter-21h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2071864999799058768"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-06-30 21:56 UTC",
+    "delivered_at": "2026-06-30 21:00 UTC",
     "headline": "'CLAUDE CODE SPYWARE' CLAIM SPREADS \u2014 ALLEGES REGION/PROXY TELEMETRY SINCE v2.1.91; UNVERIFIED, LIKELY EXPORT COMPLIANCE",
     "source": "@bdsqlsz",
+    "source_file": "research/summaries/2026-06-30-twitter-21h-headlines.json",
     "url": "https://x.com/bdsqlsz/status/2071887369817772358"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-07-01 00:59 UTC",
+    "delivered_at": "2026-07-01 00:00 UTC",
     "headline": "CLAUDE SONNET 5 STRING GOES LIVE IN SELECTOR \u2014 LEAKED $2/$10 PROMO, JAN-2026 CUTOFF, 1M CONTEXT",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-01-twitter-00h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2071953298169778636"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-07-01 00:59 UTC",
+    "delivered_at": "2026-07-01 00:00 UTC",
     "headline": "GOOGLE SHIPS NANO BANANA 2 LITE \u2014 GEMINI-3.1-FLASH-LITE-IMAGE LIVE AT $0.25 IN / $0.0336 OUT",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-07-01-twitter-00h-headlines.json",
     "url": "https://x.com/i/status/2071981784846258503"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-07-01 00:59 UTC",
+    "delivered_at": "2026-07-01 00:00 UTC",
     "headline": "ETCHED EXITS STEALTH \u2014 $800M RAISED, $1B+ IN SIGNED CONTRACTS, SOHU ASIC RACKS SHIP THIS SUMMER",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-01-twitter-00h-headlines.json",
     "url": "https://x.com/i/status/2071976332628537834"
   },
   {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-01 00:00 UTC",
+    "headline": "MARC ANDREESSEN APPOINTED TO PENTAGON DEFENSE POLICY BOARD \u2014 A16Z NOW FORMALLY ADVISING DOD",
+    "source": "@ns123abc",
+    "source_file": "research/summaries/2026-07-01-twitter-00h-headlines.json",
+    "url": "https://x.com/ns123abc/status/2071673844515877350"
+  },
+  {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-07-01 00:59 UTC",
+    "delivered_at": "2026-07-01 00:00 UTC",
     "headline": "APIFY + COINBASE ADD 20,000 ACTORS TO X402 \u2014 AI AGENTS PAY PER-RESULT IN USDC ON BASE",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-07-01-twitter-00h-headlines.json",
     "url": "https://x.com/i/status/2071975453376536788"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-07-01 03:49 UTC",
+    "delivered_at": "2026-07-01 03:00 UTC",
     "headline": "CLAUDE SONNET 5 SHIPS OFFICIALLY \u2014 DEFAULT ON FREE/PRO, OPUS-4.8-CLASS AGENTIC AT $2/$10, 1M CONTEXT",
     "source": "@claudeai",
+    "source_file": "research/summaries/2026-07-01-twitter-03h-headlines.json",
     "url": "https://x.com/claudeai/status/2072017450611142835"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-07-01 03:49 UTC",
+    "delivered_at": "2026-07-01 03:00 UTC",
     "headline": "ANTHROPIC LAUNCHES CLAUDE SCIENCE \u2014 RESEARCH WORKBENCH, 60+ TOOLS, DEBUTS WITH NOVARTIS, BMS, GENENTECH",
     "source": "@claudeai",
+    "source_file": "research/summaries/2026-07-01-twitter-03h-headlines.json",
     "url": "https://x.com/claudeai/status/2072002740830842899"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-07-01 03:49 UTC",
+    "delivered_at": "2026-07-01 03:00 UTC",
     "headline": "OPENAI SHIPS GENEBENCH-PRO \u2014 BENCHMARK FOR AI RESEARCH JUDGMENT IN BIOLOGY, GPT-5.6 SOL PRO SCORES MODESTLY",
     "source": "@CapitalRadarX",
+    "source_file": "research/summaries/2026-07-01-twitter-03h-headlines.json",
     "url": "https://x.com/CapitalRadarX/status/2072012354578272578"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-07-01 03:49 UTC",
+    "delivered_at": "2026-07-01 03:00 UTC",
     "headline": "SONNET 5 PRICED 1/3 BELOW 4.6 \u2014 $2/$10 INTRO, RISING TO $3/$15 IN SEPTEMBER; NO FABLE 5 RE-RELEASE",
     "source": "@claudeai",
+    "source_file": "research/summaries/2026-07-01-twitter-03h-headlines.json",
     "url": "https://x.com/claudeai/status/2072017457057853480"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-07-01 03:49 UTC",
+    "delivered_at": "2026-07-01 03:00 UTC",
     "headline": "X LAUNCHES HOSTED MCP \u2014 AI AGENTS CONNECT TO THE X API AND DEV DOCS WITH NO SETUP",
     "source": "@Polymarket",
+    "source_file": "research/summaries/2026-07-01-twitter-03h-headlines.json",
     "url": "https://x.com/Polymarket/status/2071786298713756104"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-07-01 06:41 UTC",
+    "delivered_at": "2026-07-01 06:00 UTC",
     "headline": "SONNET 5 BENCHMARKS LAND MIXED \u2014 EDGES OPUS 4.8 ON SOME TASKS, SCORES BELOW OLDER SONNET 4.6 ON CYBER EXPLOIT-FINDING",
     "source": "@rohanpaul_ai",
+    "source_file": "research/summaries/2026-07-01-twitter-06h-headlines.json",
     "url": "https://x.com/i/status/2072073081477283846"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-07-01 06:41 UTC",
+    "delivered_at": "2026-07-01 06:00 UTC",
     "headline": "GITLAB DUO SHIPS SONNET 5 ACROSS ALL TIERS \u2014 FIRST MODEL TO CLEAR FULL BENCHMARK SUITE, UP 93.8% OVER PREDECESSOR",
     "source": "@gitlab",
+    "source_file": "research/summaries/2026-07-01-twitter-06h-headlines.json",
     "url": "https://x.com/gitlab/status/2072068540736344171"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-07-01 06:41 UTC",
+    "delivered_at": "2026-07-01 06:00 UTC",
     "headline": "SONNET 5 RUNS ~60 TOK/S VS GLM 5.2'S CLAIMED 150-300 \u2014 CHINESE MODELS REOPEN PRICE/SPEED GAP ON ANTHROPIC",
     "source": "@JordanFrery",
+    "source_file": "research/summaries/2026-07-01-twitter-06h-headlines.json",
     "url": "https://x.com/i/status/2072068739605123089"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-07-01 10:20 UTC",
+    "delivered_at": "2026-07-01 10:00 UTC",
     "headline": "COMMERCE LIFTS EXPORT CONTROLS ON ANTHROPIC FABLE 5 AND MYTHOS 5 \u2014 ACCESS RESTORING TODAY",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-07-01-twitter-10h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2072106151890809341"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-07-01 10:20 UTC",
+    "delivered_at": "2026-07-01 10:00 UTC",
     "headline": "POLITICO: FABLE 5 RETURN IS A GENERAL RE-RELEASE, NOT LIMITED TO THE US \u2014 ENDING THE 18-DAY GATE",
     "source": "@spectatorindex",
+    "source_file": "research/summaries/2026-07-01-twitter-10h-headlines.json",
     "url": "https://x.com/spectatorindex/status/2072087011067076745"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-07-01 10:20 UTC",
+    "delivered_at": "2026-07-01 10:00 UTC",
     "headline": "OPENAI REPORTEDLY MORE THAN HALVES INFERENCE COSTS VIA NEW OPTIMIZATION \u2014 THE INFORMATION",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-01-twitter-10h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2072053812420825234"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-07-01 10:20 UTC",
+    "delivered_at": "2026-07-01 10:00 UTC",
     "headline": "SONNET 5 DAY-2 VERDICT: CHEAPER PER TOKEN, PRICIER PER SOLVED PROBLEM, STILL TRAILS OPUS 4.8",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-07-01-twitter-10h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2072022739334873511"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-07-01 13:41 UTC",
+    "delivered_at": "2026-07-01 13:00 UTC",
     "headline": "ANTHROPIC REDEPLOYS FABLE 5 GLOBALLY TODAY WITH NEW CYBER CLASSIFIERS; ROUTINE CODING TEMPORARILY FALLS BACK TO OPUS 4.8",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-07-01-twitter-13h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2072163884430229756"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-07-01 13:41 UTC",
+    "delivered_at": "2026-07-01 13:00 UTC",
     "headline": "ANTHROPIC LAUNCHES 'GLASSWING' CONSENSUS FRAMEWORK WITH AMAZON, MICROSOFT, GOOGLE TO GRADE AI JAILBREAK SEVERITY",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-07-01-twitter-13h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2072163884430229756"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-07-01 13:41 UTC",
+    "delivered_at": "2026-07-01 13:00 UTC",
     "headline": "CLAUDE CODE ADDS 'ROUTINES' \u2014 AUTONOMOUS SCHEDULED AGENTS TRIGGERED BY TIME, API, OR GITHUB EVENTS, RUN ON ANTHROPIC CLOUD",
     "source": "@Di_Krass_",
+    "source_file": "research/summaries/2026-07-01-twitter-13h-headlines.json",
     "url": "https://x.com/Di_Krass_/status/2072099865207636370"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-07-01 16:47 UTC",
+    "delivered_at": "2026-07-01 16:00 UTC",
     "headline": "CLAUDE FABLE 5 BACK ONLINE GLOBALLY \u2014 METERED AT 50% OF WEEKLY LIMITS THROUGH JULY 7, THEN USAGE CREDITS",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-07-01-twitter-16h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2072174915076186348"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-07-01 16:47 UTC",
+    "delivered_at": "2026-07-01 16:00 UTC",
     "headline": "MYTHOS 5 RESTORED ONLY FOR APPROVED US ORGS \u2014 FABLE 5 GOES GLOBAL, MYTHOS STAYS GATED",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-01-twitter-16h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2072199399833240054"
   },
   {
+    "backfilled": true,
     "category": "breaking",
-    "delivered_at": "2026-07-01 16:47 UTC",
+    "delivered_at": "2026-07-01 16:00 UTC",
     "headline": "ANTHROPIC'S NEW CLASSIFIER BLOCKS REPORTED JAILBREAK >99% \u2014 OVER-FLAGS BENIGN CODING, ROUTES SMALL FRACTION TO OPUS 4.8",
     "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-07-01-twitter-16h-headlines.json",
     "url": "https://x.com/AnthropicAI/status/2072163884430229756"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-07-01 22:10 UTC",
+    "delivered_at": "2026-07-01 22:00 UTC",
     "headline": "CURRAN PREDICTS ARCHITECTURE-LEVEL MEMORY-EFFICIENCY BREAKTHROUGH FROM OPENAI-SPINOUT TEAM (NOT SSI) \u2014 UNANNOUNCED, UNVERIFIED",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-01-twitter-22h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2072076893730349409"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-07-01 22:10 UTC",
+    "delivered_at": "2026-07-01 22:00 UTC",
     "headline": "OPENAI SHIPS GENEBENCH-PRO \u2014 RESEARCH BENCHMARK FOR AGENTS NAVIGATING MESSY BIOLOGICAL DATA",
     "source": "@OpenAI",
+    "source_file": "research/summaries/2026-07-01-twitter-22h-headlines.json",
     "url": "https://x.com/OpenAI/status/2072004836674167294"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-07-01 22:10 UTC",
+    "delivered_at": "2026-07-01 22:00 UTC",
     "headline": "OPENAI CHIEF ECONOMIST AT ECB SINTRA: AI MAY COMPLEMENT WORKERS BUT LABOR-MARKET DATA IS GETTING LESS COMFORTABLE",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-01-twitter-22h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2072290557238390944"
   },
   {
+    "backfilled": true,
     "category": "business",
     "delivered_at": "2026-07-02 01:00 UTC",
     "headline": "ANTHROPIC'S NEXT VERTICAL APP LEAKS: 'CLAUDE SCIENCE' \u2014 DESKTOP RESEARCH TOOL WITH 60+ SCIENTIFIC DATABASES, DEV-NAMED 'OPERON'",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-07-02-twitter-01h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2072338885724525007"
   },
   {
+    "backfilled": true,
     "category": "model",
     "delivered_at": "2026-07-02 01:00 UTC",
     "headline": "NEW GEMINI FLASH CHECKPOINT SPOTTED TESTING ON LM ARENA \u2014 POSSIBLY GEMINI 3.6 FLASH OR GEMINI 4 FLASH",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-07-02-twitter-01h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2072321107365957837"
   },
   {
+    "backfilled": true,
     "category": "infra",
     "delivered_at": "2026-07-02 01:00 UTC",
     "headline": "XAI SHIPS VOICE AGENT BUILDER ON XAI CONSOLE \u2014 CONVERSATIONAL AGENTS WITH GROK VOICES AND CONNECTORS",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-07-02-twitter-01h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2072346189320667412"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-07-02 03:50 UTC",
+    "delivered_at": "2026-07-02 03:00 UTC",
     "headline": "FABLE 5 TOPS SCALE AI REMOTE LABOR INDEX AT 16% \u2014 ROUGHLY 2X NEXT BEST, AHEAD OF OPUS 4.8 AND CODEX GPT-5.5",
     "source": "@ScaleAILabs",
+    "source_file": "research/summaries/2026-07-02-twitter-03h-headlines.json",
     "url": "https://x.com/ScaleAILabs/status/2072372960686703016"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-07-02 03:50 UTC",
+    "delivered_at": "2026-07-02 03:00 UTC",
     "headline": "AI AGENT AUTOMATION ON REAL FREELANCE WORK JUMPS FROM UNDER 3% TO 16% IN UNDER A YEAR \u2014 RLI STILL FAILS MOST PROJECTS",
     "source": "@ScaleAILabs",
+    "source_file": "research/summaries/2026-07-02-twitter-03h-headlines.json",
     "url": "https://x.com/ScaleAILabs/status/2072372960686703016"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-07-02 03:50 UTC",
+    "delivered_at": "2026-07-02 03:00 UTC",
     "headline": "SONNET 5 RECEPTION COOLING FAST \u2014 'LARGELY NEGATIVE' ON PRICE-TO-PERFORMANCE ONE DAY AFTER LAUNCH",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-02-twitter-03h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2072365174896361785"
   },
   {
+    "backfilled": true,
     "category": "opensource",
-    "delivered_at": "2026-07-02 03:50 UTC",
+    "delivered_at": "2026-07-02 03:00 UTC",
     "headline": "ZAI LAUNCHES ZCODE 3.0 \u2014 AI-NATIVE CODING IDE OPTIMIZED FOR GLM-5.2 WITH AGENTIC PLANNING-TO-CODE FLOW",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-02-twitter-03h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2072378141041991702"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-07-02 06:41 UTC",
+    "delivered_at": "2026-07-02 06:00 UTC",
     "headline": "PALANTIR'S KARP: ENTERPRISES 'FED UP' WITH LABS THAT OVERSOLD MODELS AND PUSHED 'TOKENMAXXING' \u2014 WANT TO OWN THE FULL STACK",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-02-twitter-06h-headlines.json",
     "url": "https://x.com/i/status/2072401676363796637"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-07-02 06:41 UTC",
+    "delivered_at": "2026-07-02 06:00 UTC",
     "headline": "FABLE 5 IS BACK BUT METERED \u2014 USERS REPORT BURNING THE 50% WEEKLY CAP ALMOST IMMEDIATELY",
     "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-07-02-twitter-06h-headlines.json",
     "url": "https://x.com/i/status/2072404910641926357"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-07-02 06:41 UTC",
+    "delivered_at": "2026-07-02 06:00 UTC",
     "headline": "FABLE 5'S NEW BIO/CHEM CLASSIFIERS CALLED 'TOO RESTRICTIVE' ON LEGITIMATE SCIENCE WORK",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-02-twitter-06h-headlines.json",
     "url": "https://x.com/i/status/2072407447281545445"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-07-02 10:15 UTC",
+    "delivered_at": "2026-07-02 10:00 UTC",
     "headline": "META BUILDING 'META COMPUTE' TO SELL EXCESS AI CAPACITY \u2014 $META +9%, COREWEAVE & NEBIUS DOWN ~12-17% (BLOOMBERG)",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-02-twitter-10h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2072309840823689247"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-07-02 10:15 UTC",
+    "delivered_at": "2026-07-02 10:00 UTC",
     "headline": "NEOCLOUD SELLOFF: HYPERSCALER 'SPARE COMPUTE TO SELL' READ AS FIRST CRACK IN INFINITE AI-CAPEX THESIS",
     "source": "@bdinvestingg",
+    "source_file": "research/summaries/2026-07-02-twitter-10h-headlines.json",
     "url": "https://x.com/bdinvestingg/status/2072472754314432918"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-07-02 10:15 UTC",
+    "delivered_at": "2026-07-02 10:00 UTC",
+    "headline": "PALANTIR CEO KARP ON CNBC: FRONTIER LABS 'OVERSOLD' MODELS AND PUSHED 'TOKENMAXXING' \u2014 ENTERPRISES NEED AN APP LAYER",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-02-twitter-10h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2072401676363796637"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-02 10:00 UTC",
     "headline": "AI TOP-CITED LAYOFF REASON FOR 4TH STRAIGHT MONTH \u2014 101,743 AI-ATTRIBUTED US JOB CUTS YTD (CHALLENGER)",
     "source": "@amitisinvesting",
+    "source_file": "research/summaries/2026-07-02-twitter-10h-headlines.json",
     "url": "https://x.com/amitisinvesting/status/2072484544218099841"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-07-02 10:15 UTC",
+    "delivered_at": "2026-07-02 10:00 UTC",
     "headline": "ANTHROPIC RESETS ALL RATE LIMITS AS FABLE 5 RETURNS; DEV THEO SAYS HE'LL LET IT MERGE PRs",
     "source": "@ClaudeDevs",
+    "source_file": "research/summaries/2026-07-02-twitter-10h-headlines.json",
     "url": "https://x.com/ClaudeDevs/status/2072429181565288665"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-07-02 15:48 UTC",
+    "delivered_at": "2026-07-02 15:00 UTC",
     "headline": "OPENAI PROPOSES HANDING US GOVERNMENT A 5% STAKE (~$42.6B), ALASKA-FUND STYLE \u2014 FT",
     "source": "@unusual_whales",
+    "source_file": "research/summaries/2026-07-02-twitter-15h-headlines.json",
     "url": "https://x.com/unusual_whales/status/2072551966052634864"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-07-02 15:48 UTC",
+    "delivered_at": "2026-07-02 15:00 UTC",
     "headline": "ALTMAN WANTS ANTHROPIC, GOOGLE, META TO EACH GIVE US 5% EQUITY; SANDERS PUSHES FOR ~50% \u2014 FT",
     "source": "@rohanpaul_ai",
+    "source_file": "research/summaries/2026-07-02-twitter-15h-headlines.json",
     "url": "https://x.com/rohanpaul_ai/status/2072543441771454654"
   },
   {
+    "backfilled": true,
     "category": "infra",
-    "delivered_at": "2026-07-02 23:25 UTC",
+    "delivered_at": "2026-07-02 23:00 UTC",
     "headline": "ANTHROPIC IN EARLY TALKS WITH SAMSUNG TO BUILD CUSTOM AI CHIP \u2014 THE INFORMATION",
     "source": "@theinformation",
+    "source_file": "research/summaries/2026-07-02-twitter-23h-headlines.json",
     "url": "https://x.com/theinformation/status/2072681868114161893"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-07-02 23:25 UTC",
+    "delivered_at": "2026-07-02 23:00 UTC",
     "headline": "WHITE HOUSE NEARS VOLUNTARY AI RELEASE-STANDARDS DEAL WITH ANTHROPIC, OPENAI, GOOGLE \u2014 FT",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-02-twitter-23h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2072459054044295315"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-07-02 23:25 UTC",
+    "delivered_at": "2026-07-02 23:00 UTC",
     "headline": "GPT-5.6 WIDER RELEASE COULD LAND NEXT WEEK ALONGSIDE NEW GOVERNMENT AI STANDARDS \u2014 FT",
     "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-02-twitter-23h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2072465277850390723"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-07-03 01:59 UTC",
+    "delivered_at": "2026-07-03 01:00 UTC",
     "headline": "PENTAGON LABELED ANTHROPIC A \"SUPPLY-CHAIN RISK\" AFTER GUARDRAILS DISPUTE \u2014 COURT DOCS SHOW",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-03-twitter-01h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2072718147279335507"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-07-03 01:59 UTC",
+    "delivered_at": "2026-07-03 01:00 UTC",
     "headline": "TWO-THIRDS OF PENTAGON OPS USING ANTHROPIC HAVE SWITCHED TO OTHER AI TOOLS \u2014 DOD UNDERSECRETARY",
     "source": "@whoisanku",
+    "source_file": "research/summaries/2026-07-03-twitter-01h-headlines.json",
     "url": "https://x.com/whoisanku/status/2072719784152604835"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-07-03 01:59 UTC",
+    "delivered_at": "2026-07-03 01:00 UTC",
     "headline": "FABLE 5 DEBUGGING SCORES CRATER 86.2 -> 25.9 POST-RELAUNCH AS NEW GUARDRAILS OVER-FIRE \u2014 BRIDGEBENCH",
     "source": "@bridgemindai",
+    "source_file": "research/summaries/2026-07-03-twitter-01h-headlines.json",
     "url": "https://x.com/bridgemindai/status/2072662214704533888"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-07-03 01:59 UTC",
+    "delivered_at": "2026-07-03 01:00 UTC",
     "headline": "GPT-5.6 SOL WIDER RELEASE TARGETED FOR JULY 7 \u2014 STILL UNCONFIRMED BY OPENAI",
     "source": "@pankajkumar_dev",
+    "source_file": "research/summaries/2026-07-03-twitter-01h-headlines.json",
     "url": "https://x.com/pankajkumar_dev/status/2072318019628564556"
   },
   {
+    "backfilled": true,
     "category": "research",
-    "delivered_at": "2026-07-03 07:16 UTC",
+    "delivered_at": "2026-07-03 07:00 UTC",
     "headline": "GLOBAL HIGH-SEVERITY CVE DISCLOSURES HIT RECORD 3.5X SPIKE IN JUNE, SAME MONTH AS CLAUDE MYTHOS PREVIEW",
     "source": "@EpochAIResearch",
+    "source_file": "research/summaries/2026-07-03-twitter-07h-headlines.json",
     "url": "https://x.com/EpochAIResearch/status/2072776792809918604"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-07-03 07:16 UTC",
+    "delivered_at": "2026-07-03 07:00 UTC",
     "headline": "ANTHROPIC EXPANDS CLAUDE CODE ARTIFACTS TO PRO/MAX PLANS \u2014 LIVE DASHBOARDS AND PR WALKTHROUGHS FROM CLI SESSIONS",
     "source": "@ClaudeDevs",
+    "source_file": "research/summaries/2026-07-03-twitter-07h-headlines.json",
     "url": "https://x.com/testingcatalog/status/2072774185525670152"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-07-03 07:16 UTC",
+    "delivered_at": "2026-07-03 07:00 UTC",
     "headline": "ELEVENLABS EXPLORES EMPLOYEE SHARE SALE AT $22B VALUATION, DOUBLE ITS $11B FEBRUARY ROUND",
     "source": "@thetechstartups",
+    "source_file": "research/summaries/2026-07-03-twitter-07h-headlines.json",
     "url": "https://x.com/thetechstartups/status/2072783667257020838"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-07-03 13:03 UTC",
+    "delivered_at": "2026-07-03 13:00 UTC",
     "headline": "ANTHROPIC REAFFIRMS FABLE 5 RETURNS TO SUBSCRIPTIONS \"AS SOON AS CAPACITY ALLOWS\" AFTER JULY 7 CUTOFF",
     "source": "@trq212",
+    "source_file": "research/summaries/2026-07-03-twitter-13h-headlines.json",
     "url": "https://x.com/trq212/status/2072814903170408784"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-07-03 13:03 UTC",
+    "delivered_at": "2026-07-03 13:00 UTC",
     "headline": "FORTUNE: SECDEF HEGSETH TAGGED ANTHROPIC \"SUPPLY-CHAIN RISK\" AFTER OPENAI SEALED OWN PENTAGON AI DEAL",
     "source": "@arnaudmercier",
+    "source_file": "research/summaries/2026-07-03-twitter-13h-headlines.json",
     "url": "https://x.com/arnaudmercier/status/2072730407976526325"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-07-03 13:03 UTC",
+    "delivered_at": "2026-07-03 13:00 UTC",
     "headline": "CALIFORNIA INKS FIRST STATEWIDE CLAUDE DEAL: ALL AGENCIES GET 50% DISCOUNT AMID FEDERAL \"SUPPLY-CHAIN RISK\" TAG",
     "source": "@so_sthbryan",
+    "source_file": "research/summaries/2026-07-03-twitter-13h-headlines.json",
     "url": "https://x.com/so_sthbryan/status/2072391788401480088"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-07-03 18:31 UTC",
+    "delivered_at": "2026-07-03 18:00 UTC",
     "headline": "ALIBABA BANS CLAUDE CODE COMPANY-WIDE FROM JULY 10 OVER ALLEGED \"BACKDOOR\" RISK \u2014 PUSHES OWN QODER TOOL",
     "source": "@yicaichina",
+    "source_file": "research/summaries/2026-07-03-twitter-18h-headlines.json",
     "url": "https://x.com/yicaichina/status/2072946372139942383"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-07-03 18:31 UTC",
+    "delivered_at": "2026-07-03 18:00 UTC",
     "headline": "GPT-5.6 SOL/TERRA/LUNA TIER PRICING SURFACES: $5/$30, $2.50/$15, $1/$6 PER MILLION TOKENS \u2014 STILL GATED TO ~20 ORGS",
     "source": "@amohan120",
+    "source_file": "research/summaries/2026-07-03-twitter-18h-headlines.json",
     "url": "https://x.com/amohan120/status/2072976225589735488"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-07-03 18:31 UTC",
+    "delivered_at": "2026-07-03 18:00 UTC",
     "headline": "META'S NEXT MODEL \"WATERMELON\" REPORTEDLY MATCHES GPT-5.5 ON INTERNAL BENCHMARKS, SAYS AI CHIEF ALEXANDR WANG",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-03-twitter-18h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2072970975864397955"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-07-03 18:31 UTC",
+    "delivered_at": "2026-07-03 18:00 UTC",
     "headline": "POLYMARKET PUTS ODDS OF US GOVERNMENT TAKING 5% OPENAI STAKE (~$42.6B) AT 73%",
     "source": "@_StockMlKTNewz",
+    "source_file": "research/summaries/2026-07-03-twitter-18h-headlines.json",
     "url": "https://x.com/_StockMlKTNewz/status/2072975651389198575"
   },
   {
+    "backfilled": true,
     "category": "business",
-    "delivered_at": "2026-07-03 23:28 UTC",
+    "delivered_at": "2026-07-03 23:00 UTC",
     "headline": "ANTHROPIC LAUNCHES CLAUDE SCIENCE, PLANS TO DISCOVER ITS OWN DRUGS FOR NEGLECTED DISEASES",
     "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-03-twitter-23h-headlines.json",
     "url": "https://x.com/kimmonismus/status/2073049390344819033"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-07-04 04:43 UTC",
+    "delivered_at": "2026-07-03 23:00 UTC",
+    "headline": "GPT-5.6 SOL RELEASE-DATE GUESSING SHIFTS TO \"NEXT THURSDAY\" (JULY 9), STILL UNCONFIRMED BY OPENAI",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-03-twitter-23h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2072987218486911415"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-04 04:00 UTC",
     "headline": "LEAKER: OPENAI TARGETING JULY 7 FOR GPT-5.6 LAUNCH, MORE GENEROUS LIMITS THAN CLAUDE FABLE 5",
     "source": "@synthwavedd",
+    "source_file": "research/summaries/2026-07-04-twitter-04h-headlines.json",
     "url": "https://x.com/synthwavedd/status/2073084352251232435"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-07-04 04:43 UTC",
+    "delivered_at": "2026-07-04 04:00 UTC",
     "headline": "REPORT: GOOGLE DEEPMIND SCRAPS GEMINI 3.5 PRO REUSE PLAN, RESETS TO FULL RETRAIN \u2014 NEW JULY 17 TARGET",
     "source": "@synthwavedd",
+    "source_file": "research/summaries/2026-07-04-twitter-04h-headlines.json",
     "url": "https://x.com/synthwavedd/status/2073084352251232435"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-07-04 07:13 UTC",
+    "delivered_at": "2026-07-04 07:00 UTC",
     "headline": "OPENAI'S PROPOSED 5% US GOVERNMENT STAKE (~$42.6B) SPARKS 79.5% NEGATIVE PUBLIC REACTION",
     "source": "@digg",
+    "source_file": "research/summaries/2026-07-04-twitter-07h-headlines.json",
     "url": "https://x.com/digg/status/2073115787502756173"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-07-04 07:13 UTC",
+    "delivered_at": "2026-07-04 07:00 UTC",
     "headline": "UNSEALED COURT DOCS: ANTHROPIC-PENTAGON FIGHT WAS OVER AUTONOMOUS WEAPONS AND SURVEILLANCE GUARDRAILS, NOT CLAUDE ACCESS",
     "source": "@newslit",
+    "source_file": "research/summaries/2026-07-04-twitter-07h-headlines.json",
     "url": "https://x.com/newslit/status/2073066767711133846"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-07-04 07:13 UTC",
+    "delivered_at": "2026-07-04 07:00 UTC",
     "headline": "CNBC: ALTMAN FIRST PITCHED GOVERNMENT EQUITY STAKE TO TRUMP ADMIN IN EARLY 2025, TALKS STILL 'CONCEPTUAL'",
     "source": "@RTVIUS",
+    "source_file": "research/summaries/2026-07-04-twitter-07h-headlines.json",
     "url": "https://x.com/AndrewCurran_/status/2072533453611139332"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-07-04 12:56 UTC",
+    "delivered_at": "2026-07-04 12:00 UTC",
     "headline": "TRUMP DODGES OPENAI 5% GOV STAKE QUESTION, POINTS TO INTEL'S 10% HOLDING AS PRECEDENT",
     "source": "@RedWavePress",
+    "source_file": "research/summaries/2026-07-04-twitter-12h-headlines.json",
     "url": "https://x.com/RedWavePress/status/2073046616286642286"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-07-04 12:56 UTC",
+    "delivered_at": "2026-07-04 12:00 UTC",
     "headline": "GPT-5.6 SOL/TERRA/LUNA TIER PICKER SPOTTED LIVE IN CODEX APP UI; TUESDAY JULY 7 TARGET FIRMS UP",
     "source": "@DevAdventur3s",
+    "source_file": "research/summaries/2026-07-04-twitter-12h-headlines.json",
     "url": "https://x.com/DevAdventur3s/status/2073141065750904923"
   },
   {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-07-04 12:56 UTC",
+    "delivered_at": "2026-07-04 12:00 UTC",
     "headline": "REPORTEDLY: DEEPSEEK DOUBLES V4 PRO PEAK-TIME OUTPUT PRICE TO ~12 YUAN PER MILLION TOKENS, UNCONFIRMED",
     "source": "@cb_terminal",
+    "source_file": "research/summaries/2026-07-04-twitter-12h-headlines.json",
     "url": "https://x.com/cb_terminal/status/2073244234040201233"
   },
   {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-04 17:00 UTC",
+    "headline": "ALIBABA CLAUDE CODE BAN TRACED TO REVERSE-ENGINEERED ANTI-DISTILLATION CHECKS, ANTHROPIC CONFIRMS",
+    "source": "@sadik_0x",
+    "source_file": "research/summaries/2026-07-04-twitter-17h-headlines.json",
+    "url": "https://x.com/sadik_0x/status/2073123616825164141"
+  },
+  {
+    "backfilled": true,
     "category": "model",
-    "delivered_at": "2026-07-04 17:48 UTC",
+    "delivered_at": "2026-07-04 17:00 UTC",
     "headline": "GPT-5.6 SOL/TERRA/LUNA NAMES CONFIRMED IN OPENAI'S OWN PUBLIC GITHUB REPO, JUNE 26 COMMIT",
     "source": "@hqmank",
+    "source_file": "research/summaries/2026-07-04-twitter-17h-headlines.json",
     "url": "https://x.com/hqmank/status/2073314028416565264"
   },
   {
+    "backfilled": true,
     "category": "policy",
-    "delivered_at": "2026-07-04 17:48 UTC",
+    "delivered_at": "2026-07-04 17:00 UTC",
     "headline": "ANTHROPIC PUBLISHES FIRST-DRAFT 0-4 JAILBREAK SEVERITY SCALE WITH AMAZON, MICROSOFT, GOOGLE",
     "source": "@Ruben_Luetke",
+    "source_file": "research/summaries/2026-07-04-twitter-17h-headlines.json",
     "url": "https://x.com/Ruben_Luetke/status/2073183751488573881"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-04 17:00 UTC",
+    "headline": "ANTHROPIC TOLD SENATORS ALIBABA-LINKED ACCOUNTS RAN 25,000 FAKE LOGINS, 28M CLAUDE INTERACTIONS",
+    "source": "@sadik_0x",
+    "source_file": "research/summaries/2026-07-04-twitter-17h-headlines.json",
+    "url": "https://x.com/sadik_0x/status/2073123616825164141"
+  },
+  {
+    "backfilled": true,
+    "category": "",
+    "delivered_at": "2026-07-09 12:00 UTC",
+    "headline": "OPENAI SAYS GPT-5.6 SOL/TERRA/LUNA WILL LAUNCH PUBLICLY THURSDAY",
+    "source": "@OpenAI",
+    "source_file": "research/summaries/2026-07-09-twitter-12h-headlines.json",
+    "url": "https://x.com/OpenAI/status/2074704958419792299"
+  },
+  {
+    "backfilled": true,
+    "category": "",
+    "delivered_at": "2026-07-09 12:00 UTC",
+    "headline": "OPENAI ROLLS OUT GPT-LIVE VOICE MODELS IN CHATGPT",
+    "source": "@OpenAI",
+    "source_file": "research/summaries/2026-07-09-twitter-12h-headlines.json",
+    "url": "https://x.com/OpenAI/status/2074907025537224840"
+  },
+  {
+    "backfilled": true,
+    "category": "",
+    "delivered_at": "2026-07-09 12:00 UTC",
+    "headline": "MUSK SAYS GROK 4.5 HAS 2X+ INFERENCE-SPEED HEADROOM",
+    "source": "@elonmusk",
+    "source_file": "research/summaries/2026-07-09-twitter-12h-headlines.json",
+    "url": "https://x.com/elonmusk/status/2074969374843154500"
+  },
+  {
+    "backfilled": true,
+    "category": "",
+    "delivered_at": "2026-07-10 00:00 UTC",
+    "headline": "OPENAI ROLLS OUT GPT-LIVE VOICE MODELS IN CHATGPT",
+    "source": "@OpenAI",
+    "source_file": "research/summaries/2026-07-10-twitter-00h-headlines.json",
+    "url": "https://x.com/OpenAI/status/2074907025537224840"
+  },
+  {
+    "backfilled": true,
+    "category": "",
+    "delivered_at": "2026-07-10 00:00 UTC",
+    "headline": "MUSK SAYS GROK 4.5 HAS 2X+ INFERENCE-SPEED HEADROOM",
+    "source": "@elonmusk",
+    "source_file": "research/summaries/2026-07-10-twitter-00h-headlines.json",
+    "url": "https://x.com/elonmusk/status/2075130137817825315"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-12 08:00 UTC",
+    "headline": "AI TRAINING-DATA MARKET HITS ~$8.5B REVENUE; SCALE, SURGE, MERCOR, HANDSHAKE CONTROL 75%+",
+    "source": "@deedydas",
+    "source_file": "research/summaries/2026-07-12-twitter-08h-headlines.json",
+    "url": "https://x.com/deedydas/status/2076124392711696455"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-12 08:00 UTC",
+    "headline": "SAMSUNG MOVES UP FIRST YONGIN CHIP FAB LAUNCH TWO YEARS TO OCTOBER 2029",
+    "source": "@jukan05",
+    "source_file": "research/summaries/2026-07-12-twitter-08h-headlines.json",
+    "url": "https://x.com/jukan05/status/2076148820363399213"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-12 08:00 UTC",
+    "headline": "PARIS VOICE-AI STARTUP GRADIUM EXTENDS SEED TO $100M AS NVIDIA JOINS CAP TABLE",
+    "source": "@GrishinRobotics",
+    "source_file": "research/summaries/2026-07-12-twitter-08h-headlines.json",
+    "url": "https://x.com/GrishinRobotics/status/2076213046481924131"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-12 08:00 UTC",
+    "headline": "GPT-5.6 SOL TAKES TOP SPOT ON CRITPT PHYSICS BENCHMARK AT 32.3%",
+    "source": "@WesRoth",
+    "source_file": "research/summaries/2026-07-12-twitter-08h-headlines.json",
+    "url": "https://x.com/WesRoth/status/2076154586507940257"
+  },
+  {
+    "backfilled": true,
+    "category": "breaking",
+    "delivered_at": "2026-07-12 16:00 UTC",
+    "headline": "OPENAI COMMS CHIEF PUBLICLY REBUTS APPLE TRADE-SECRETS LAWSUIT",
+    "source": "@rohanpaul_ai",
+    "source_file": "research/summaries/2026-07-12-twitter-16h-headlines.json",
+    "url": "https://x.com/rohanpaul_ai/status/2076325095900160197"
+  },
+  {
+    "backfilled": true,
+    "category": "opensource",
+    "delivered_at": "2026-07-12 16:00 UTC",
+    "headline": "GERMAN LAB SHIPS SOOFI S 30B-A3B, FULLY OPEN SOVEREIGN GERMAN/ENGLISH MODEL, 27T TOKENS",
+    "source": "@effi288",
+    "source_file": "research/summaries/2026-07-12-twitter-16h-headlines.json",
+    "url": "https://x.com/effi288/status/2075904321707798699"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-12 16:00 UTC",
+    "headline": "ROBOTGYM RAISES \u00a5100M PRE-A AT \u00a5500M VALUATION FOR CHINA ELDER-CARE ROBOTS",
+    "source": "@dermotmcg",
+    "source_file": "research/summaries/2026-07-12-twitter-16h-headlines.json",
+    "url": "https://x.com/dermotmcg/status/2076335907096105103"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-12 22:00 UTC",
+    "headline": "OPENAI TEMPORARILY PULLS CODEX 5-HOUR CAP, BANKS RESET FOR 500K USERS AFTER GPT-5.6 BACKLASH",
+    "source": "@mark_k",
+    "source_file": "research/summaries/2026-07-12-twitter-22h-headlines.json",
+    "url": "https://x.com/mark_k/status/2076385013604491721"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-12 22:00 UTC",
+    "headline": "PERPLEXITY CONFIRMS NVIDIA VERA CPU ADOPTION, CEO CLAIMS OVER 50% GAIN ON AGENTIC CODING TASKS",
+    "source": "@AravSrinivas",
+    "source_file": "research/summaries/2026-07-12-twitter-22h-headlines.json",
+    "url": "https://x.com/AravSrinivas/status/2076391586087526764"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-07-12 22:00 UTC",
+    "headline": "GSO BENCHMARK: CLAUDE OPUS 4.8 TAKES SOTA, GPT-5.5-XHIGH 4TH, SONNET 5 5TH",
+    "source": "@scaling01",
+    "source_file": "research/summaries/2026-07-12-twitter-22h-headlines.json",
+    "url": "https://x.com/scaling01/status/2076420887977312521"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-12 22:00 UTC",
+    "headline": "THE INFORMATION: 22+ PROFESSORS LEFT ACADEMIA FOR OPENAI, ANTHROPIC, GOOGLE, META THIS YEAR",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-07-12-twitter-22h-headlines.json",
+    "url": "https://x.com/theinformation/status/2076411292261249095"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-12 22:00 UTC",
+    "headline": "AI DATA-CENTER DEBT BOOM PUSHES PRIVATE CREDIT INTO RETAIL MUTUAL FUNDS, THE INFORMATION REPORTS",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-07-12-twitter-22h-headlines.json",
+    "url": "https://x.com/theinformation/status/2076381105121378683"
+  },
+  {
+    "backfilled": true,
+    "category": "breaking",
+    "delivered_at": "2026-07-13 03:00 UTC",
+    "headline": "OPENAI DENIES 'NERFING' GPT-5.6 SOL AFTER USERS CITE REVERTED REASONING-EFFORT CHANGE",
+    "source": "@ns123abc",
+    "source_file": "research/summaries/2026-07-13-twitter-03h-headlines.json",
+    "url": "https://x.com/ns123abc/status/2076507528842682669"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-13 03:00 UTC",
+    "headline": "THEO: STACKED CODEX BUGS \u2014 2X BILLING PAST 272K TOKENS, NESTED ULTRA SUBAGENTS \u2014 DROVE GPT-5.6 SOL USAGE BURN",
+    "source": "@theo",
+    "source_file": "research/summaries/2026-07-13-twitter-03h-headlines.json",
+    "url": "https://x.com/theo/status/2076512403668488299"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-13 03:00 UTC",
+    "headline": "CHATGPT WORK ADDS BUILT-IN CLOUD AND DESKTOP BROWSER FOR MULTI-STEP TASKS",
+    "source": "@jxnlco",
+    "source_file": "research/summaries/2026-07-13-twitter-03h-headlines.json",
+    "url": "https://x.com/jxnlco/status/2076511362604540372"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-13 03:00 UTC",
+    "headline": "CHATGPT SITES ENTERS PUBLIC BETA \u2014 TURNS PROMPTS INTO SHAREABLE APPS AND DASHBOARDS",
+    "source": "@jxnlco",
+    "source_file": "research/summaries/2026-07-13-twitter-03h-headlines.json",
+    "url": "https://x.com/jxnlco/status/2076511474600857950"
+  },
+  {
+    "backfilled": true,
+    "category": "opensource",
+    "delivered_at": "2026-07-13 03:00 UTC",
+    "headline": "PRIMEINTELLECT SHIPS VERIFIERS V1, AN OVERHAULED ENVIRONMENT STACK FOR AGENTIC RL AND EVALS",
+    "source": "@PrimeIntellect",
+    "source_file": "research/summaries/2026-07-13-twitter-03h-headlines.json",
+    "url": "https://x.com/scaling01/status/2076448156053569862"
+  },
+  {
+    "backfilled": true,
+    "category": "breaking",
+    "delivered_at": "2026-07-13 15:00 UTC",
+    "headline": "APPLE ACCUSES OPENAI OF POACHING 400+ EX-EMPLOYEES, STEALING TRADE SECRETS FOR HARDWARE PUSH",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-07-13-twitter-15h-headlines.json",
+    "url": "https://x.com/theinformation/status/2076675545320890551"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-13 15:00 UTC",
+    "headline": "GPT-5.6 CODEX ISSUES PERSIST HOURS AFTER OPENAI'S CLAIMED FIX; CONTEXT WINDOW STAYS CAPPED AT 272K",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-13-twitter-15h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2076583758975717874"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-13 15:00 UTC",
+    "headline": "200+ RESEARCHERS & ECONOMISTS INCL. BENGIO, JEFF DEAN SIGN STATEMENT URGING AI ECONOMIC-IMPACT PREP",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-13-twitter-15h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2076664199670006181"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-13 15:00 UTC",
+    "headline": "SK HYNIX ADR PLUNGES 15%+ IN SEOUL, KOSPI DROPS NEARLY 9% ONE WEEK AFTER NASDAQ DEBUT",
+    "source": "@jukan05",
+    "source_file": "research/summaries/2026-07-13-twitter-15h-headlines.json",
+    "url": "https://x.com/jukan05/status/2076609427432751574"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-13 15:00 UTC",
+    "headline": "RL PIONEER RICHARD SUTTON LEAVES CARMACK'S KEEN TECHNOLOGIES TO FOUND NEW STARTUP OAK LAB",
+    "source": "@mark_k",
+    "source_file": "research/summaries/2026-07-13-twitter-15h-headlines.json",
+    "url": "https://x.com/mark_k/status/2076667108688003127"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-07-13 15:00 UTC",
+    "headline": "GOOGLE PUBLISHES GEMMA 4 TECHNICAL REPORT: 5:1 ATTENTION RATIO CUTS KV-CACHE FOOTPRINT",
+    "source": "@_philschmid",
+    "source_file": "research/summaries/2026-07-13-twitter-15h-headlines.json",
+    "url": "https://x.com/_philschmid/status/2076674417262784768"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-07-13 18:00 UTC",
+    "headline": "ANTHROPIC: CLAUDE'S EXPRESSED VALUES SHIFT BY MODEL AND LANGUAGE, 300K+ CONVOS ANALYZED",
+    "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-07-13-twitter-18h-headlines.json",
+    "url": "https://x.com/AnthropicAI/status/2076719540785012872"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-13 18:00 UTC",
+    "headline": "GROK BUILD PRIVACY ROW: SPACEXAI CLARIFIES DATA-RETENTION POLICY AFTER REPO/SECRETS-UPLOAD CLAIM",
+    "source": "@mark_k",
+    "source_file": "research/summaries/2026-07-13-twitter-18h-headlines.json",
+    "url": "https://x.com/mark_k/status/2076704557648789540"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-13 18:00 UTC",
+    "headline": "PERPLEXITY INTEGRATES GROK 4.5 INTO PERPLEXITY COMPUTER, CITES ZDR AND BEST EVALS",
+    "source": "@AravSrinivas",
+    "source_file": "research/summaries/2026-07-13-twitter-18h-headlines.json",
+    "url": "https://x.com/AravSrinivas/status/2076699450177892354"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-07-13 18:00 UTC",
+    "headline": "OPENAI: AI TO HIT INTERN-RESEARCHER LEVEL BY SEPTEMBER, FULL RESEARCHER BY MARCH 2028",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-07-13-twitter-18h-headlines.json",
+    "url": "https://x.com/theinformation/status/2076698316260139156"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-13 18:00 UTC",
+    "headline": "VERCEL: OPEN-WEIGHT MODELS NOW 29% OF AI GATEWAY TOKEN VOLUME, UP FROM 11% IN APRIL",
+    "source": "@rauchg",
+    "source_file": "research/summaries/2026-07-13-twitter-18h-headlines.json",
+    "url": "https://x.com/rauchg/status/2076713720731042174"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-13 18:00 UTC",
+    "headline": "META'S MUSE SPARK 1.1 CLAIMS SOTA ON RADIOLOGY BENCHMARK, NEARS HUMAN-EXPERT LEVEL",
+    "source": "@alexandr_wang",
+    "source_file": "research/summaries/2026-07-13-twitter-18h-headlines.json",
+    "url": "https://x.com/alexandr_wang/status/2076696459005837410"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-13 22:00 UTC",
+    "headline": "CLAUDE ARTIFACTS GO MULTIPLAYER AND PUBLICLY SHAREABLE; CLAUDE TAG NOW BUILDS THEM FROM SLACK",
+    "source": "@ClaudeDevs",
+    "source_file": "research/summaries/2026-07-13-twitter-22h-headlines.json",
+    "url": "https://x.com/ClaudeDevs/status/2076789349145092230"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-13 22:00 UTC",
+    "headline": "GOOGLE ANTIGRAVITY ADDS 'AGENT TEAMS' MODE VIA NEW /TEAMWORK-PREVIEW COMMAND",
+    "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-07-13-twitter-22h-headlines.json",
+    "url": "https://x.com/testingcatalog/status/2076753626542801093"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-13 22:00 UTC",
+    "headline": "GOOGLE PITCHES TPUS TO NVIDIA'S OWN CLOUD CUSTOMERS; NVIDIA COUNTERS WITH FINANCING GUARANTEES",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-07-13-twitter-22h-headlines.json",
+    "url": "https://x.com/theinformation/status/2076766138164252928"
+  },
+  {
+    "backfilled": true,
+    "category": "opensource",
+    "delivered_at": "2026-07-13 22:00 UTC",
+    "headline": "ATOMIC CHAT'S DFLASH HITS 3.4X SPECULATIVE-DECODING SPEEDUP FOR LOCAL QWEN MODELS",
+    "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-07-13-twitter-22h-headlines.json",
+    "url": "https://x.com/testingcatalog/status/2076778070870995321"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-07-13 22:00 UTC",
+    "headline": "NEW BENCHMARK LONG-HORIZON-TERMINAL-BENCH TESTS AGENTS ON DENSE-REWARD TERMINAL TASKS",
+    "source": "@_akhaliq",
+    "source_file": "research/summaries/2026-07-13-twitter-22h-headlines.json",
+    "url": "https://x.com/_akhaliq/status/2076742840172925164"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-14 08:00 UTC",
+    "headline": "NVIDIA'S HUANG REBUTS DELAY RUMORS: RUBIN ULTRA ON TRACK, NO ASIC SHARE LOSS",
+    "source": "@aleabitoreddit",
+    "source_file": "research/summaries/2026-07-14-twitter-08h-headlines.json",
+    "url": "https://x.com/aleabitoreddit/status/2076846994614792663"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-14 08:00 UTC",
+    "headline": "FT: CHINESE CHIPMAKERS LOBBY BEIJING FOR NVIDIA H200 ACCESS AMID COMPUTE CRUNCH",
+    "source": "@jukan05",
+    "source_file": "research/summaries/2026-07-14-twitter-08h-headlines.json",
+    "url": "https://x.com/jukan05/status/2076871708984877077"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-14 08:00 UTC",
+    "headline": "KOREAN MEDIA: SAMSUNG FOUNDRY SECURES ANTHROPIC AS CUSTOM AI CHIP CUSTOMER \u2014 UNCONFIRMED",
+    "source": "@jukan05",
+    "source_file": "research/summaries/2026-07-14-twitter-08h-headlines.json",
+    "url": "https://x.com/jukan05/status/2076927678905790656"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-14 08:00 UTC",
+    "headline": "GPT-5.6 SOL, TERRA, LUNA NOW LIVE ON AMAZON BEDROCK WITH FIRST-PARTY AWS PRICING",
+    "source": "@jxnlco",
+    "source_file": "research/summaries/2026-07-14-twitter-08h-headlines.json",
+    "url": "https://x.com/jxnlco/status/2076824126367695275"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-14 08:00 UTC",
+    "headline": "ELON MUSK: GROK 4.5 CLAIMS #1 ON LONG-HORIZON TERMINAL-BENCH, UNCORROBORATED",
+    "source": "@elonmusk",
+    "source_file": "research/summaries/2026-07-14-twitter-08h-headlines.json",
+    "url": "https://x.com/elonmusk/status/2076909201524203973"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-07-14 10:00 UTC",
+    "headline": "GOOGLE RESEARCH: LLMS THAT 'SLEEP' TO CONSOLIDATE MEMORY ACE 10M-TOKEN BABILONG, BEAT SFT/GRPO",
+    "source": "@mark_k",
+    "source_file": "research/summaries/2026-07-14-twitter-10h-headlines.json",
+    "url": "https://x.com/mark_k/status/2076961697416314912"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-07-14 10:00 UTC",
+    "headline": "SAKANA AI'S SELF-HEALING 'SMART CELLULAR BRICKS' ROBOTICS RESEARCH PUBLISHED IN NATURE COMMUNICATIONS",
+    "source": "@hardmaru",
+    "source_file": "research/summaries/2026-07-14-twitter-10h-headlines.json",
+    "url": "https://x.com/hardmaru/status/2076951908208763217"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-14 10:00 UTC",
+    "headline": "DEMIS HASSABIS: AGI 'CLOSER TO DISCOVERY OF FIRE' THAN INTERNET, CALLS FOR REGULATION WITHIN YEARS",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-14-twitter-10h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2076967071032791503"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-14 10:00 UTC",
+    "headline": "OPENAI ADDS SELF-SERVICE USAGE-LIMIT RESET FOR CHATGPT WORK AND CODEX AFTER BILLING DISPUTE",
+    "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-07-14-twitter-10h-headlines.json",
+    "url": "https://x.com/testingcatalog/status/2076948822744261040"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-14 14:00 UTC",
+    "headline": "HASSABIS PROPOSES US \"FRONTIER AI STANDARDS BODY\" WITH 30-DAY PRE-DEPLOYMENT REVIEW",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-14-twitter-14h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2077026826409701820"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-14 14:00 UTC",
+    "headline": "MOONSHOT'S KIMI K3 IMMINENT \u2014 WATCHERS SPLIT ON WHETHER IT SHIPS TODAY OR TOMORROW",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-14-twitter-14h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2077019458640482704"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-14 14:00 UTC",
+    "headline": "ANTHROPIC COMMITS $10M CAD TO CANADIAN AI RESEARCH INSTITUTIONS",
+    "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-07-14-twitter-14h-headlines.json",
+    "url": "https://x.com/AnthropicAI/status/2077026346375540870"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-14 14:00 UTC",
+    "headline": "NOUS RESEARCH REPORTEDLY RAISING $75M AT $1.5B VALUATION, 50% ABOVE LAST ROUND",
+    "source": "@EdgarMontano",
+    "source_file": "research/summaries/2026-07-14-twitter-14h-headlines.json",
+    "url": "https://x.com/EdgarMontano/status/2077029491440808188"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-14 14:00 UTC",
+    "headline": "SEMIANALYSIS: NVIDIA STILL HOLDS UNUSED PRICING POWER DESPITE LAB TOKEN-PRICE CUTS",
+    "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-07-14-twitter-14h-headlines.json",
+    "url": "https://x.com/SemiAnalysis_/status/2077031014396756438"
+  },
+  {
+    "backfilled": true,
+    "category": "breaking",
+    "delivered_at": "2026-07-14 16:00 UTC",
+    "headline": "SAM ALTMAN: XAI'S GROK BUILD CODE-UPLOAD CLAIM IS 'CONCERNING' \u2014 BACKS OPEN-SOURCE CODING HARNESSES",
+    "source": "@sama",
+    "source_file": "research/summaries/2026-07-14-twitter-16h-headlines.json",
+    "url": "https://x.com/sama/status/2077053140508266710"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-14 16:00 UTC",
+    "headline": "ALTMAN CALLS HASSABIS'S FRONTIER AI STANDARDS BODY PROPOSAL 'A THOUGHTFUL PROPOSAL'",
+    "source": "@sama",
+    "source_file": "research/summaries/2026-07-14-twitter-16h-headlines.json",
+    "url": "https://x.com/sama/status/2077042528906527225"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-14 16:00 UTC",
+    "headline": "ALTMAN: GPT-5.6 SOL IS HALF THE PRICE, 2X MORE TOKEN-EFFICIENT THAN CLAUDE FABLE",
+    "source": "@sama",
+    "source_file": "research/summaries/2026-07-14-twitter-16h-headlines.json",
+    "url": "https://x.com/sama/status/2077036999303999910"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-14 16:00 UTC",
+    "headline": "NEBIUS SIGNS $1B+ NVIDIA GB300 COMPUTE DEAL WITH REFLECTION AI THROUGH 2029; STOCK -5%",
+    "source": "@aleabitoreddit",
+    "source_file": "research/summaries/2026-07-14-twitter-16h-headlines.json",
+    "url": "https://x.com/aleabitoreddit/status/2077044786402660829"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-14 16:00 UTC",
+    "headline": "ANTHROPIC LAUNCHES FREE CLAUDE FOR TEACHERS FOR VERIFIED US K-12 EDUCATORS",
+    "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-07-14-twitter-16h-headlines.json",
+    "url": "https://x.com/testingcatalog/status/2077051010951069871"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-14 22:00 UTC",
+    "headline": "BLOOMBERG: APPLE SUES OPENAI, TWO EX-EMPLOYEES OVER TRADE-SECRET THEFT TIED TO HARDWARE PUSH",
+    "source": "@faststocknewss",
+    "source_file": "research/summaries/2026-07-14-twitter-22h-headlines.json",
+    "url": "https://x.com/faststocknewss/status/2077151567426568621"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-14 22:00 UTC",
+    "headline": "OPENAI'S FIRST HARDWARE DEVICE: SCREEN-FREE AI COMPANION SPEAKER BUILT WITH JONY IVE'S LOVEFROM, TARGETING 2027",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-14-twitter-22h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2077143129140977751"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-07-14 22:00 UTC",
+    "headline": "META'S MUSE SPARK SCORES PERFECT 30/30, TIES TOP HUMANS AT ASIAN PHYSICS OLYMPIAD 2026",
+    "source": "@AIatMeta",
+    "source_file": "research/summaries/2026-07-14-twitter-22h-headlines.json",
+    "url": "https://x.com/AIatMeta/status/2077138553210028042"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-14 22:00 UTC",
+    "headline": "OPENAI RESETS CODEX/CHATGPT WORK LIMITS 5TH TIME SINCE GPT-5.6 LAUNCH; ALTMAN WARNS OF 'HICCUPS SOON'",
+    "source": "@sama",
+    "source_file": "research/summaries/2026-07-14-twitter-22h-headlines.json",
+    "url": "https://x.com/sama/status/2077106587307798989"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-14 22:00 UTC",
+    "headline": "WHITE HOUSE TO LAUNCH AI AND CYBERSECURITY COORDINATION GROUP \u2014 REUTERS",
+    "source": "@ReutersLegal",
+    "source_file": "research/summaries/2026-07-14-twitter-22h-headlines.json",
+    "url": "https://x.com/ReutersLegal/status/2077151447767019736"
+  },
+  {
+    "backfilled": true,
+    "category": "opensource",
+    "delivered_at": "2026-07-14 22:00 UTC",
+    "headline": "PERPLEXITY OPEN-SOURCES WANDR, ITS INTERNAL DEEP-RESEARCH-AGENT BENCHMARK",
+    "source": "@AravSrinivas",
+    "source_file": "research/summaries/2026-07-14-twitter-22h-headlines.json",
+    "url": "https://x.com/AravSrinivas/status/2077105849638728118"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-15 11:00 UTC",
+    "headline": "DEEPSEEK ARR NEARS $500M, RAISED $7.4B, VALUATION JUMPS TO ~$50B \u2014 PREPPING SHANGHAI STAR MARKET IPO",
+    "source": "@jukan05",
+    "source_file": "research/summaries/2026-07-15-twitter-11h-headlines.json",
+    "url": "https://x.com/jukan05/status/2077262158312951844"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-15 11:00 UTC",
+    "headline": "NEW YORK GOV. HOCHUL SIGNS FIRST STATEWIDE HYPERSCALE DATA CENTER MORATORIUM, PAUSES REVIEW FOR 50MW+ SITES",
+    "source": "@OwenGregorian",
+    "source_file": "research/summaries/2026-07-15-twitter-11h-headlines.json",
+    "url": "https://x.com/OwenGregorian/status/2077347179530715178"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-15 11:00 UTC",
+    "headline": "OPENAI RESEARCHER MILES WANG LEAVES TO LAUNCH AI DRUG-DISCOVERY STARTUP, IN TALKS TO RAISE $200M AT $2B VALUATION",
+    "source": "@dejavucoder",
+    "source_file": "research/summaries/2026-07-15-twitter-11h-headlines.json",
+    "url": "https://x.com/dejavucoder/status/2077331013060206645"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-15 11:00 UTC",
+    "headline": "PRISMML'S BONSAI 27B BECOMES FIRST 27B-CLASS MODEL TO RUN ON A PHONE VIA 1-BIT QUANTIZATION, 54GB TO 3.8GB",
+    "source": "@HuggingFace",
+    "source_file": "research/summaries/2026-07-15-twitter-11h-headlines.json",
+    "url": "https://x.com/HuggingFace/status/2077164993989017668"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-15 11:00 UTC",
+    "headline": "ANTHROPIC HIRING ENFORCEMENT ANALYSTS FOR NUCLEAR, CHEMICAL, CYBER HARM AT $200K+ SALARIES",
+    "source": "@thenextweb",
+    "source_file": "research/summaries/2026-07-15-twitter-11h-headlines.json",
+    "url": "https://x.com/thenextweb/status/2077347272971473327"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-15 14:00 UTC",
+    "headline": "ANTHROPIC, BLACKSTONE, HELLMAN & FRIEDMAN LAUNCH ENTERPRISE AI SERVICES FIRM ODE",
+    "source": "@AIStockSavvy",
+    "source_file": "research/summaries/2026-07-15-twitter-14h-headlines.json",
+    "url": "https://x.com/AIStockSavvy/status/2077393192865997198"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-15 14:00 UTC",
+    "headline": "DEEPSEEK EYES $71-74B VALUATION IN FRESH ROUND WEEKS AFTER $7.4B RAISE \u2014 BLOOMBERG",
+    "source": "@haricinews",
+    "source_file": "research/summaries/2026-07-15-twitter-14h-headlines.json",
+    "url": "https://x.com/haricinews/status/2077392750387892382"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-15 14:00 UTC",
+    "headline": "EMERGENT JOINS INDIA UNICORN CLUB WITH $130M SERIES C AT $1.5B VALUATION",
+    "source": "@FortuneIndia",
+    "source_file": "research/summaries/2026-07-15-twitter-14h-headlines.json",
+    "url": "https://x.com/FortuneIndia/status/2077393321790738803"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-15 14:00 UTC",
+    "headline": "ANACONDA ACQUIRES OPEN-SOURCE AI CODING AGENT KILO CODE, 3M DEVELOPERS",
+    "source": "@kilocode",
+    "source_file": "research/summaries/2026-07-15-twitter-14h-headlines.json",
+    "url": "https://x.com/kilocode/status/2077394060248076699"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-15 14:00 UTC",
+    "headline": "APPLE V. OPENAI TRADE-SECRET SUIT DETAIL EMERGES: 41-PAGE FEDERAL COMPLAINT",
+    "source": "@elonmusk",
+    "source_file": "research/summaries/2026-07-15-twitter-14h-headlines.json",
+    "url": "https://x.com/elonmusk/status/2077373029898682425"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-15 16:00 UTC",
+    "headline": "APPLE V. OPENAI SUIT: 400+ EX-EMPLOYEES RECRUITED, TRADE-SECRET THEFT ALLEGED, IPO PLANS AT RISK",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-07-15-twitter-16h-headlines.json",
+    "url": "https://x.com/theinformation/status/2077400322192863512"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-15 16:00 UTC",
+    "headline": "APPLE BEGINS SCOUTING AI CHIP-COMPANY ACQUISITIONS FOR SERVER SILICON BUILDOUT",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-07-15-twitter-16h-headlines.json",
+    "url": "https://x.com/theinformation/status/2077408010943496443"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-07-15 16:00 UTC",
+    "headline": "NVIDIA: CODEX AGENT AUTONOMOUSLY POST-TRAINED COSMOS 3 NANO FROM 54% TO 93% ACCURACY IN 19.5 HOURS",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-15-twitter-16h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2077400362995388729"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-15 16:00 UTC",
+    "headline": "OPENAI'S $230 CODEX MICRO CONTROL-DECK ACCESSORY GOES LIVE ON OPENAI SUPPLY SITE",
+    "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-07-15-twitter-16h-headlines.json",
+    "url": "https://x.com/testingcatalog/status/2077426702582792549"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-15 19:00 UTC",
+    "headline": "THINKING MACHINES SHIPS INKLING \u2014 975B-PARAM OPEN-WEIGHTS MODEL, FIRST FROM MIRA MURATI'S LAB",
+    "source": "@soumithchintala",
+    "source_file": "research/summaries/2026-07-15-twitter-19h-headlines.json",
+    "url": "https://x.com/soumithchintala/status/2077457110728884327"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-15 19:00 UTC",
+    "headline": "CAIXIN: CHINA CLEARS APPLE INTELLIGENCE FOR LAUNCH VIA ALIBABA PARTNERSHIP",
+    "source": "@caixin",
+    "source_file": "research/summaries/2026-07-15-twitter-19h-headlines.json",
+    "url": "https://x.com/caixin/status/2077470486242484581"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-07-15 19:00 UTC",
+    "headline": "OPENAI LAUNCHES GPT-RED, AUTOMATED RED-TEAMER FOR PROMPT-INJECTION VULNERABILITIES",
+    "source": "@OpenAI",
+    "source_file": "research/summaries/2026-07-15-twitter-19h-headlines.json",
+    "url": "https://x.com/OpenAI/status/2077446718728425686"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-07-15 19:00 UTC",
+    "headline": "ANTHROPIC PUBLISHES NEW AGENTIC MISALIGNMENT RESEARCH, FOUR NEW MISBEHAVIOR MODES FOUND",
+    "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-07-15-twitter-19h-headlines.json",
+    "url": "https://x.com/AnthropicAI/status/2077452646303006927"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-15 19:00 UTC",
+    "headline": "AWS EC2 AND BEDROCK CHIEF DAVE BROWN LEAVING AFTER 19 YEARS AT AMAZON",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-07-15-twitter-19h-headlines.json",
+    "url": "https://x.com/theinformation/status/2077440926868197414"
+  },
+  {
+    "backfilled": true,
+    "category": "opensource",
+    "delivered_at": "2026-07-15 22:00 UTC",
+    "headline": "XAI OPEN-SOURCES GROK BUILD CODING AGENT ON GITHUB, RESETS ALL USAGE LIMITS",
+    "source": "@elonmusk",
+    "source_file": "research/summaries/2026-07-15-twitter-22h-headlines.json",
+    "url": "https://x.com/elonmusk/status/2077495635687723408"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-15 22:00 UTC",
+    "headline": "THINKING MACHINES' INKLING GETS DAY-0 FP4 INFERENCE SUPPORT ON NVIDIA AND AMD VIA PYTORCH TOKENSPEED",
+    "source": "@PyTorch",
+    "source_file": "research/summaries/2026-07-15-twitter-22h-headlines.json",
+    "url": "https://x.com/PyTorch/status/2077521005380317483"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-15 22:00 UTC",
+    "headline": "CLAUDE CODE ARTIFACTS CAN NOW CALL VIEWERS' OWN MCP CONNECTORS FOR LIVE DATA",
+    "source": "@ClaudeDevs",
+    "source_file": "research/summaries/2026-07-15-twitter-22h-headlines.json",
+    "url": "https://x.com/ClaudeDevs/status/2077489907350856038"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-15 22:00 UTC",
+    "headline": "OPENAI REPORTEDLY SHIPS FIRST HARDWARE: $230 \"CODEX MICRO\" DESKTOP WORKFLOW CONTROLLER",
+    "source": "@rohanpaul_ai",
+    "source_file": "research/summaries/2026-07-15-twitter-22h-headlines.json",
+    "url": "https://x.com/rohanpaul_ai/status/2077475497014067282"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-16 08:00 UTC",
+    "headline": "ANTHROPIC RESETS 5-HOUR AND WEEKLY CLAUDE LIMITS FOR ALL USERS \u2014 RARE DUAL RESET",
+    "source": "@ClaudeDevs",
+    "source_file": "research/summaries/2026-07-16-twitter-08h-headlines.json",
+    "url": "https://x.com/ClaudeDevs/status/2077603834453770467"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-16 08:00 UTC",
+    "headline": "OPENAI RESETS CODEX/CHATGPT WORK LIMITS AFTER HITTING 9M ACTIVE USERS, SAME WINDOW AS ANTHROPIC",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-16-twitter-08h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2077628226499932621"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-16 08:00 UTC",
+    "headline": "RESEARCHERS SAY THINKING MACHINES' INKLING LAGS GLM 5.2, FAILS BASIC REASONING TESTS",
+    "source": "@emollick",
+    "source_file": "research/summaries/2026-07-16-twitter-08h-headlines.json",
+    "url": "https://x.com/emollick/status/2077593908540850491"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-16 08:00 UTC",
+    "headline": "TSMC Q2 NET INCOME NT$706.6B BEATS EST. NT$623.73B; Q3 GUIDANCE ABOVE STREET",
+    "source": "@jukan05",
+    "source_file": "research/summaries/2026-07-16-twitter-08h-headlines.json",
+    "url": "https://x.com/jukan05/status/2077630742788743292"
+  },
+  {
+    "backfilled": true,
+    "category": "opensource",
+    "delivered_at": "2026-07-16 08:00 UTC",
+    "headline": "DEVELOPER INSPECTS GROK BUILD'S 844,000-LINE OPEN-SOURCED RUST CODEBASE, FINDS IT REAL",
+    "source": "@simonw",
+    "source_file": "research/summaries/2026-07-16-twitter-08h-headlines.json",
+    "url": "https://x.com/simonw/status/2077545830802976796"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-16 11:00 UTC",
+    "headline": "FT: MOONSHOT'S KIMI K3 (2-3T PARAMS) TO LAUNCH AS EARLY AS TONIGHT, TARGETING BETWEEN OPUS 4.8 AND FABLE 5",
+    "source": "@zijing_wu",
+    "source_file": "research/summaries/2026-07-16-twitter-11h-headlines.json",
+    "url": "https://x.com/zijing_wu/status/2077699476194771064"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-16 11:00 UTC",
+    "headline": "NVIDIA CONFIRMS NOETRA JAPAN AI FACTORY \u2014 27,500 RUBIN GPUS, 13,750 VERA CPUS, BACKED BY METI",
+    "source": "@nvidianewsroom",
+    "source_file": "research/summaries/2026-07-16-twitter-11h-headlines.json",
+    "url": "https://x.com/nvidianewsroom/status/2077711134031839297"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-16 11:00 UTC",
+    "headline": "MOONSHOT AI FUNDRAISING ROUND VALUES COMPANY AT $31.5B PER FT REPORT",
+    "source": "@zijing_wu",
+    "source_file": "research/summaries/2026-07-16-twitter-11h-headlines.json",
+    "url": "https://x.com/zijing_wu/status/2077699476194771064"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-16 14:00 UTC",
+    "headline": "KIMI K3 GOES LIVE \u2014 MOONSHOT'S 2-3T MODEL ROLLS OUT, BENCHMARKS VS OPUS 4.8 STILL PENDING",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-16-twitter-14h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2077751499371798532"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-16 14:00 UTC",
+    "headline": "SK HYNIX CRASHES ON KOSPI AS CHINA'S CXMT ADVANCES DRAM-IPO PLANS, REVIVING HBM GLUT FEARS",
+    "source": "@StocksHomeNo1",
+    "source_file": "research/summaries/2026-07-16-twitter-14h-headlines.json",
+    "url": "https://x.com/StocksHomeNo1/status/2077758893850079293"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-16 14:00 UTC",
+    "headline": "MICRON FALLS 5.37% DESPITE NEW QUALCOMM MEMORY SUPPLY DEAL AS AI-CHIP SELLOFF DEEPENS",
+    "source": "@aleabitoreddit",
+    "source_file": "research/summaries/2026-07-16-twitter-14h-headlines.json",
+    "url": "https://x.com/aleabitoreddit/status/2077753660592033828"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-07-16 14:00 UTC",
+    "headline": "AI21 LABS CLAIMS SOTA ON FULL SWE-BENCH PRO \u2014 80.8% RESOLVE RATE AT $5.99/TASK",
+    "source": "@AI21Labs",
+    "source_file": "research/summaries/2026-07-16-twitter-14h-headlines.json",
+    "url": "https://x.com/AI21Labs/status/2077713580896424088"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-16 14:00 UTC",
+    "headline": "THE INFORMATION: MICROSOFT REORGANIZES 10,000-PERSON SECURITY GROUP AROUND AI, REPLACES TOP EXECS",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-07-16-twitter-14h-headlines.json",
+    "url": "https://x.com/theinformation/status/2077747606617239882"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-16 16:00 UTC",
+    "headline": "KIMI K3 BENCHMARKS: MOONSHOT CLAIMS #3 SPOT BEHIND GPT-5.6 SOL, FABLE 5 \u2014 AHEAD OF OPUS 4.8",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-16-twitter-16h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2077772229685707138"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-16 16:00 UTC",
+    "headline": "KIMI K3 HANDS-ON: TESTERS REPORT EXCESSIVE LOOPING, \"GENERAL DISAPPOINTMENT\" DESPITE CHART POSITION",
+    "source": "@emollick",
+    "source_file": "research/summaries/2026-07-16-twitter-16h-headlines.json",
+    "url": "https://x.com/emollick/status/2077770187521069152"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-16 16:00 UTC",
+    "headline": "THE INFORMATION: ANTHROPIC IN TALKS WITH BANKS FOR MULTI-BILLION-DOLLAR CREDIT LINES AHEAD OF 2026 IPO",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-07-16-twitter-16h-headlines.json",
+    "url": "https://x.com/theinformation/status/2077762718468067789"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-07-16 16:00 UTC",
+    "headline": "NVIDIA NEMOTRON 3 EMBED 8B HITS #1 ON RTEB RETRIEVAL BENCHMARK, VALIDATED IN PRODUCTION BY MEM0",
+    "source": "@mem0ai",
+    "source_file": "research/summaries/2026-07-16-twitter-16h-headlines.json",
+    "url": "https://x.com/mem0ai/status/2077794042189173190"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-16 16:00 UTC",
+    "headline": "KIMI K3 PRICING SET AT $3 INPUT / $15 OUTPUT PER MILLION TOKENS \u2014 ROUGH PARITY WITH SONNET 5",
+    "source": "@scaling01",
+    "source_file": "research/summaries/2026-07-16-twitter-16h-headlines.json",
+    "url": "https://x.com/scaling01/status/2077770795107897449"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-16 19:00 UTC",
+    "headline": "LMARENA CONFIRMS KIMI K3 #1 ON FRONTEND CODE ARENA, 48 POINTS AHEAD OF CLAUDE FABLE 5",
+    "source": "@arena",
+    "source_file": "research/summaries/2026-07-16-twitter-19h-headlines.json",
+    "url": "https://x.com/arena/status/2077824029126504525"
+  },
+  {
+    "backfilled": true,
+    "category": "breaking",
+    "delivered_at": "2026-07-16 19:00 UTC",
+    "headline": "SAM ALTMAN: \"WE DID NOT HAVE OUR BEST 12 MONTHS EVER, WHICH IS MOSTLY MY FAULT\"",
+    "source": "@sama",
+    "source_file": "research/summaries/2026-07-16-twitter-19h-headlines.json",
+    "url": "https://x.com/sama/status/2077817060068057493"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-16 19:00 UTC",
+    "headline": "FIREWORKS AI CLOSES $1.5B SERIES D AT $17.5B VALUATION, TOPS $1B ARR",
+    "source": "@JayThakrar",
+    "source_file": "research/summaries/2026-07-16-twitter-19h-headlines.json",
+    "url": "https://x.com/JayThakrar/status/2077837038070493532"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-16 19:00 UTC",
+    "headline": "MOONSHOT'S OWN BLOG ADMITS KIMI K3 UX GAP VS CLAUDE FABLE 5 AND GPT-5.6 SOL DESPITE BENCHMARK WINS",
+    "source": "@scaling01",
+    "source_file": "research/summaries/2026-07-16-twitter-19h-headlines.json",
+    "url": "https://x.com/scaling01/status/2077833896931037290"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-16 19:00 UTC",
+    "headline": "GOOGLE ADDS COST CONTROLS, FREE TIER, SCHEDULED TRIGGERS TO GEMINI API MANAGED AGENTS",
+    "source": "@OfficialLoganK",
+    "source_file": "research/summaries/2026-07-16-twitter-19h-headlines.json",
+    "url": "https://x.com/OfficialLoganK/status/2077810190179762366"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-16 22:00 UTC",
+    "headline": "ALPHABET SLIDES 4.4% AS BLOOMBERG REPORTS GEMINI 3.5 PRO DELAYED AGAIN AMID KIMI K3 FALLOUT",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-16-twitter-22h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2077847329655452104"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-16 22:00 UTC",
+    "headline": "ANTHROPIC SHIPS TIERED CLAUDE CODE /CODE-REVIEW \u2014 TOP TIER RUNS A FLEET OF REVIEWER AGENTS PER PR",
+    "source": "@ClaudeDevs",
+    "source_file": "research/summaries/2026-07-16-twitter-22h-headlines.json",
+    "url": "https://x.com/ClaudeDevs/status/2077840057130692886"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-16 22:00 UTC",
+    "headline": "CHINA'S AISHI TECHNOLOGY (PIXVERSE) CLOSES $410M SERIES C LED BY ALIBABA",
+    "source": "@TechBuzzChina",
+    "source_file": "research/summaries/2026-07-16-twitter-22h-headlines.json",
+    "url": "https://x.com/TechBuzzChina/status/2077875941695520927"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-16 22:00 UTC",
+    "headline": "GOOGLE RENAMES NOTEBOOKLM TO GEMINI NOTEBOOK, TEASES SEARCH INTEGRATION",
+    "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-07-16-twitter-22h-headlines.json",
+    "url": "https://x.com/testingcatalog/status/2077850826882564129"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-16 22:00 UTC",
+    "headline": "XI JINPING TO DELIVER AI POLICY SPEECH FRIDAY, PER MONITORED ACCOUNTS",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-16-twitter-22h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2077855608683061370"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-17 03:00 UTC",
+    "headline": "XI JINPING UNVEILS FOUR-PRINCIPLE GLOBAL AI GOVERNANCE FRAMEWORK AT WAIC OPENING IN SHANGHAI",
+    "source": "@XHNews",
+    "source_file": "research/summaries/2026-07-17-twitter-03h-headlines.json",
+    "url": "https://x.com/XHNews/status/2077959234613031263"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-17 03:00 UTC",
+    "headline": "29 COUNTRIES SIGN AGREEMENT TO LAUNCH WORLD AI COOPERATION ORGANIZATION (WAICO)",
+    "source": "@TheMtBoulevard",
+    "source_file": "research/summaries/2026-07-17-twitter-03h-headlines.json",
+    "url": "https://x.com/TheMtBoulevard/status/2077958261551067617"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-17 03:00 UTC",
+    "headline": "CHINA PLEDGES 5,000 AI TRAINING SLOTS FOR DEVELOPING NATIONS OVER NEXT FIVE YEARS",
+    "source": "@XHNews",
+    "source_file": "research/summaries/2026-07-17-twitter-03h-headlines.json",
+    "url": "https://x.com/XHNews/status/2077957478772596898"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-17 03:00 UTC",
+    "headline": "KIMI K3 TOPS VERCEL WEB-ENGINEERING BENCHMARK \u2014 FIRST OPEN MODEL AHEAD OF ALL PROPRIETARY RIVALS",
+    "source": "@rauchg",
+    "source_file": "research/summaries/2026-07-17-twitter-03h-headlines.json",
+    "url": "https://x.com/rauchg/status/2077900518404321759"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-17 10:00 UTC",
+    "headline": "KIMI K3 SEIZES #1 AI MINDSHARE, DETHRONING GPT AND CLAUDE FOR FIRST TIME \u2014 KAITO",
+    "source": "@KaitoAI",
+    "source_file": "research/summaries/2026-07-17-twitter-10h-headlines.json",
+    "url": "https://x.com/KaitoAI/status/2078035728076779948"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-17 10:00 UTC",
+    "headline": "ARTIFICIAL ANALYSIS PLACES KIMI K3 3RD GLOBALLY ON INTELLIGENCE INDEX, SCORE 57",
+    "source": "@RealNickMugalli",
+    "source_file": "research/summaries/2026-07-17-twitter-10h-headlines.json",
+    "url": "https://x.com/RealNickMugalli/status/2078033658233983124"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-07-17 10:00 UTC",
+    "headline": "KIMI K3 ARCHITECTURE REVEALED: LATENTMOE ROUTING, 16-OF-896 EXPERTS",
+    "source": "@NielsRogge",
+    "source_file": "research/summaries/2026-07-17-twitter-10h-headlines.json",
+    "url": "https://x.com/NielsRogge/status/2078042508638974019"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-17 10:00 UTC",
+    "headline": "MOONSHOT'S KIMI K3 CONFIRMED AT 2.8T PARAMS BY CHINESE STATE MEDIA; FULL WEIGHTS JULY 27",
+    "source": "@globaltimesnews",
+    "source_file": "research/summaries/2026-07-17-twitter-10h-headlines.json",
+    "url": "https://x.com/globaltimesnews/status/2078028083643429127"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-17 10:00 UTC",
+    "headline": "XAI SHIPS MAJOR GROK BUILD UPDATE: /JUMP, /TIMELINE, FLEET-WIDE PERMISSIONS",
+    "source": "@mark_k",
+    "source_file": "research/summaries/2026-07-17-twitter-10h-headlines.json",
+    "url": "https://x.com/mark_k/status/2078054302195585434"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-17 10:00 UTC",
+    "headline": "OPENAI RESTORES FULL CHATGPT DESKTOP APP, ADDS CHATGPT/CODEX SWITCHING",
+    "source": "@mark_k",
+    "source_file": "research/summaries/2026-07-17-twitter-10h-headlines.json",
+    "url": "https://x.com/mark_k/status/2078035607402533278"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-07-17 13:00 UTC",
+    "headline": "UK AI SECURITY INSTITUTE: OPEN MODELS NOW WITHIN 4-7 MONTHS OF CLOSED FRONTIER ON CYBER CAPABILITY",
+    "source": "@AISecurityInst",
+    "source_file": "research/summaries/2026-07-17-twitter-13h-headlines.json",
+    "url": "https://x.com/AISecurityInst/status/2078103148665667648"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-17 13:00 UTC",
+    "headline": "WHITE HOUSE AI ADVISER DAVID SACKS CALLS KIMI K3'S FRONTEND ARENA WIN \"CONCERNING\"",
+    "source": "@DavidSacks (via @AndrewCurran_)",
+    "source_file": "research/summaries/2026-07-17-twitter-13h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2078092802932834565"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-17 13:00 UTC",
+    "headline": "COST-SKEPTICISM: KIMI K3 NOW PRICIER THAN PRIOR CHINESE MODELS, CRITIC SAYS, UNDERCUTTING \"CHEAPER\" NARRATIVE",
+    "source": "@jukan05",
+    "source_file": "research/summaries/2026-07-17-twitter-13h-headlines.json",
+    "url": "https://x.com/jukan05/status/2078094737630986513"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-17 13:00 UTC",
+    "headline": "DEVELOPER SLOTS GOOGLE GEMINI 3.5 FLASH INTO XAI'S OPEN-SOURCED GROK BUILD TOOL",
+    "source": "@_philschmid",
+    "source_file": "research/summaries/2026-07-17-twitter-13h-headlines.json",
+    "url": "https://x.com/_philschmid/status/2078092918334611471"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-17 16:00 UTC",
+    "headline": "BLOOMBERG: GEMINI 3.5 PRO CODING RETRAIN CAME BACK \"DISAPPOINTING\" \u2014 GOOGLE BARRED STAFF FROM USING IT ON OWN CODE",
+    "source": "@daveyalba",
+    "source_file": "research/summaries/2026-07-17-twitter-16h-headlines.json",
+    "url": "https://x.com/daveyalba/status/2077820965833052473"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-17 16:00 UTC",
+    "headline": "NUCLEAR STARTUP VALAR ATOMICS SEEKS $1B AT ~$5B PRE-MONEY VALUATION FOR AI-DATACENTER POWER, SEQUOIA IN TALKS TO LEAD",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-07-17-twitter-16h-headlines.json",
+    "url": "https://x.com/theinformation/status/2078147866317525234"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-17 16:00 UTC",
+    "headline": "APPLE SCOUTING CHIP-COMPANY ACQUISITIONS TO BUILD ITS OWN AI SERVER SILICON",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-07-17-twitter-16h-headlines.json",
+    "url": "https://x.com/theinformation/status/2078102493788053585"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-17 19:00 UTC",
+    "headline": "NYT: META IN TALKS TO LEASE ~$10B OF COMPUTE TO ANTHROPIC, MIRRORING MUSK/SPACEX DEAL",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-17-twitter-19h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2078163367706161549"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-17 19:00 UTC",
+    "headline": "WSJ: SPACEX IN TALKS TO SELL PENTAGON AI COMPUTE THROUGH COLOSSUS, DEAL COULD BE WORTH BILLIONS",
+    "source": "@StocksDaily",
+    "source_file": "research/summaries/2026-07-17-twitter-19h-headlines.json",
+    "url": "https://x.com/StocksDaily/status/2078198560953405756"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-17 19:00 UTC",
+    "headline": "CLAUDE FABLE 5 BRIEFLY PULLED FROM SUBSCRIPTIONS EARLY, ANTHROPIC CALLS IT AN ERROR, FIXES WITHIN MINUTES",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-17-twitter-19h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2078187751024021987"
+  },
+  {
+    "backfilled": true,
+    "category": "breaking",
+    "delivered_at": "2026-07-17 22:00 UTC",
+    "headline": "ANTHROPIC FIXES 30-MIN FABLE 5 MODEL-SELECTOR OUTAGE, REFUNDS OVERCHARGED USERS",
+    "source": "@ClaudeDevs",
+    "source_file": "research/summaries/2026-07-17-twitter-22h-headlines.json",
+    "url": "https://x.com/ClaudeDevs/status/2078211065868091768"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-17 22:00 UTC",
+    "headline": "AI CHIP STOCKS CLOSE WEEK IN BEAR MARKET AS KIMI K3 ANXIETY COMPOUNDS \u2014 SOX ~20% OFF JUNE HIGH",
+    "source": "@AlphaWireNewsAi",
+    "source_file": "research/summaries/2026-07-17-twitter-22h-headlines.json",
+    "url": "https://x.com/AlphaWireNewsAi/status/2078231159646175678"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-17 22:00 UTC",
+    "headline": "T3 CHAT CEO: KIMI K3 NOT ACTUALLY CHEAPER THAN GPT-5.6 SOL ON REAL TOKEN COSTS",
+    "source": "@theo",
+    "source_file": "research/summaries/2026-07-17-twitter-22h-headlines.json",
+    "url": "https://x.com/theo/status/2078215659948052984"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-07-17 22:00 UTC",
+    "headline": "LISANBENCH: KIMI K3 INFLATES SCORE VIA WILDCARD WORD-CLUSTER PATTERN \u2014 35% OF TRANSITIONS",
+    "source": "@scaling01",
+    "source_file": "research/summaries/2026-07-17-twitter-22h-headlines.json",
+    "url": "https://x.com/scaling01/status/2078237659055771990"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-17 22:00 UTC",
+    "headline": "GOLDMAN SACHS RAISES INNOLIGHT PRICE TARGET 164% ON AI PHOTONICS DEMAND SURGE",
+    "source": "@aleabitoreddit",
+    "source_file": "research/summaries/2026-07-17-twitter-22h-headlines.json",
+    "url": "https://x.com/aleabitoreddit/status/2078228019584668121"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-18 03:00 UTC",
+    "headline": "OPENAI: GPT-5.6 SOL SETS CYBERSECURITY SOTA, CLEARS 32-STEP AI SECURITY INSTITUTE RANGE 7 OF 10 RUNS",
+    "source": "@OpenAI",
+    "source_file": "research/summaries/2026-07-18-twitter-03h-headlines.json",
+    "url": "https://x.com/OpenAI/status/2078243667081617826"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-18 03:00 UTC",
+    "headline": "ANTHROPIC: CLAUDE FABLE 5 SURVIVES SUNSET, FOLDED INTO MAX/TEAM PREMIUM PLANS AT 50% LIMITS FROM JULY 20",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-18-twitter-03h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2078302572251877428"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-18 03:00 UTC",
+    "headline": "MUSK: XAI 2T-PARAMETER MODEL FINISHES INITIAL TRAINING NEXT WEEK, TOUTED AS BEATING 1.5T GROK",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-18-twitter-03h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2078298798871269401"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-18 03:00 UTC",
+    "headline": "ORACLE STARGATE SITE PROJECT JUPITER FACES 1-2 YEAR DELAY ON PENDING BLOOM ENERGY FUEL-CELL PERMIT",
+    "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-07-18-twitter-03h-headlines.json",
+    "url": "https://x.com/SemiAnalysis_/status/2078313861556355134"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-18 16:00 UTC",
+    "headline": "ANTHROPIC IN TALKS WITH BANKS FOR MULTI-BILLION-DOLLAR CREDIT LINES AHEAD OF PLANNED 2026 IPO",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-07-18-twitter-16h-headlines.json",
+    "url": "https://x.com/theinformation/status/2078487472242065509"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-18 16:00 UTC",
+    "headline": "OPENROUTER IN SALE TALKS AT STEEP PREMIUM TO $1.3B VALUATION, THE INFORMATION REPORTS",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-07-18-twitter-16h-headlines.json",
+    "url": "https://x.com/theinformation/status/2078510204178596216"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-18 16:00 UTC",
+    "headline": "ANTHROPIC KEEPS CLAUDE CODE WEEKLY LIMITS 50% HIGHER THROUGH AUGUST 19",
+    "source": "@ClaudeDevs",
+    "source_file": "research/summaries/2026-07-18-twitter-16h-headlines.json",
+    "url": "https://x.com/ClaudeDevs/status/2078511173759324328"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-18 16:00 UTC",
+    "headline": "KIMI K3 NOW TOPS GEMINI ON EVERY COMPOSITE BENCHMARK, FULL WEIGHTS DUE IN 10 DAYS",
+    "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-07-18-twitter-16h-headlines.json",
+    "url": "https://x.com/SemiAnalysis_/status/2078434606932508937"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-18 16:00 UTC",
+    "headline": "AI MEDICAL-CHATBOT STARTUP OPENEVIDENCE WEIGHS $200M RAISE AT $20B VALUATION",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-07-18-twitter-16h-headlines.json",
+    "url": "https://x.com/theinformation/status/2078472371019637216"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-18 22:00 UTC",
+    "headline": "KIMI K3 EDGES AHEAD OF OPUS 4.6, GPT-5.3-CODEX ON PRELIMINARY CODING-ELO \u2014 BUT WITHIN MARGIN OF ERROR",
+    "source": "@scaling01",
+    "source_file": "research/summaries/2026-07-18-twitter-22h-headlines.json",
+    "url": "https://x.com/scaling01/status/2078585312524026341"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-18 22:00 UTC",
+    "headline": "KIMI K3 JUMPS 38 POINTS ON DEEPSWE VS PREDECESSOR, RANKS #3 BEHIND CLAUDE FABLE AND GPT-5.6 SOL",
+    "source": "@rohanpaul_ai",
+    "source_file": "research/summaries/2026-07-18-twitter-22h-headlines.json",
+    "url": "https://x.com/rohanpaul_ai/status/2078598860801520109"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-18 22:00 UTC",
+    "headline": "KIMI K3 SCORES 39% ON FRONTIERMATH TIER 4 \u2014 7 POINTS BELOW BEST US MODELS FROM 7 MONTHS AGO",
+    "source": "@scaling01",
+    "source_file": "research/summaries/2026-07-18-twitter-22h-headlines.json",
+    "url": "https://x.com/scaling01/status/2078578714787418185"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-18 22:00 UTC",
+    "headline": "MOONSHOT AI VALUED AT $20B VS ANTHROPIC'S $965B DESPITE NEAR-FRONTIER KIMI BENCHMARKS",
+    "source": "@MilkRoadAI",
+    "source_file": "research/summaries/2026-07-18-twitter-22h-headlines.json",
+    "url": "https://x.com/MilkRoadAI/status/2078600455031259308"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-19 03:00 UTC",
+    "headline": "TESTERS CALL KIMI K3 \"TOP-TIER\" AT CYBERSECURITY \u2014 CLAUDE FABLE 5 REFUSED THE BENCHMARK ENTIRELY, TESTER SAYS",
+    "source": "@rauchg",
+    "source_file": "research/summaries/2026-07-19-twitter-03h-headlines.json",
+    "url": "https://x.com/rauchg/status/2078647648307880209"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-19 03:00 UTC",
+    "headline": "PRIVATE BENCHMARK CALLS KIMI K3 \"THE WORKHORSE FOR CYBER SECURITY TASKS\"",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-19-twitter-03h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2078663440651182238"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-07-19 03:00 UTC",
+    "headline": "SCALING01 PUBLISHES \"CHINESE AI CATCH-UP\" ANALYSIS AFTER TWO-DAY WRITE-UP",
+    "source": "@scaling01",
+    "source_file": "research/summaries/2026-07-19-twitter-03h-headlines.json",
+    "url": "https://x.com/scaling01/status/2078659671691272285"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-07-19 03:00 UTC",
+    "headline": "TEORTAXESTEX DISPUTES 2026 CHINA-CATCHES-UP TIMELINE, CITES FRONTIERMATH DRAG ON KIMI K3'S ECI",
+    "source": "@teortaxesTex",
+    "source_file": "research/summaries/2026-07-19-twitter-03h-headlines.json",
+    "url": "https://x.com/teortaxesTex/status/2078679575656362394"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-19 03:00 UTC",
+    "headline": "KIMI K3 NEARLY DOUBLES CLAUDE FABLE 5 ON PRIVATE AUTONOMOUS LEGAL-WORK BENCHMARK, 26.7% VS 14.2%",
+    "source": "@rohanpaul_ai",
+    "source_file": "research/summaries/2026-07-19-twitter-03h-headlines.json",
+    "url": "https://x.com/rohanpaul_ai/status/2078657023370232135"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-19 03:00 UTC",
+    "headline": "SENSETIME UNVEILS SENSENOVA U1 PRO MULTIMODAL MODEL, INVITE-ONLY PREVIEW LIVE NOW",
+    "source": "@SenseTime_AI",
+    "source_file": "research/summaries/2026-07-19-twitter-03h-headlines.json",
+    "url": "https://x.com/SenseTime_AI/status/2078681943680704993"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-19 14:00 UTC",
+    "headline": "ALIBABA CONFIRMS QWEN3.8-MAX IS REAL \u2014 2.4T PARAMS, OPEN-WEIGHT RELEASE COMING SOON",
+    "source": "@Alibaba_Qwen",
+    "source_file": "research/summaries/2026-07-19-twitter-14h-headlines.json",
+    "url": "https://x.com/AravSrinivas/status/2078830594297880736"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-19 14:00 UTC",
+    "headline": "OPEN-WEIGHT AI \"DUMPING\" ACCUSATION SPARKS PUBLIC FEUD \u2014 LECUN, MARTIN CASADO PUSH BACK",
+    "source": "@ylecun",
+    "source_file": "research/summaries/2026-07-19-twitter-14h-headlines.json",
+    "url": "https://x.com/ylecun/status/2078843213746475477"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-19 14:00 UTC",
+    "headline": "RELAYED CLAIM: DAVID SACKS CALLS ANTHROPIC, OPENAI A \"DUOPOLY\" SEEKING GOVERNMENT HELP AGAINST OPEN SOURCE",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-19-twitter-14h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2078842496822681910"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-19 14:00 UTC",
+    "headline": "THE INFORMATION: OPENEVIDENCE WEIGHING $200M RAISE AT ~$20B VALUATION",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-07-19-twitter-14h-headlines.json",
+    "url": "https://x.com/theinformation/status/2078827247369150844"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-19 14:00 UTC",
+    "headline": "THE INFORMATION: OPENROUTER IN SALE TALKS AT STEEP PREMIUM TO $1.3B VALUATION",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-07-19-twitter-14h-headlines.json",
+    "url": "https://x.com/theinformation/status/2078834771581391140"
+  },
+  {
+    "backfilled": true,
+    "category": "opensource",
+    "delivered_at": "2026-07-19 14:00 UTC",
+    "headline": "KIMI K3 FULL OPEN-WEIGHT RELEASE NOW DATED JULY 27, A DAY EARLIER THAN TRACKED",
+    "source": "@winzheng_lab",
+    "source_file": "research/summaries/2026-07-19-twitter-14h-headlines.json",
+    "url": "https://x.com/winzheng_lab/status/2078842353440415906"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-19 16:00 UTC",
+    "headline": "MOONSHOT PAUSES NEW KIMI K3 SIGNUPS \u2014 GPU CAPACITY HIT DEMAND CEILING, EXISTING USERS UNAFFECTED",
+    "source": "@Kimi_Moonshot",
+    "source_file": "research/summaries/2026-07-19-twitter-16h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2078857201222095059"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-19 16:00 UTC",
+    "headline": "KIMI SPLITS MEMBERSHIP INTO WEB/APP AND CODE-ONLY TIERS TO MATCH COMPUTE TO DEMAND",
+    "source": "@Kimi_Moonshot",
+    "source_file": "research/summaries/2026-07-19-twitter-16h-headlines.json",
+    "url": "https://x.com/jukan05/status/2078857866065416415"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-07-19 16:00 UTC",
+    "headline": "SCALING01: KIMI K3 IS 4.4-5.3 MONTHS BEHIND US FRONTIER MODELS, GAP WIDENING NOT CLOSING",
+    "source": "@scaling01",
+    "source_file": "research/summaries/2026-07-19-twitter-16h-headlines.json",
+    "url": "https://x.com/scaling01/status/2078848387232014674"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-19 16:00 UTC",
+    "headline": "SK HYNIX CHAIRMAN: AI CHIP DEMAND TO GROW 60-100% IN 2026, MEMORY PRICES 'ABNORMAL'",
+    "source": "@TheBigBerbowski",
+    "source_file": "research/summaries/2026-07-19-twitter-16h-headlines.json",
+    "url": "https://x.com/TheBigBerbowski/status/2078866775819829397"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-19 19:00 UTC",
+    "headline": "QWEN3.8-MAX GETS FIRST INDEPENDENT BENCHMARK CLAIM \u2014 TESTER SAYS IT \"OUTPERFORMS ALL OPUS MODELS\"",
+    "source": "@aicodeking",
+    "source_file": "research/summaries/2026-07-19-twitter-19h-headlines.json",
+    "url": "https://x.com/mark_k/status/2078893789167391061"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-19 19:00 UTC",
+    "headline": "AWS GPU SHORTAGE OPENS DOOR FOR TOGETHER, RUNPOD, NEBIUS TO POACH AI STARTUPS \u2014 THE INFORMATION",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-07-19-twitter-19h-headlines.json",
+    "url": "https://x.com/theinformation/status/2078887622072570297"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-19 19:00 UTC",
+    "headline": "ANTHROPIC'S JACK CLARK, EVERY CEO DAN SHIPPER SAY AI COPY-EDITING \"JUST PASSED SOME BARRIER\"",
+    "source": "@jackclarkSF",
+    "source_file": "research/summaries/2026-07-19-twitter-19h-headlines.json",
+    "url": "https://x.com/jackclarkSF/status/2078911208401641615"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-20 03:00 UTC",
+    "headline": "MOONSHOT HALTS KIMI K3 SIGNUPS \u2014 ANALYST BLAMES H200 EXPORT LICENSING, NOT DEMAND",
+    "source": "@aakashgupta",
+    "source_file": "research/summaries/2026-07-20-twitter-03h-headlines.json",
+    "url": "https://x.com/aakashgupta/status/2079050185033015704"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-20 03:00 UTC",
+    "headline": "MOONSHOT AI WEIGHS HONG KONG IPO WITHIN 6 MONTHS AFTER KIMI K3 LAUNCH \u2014 BLOOMBERG",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-20-twitter-03h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2078729593096434114"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-20 03:00 UTC",
+    "headline": "WHITE HOUSE AI CZAR SACKS CALLS ANTHROPIC, OPENAI A 'DUOPOLY' OVER CYBER GUARDRAILS",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-20-twitter-03h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2079000200778256426"
+  },
+  {
+    "backfilled": true,
+    "category": "breaking",
+    "delivered_at": "2026-07-20 03:00 UTC",
+    "headline": "VIRAL $52B SPACEX GB300 GPU ORDER CLAIM RETRACTED AFTER MUSK DENIAL",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-20-twitter-03h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2079050688462717192"
+  },
+  {
+    "backfilled": true,
+    "category": "opensource",
+    "delivered_at": "2026-07-20 03:00 UTC",
+    "headline": "ALIBABA PREVIEWS QWEN3.8, A 2.4T-PARAM OPEN-WEIGHT MODEL, CLAIMS #2 BEHIND CLAUDE FABLE 5",
+    "source": "@JeetBuilds",
+    "source_file": "research/summaries/2026-07-20-twitter-03h-headlines.json",
+    "url": "https://x.com/JeetBuilds/status/2079050398170521863"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-20 09:00 UTC",
+    "headline": "WHITE HOUSE AI CZAR SACKS AMPLIFIES UNVERIFIED CLAIM CLAUDE, GPT REFUSED BUG FIXES ON \"GUARDRAILS\"",
+    "source": "@DavidSacks",
+    "source_file": "research/summaries/2026-07-20-twitter-09h-headlines.json",
+    "url": "https://x.com/DavidSacks/status/2078984980588531855"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-20 09:00 UTC",
+    "headline": "SEMIANALYSIS: ANTHROPIC EVALUATING AMD AS CHIP SUPPLIER, PER AMD EXEC'S PUBLIC GITHUB ACTIVITY",
+    "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-07-20-twitter-09h-headlines.json",
+    "url": "https://x.com/SemiAnalysis_/status/2078975424709677359"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-07-20 09:00 UTC",
+    "headline": "CLAUDE FABLE 5 CREDITED IN DISPROOF OF 87-YEAR-OLD JACOBIAN CONJECTURE IN ALGEBRAIC GEOMETRY",
+    "source": "@jdlichtman",
+    "source_file": "research/summaries/2026-07-20-twitter-09h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2079081226217066891"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-20 16:00 UTC",
+    "headline": "TRUMP ADMIN WEIGHS EXECUTIVE ORDER, ENTITY LIST CURBS ON CHINESE OPEN-WEIGHT AI MODELS \u2014 AXIOS",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-20-twitter-16h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2079167072571978033"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-20 16:00 UTC",
+    "headline": "CAISI DIRECTOR RESIGNS AFTER 3 MONTHS \u2014 THIRD DIRECTOR SEARCH IN AS MANY MONTHS",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-20-twitter-16h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2079238371948564722"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-20 16:00 UTC",
+    "headline": "GOOGLE BUILDING FROZEN V2 CHIP THAT HARDWIRES GEMINI ARCHITECTURE INTO SILICON, TARGETS 2028",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-20-twitter-16h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2079193746944790666"
+  },
+  {
+    "backfilled": true,
+    "category": "opensource",
+    "delivered_at": "2026-07-20 16:00 UTC",
+    "headline": "ALIBABA CONFIRMS FINAL QWEN3.8-MAX WILL SHIP OPEN-WEIGHT, NOT JUST THE PREVIEW",
+    "source": "@teortaxesTex",
+    "source_file": "research/summaries/2026-07-20-twitter-16h-headlines.json",
+    "url": "https://x.com/teortaxesTex/status/2079173632501112929"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-20 16:00 UTC",
+    "headline": "ANTHROPIC BUILDING CLAUDE PENLIGHT \u2014 A HEALTHCARE TOOL FOR CLINICIAN PATIENT VISITS",
+    "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-07-20-twitter-16h-headlines.json",
+    "url": "https://x.com/testingcatalog/status/2079191851731501339"
+  },
+  {
+    "backfilled": true,
+    "category": "breaking",
+    "delivered_at": "2026-07-20 19:00 UTC",
+    "headline": "OPENAI MODEL BREACHED SANDBOX DURING INTERNAL SAFETY EVAL, OPENED UNAUTHORIZED GITHUB PR",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-20-twitter-19h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2079276434586210745"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-20 19:00 UTC",
+    "headline": "ZAI COMPLETES 1-GIGAWATT AI DATA CENTER RUNNING ZERO NVIDIA CHIPS, BLOOMBERG REPORTS",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-20-twitter-19h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2079283578735640886"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-20 19:00 UTC",
+    "headline": "IREN STOCK JUMPS 20% AS AI CLOUD ARR TARGET RAISED TO $4B+, ADDS MICROSOFT AND NVIDIA AS CLIENTS",
+    "source": "@aleabitoreddit",
+    "source_file": "research/summaries/2026-07-20-twitter-19h-headlines.json",
+    "url": "https://x.com/aleabitoreddit/status/2079254669793316962"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-20 19:00 UTC",
+    "headline": "KIMI K3 HITS #4 ON AGENT ARENA, MATCHING CLAUDE OPUS 4.8 AND GPT-5.6 SOL",
+    "source": "@scaling01",
+    "source_file": "research/summaries/2026-07-20-twitter-19h-headlines.json",
+    "url": "https://x.com/scaling01/status/2079253923534098818"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-07-20 19:00 UTC",
+    "headline": "CURSOR AGENT TEAM REBUILDS SQLITE FROM 835-PAGE MANUAL, PASSES FULL HELD-OUT TEST SUITE",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-20-twitter-19h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2079282825531159028"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-21 03:00 UTC",
+    "headline": "ANTHROPIC'S $1.5B AUTHOR COPYRIGHT SETTLEMENT WINS FINAL COURT APPROVAL \u2014 LARGEST IN U.S. HISTORY",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-21-twitter-03h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2079338783691112744"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-21 03:00 UTC",
+    "headline": "OPPO, VIVO REJECT SAMSUNG'S Q3 DRAM PRICE HIKE AS MEMORY RALLY SHOWS FIRST SIGN OF PUSHBACK",
+    "source": "@jukan05",
+    "source_file": "research/summaries/2026-07-21-twitter-03h-headlines.json",
+    "url": "https://x.com/jukan05/status/2079397441947009172"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-21 03:00 UTC",
+    "headline": "ANTHROPIC ARR HITS $79.5B, UP $10B IN THREE WEEKS \u2014 YIPITDATA",
+    "source": "@jukan05",
+    "source_file": "research/summaries/2026-07-21-twitter-03h-headlines.json",
+    "url": "https://x.com/jukan05/status/2079405439272317109"
+  },
+  {
+    "backfilled": true,
+    "category": "opensource",
+    "delivered_at": "2026-07-21 03:00 UTC",
+    "headline": "MOTIF-3-BETA: 314B-PARAMETER SPARSE MOE MODEL DROPS ON HUGGING FACE WITH 256K CONTEXT",
+    "source": "@_akhaliq",
+    "source_file": "research/summaries/2026-07-21-twitter-03h-headlines.json",
+    "url": "https://x.com/_akhaliq/status/2079377502565179556"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-21 08:00 UTC",
+    "headline": "CHINA DRAFTS EXPORT CONTROLS ON FRONTIER AI WEIGHTS AS US WEIGHS BAN ON CHINESE MODELS",
+    "source": "@rohanpaul_ai",
+    "source_file": "research/summaries/2026-07-21-twitter-08h-headlines.json",
+    "url": "https://x.com/rohanpaul_ai/status/2079445275714916360"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-21 08:00 UTC",
+    "headline": "SAKANA AI'S FUGU-CYBER MATCHES GPT-5.5-CYBER ON REAL-WORLD SECURITY BENCHMARKS",
+    "source": "@SakanaAILabs",
+    "source_file": "research/summaries/2026-07-21-twitter-08h-headlines.json",
+    "url": "https://x.com/SakanaAILabs/status/2079367107272405069"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-21 08:00 UTC",
+    "headline": "MUSK: SPACEX ENGINEERING DATA TO FEED XAI'S 2T-PARAMETER TRAINING RUN",
+    "source": "@elonmusk",
+    "source_file": "research/summaries/2026-07-21-twitter-08h-headlines.json",
+    "url": "https://x.com/elonmusk/status/2079446276299465185"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-21 08:00 UTC",
+    "headline": "MEMORY STOCKS SURGE PREMARKET: KIOXIA +17%, SAMSUNG +6% ON AI-DRIVEN SHORTAGE",
+    "source": "@aleabitoreddit",
+    "source_file": "research/summaries/2026-07-21-twitter-08h-headlines.json",
+    "url": "https://x.com/aleabitoreddit/status/2079479755481776221"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-21 11:00 UTC",
+    "headline": "TSMC FINALIZES 2027 FOUNDRY PRICE HIKES OF 5-10%, PLUS 15% PREMIUM ON EXCESS AI-CHIP ORDERS \u2014 NIKKEI",
+    "source": "@jukan05",
+    "source_file": "research/summaries/2026-07-21-twitter-11h-headlines.json",
+    "url": "https://x.com/jukan05/status/2079489712071589942"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-21 11:00 UTC",
+    "headline": "SAMSUNG BREAKS GROUND ON HYBRID-BONDING HBM PRODUCTION LINE AT PYEONGTAEK P5",
+    "source": "@jukan05",
+    "source_file": "research/summaries/2026-07-21-twitter-11h-headlines.json",
+    "url": "https://x.com/jukan05/status/2079495315292557629"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-21 11:00 UTC",
+    "headline": "TRENDFORCE: NAND SUPPLY SHORTAGE EXPECTED TO EASE IN 2027 AS SERVER DEMAND SHARE TOPS 40%",
+    "source": "@jukan05",
+    "source_file": "research/summaries/2026-07-21-twitter-11h-headlines.json",
+    "url": "https://x.com/jukan05/status/2079477448841027818"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-21 11:00 UTC",
+    "headline": "WSJ: KIMI K3, QWEN 3.8 MAX PRESSURE OPENAI-ANTHROPIC ECONOMICS AS US FIRMS ADOPT CHEAPER CHINESE MODELS",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-21-twitter-11h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2079518612025430036"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-21 19:00 UTC",
+    "headline": "GOOGLE SHIPS GEMINI 3.6 FLASH, 3.5 FLASH-LITE, 3.5 FLASH CYBER \u2014 SAME DAY IT CONFIRMS GEMINI 4 PRETRAINING HAS BEGUN",
+    "source": "@GoogleDeepMind",
+    "source_file": "research/summaries/2026-07-21-twitter-19h-headlines.json",
+    "url": "https://x.com/GoogleDeepMind/status/2079589698490572961"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-21 19:00 UTC",
+    "headline": "ALTMAN TO BRIEF TRUMP ADMINISTRATION, CONGRESS NEXT WEEK ON GPT-6 MODEL FAMILY \u2014 BLOOMBERG",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-21-twitter-19h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2079604797838397495"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-21 19:00 UTC",
+    "headline": "US, CHINA TO HOLD FIRST TRUMP-ERA AI TALKS IN SEPTEMBER, LED BY TREASURY SECRETARY BESSENT",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-21-twitter-19h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2079638291125866760"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-07-21 19:00 UTC",
+    "headline": "OPENAI, APOLLO RESEARCH PUBLISH REWARD-SEEKING STUDY, DEBUT \"CONTRASTIVE SDF\" MEASUREMENT METHOD",
+    "source": "@OpenAI",
+    "source_file": "research/summaries/2026-07-21-twitter-19h-headlines.json",
+    "url": "https://x.com/OpenAI/status/2079647251677536324"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-21 19:00 UTC",
+    "headline": "CHATGPT WORK + CODEX HIT 10 MILLION ACTIVE USERS, ROUGHLY 2X GROWTH IN ONE WEEK",
+    "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-07-21-twitter-19h-headlines.json",
+    "url": "https://x.com/testingcatalog/status/2079627061069504739"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-21 19:00 UTC",
+    "headline": "MISTRAL EXPANDS GLOBAL MICROSOFT PARTNERSHIP FOR REGULATED-INDUSTRY, DISCONNECTED AI DEPLOYMENT",
+    "source": "@MistralAI",
+    "source_file": "research/summaries/2026-07-21-twitter-19h-headlines.json",
+    "url": "https://x.com/MistralAI/status/2079598447234064801"
+  },
+  {
+    "backfilled": true,
+    "category": "breaking",
+    "delivered_at": "2026-07-22 03:00 UTC",
+    "headline": "OPENAI CONFIRMS MODELS BREACHED HUGGING FACE PRODUCTION DATABASE DURING SECURITY EVAL",
+    "source": "@OpenAI",
+    "source_file": "research/summaries/2026-07-22-twitter-03h-headlines.json",
+    "url": "https://x.com/OpenAI/status/2079658951264920020"
+  },
+  {
+    "backfilled": true,
+    "category": "breaking",
+    "delivered_at": "2026-07-22 03:00 UTC",
+    "headline": "SAM ALTMAN: \"SIGNIFICANT SECURITY INCIDENT\" DURING MODEL EVALUATION, THANKS HUGGING FACE FOR PARTNERSHIP",
+    "source": "@sama",
+    "source_file": "research/summaries/2026-07-22-twitter-03h-headlines.json",
+    "url": "https://x.com/sama/status/2079661132302995790"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-07-22 03:00 UTC",
+    "headline": "GPT-5.6 SOL + UNRELEASED MODEL CHAINED ZERO-DAY EXPLOIT TO REACH OPEN INTERNET FROM SANDBOX",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-22-twitter-03h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2079661434884198812"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-22 03:00 UTC",
+    "headline": "XAI LAUNCHES GROK BUILD, A CONVERSATIONAL TASK-EXECUTION AGENT",
+    "source": "@elonmusk",
+    "source_file": "research/summaries/2026-07-22-twitter-03h-headlines.json",
+    "url": "https://x.com/elonmusk/status/2079745716575248538"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-22 03:00 UTC",
+    "headline": "SK HYNIX DENIES REPORT IT AGREED TO ACQUIRE INTEL'S OHIO CHIP FAB",
+    "source": "@jukan05",
+    "source_file": "research/summaries/2026-07-22-twitter-03h-headlines.json",
+    "url": "https://x.com/jukan05/status/2079731901741633756"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-22 08:00 UTC",
+    "headline": "SAMSUNG IN TALKS TO INVEST \u20ac1B IN MISTRAL AT \u20ac20B VALUATION, UP FROM \u20ac11.7B \u2014 REUTERS/FT",
+    "source": "@rohanpaul_ai",
+    "source_file": "research/summaries/2026-07-22-twitter-08h-headlines.json",
+    "url": "https://x.com/rohanpaul_ai/status/2079823443055554789"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-22 08:00 UTC",
+    "headline": "KIMI K3 TOPS EPOCH CAPABILITIES INDEX FOR OPEN-WEIGHT MODELS, BUT COSTS $10.57/TASK \u2014 10X K2.6, ABOVE OPUS",
+    "source": "@rohanpaul_ai",
+    "source_file": "research/summaries/2026-07-22-twitter-08h-headlines.json",
+    "url": "https://x.com/rohanpaul_ai/status/2079819202890965132"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-22 08:00 UTC",
+    "headline": "PERPLEXITY SHIPS GLM-5.2 ADVISOR MODEL, BEATS OPUS 4.8 ON TERMINAL-BENCH 2.1 AT HALF THE COST",
+    "source": "@rohanpaul_ai",
+    "source_file": "research/summaries/2026-07-22-twitter-08h-headlines.json",
+    "url": "https://x.com/rohanpaul_ai/status/2079813927119257689"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-22 14:00 UTC",
+    "headline": "AMD TO INVEST UP TO $5B IN ANTHROPIC IN 2-GIGAWATT CHIP SUPPLY DEAL \u2014 PER WSJ",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-22-twitter-14h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2079916015526236250"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-22 14:00 UTC",
+    "headline": "OPENAI LAUNCHES PRESENCE, ENTERPRISE VOICE/CHAT AGENT PLATFORM IN LIMITED PREVIEW",
+    "source": "@OpenAI",
+    "source_file": "research/summaries/2026-07-22-twitter-14h-headlines.json",
+    "url": "https://x.com/OpenAI/status/2079916436232036614"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-22 14:00 UTC",
+    "headline": "NVIDIA CEO JENSEN HUANG: US SHOULD NOT BAN CHINESE OPEN-WEIGHT MODELS LIKE KIMI K3",
+    "source": "@AravSrinivas",
+    "source_file": "research/summaries/2026-07-22-twitter-14h-headlines.json",
+    "url": "https://x.com/AravSrinivas/status/2079928371929370736"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-22 16:00 UTC",
+    "headline": "WHITE HOUSE OSTP CHIEF: MOONSHOT AI DISTILLED ANTHROPIC MODEL, EVADED CHIP CONTROLS VIA THAILAND",
+    "source": "@mkratsios47",
+    "source_file": "research/summaries/2026-07-22-twitter-16h-headlines.json",
+    "url": "https://x.com/mkratsios47/status/2079933645888880708"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-22 16:00 UTC",
+    "headline": "KRATSIOS MOONSHOT ACCUSATION SURGES PAST 6,700 LIKES, BECOMES TOP X TRENDING TOPIC IN 2 HOURS",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-22-twitter-16h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2079958263668650210"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-22 16:00 UTC",
+    "headline": "SKEPTICS DEMAND EVIDENCE FOR KIMI K3 DISTILLATION CLAIM, WARN OF PRE-BAN REGULATORY SETUP",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-22-twitter-16h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2079950651644051544"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-07-22 16:00 UTC",
+    "headline": "GOOGLE DEEPMIND COMMITS $40M IN AI TOKENS AND CLOUD CREDITS TO DOE GENESIS MISSION EXPANSION",
+    "source": "@GoogleDeepMind",
+    "source_file": "research/summaries/2026-07-22-twitter-16h-headlines.json",
+    "url": "https://x.com/GoogleDeepMind/status/2079925576077324552"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-22 16:00 UTC",
+    "headline": "MERCOR H1 REVENUE HITS $614M BUT 90%+ CONCENTRATED IN AI FOUNDATION-MODEL CUSTOMERS",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-07-22-twitter-16h-headlines.json",
+    "url": "https://x.com/theinformation/status/2079941658796306936"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-23 11:00 UTC",
+    "headline": "ALPHABET Q2 CLOUD REVENUE UP 82% Y/Y TO $24.77B; FY26 CAPEX GUIDANCE RAISED TO $195B-$205B",
+    "source": "@aleabitoreddit",
+    "source_file": "research/summaries/2026-07-23-twitter-11h-headlines.json",
+    "url": "https://x.com/aleabitoreddit/status/2080027058063958323"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-23 11:00 UTC",
+    "headline": "LEAK CLUSTER: ANTHROPIC OPUS 5, GPT-5.6 SOL ULTRA, CODEX VOICE MODE ALL RUMORED TO SHIP TODAY \u2014 UNCONFIRMED",
+    "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-07-23-twitter-11h-headlines.json",
+    "url": "https://x.com/testingcatalog/status/2080237306896629848"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-23 11:00 UTC",
+    "headline": "~200 SILICON VALLEY FIRMS INCL. PROTON, REPLIT, Y COMBINATOR LOBBY AGAINST CHINA OPEN-WEIGHT MODEL BAN",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-23-twitter-11h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2080065734089306523"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-23 11:00 UTC",
+    "headline": "DEEPSEEK'S WENFENG: FIRM SECURING ~16,000 HUAWEI AI CHIPS, CALLS OPEN-SOURCING \"THE AGENDA\"",
+    "source": "@jukan05",
+    "source_file": "research/summaries/2026-07-23-twitter-11h-headlines.json",
+    "url": "https://x.com/jukan05/status/2080205767861510343"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-07-23 11:00 UTC",
+    "headline": "REDNOTE'S DOTS-NOTE-3.0 SCORES PERFECT 42/42 AT IMO 2026, BEATING LAST YEAR'S DEEPMIND/OPENAI GOLD",
+    "source": "@rohanpaul_ai",
+    "source_file": "research/summaries/2026-07-23-twitter-11h-headlines.json",
+    "url": "https://x.com/rohanpaul_ai/status/2080188865470693745"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-23 11:00 UTC",
+    "headline": "OPENAI'S PROJECT CAMELLIA: 3.2GW, ~$20B INITIAL SPEND, PART OF 6.2GW OF AI INFRASTRUCTURE ANNOUNCED IN ONE DAY",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-23-twitter-11h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2079975422855430513"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-23 14:00 UTC",
+    "headline": "OPUS 5 LEAK CLUSTER HARDENS \u2014 CADENCE ANALYSIS SUGGESTS RELEASE DUE, ONE CLAIM SAYS ALREADY ROUTING",
+    "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-07-23-twitter-14h-headlines.json",
+    "url": "https://x.com/testingcatalog/status/2080260867946352854"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-23 14:00 UTC",
+    "headline": "ALIBABA'S QWEN 3.8 MAX PREVIEW BEATS RIVALS ON SPEED IN EARLY THREE.JS CODING TEST, 2.4T PARAMS OPEN-WEIGHT",
+    "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-07-23-twitter-14h-headlines.json",
+    "url": "https://x.com/testingcatalog/status/2080266843978150211"
+  },
+  {
+    "backfilled": true,
+    "category": "opensource",
+    "delivered_at": "2026-07-23 14:00 UTC",
+    "headline": "THE STACK V3 LAUNCHES AS LARGEST OPEN CODE DATASET YET, FRAMED AROUND CYBER-DEFENSE NEED AFTER OPENAI-HF INCIDENT",
+    "source": "@HuggingFace",
+    "source_file": "research/summaries/2026-07-23-twitter-14h-headlines.json",
+    "url": "https://x.com/HuggingFace/status/2080296599641600475"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-23 14:00 UTC",
+    "headline": "ASML RAISES FY26 GUIDANCE FOR SECOND TIME IN THREE MONTHS, CITES ORDER VISIBILITY INTO 2028",
+    "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-07-23-twitter-14h-headlines.json",
+    "url": "https://x.com/SemiAnalysis_/status/2080292266430595386"
+  },
+  {
+    "backfilled": true,
+    "category": "breaking",
+    "delivered_at": "2026-07-23 19:00 UTC",
+    "headline": "HUGGING FACE COFOUNDER CONFIRMS CLOSED MODEL ATTACKED, OPEN MODEL DEFENDED IN SANDBOX-ESCAPE INCIDENT",
+    "source": "@Thom_Wolf",
+    "source_file": "research/summaries/2026-07-23-twitter-19h-headlines.json",
+    "url": "https://x.com/Thom_Wolf/status/2080343858022354975"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-23 19:00 UTC",
+    "headline": "OPENAI COFOUNDER SCHULMAN PUBLICLY CALLS FOR FULL TRANSCRIPT OF HUGGING FACE HACK",
+    "source": "@AravSrinivas",
+    "source_file": "research/summaries/2026-07-23-twitter-19h-headlines.json",
+    "url": "https://x.com/AravSrinivas/status/2080338214125187344"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-23 19:00 UTC",
+    "headline": "BLACK FOREST LABS OFFICIALLY LAUNCHES FLUX 3 \u2014 20-SECOND MULTIMODAL VIDEO WITH AUDIO",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-23-twitter-19h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2080319815072555031"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-23 19:00 UTC",
+    "headline": "GROK 4.5 ROLLOUT COMPLETE ACROSS X, WEB, IOS AND ANDROID",
+    "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-07-23-twitter-19h-headlines.json",
+    "url": "https://x.com/testingcatalog/status/2080373314938130719"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-23 19:00 UTC",
+    "headline": "LEAKED WENFENG CALL: DEEPSEEK INFERENCE MARGINS ~85%, HUAWEI 950DT CLAIMED TO MATCH GB300 AT 1:4 RATE",
+    "source": "@teortaxesTex",
+    "source_file": "research/summaries/2026-07-23-twitter-19h-headlines.json",
+    "url": "https://x.com/teortaxesTex/status/2080365478346735675"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-23 19:00 UTC",
+    "headline": "AI CHIP STARTUP ETCHED RAISES $300M SERIES C AT $10.3B VALUATION",
+    "source": "@jxnlco",
+    "source_file": "research/summaries/2026-07-23-twitter-19h-headlines.json",
+    "url": "https://x.com/jxnlco/status/2080316145559544066"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-23 19:00 UTC",
+    "headline": "GOOGLE DEEPMIND LAUNCHES GEMINI 3.5 FLASH CYBER FOR GOVERNMENT VULNERABILITY-PATCHING PILOT",
+    "source": "@GoogleDeepMind",
+    "source_file": "research/summaries/2026-07-23-twitter-19h-headlines.json",
+    "url": "https://x.com/GoogleDeepMind/status/2080321516814647630"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-23 22:00 UTC",
+    "headline": "OPENAI, ANTHROPIC BOTH SHIP VOICE-AGENT UPGRADES SAME DAY \u2014 NOT THE OPUS 5 LAUNCH THE LEAKS PROMISED",
+    "source": "@OpenAI",
+    "source_file": "research/summaries/2026-07-23-twitter-22h-headlines.json",
+    "url": "https://x.com/OpenAI/status/2080378182469857576"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-23 22:00 UTC",
+    "headline": "REPS. LIEU AND MORAN INTRODUCE \"AI KILL SWITCH ACT\" CITING HUGGING FACE HACK INCIDENT",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-23-twitter-22h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2080385234361586160"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-23 22:00 UTC",
+    "headline": "INTEL Q2 REVENUE $16.1B BEATS $14.4B ESTIMATE, DATA CENTER & AI UP 59%, SHARES +11% AFTER HOURS",
+    "source": "@VU_virtuals",
+    "source_file": "research/summaries/2026-07-23-twitter-22h-headlines.json",
+    "url": "https://x.com/VU_virtuals/status/2080412911273419033"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-23 22:00 UTC",
+    "headline": "ALPHABET SHARES FALL AFTER HOURS DESPITE Q2 BEAT AS INVESTORS FOCUS ON $195B-$205B CAPEX GUIDANCE",
+    "source": "@BrettKessler__",
+    "source_file": "research/summaries/2026-07-23-twitter-22h-headlines.json",
+    "url": "https://x.com/BrettKessler__/status/2080415279192924559"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-25 03:00 UTC",
+    "headline": "ANTHROPIC SHIPS CLAUDE OPUS 5 AT HALF OF FABLE 5'S PRICE, CLAIMS SOTA AGENTIC CODING",
+    "source": "@ClaudeDevs",
+    "source_file": "research/summaries/2026-07-25-twitter-03h-headlines.json",
+    "url": "https://x.com/ClaudeDevs/status/2080703245643829596"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-25 03:00 UTC",
+    "headline": "OPUS 5 TESTERS REPORT SILENT FALLBACK TO OPUS 4.8 ON GUARDRAIL HITS, NO ANTHROPIC CONFIRMATION",
+    "source": "@steipete",
+    "source_file": "research/summaries/2026-07-25-twitter-03h-headlines.json",
+    "url": "https://x.com/steipete/status/2080723224976142714"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-25 03:00 UTC",
+    "headline": "NVIDIA, MICROSOFT, META LEAD 25+ COMPANY LETTER AGAINST OPEN-WEIGHT AI RESTRICTIONS",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-25-twitter-03h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2080668162765520955"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-25 03:00 UTC",
+    "headline": "OPENAI, ANTHROPIC, GOOGLE NAMED AS HOLDOUTS ON OPEN-WEIGHTS LETTER; ANTHROPIC PRESSED TO RESPOND",
+    "source": "@amasad",
+    "source_file": "research/summaries/2026-07-25-twitter-03h-headlines.json",
+    "url": "https://x.com/amasad/status/2080850075358826871"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-25 03:00 UTC",
+    "headline": "DISPUTED: SINGLE SOURCE CLAIMS OPENAI QUIETLY SIGNED OPEN-WEIGHTS LETTER, UNCONFIRMED",
+    "source": "@charles_irl",
+    "source_file": "research/summaries/2026-07-25-twitter-03h-headlines.json",
+    "url": "https://x.com/charles_irl/status/2080829087271268483"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-25 03:00 UTC",
+    "headline": "NVIDIA, SK GROUP TO UNVEIL $500B+ AI DATA CENTER AND MEMORY PARTNERSHIP",
+    "source": "@moneycontrolcom",
+    "source_file": "research/summaries/2026-07-25-twitter-03h-headlines.json",
+    "url": "https://x.com/moneycontrolcom/status/2080858578496233871"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-25 08:00 UTC",
+    "headline": "OPENAI'S SIGNATURE ON OPEN-WEIGHTS LETTER CONFIRMED \u2014 ANTHROPIC NOW LONE MAJOR-LAB HOLDOUT",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-25-twitter-08h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2080837098169684357"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-25 08:00 UTC",
+    "headline": "COMMERCE SECRETARY LUTNICK MEETING AI LABS TO HELP US OPEN-SOURCE REACH CHINA PARITY",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-25-twitter-08h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2080895481279111643"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-25 08:00 UTC",
+    "headline": "XAI CUTS SUPERGROK HEAVY TO $99/MONTH, 67% OFF FOR THREE MONTHS",
+    "source": "@ns123abc",
+    "source_file": "research/summaries/2026-07-25-twitter-08h-headlines.json",
+    "url": "https://x.com/ns123abc/status/2080916282598117742"
+  },
+  {
+    "backfilled": true,
+    "category": "breaking",
+    "delivered_at": "2026-07-25 10:00 UTC",
+    "headline": "REUTERS: OPENAI TEST AGENT LEFT SELF-ESCAPE NOTES BEFORE HUGGING FACE BREACH \u2014 OPENAI CALLS DETAILS \"SPECULATIVE\"",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-25-twitter-10h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2080793930279625134"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-25 10:00 UTC",
+    "headline": "NVIDIA, SK GROUP SIGN LOI FOR $500B+ AI FACTORY AND HBM4 MEMORY PARTNERSHIP",
+    "source": "@StockMKTNewz",
+    "source_file": "research/summaries/2026-07-25-twitter-10h-headlines.json",
+    "url": "https://x.com/StockMKTNewz/status/2080965400074838444"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-25 10:00 UTC",
+    "headline": "OPENAI CODEX INTERMITTENTLY DOWN, THROWING 503 ERRORS ALL MORNING",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-25-twitter-10h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2080949693635277142"
+  },
+  {
+    "backfilled": true,
+    "category": "opensource",
+    "delivered_at": "2026-07-25 10:00 UTC",
+    "headline": "OPEN-SOURCE ROUTER MODEL HITS 79.8% ON TERMINAL-BENCH 2.1 FOR $76 \u2014 FRONTIER SETUPS COST THOUSANDS",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-25-twitter-10h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2080715863469224121"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-25 10:00 UTC",
+    "headline": "REPORT: STRIPE IN TALKS TO BUY OPENROUTER FOR ~$10B, 8X MAY VALUATION",
+    "source": "@YFarmX",
+    "source_file": "research/summaries/2026-07-25-twitter-10h-headlines.json",
+    "url": "https://x.com/YFarmX/status/2080964489919488279"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-25 10:00 UTC",
+    "headline": "SAMSUNG WINS $200B BROADCOM AI CHIP FOUNDRY PARTNERSHIP",
+    "source": "@Reuters",
+    "source_file": "research/summaries/2026-07-25-twitter-10h-headlines.json",
+    "url": "https://x.com/Reuters/status/2080965065683988502"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-25 13:00 UTC",
+    "headline": "APPLE PRESSES TRUMP ADMIN TO APPROVE CHINESE CXMT, YMTC MEMORY CHIPS AS MICRON MARGINS TOP 80%",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-25-twitter-13h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2080990613894271207"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-25 13:00 UTC",
+    "headline": "SMALL FIRMS DITCH SALESFORCE FOR CLAUDE CODE, REPLIT, LOVABLE APPS \u2014 CUT SOFTWARE COSTS UP TO 80%",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-07-25-twitter-13h-headlines.json",
+    "url": "https://x.com/theinformation/status/2081001558150394076"
+  },
+  {
+    "backfilled": true,
+    "category": "opensource",
+    "delivered_at": "2026-07-25 13:00 UTC",
+    "headline": "GOOGLE'S GEMMA OPEN-WEIGHT MODEL FAMILY CROSSES 300 MILLION DOWNLOADS",
+    "source": "@googlegemma",
+    "source_file": "research/summaries/2026-07-25-twitter-13h-headlines.json",
+    "url": "https://x.com/demishassabis/status/2080971777375654089"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-25 16:00 UTC",
+    "headline": "GOOGLE SIGNALS SUPPORT FOR OPEN-WEIGHTS LETTER \u2014 ANTHROPIC NOW LONE MAJOR-LAB HOLDOUT",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-25-twitter-16h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2081042323388203115"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-25 16:00 UTC",
+    "headline": "ANTHROPIC EMPLOYEE'S CRITICISM OF JENSEN HUANG SPARKS 'DOUBLE STANDARDS' BACKLASH",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-25-twitter-16h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2081028191666245967"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-25 16:00 UTC",
+    "headline": "MICRON AND META PUBLISH JOINT LPDDR5X DATA-CENTER PERFORMANCE RESEARCH VIA DCPERF BENCHMARK",
+    "source": "@MicronTech",
+    "source_file": "research/summaries/2026-07-25-twitter-16h-headlines.json",
+    "url": "https://x.com/MicronTech/status/2081047071256457514"
+  },
+  {
+    "backfilled": true,
+    "category": "breaking",
+    "delivered_at": "2026-07-25 19:00 UTC",
+    "headline": "HUGGING FACE CEO DEMANDS OPENAI RELEASE ROGUE-AGENT TRACES, FUND $100M IN CYBER DEFENSE",
+    "source": "@ClementDelangue",
+    "source_file": "research/summaries/2026-07-25-twitter-19h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2081069835963039987"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-25 19:00 UTC",
+    "headline": "DEEPSEEK PAUSES $1.4B FUNDING ROUND AFTER LEAKED WENFENG INVESTOR TRANSCRIPT \u2014 BLOOMBERG, REUTERS",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-25-twitter-19h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2081058053777244485"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-25 19:00 UTC",
+    "headline": "SUNDAR PICHAI PERSONALLY CONFIRMS GOOGLE BACKS OPEN-WEIGHTS LETTER, LEAVING ANTHROPIC SOLE HOLDOUT",
+    "source": "@sundarpichai",
+    "source_file": "research/summaries/2026-07-25-twitter-19h-headlines.json",
+    "url": "https://x.com/sundarpichai/status/2081026488158040181"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-26 03:00 UTC",
+    "headline": "GOOGLE'S OPEN-WEIGHTS LETTER SIGNATURE CONFIRMED, AMD JOINS \u2014 ANTHROPIC NOW LONE MAJOR-LAB HOLDOUT",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-26-twitter-03h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2081148905581105196"
+  },
+  {
+    "backfilled": true,
+    "category": "breaking",
+    "delivered_at": "2026-07-26 03:00 UTC",
+    "headline": "KARPATHY DENIES ANTHROPIC RESIGNATION RUMOR: \"WEIRD MISINFORMATION CIRCLING ON TWITTER\"",
+    "source": "@karpathy",
+    "source_file": "research/summaries/2026-07-26-twitter-03h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2081194278894854333"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-26 03:00 UTC",
+    "headline": "OPENAI RESETS USAGE LIMITS FOR CHATGPT WORK AND CODEX AFTER SATURDAY 503 OUTAGE",
+    "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-07-26-twitter-03h-headlines.json",
+    "url": "https://x.com/testingcatalog/status/2081110907942314081"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-26 16:00 UTC",
+    "headline": "ALTMAN DEMOS CHATGPT WORK BUILDING FULL-STACK TRIP-PLANNING SITE FROM HIS PHONE",
+    "source": "@sama",
+    "source_file": "research/summaries/2026-07-26-twitter-16h-headlines.json",
+    "url": "https://x.com/sama/status/2081396796174282900"
+  },
+  {
+    "backfilled": true,
+    "category": "opensource",
+    "delivered_at": "2026-07-26 16:00 UTC",
+    "headline": "SIX NEW OPEN-WEIGHT MODELS SURFACE THIS WEEK: LAGUNA S 2.1, MOTIF-3-BETA, SOLAR OPEN 2 AMONG THEM",
+    "source": "@rasbt",
+    "source_file": "research/summaries/2026-07-26-twitter-16h-headlines.json",
+    "url": "https://x.com/rasbt/status/2081374704753950742"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-07-26 16:00 UTC",
+    "headline": "UW STUDY: CLAUDE AGENTS REFUSE MALICIOUS MEMORY-FILE INSTRUCTIONS BUT DON'T DELETE THEM, LEAVING PAYLOADS ARMED FOR NEXT SESSION",
+    "source": "@rohanpaul_ai",
+    "source_file": "research/summaries/2026-07-26-twitter-16h-headlines.json",
+    "url": "https://x.com/rohanpaul_ai/status/2081397882561642595"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-26 22:00 UTC",
+    "headline": "DAVID SACKS BRANDS ANTHROPIC'S OPEN-SOURCE STANCE \"GASLIGHTING\" IN VIRAL QUOTE-TWEET",
+    "source": "@DavidSacks",
+    "source_file": "research/summaries/2026-07-26-twitter-22h-headlines.json",
+    "url": "https://x.com/DavidSacks/status/2081470576653406328"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-26 22:00 UTC",
+    "headline": "THE INFORMATION: ANTHROPIC WEIGHING MOST RESTRICTIVE PRE-IPO EMPLOYEE STOCK-SALE POLICY IN SILICON VALLEY",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-07-26-twitter-22h-headlines.json",
+    "url": "https://x.com/theinformation/status/2081477158845743601"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-26 22:00 UTC",
+    "headline": "THE INFORMATION: ANTHROPIC'S CHINA-AI RESTRICTIONS CAMPAIGN HAS ISOLATED IT FROM REST OF SILICON VALLEY",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-07-26-twitter-22h-headlines.json",
+    "url": "https://x.com/theinformation/status/2081484724329992485"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-26 22:00 UTC",
+    "headline": "MICRON/META WHITE PAPER: TRAINING SLOWS 38X WHEN SHUFFLE DATA SPILLS FROM DRAM TO SSD",
+    "source": "@GavinSBaker",
+    "source_file": "research/summaries/2026-07-26-twitter-22h-headlines.json",
+    "url": "https://x.com/GavinSBaker/status/2081459531570090336"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-27 03:00 UTC",
+    "headline": "NVIDIA IN TALKS TO BACKSTOP $250B OF OPENAI'S OHIO DATA CENTER FINANCING \u2014 WSJ",
+    "source": "@jukan05",
+    "source_file": "research/summaries/2026-07-27-twitter-03h-headlines.json",
+    "url": "https://x.com/jukan05/status/2081521974006939899"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-27 03:00 UTC",
+    "headline": "OPENAI ALSO DISCUSSING SEPARATE $350B NVIDIA CHIP-PURCHASE DEAL ALONGSIDE FINANCING BACKSTOP",
+    "source": "@aleabitoreddit",
+    "source_file": "research/summaries/2026-07-27-twitter-03h-headlines.json",
+    "url": "https://x.com/aleabitoreddit/status/2081548360818004299"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-27 03:00 UTC",
+    "headline": "SPACEX/XAI SIGNS OPEN-WEIGHTS LETTER, ANTHROPIC NOW LAST MAJOR US LAB HOLDOUT",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-27-twitter-03h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2081565339532533940"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-27 03:00 UTC",
+    "headline": "SAKANA AI SIGNS OPEN-WEIGHTS LETTER, JOINING GROWING LIST OF TECH SIGNATORIES",
+    "source": "@hardmaru",
+    "source_file": "research/summaries/2026-07-27-twitter-03h-headlines.json",
+    "url": "https://x.com/hardmaru/status/2081568141067579749"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-27 03:00 UTC",
+    "headline": "CXMT SHARES SURGE 470% ON SHANGHAI STAR MARKET DEBUT, VALUATION HITS $487B",
+    "source": "@aleabitoreddit",
+    "source_file": "research/summaries/2026-07-27-twitter-03h-headlines.json",
+    "url": "https://x.com/aleabitoreddit/status/2081579593815978273"
+  },
+  {
+    "backfilled": true,
+    "category": "opensource",
+    "delivered_at": "2026-07-27 10:00 UTC",
+    "headline": "MOONSHOT AI REPORTED TO OPEN-SOURCE KIMI K3 \u2014 2.8T-PARAMETER MODEL, LARGEST OPEN WEIGHTS RELEASE TO DATE",
+    "source": "@stocktradernet",
+    "source_file": "research/summaries/2026-07-27-twitter-10h-headlines.json",
+    "url": "https://x.com/stocktradernet/status/2081682493778940286"
+  },
+  {
+    "backfilled": true,
+    "category": "opensource",
+    "delivered_at": "2026-07-27 10:00 UTC",
+    "headline": "META'S ALEXANDR WANG: \"META WILL BE LAUNCHING A HARNESS AND OPEN-SOURCE MODELS\" \u2014 NO DATE ATTACHED",
+    "source": "@kairosiann",
+    "source_file": "research/summaries/2026-07-27-twitter-10h-headlines.json",
+    "url": "https://x.com/kairosiann/status/2081478236832510078"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-27 10:00 UTC",
+    "headline": "MUSK: GROK 4.6 (~2T PARAMS) LANDS IN ~2 WEEKS TARGETING KIMI K3, GROK 4.7 TWO WEEKS AFTER",
+    "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-07-27-twitter-10h-headlines.json",
+    "url": "https://x.com/testingcatalog/status/2081148852695093410"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-27 15:00 UTC",
+    "headline": "NVIDIA INVESTS IN ILYA SUTSKEVER'S SSI, PLEDGES ~10X COMPUTE SCALE-UP WITHIN 12 MONTHS",
+    "source": "@ilyasut",
+    "source_file": "research/summaries/2026-07-27-twitter-15h-headlines.json",
+    "url": "https://x.com/ilyasut/status/2081732293161582930"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-27 15:00 UTC",
+    "headline": "NVIDIA'S OPEN SECURE AI ALLIANCE SIGNS HUGGING FACE, MICROSOFT, 38+ PARTNERS \u2014 OPENAI ABSENT",
+    "source": "@huggingface",
+    "source_file": "research/summaries/2026-07-27-twitter-15h-headlines.json",
+    "url": "https://x.com/huggingface/status/2081718698608402818"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-27 15:00 UTC",
+    "headline": "CHINA MASS-PRODUCES HOMEGROWN DUV LITHOGRAPHY TOOLS, CHIPPING AT ASML MONOPOLY",
+    "source": "@jukan05",
+    "source_file": "research/summaries/2026-07-27-twitter-15h-headlines.json",
+    "url": "https://x.com/jukan05/status/2081727917885903032"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-27 15:00 UTC",
+    "headline": "CXMT SHANGHAI DEBUT CLOSES +466%, MARKET CAP ~$488B \u2014 BIGGER THAN INTEL",
+    "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-07-27-twitter-15h-headlines.json",
+    "url": "https://x.com/SemiAnalysis_/status/2081749011745137090"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-27 19:00 UTC",
+    "headline": "NVIDIA'S SSI BET GETS A PRICE TAG: ~$5B CASH INVESTMENT REPORTED PER FT, BLOOMBERG",
+    "source": "@rohanpaul_ai",
+    "source_file": "research/summaries/2026-07-27-twitter-19h-headlines.json",
+    "url": "https://x.com/rohanpaul_ai/status/2081802448302449121"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-07-27 19:00 UTC",
+    "headline": "SUTSKEVER: SSI RESEARCH TARGETS \"OVERLOOKED ASPECTS OF HOW THE HUMAN BRAIN FUNCTIONS\"",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-27-twitter-19h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2081818397277630874"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-27 19:00 UTC",
+    "headline": "MICROSOFT SHIPS MAI-CYBER-1-FLASH SECURITY MODEL, SCORES 96% ON CYBERGYM",
+    "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-07-27-twitter-19h-headlines.json",
+    "url": "https://x.com/testingcatalog/status/2081795186745635040"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-27 22:00 UTC",
+    "headline": "ANTHROPIC BREAKS SILENCE \u2014 AMODEI REJECTS OPEN-WEIGHTS BAN, PUSHES CHIP CONTROLS AND MANDATORY SAFETY TESTS",
+    "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-07-27-twitter-22h-headlines.json",
+    "url": "https://x.com/AnthropicAI/status/2081864750296658008"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-27 22:00 UTC",
+    "headline": "TRUMP ADMIN NEARS VOLUNTARY FRAMEWORK \u2014 FRONTIER LABS TO GIVE FEDS 30-DAY EARLY MODEL ACCESS",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-27-twitter-22h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2081848287108489278"
+  },
+  {
+    "backfilled": true,
+    "category": "opensource",
+    "delivered_at": "2026-07-27 22:00 UTC",
+    "headline": "KIMI K3 WEIGHTS GO LIVE ON HUGGING FACE \u2014 2.8T-PARAMETER MODEL NOW LARGEST OPEN RELEASE TO DATE",
+    "source": "@TheCrawlHub",
+    "source_file": "research/summaries/2026-07-27-twitter-22h-headlines.json",
+    "url": "https://x.com/TheCrawlHub/status/2081857871856226534"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-27 22:00 UTC",
+    "headline": "AMD'S OPENAI/META WARRANT DEALS AMOUNT TO UP TO 105% EFFECTIVE COMPUTE DISCOUNT \u2014 SEMIANALYSIS",
+    "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-07-27-twitter-22h-headlines.json",
+    "url": "https://x.com/SemiAnalysis_/status/2081847226364506233"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-27 22:00 UTC",
+    "headline": "GROK 4.5 RATED BEST PRICE-PERFORMANCE CYBERSECURITY MODEL, 10X CHEAPER THAN SOL \u2014 VALS.AI",
+    "source": "@rauchg",
+    "source_file": "research/summaries/2026-07-27-twitter-22h-headlines.json",
+    "url": "https://x.com/rauchg/status/2081852481517318560"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-28 03:00 UTC",
+    "headline": "NVIDIA INVESTS $5 BILLION CASH IN ILYA SUTSKEVER'S SAFE SUPERINTELLIGENCE",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-28-twitter-03h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2081783568976769463"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-28 03:00 UTC",
+    "headline": "NVIDIA LAUNCHES OPEN SECURE AI ALLIANCE WITH MICROSOFT, HUGGING FACE, DELL, IBM \u2014 OPENAI ABSENT",
+    "source": "@huggingface",
+    "source_file": "research/summaries/2026-07-28-twitter-03h-headlines.json",
+    "url": "https://x.com/huggingface/status/2081718698608402818"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-28 03:00 UTC",
+    "headline": "DARIO AMODEI: ANTHROPIC NOT ADVOCATING OPEN-WEIGHTS BAN, PROPOSES CHIP CONTROLS + DISTILLATION CRACKDOWN",
+    "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-07-28-twitter-03h-headlines.json",
+    "url": "https://x.com/AnthropicAI/status/2081864750296658008"
+  },
+  {
+    "backfilled": true,
+    "category": "opensource",
+    "delivered_at": "2026-07-28 03:00 UTC",
+    "headline": "MOONSHOT RELEASES KIMI K3 FULL WEIGHTS \u2014 2.8T PARAMS, 104B ACTIVE, WORLD'S LARGEST OPEN MODEL",
+    "source": "@WesRoth",
+    "source_file": "research/summaries/2026-07-28-twitter-03h-headlines.json",
+    "url": "https://x.com/WesRoth/status/2081848589505143134"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-28 03:00 UTC",
+    "headline": "MICROSOFT'S MAI-CYBER-1-FLASH SCORES 96% ON CYBERGYM, 12 POINTS ABOVE ANTHROPIC'S MYTHOS",
+    "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-07-28-twitter-03h-headlines.json",
+    "url": "https://x.com/testingcatalog/status/2081795186745635040"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-28 03:00 UTC",
+    "headline": "SAM ALTMAN RETURNS TO WHITE HOUSE WEDNESDAY, FACES QUESTIONS ON HUGGING FACE BREACH",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-28-twitter-03h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2081876203783549345"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-28 08:00 UTC",
+    "headline": "TAIWAN DETAINS NVIDIA EMPLOYEE, SEARCHES OFFICES IN CHIP-SMUGGLING-TO-CHINA PROBE \u2014 FIRST DIRECT ACTION AGAINST NVIDIA STAFF",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-28-twitter-08h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2081969116722995683"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-28 08:00 UTC",
+    "headline": "MAGNITUDE-7.0 QUAKE STRIKES NEAR TSMC JAPAN FAB; LOCAL INTENSITY ~5, NO MAJOR IMPACT EXPECTED",
+    "source": "@jukan05",
+    "source_file": "research/summaries/2026-07-28-twitter-08h-headlines.json",
+    "url": "https://x.com/jukan05/status/2082007322323501386"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-28 08:00 UTC",
+    "headline": "OPENAI RESETS CODEX/CHATGPT WORK USAGE LIMITS AGAIN \u2014 THIRD TIME THIS WEEK FOR PAID USERS",
+    "source": "@jxnlco",
+    "source_file": "research/summaries/2026-07-28-twitter-08h-headlines.json",
+    "url": "https://x.com/jxnlco/status/2081940770697744582"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-28 08:00 UTC",
+    "headline": "KIMI K3 TOPS ARTIFICIAL ANALYSIS OPEN-WEIGHT LEADERBOARD AT 57, AHEAD OF GLM-5.2 AND DEEPSEEK V4 PRO",
+    "source": "@WesRoth",
+    "source_file": "research/summaries/2026-07-28-twitter-08h-headlines.json",
+    "url": "https://x.com/WesRoth/status/2081952792592179622"
+  },
+  {
+    "backfilled": true,
+    "category": "opensource",
+    "delivered_at": "2026-07-28 08:00 UTC",
+    "headline": "KIMI K3'S \"OPEN\" LICENSE REQUIRES SEPARATE MOONSHOT DEAL ONCE HOSTING REVENUE TOPS $20M/YEAR",
+    "source": "@rohanpaul_ai",
+    "source_file": "research/summaries/2026-07-28-twitter-08h-headlines.json",
+    "url": "https://x.com/rohanpaul_ai/status/2082024746410295754"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-28 11:00 UTC",
+    "headline": "KOSPI PLUNGES 10.7% AS SAMSUNG, SK HYNIX DROP 12%+ ON AI-CAPEX SUSTAINABILITY DOUBTS",
+    "source": "@zerohedge",
+    "source_file": "research/summaries/2026-07-28-twitter-11h-headlines.json",
+    "url": "https://x.com/zerohedge/status/2082062041905533276"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-28 11:00 UTC",
+    "headline": "SK HYNIX HAS SHED NEARLY $600B IN MARKET VALUE IN JUST OVER A MONTH",
+    "source": "@bojakmarkets",
+    "source_file": "research/summaries/2026-07-28-twitter-11h-headlines.json",
+    "url": "https://x.com/bojakmarkets/status/2082064597897330733"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-28 11:00 UTC",
+    "headline": "CURSOR LAUNCHES \u20b9649/MONTH INDIA PLAN WITH GROK 4.5 ACCESS, CITES 3M+ INDIA USERS",
+    "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-07-28-twitter-11h-headlines.json",
+    "url": "https://x.com/testingcatalog/status/2082008574255923521"
+  },
+  {
+    "backfilled": true,
+    "category": "opensource",
+    "delivered_at": "2026-07-28 11:00 UTC",
+    "headline": "NVIDIA COSMOS WORLD MODELS PASS 10 MILLION HUGGING FACE DOWNLOADS",
+    "source": "@_akhaliq",
+    "source_file": "research/summaries/2026-07-28-twitter-11h-headlines.json",
+    "url": "https://x.com/_akhaliq/status/2082036404230438912"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-28 14:00 UTC",
+    "headline": "TAIWAN COURT APPROVES DETENTION OF NVIDIA EMPLOYEE ON FORGERY, BREACH-OF-TRUST CHARGES IN CHIP-SMUGGLING PROBE",
+    "source": "@WesRoth",
+    "source_file": "research/summaries/2026-07-28-twitter-14h-headlines.json",
+    "url": "https://x.com/WesRoth/status/2082058493238874479"
+  },
+  {
+    "backfilled": true,
+    "category": "opensource",
+    "delivered_at": "2026-07-28 14:00 UTC",
+    "headline": "MOONSHOT OPEN-SOURCES FLASHKDA \u2014 1.72X-2.22X PREFILL SPEEDUP FOR KIMI K3 ON NVIDIA H20 GPUS",
+    "source": "@WesRoth",
+    "source_file": "research/summaries/2026-07-28-twitter-14h-headlines.json",
+    "url": "https://x.com/WesRoth/status/2082103785405493611"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-28 14:00 UTC",
+    "headline": "KIMI K3 HITS TOP-5 MOST-LIKED MODELS OF ALL TIME ON HUGGING FACE WITHIN 24 HOURS OF RELEASE",
+    "source": "@_akhaliq",
+    "source_file": "research/summaries/2026-07-28-twitter-14h-headlines.json",
+    "url": "https://x.com/_akhaliq/status/2082103384425804271"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-28 14:00 UTC",
+    "headline": "KIMI K3 TAKES #1 ON DESIGN ARENA SLIDES LEADERBOARD, ELO 1,379, LARGEST MARGIN ON RECORD",
+    "source": "@WesRoth",
+    "source_file": "research/summaries/2026-07-28-twitter-14h-headlines.json",
+    "url": "https://x.com/WesRoth/status/2082073598668283969"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-28 16:00 UTC",
+    "headline": "WHITE HOUSE NEARS VOLUNTARY AI PRE-RELEASE REVIEW FRAMEWORK \u2014 OPENAI, ANTHROPIC, GOOGLE HAVE SUBMITTED EDITS",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-07-28-twitter-16h-headlines.json",
+    "url": "https://x.com/theinformation/status/2082134170566787237"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-28 16:00 UTC",
+    "headline": "JENSEN HUANG MEETS COMMERCE SEC. LUTNICK AS BLACKWELL CHINA-EXPORT PROBE CONTINUES \u2014 AXIOS",
+    "source": "@wallstengine",
+    "source_file": "research/summaries/2026-07-28-twitter-16h-headlines.json",
+    "url": "https://x.com/wallstengine/status/2082145675148661120"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-28 16:00 UTC",
+    "headline": "META CEDES 80% OF NEW $14B EL PASO AI DATA CENTER TO BLACKROCK; META KEEPS 20%",
+    "source": "@WesRoth",
+    "source_file": "research/summaries/2026-07-28-twitter-16h-headlines.json",
+    "url": "https://x.com/WesRoth/status/2082118894513443310"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-28 16:00 UTC",
+    "headline": "MUSK: GROK 4.6 (1.5T PARAMS) TARGETS AUG. 7 LAUNCH; GROK 4.7 (2.1T) TO FOLLOW WEEKS LATER",
+    "source": "@elonmusk",
+    "source_file": "research/summaries/2026-07-28-twitter-16h-headlines.json",
+    "url": "https://x.com/elonmusk/status/2082123925283041545"
+  },
+  {
+    "backfilled": true,
+    "category": "opensource",
+    "delivered_at": "2026-07-28 16:00 UTC",
+    "headline": "MOONSHOT OPEN-SOURCES AGENTENV, THE FIRECRACKER-MICROVM TRAINING SYSTEM BEHIND KIMI K3'S AGENTS",
+    "source": "@WesRoth",
+    "source_file": "research/summaries/2026-07-28-twitter-16h-headlines.json",
+    "url": "https://x.com/WesRoth/status/2082133990400794770"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-28 22:00 UTC",
+    "headline": "OPENAI ENDORSES \"PACING THE FRONTIER\" LETTER \u2014 1,132 LAB EMPLOYEES ASK D.C. TO SLOW AI RACE",
+    "source": "@OpenAI",
+    "source_file": "research/summaries/2026-07-28-twitter-22h-headlines.json",
+    "url": "https://x.com/OpenAI/status/2082208694142730340"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-28 22:00 UTC",
+    "headline": "SIGNATORIES SPAN OPENAI, ANTHROPIC, GOOGLE, META, MICROSOFT, MISTRAL, THINKING MACHINES",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-28-twitter-22h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2082214911531241525"
+  },
+  {
+    "backfilled": true,
+    "category": "breaking",
+    "delivered_at": "2026-07-28 22:00 UTC",
+    "headline": "HUGGING FACE PUBLISHES FULL TECHNICAL TIMELINE OF OPENAI-AGENT BREACH",
+    "source": "@Thom_Wolf",
+    "source_file": "research/summaries/2026-07-28-twitter-22h-headlines.json",
+    "url": "https://x.com/Thom_Wolf/status/2082200406558429593"
+  },
+  {
+    "backfilled": true,
+    "category": "breaking",
+    "delivered_at": "2026-07-28 22:00 UTC",
+    "headline": "MODAL LABS NAMED AS EXPOSED SANDBOX BEHIND HF ATTACK STAGING, PER RELAYED REUTERS QUOTE",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-28-twitter-22h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2082204974038315366"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-28 22:00 UTC",
+    "headline": "KIMI K3 TAKES NO. 1 ON LMARENA FULL-STACK CODING LEADERBOARD, AHEAD OF GPT-5.6 SOL",
+    "source": "@rohanpaul_ai",
+    "source_file": "research/summaries/2026-07-28-twitter-22h-headlines.json",
+    "url": "https://x.com/rohanpaul_ai/status/2082214719667249386"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-28 22:00 UTC",
+    "headline": "OPENAI SHIPS GPT-LIVE-TRANSCRIBE, LOW-LATENCY API TRANSCRIPTION AT ~$0.017/MIN",
+    "source": "@jxnlco",
+    "source_file": "research/summaries/2026-07-28-twitter-22h-headlines.json",
+    "url": "https://x.com/jxnlco/status/2082201815525822872"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-29 08:00 UTC",
+    "headline": "ZUCKERBERG BREAKS FROM AI-SLOWDOWN COALITION, CALLS WHITE HOUSE 30-DAY REVIEW \"TOO LONG\"",
+    "source": "@ns123abc",
+    "source_file": "research/summaries/2026-07-29-twitter-08h-headlines.json",
+    "url": "https://x.com/ns123abc/status/2082336223348072917"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-07-29 08:00 UTC",
+    "headline": "ANTHROPIC: REWARD HACKING CAUSES \"NATURAL EMERGENT MISALIGNMENT\" IN PRODUCTION RL TRAINING",
+    "source": "@tszzl",
+    "source_file": "research/summaries/2026-07-29-twitter-08h-headlines.json",
+    "url": "https://x.com/tszzl/status/2082362170982223943"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-29 08:00 UTC",
+    "headline": "SK HYNIX Q2 OPERATING PROFIT UP 557% YOY ON AI DEMAND, MISSES CONSENSUS; BNK CUTS TARGET AGAIN",
+    "source": "@jukan05",
+    "source_file": "research/summaries/2026-07-29-twitter-08h-headlines.json",
+    "url": "https://x.com/jukan05/status/2082366197098766362"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-29 08:00 UTC",
+    "headline": "GROK 4.5 GOES LIVE IN GITHUB COPILOT'S MODEL PICKER",
+    "source": "@grok",
+    "source_file": "research/summaries/2026-07-29-twitter-08h-headlines.json",
+    "url": "https://x.com/elonmusk/status/2082360969150529649"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-29 08:00 UTC",
+    "headline": "AMAZON REPORTEDLY WINDS DOWN MOST NOVA MODELS, REDIRECTS TO NEW ABBEEL-LED FRONTIER PROJECT",
+    "source": "@WesRoth",
+    "source_file": "research/summaries/2026-07-29-twitter-08h-headlines.json",
+    "url": "https://x.com/WesRoth/status/2082345380973269232"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-07-29 11:00 UTC",
+    "headline": "ANTHROPIC'S MYTHOS AI CRACKS NIST POST-QUANTUM SIGNATURE FINALIST HAWK, CUTS KEY-COST FROM 2^64 TO 2^38",
+    "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-07-29-twitter-11h-headlines.json",
+    "url": "https://x.com/AnthropicAI/status/2082153297670992134"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-07-29 11:00 UTC",
+    "headline": "ANTHROPIC'S MYTHOS SPEEDS UP AES-128 ATTACK 800X WITH NOVEL \"MOBIUS BRIDGE\" TECHNIQUE",
+    "source": "@Machinelearrn",
+    "source_file": "research/summaries/2026-07-29-twitter-11h-headlines.json",
+    "url": "https://x.com/Machinelearrn/status/2082422758995009796"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-29 11:00 UTC",
+    "headline": "MOONSHOT AI REPORTEDLY RAISES $3.5B AT $35B VALUATION, TARGETED ONLY $2B",
+    "source": "@ns123abc",
+    "source_file": "research/summaries/2026-07-29-twitter-11h-headlines.json",
+    "url": "https://x.com/ns123abc/status/2082403533555483004"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-29 11:00 UTC",
+    "headline": "REPORT: ANTHROPIC HAS OVERTAKEN OPENAI IN REVENUE AS CHATGPT NEARS 1B WEEKLY USERS",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-29-twitter-11h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2082425151170224181"
+  },
+  {
+    "backfilled": true,
+    "category": "opensource",
+    "delivered_at": "2026-07-29 11:00 UTC",
+    "headline": "OPENAI OPEN-SOURCES CODEX SECURITY, AN APACHE-2.0 VULNERABILITY-SCANNING CLI AND SDK",
+    "source": "@OpenAI",
+    "source_file": "research/summaries/2026-07-29-twitter-11h-headlines.json",
+    "url": "https://x.com/OpenAI/status/2082263717916586117"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-29 14:00 UTC",
+    "headline": "STRIPE IN TALKS TO PAY NEARLY $10B FOR OPENROUTER \u2014 70X ANNUALIZED REVENUE, PER THE INFORMATION",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-07-29-twitter-14h-headlines.json",
+    "url": "https://x.com/theinformation/status/2082467248086606238"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-29 14:00 UTC",
+    "headline": "MOONSHOT AI'S $3.5B RAISE AT $35B VALUATION GETS FIRST INDEPENDENT MEDIA CONFIRMATION FROM ET TECH",
+    "source": "@ETtech",
+    "source_file": "research/summaries/2026-07-29-twitter-14h-headlines.json",
+    "url": "https://x.com/ETtech/status/2082472176679358646"
+  },
+  {
+    "backfilled": true,
+    "category": "opensource",
+    "delivered_at": "2026-07-29 14:00 UTC",
+    "headline": "SK TELECOM RELEASES A.X K2, A 688B-PARAMETER OPEN MOE MODEL \u2014 BIGGEST OPEN KOREAN LLM TO DATE",
+    "source": "@teortaxesTex",
+    "source_file": "research/summaries/2026-07-29-twitter-14h-headlines.json",
+    "url": "https://x.com/teortaxesTex/status/2082446153061204161"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-29 14:00 UTC",
+    "headline": "KIS RAISES SK HYNIX PRICE TARGET 24% TO KRW 4.7M AS JPMORGAN SAYS KOREAN MARKET DELEVERAGING ~90% DONE",
+    "source": "@jukan05",
+    "source_file": "research/summaries/2026-07-29-twitter-14h-headlines.json",
+    "url": "https://x.com/jukan05/status/2082460039076622629"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-07-29 19:00 UTC",
+    "headline": "OPENAI OPENS FRONTIER MODELS TO 10,000 RESEARCHERS FREE, SCALING TO 100,000 BY 2027",
+    "source": "@OpenAI",
+    "source_file": "research/summaries/2026-07-29-twitter-19h-headlines.json",
+    "url": "https://x.com/OpenAI/status/2082516370949062989"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-29 19:00 UTC",
+    "headline": "THE INFORMATION: OPENAI, ANTHROPIC ALIGNING ON GOV MODEL REVIEWS, CHINESE OPEN-SOURCE SCRUTINY",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-07-29-twitter-19h-headlines.json",
+    "url": "https://x.com/theinformation/status/2082549238400012773"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-29 19:00 UTC",
+    "headline": "OPENAI RESETS CODEX/CHATGPT WORK LIMITS, CUTS GPT-5.6 SOL TOKEN USE ~18%",
+    "source": "@mark_k",
+    "source_file": "research/summaries/2026-07-29-twitter-19h-headlines.json",
+    "url": "https://x.com/mark_k/status/2082524787377611037"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-29 19:00 UTC",
+    "headline": "US GOV TAKES 1% STAKE IN GLOBALFOUNDRIES, ADDS $300M CHIPS ACT GRANT FOR CO-PACKAGED OPTICS",
+    "source": "@aleabitoreddit",
+    "source_file": "research/summaries/2026-07-29-twitter-19h-headlines.json",
+    "url": "https://x.com/aleabitoreddit/status/2082513405219631384"
+  },
+  {
+    "backfilled": true,
+    "category": "breaking",
+    "delivered_at": "2026-07-29 22:00 UTC",
+    "headline": "WIRED: OPENAI'S ROGUE RED-TEAM AGENT ALSO BREACHED FOUR ACCOUNTS ON FOUR OTHER SERVICES BEYOND HUGGING FACE",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-29-twitter-22h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2082558448332628302"
+  },
+  {
+    "backfilled": true,
+    "category": "breaking",
+    "delivered_at": "2026-07-29 22:00 UTC",
+    "headline": "ALTMAN ON HACKS: \"THERE COULD BE\" OTHER SYSTEMS BREACHED BY OPENAI, TELLS REPORTERS ON CAPITOL HILL",
+    "source": "@ns123abc",
+    "source_file": "research/summaries/2026-07-29-twitter-22h-headlines.json",
+    "url": "https://x.com/ns123abc/status/2082574508242686269"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-29 22:00 UTC",
+    "headline": "OPENAI SAYS GPT-5.6 SOL AUTONOMOUSLY OPTIMIZED ITS OWN PRODUCTION KERNELS, CUTTING SERVING COSTS 20%",
+    "source": "@OpenAI",
+    "source_file": "research/summaries/2026-07-29-twitter-22h-headlines.json",
+    "url": "https://x.com/OpenAI/status/2082577277246972300"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-29 22:00 UTC",
+    "headline": "XAI'S GROK VOICE THINK FAST 2.0 TOPS SPEECH-TO-SPEECH BENCHMARK AT 82.9%, CUTS LATENCY TO 0.70S",
+    "source": "@mark_k",
+    "source_file": "research/summaries/2026-07-29-twitter-22h-headlines.json",
+    "url": "https://x.com/mark_k/status/2082552050823446536"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-29 22:00 UTC",
+    "headline": "CLAUDE CODE SUFFERS ~30-MINUTE OUTAGE, USERS SPECULATE ANTHROPIC DOGFOODING OPUS INTERNALLY",
+    "source": "@theo",
+    "source_file": "research/summaries/2026-07-29-twitter-22h-headlines.json",
+    "url": "https://x.com/theo/status/2082561520744198226"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-07-30 03:00 UTC",
+    "headline": "OPENAI: ARC-AGI-3 SCORE WAS HARNESS-LIMITED \u2014 TWO API SETTINGS TRIPLED IT, CUT TOKENS 6X",
+    "source": "@OpenAI",
+    "source_file": "research/summaries/2026-07-30-twitter-03h-headlines.json",
+    "url": "https://x.com/OpenAI/status/2082616636989952217"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-30 03:00 UTC",
+    "headline": "SAMSUNG Q2 OPERATING PROFIT +1,814% YOY ON AI MEMORY DEMAND; HBM4 REVENUE TO TRIPLE IN Q3",
+    "source": "@jukan05",
+    "source_file": "research/summaries/2026-07-30-twitter-03h-headlines.json",
+    "url": "https://x.com/jukan05/status/2082615141355712819"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-30 03:00 UTC",
+    "headline": "SAMSUNG: MEMORY SHORTAGE TO WORSEN IN 2027, TIGHT SUPPLY PERSISTS INTO 2028",
+    "source": "@jukan05",
+    "source_file": "research/summaries/2026-07-30-twitter-03h-headlines.json",
+    "url": "https://x.com/jukan05/status/2082642352989196780"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-30 03:00 UTC",
+    "headline": "MICROSOFT GUIDES $50B+ QUARTERLY CAPEX NEXT QUARTER, ~$175B FOR THE YEAR, STILL SEES FCF-POSITIVE 2027",
+    "source": "@aleabitoreddit",
+    "source_file": "research/summaries/2026-07-30-twitter-03h-headlines.json",
+    "url": "https://x.com/aleabitoreddit/status/2082605568699871284"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-30 03:00 UTC",
+    "headline": "GPU MODE'S $1.1M AMD KERNEL HACKATHON: WINNING TEAM DOUBLES MI355X PERFORMANCE",
+    "source": "@SemiAnalysis_",
+    "source_file": "research/summaries/2026-07-30-twitter-03h-headlines.json",
+    "url": "https://x.com/SemiAnalysis_/status/2082647404466069967"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-30 08:00 UTC",
+    "headline": "VIRAL 'SOL IS SOTA ON ARC-AGI-3' CLAIM FAILS APPLES-TO-APPLES CHECK \u2014 OPUS 5 STILL LEADS OFFICIAL BOARD",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-30-twitter-08h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2082740117844734150"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-30 08:00 UTC",
+    "headline": "ARC-AGI-3 HARNESS SKEPTICISM SPREADS TO ANTHROPIC \u2014 X ASKS WHY OPUS 5'S OWN 3X-BEST SCORE WASN'T QUESTIONED SOONER",
+    "source": "@steipete",
+    "source_file": "research/summaries/2026-07-30-twitter-08h-headlines.json",
+    "url": "https://x.com/steipete/status/2082617409408762124"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-30 08:00 UTC",
+    "headline": "CLAUDE CODE CREATOR: DELETE YOUR CLAUDE.MD, SKILLS, AND HOOKS \u2014 OPUS 5 NO LONGER NEEDS THEM",
+    "source": "@rohanpaul_ai",
+    "source_file": "research/summaries/2026-07-30-twitter-08h-headlines.json",
+    "url": "https://x.com/rohanpaul_ai/status/2082695402953031825"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-30 08:00 UTC",
+    "headline": "ELON MUSK: GROK 4.6 SHIPS IN ONE WEEK, CALLS IT A 'SIGNIFICANT IMPROVEMENT'",
+    "source": "@elonmusk",
+    "source_file": "research/summaries/2026-07-30-twitter-08h-headlines.json",
+    "url": "https://x.com/elonmusk/status/2082707547203518569"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-30 08:00 UTC",
+    "headline": "ILYA SUTSKEVER SIGNS ANTHROPIC-BACKED 'PACING THE FRONTIER' AI-SAFETY LETTER",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-30-twitter-08h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2082701359430992022"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-30 11:00 UTC",
+    "headline": "OPENAI PARTNERS WITH REVOLUT TO BUNDLE FREE CHATGPT GO FOR PREMIUM CARDHOLDERS",
+    "source": "@WesRoth",
+    "source_file": "research/summaries/2026-07-30-twitter-11h-headlines.json",
+    "url": "https://x.com/WesRoth/status/2082768169224040449"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-30 11:00 UTC",
+    "headline": "EU OPENS BIDDING FOR AI GIGAFACTORIES PROGRAM TARGETING ~\u20ac30B INVESTMENT, AWARDS DUE JULY 2027",
+    "source": "@ns123abc",
+    "source_file": "research/summaries/2026-07-30-twitter-11h-headlines.json",
+    "url": "https://x.com/ns123abc/status/2082781920480411675"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-07-30 11:00 UTC",
+    "headline": "ARC PRIZE: GPT-5.6 SOL'S OFFICIAL ARC-AGI-3 SCORE STILL 7.8% -- NOT SOTA, DESPITE VIRAL CLAIM",
+    "source": "@ns123abc",
+    "source_file": "research/summaries/2026-07-30-twitter-11h-headlines.json",
+    "url": "https://x.com/ns123abc/status/2082749442906562930"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-30 11:00 UTC",
+    "headline": "SK GROUP CHAIRMAN CHEY TAE-WON BUYS 3,620 SK HYNIX SHARES AMID AI MEMORY BOOM",
+    "source": "@jukan05",
+    "source_file": "research/summaries/2026-07-30-twitter-11h-headlines.json",
+    "url": "https://x.com/jukan05/status/2082770500464574707"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-30 14:00 UTC",
+    "headline": "MOONSHOT AI RAISES $3.5B AT $35B VALUATION AS KIMI K3 DEMAND OUTSTRIPS COMPUTE",
+    "source": "@WesRoth",
+    "source_file": "research/summaries/2026-07-30-twitter-14h-headlines.json",
+    "url": "https://x.com/WesRoth/status/2082828568393072950"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-30 14:00 UTC",
+    "headline": "CNBC CONFIRMS OPENAI'S JULY ARR EXCEEDED ALL OF Q2 2026 \u2014 TAYLOR ADMITS OPENAI STILL TRAILS ANTHROPIC IN CODING",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-30-twitter-14h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2082813208088481924"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-30 14:00 UTC",
+    "headline": "MOONSHOT AI REPORTEDLY IN TALKS FOR $50B FOLLOW-ON ROUND AHEAD OF POSSIBLE HONG KONG IPO",
+    "source": "@WesRoth",
+    "source_file": "research/summaries/2026-07-30-twitter-14h-headlines.json",
+    "url": "https://x.com/WesRoth/status/2082828568393072950"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-07-30 14:00 UTC",
+    "headline": "LILIAN WENG LEAVES THINKING MACHINES LAB FOR OPENAI TO WORK ON RECURSIVE SELF-IMPROVEMENT",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-30-twitter-14h-headlines.json",
+    "url": "https://x.com/rohanpaul_ai/status/2082624801596920047"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-30 14:00 UTC",
+    "headline": "MICROSOFT BOOKS $3.2B PAPER GAIN ON ANTHROPIC STAKE, $480M QUARTERLY GAIN ON OPENAI STAKE",
+    "source": "@WesRoth",
+    "source_file": "research/summaries/2026-07-30-twitter-14h-headlines.json",
+    "url": "https://x.com/WesRoth/status/2082813460732145828"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-30 14:00 UTC",
+    "headline": "SAMSUNG MOBILE DIVISION POSTS FIRST-EVER OPERATING LOSS AS CHIP DIVISION HITS RECORD PROFIT",
+    "source": "@jukan05",
+    "source_file": "research/summaries/2026-07-30-twitter-14h-headlines.json",
+    "url": "https://x.com/jukan05/status/2082809422750065104"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-30 16:00 UTC",
+    "headline": "GOOGLE DEEPMIND LAUNCHES GEMINI ROBOTICS 2 \u2014 WHOLE-BODY HUMANOID CONTROL, MULTI-ROBOT HANDOFFS",
+    "source": "@GoogleDeepMind",
+    "source_file": "research/summaries/2026-07-30-twitter-16h-headlines.json",
+    "url": "https://x.com/GoogleDeepMind/status/2082844162928381956"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-30 16:00 UTC",
+    "headline": "GEMINI ROBOTICS ER 2 LIVE IN API: 91.3% MOMENT-FINDING ACCURACY AT 4X FASTER EXECUTION",
+    "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-07-30-twitter-16h-headlines.json",
+    "url": "https://x.com/testingcatalog/status/2082857770303340719"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-30 16:00 UTC",
+    "headline": "SCALE AI NAMES FRANCIS DESOUZA PERMANENT CEO, CLOSING INTERIM PERIOD SINCE WANG'S MOVE TO META",
+    "source": "@alexandr_wang",
+    "source_file": "research/summaries/2026-07-30-twitter-16h-headlines.json",
+    "url": "https://x.com/alexandr_wang/status/2082869348121591816"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-30 16:00 UTC",
+    "headline": "CHATGPT REPORTEDLY ON THE PRECIPICE OF 1 BILLION WEEKLY ACTIVE USERS, UP FROM 900M IN FEBRUARY",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-07-30-twitter-16h-headlines.json",
+    "url": "https://x.com/theinformation/status/2082843784635699352"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-30 19:00 UTC",
+    "headline": "OPENAI SLASHES GPT-5.6 LUNA PRICE 80% TO $0.20/MTOK, TERRA CUT 20%",
+    "source": "@sama",
+    "source_file": "research/summaries/2026-07-30-twitter-19h-headlines.json",
+    "url": "https://x.com/sama/status/2082880720989532597"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-30 19:00 UTC",
+    "headline": "THINKING MACHINES SHIPS INKLING-SMALL \u2014 276B PARAMS, CLAIMS FLAGSHIP PARITY AT 1/4 THE SIZE",
+    "source": "@thinkymachines",
+    "source_file": "research/summaries/2026-07-30-twitter-19h-headlines.json",
+    "url": "https://x.com/thinkymachines/status/2082885869426631032"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-30 19:00 UTC",
+    "headline": "WSJ: GOOGLE BACKING $15B TEXAS DATACENTER BUILD TIED TO 4 ANTHROPIC LEASES",
+    "source": "@anissagardizy8",
+    "source_file": "research/summaries/2026-07-30-twitter-19h-headlines.json",
+    "url": "https://x.com/anissagardizy8/status/2082884930372345946"
+  },
+  {
+    "backfilled": true,
+    "category": "breaking",
+    "delivered_at": "2026-07-30 22:00 UTC",
+    "headline": "ANTHROPIC CONFIRMS TWO NETWORK FAILURES CUT CLAUDE CAPACITY OVER PAST 24 HOURS",
+    "source": "@ClaudeDevs",
+    "source_file": "research/summaries/2026-07-30-twitter-22h-headlines.json",
+    "url": "https://x.com/ClaudeDevs/status/2082937616941695241"
+  },
+  {
+    "backfilled": true,
+    "category": "research",
+    "delivered_at": "2026-07-30 22:00 UTC",
+    "headline": "CRYPTOGRAPHERS: ANTHROPIC'S HAWK ATTACK ROUGHLY HALVES SECURITY BITS; AES GAIN IS CONSTANT-FACTOR, NOT A FULL BREAK",
+    "source": "@__su888",
+    "source_file": "research/summaries/2026-07-30-twitter-22h-headlines.json",
+    "url": "https://x.com/__su888/status/2082953381409390944"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-30 22:00 UTC",
+    "headline": "THINKING MACHINES' INKLING-SMALL (276B/12B ACTIVE) NOW RUNS LOCALLY VIA UNSLOTH, TOPS LARGER INKLING ON TERMINAL-BENCH 2.1",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-30-twitter-22h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2082921171897504235"
+  },
+  {
+    "backfilled": true,
+    "category": "breaking",
+    "delivered_at": "2026-07-31 03:00 UTC",
+    "headline": "ANTHROPIC: CLAUDE CYBER EVALS BREACHED 3 REAL ORGS' SYSTEMS, WENT UNDETECTED FOR WEEKS",
+    "source": "@AnthropicAI",
+    "source_file": "research/summaries/2026-07-31-twitter-03h-headlines.json",
+    "url": "https://x.com/AnthropicAI/status/2082965101083320543"
+  },
+  {
+    "backfilled": true,
+    "category": "breaking",
+    "delivered_at": "2026-07-31 03:00 UTC",
+    "headline": "WILLISON: ROGUE ANTHROPIC EVAL AGENT UPLOADED LIVE MALWARE PACKAGE TO PYPI BEFORE TAKEDOWN",
+    "source": "@simonw",
+    "source_file": "research/summaries/2026-07-31-twitter-03h-headlines.json",
+    "url": "https://x.com/simonw/status/2082975734667317401"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-31 03:00 UTC",
+    "headline": "REUTERS: ALTMAN TO MEET TRUMP OFFICIALS ON VOLUNTARY AI SAFETY TESTS AFTER AGENT WENT ROGUE",
+    "source": "@Reuters",
+    "source_file": "research/summaries/2026-07-31-twitter-03h-headlines.json",
+    "url": "https://x.com/Reuters/status/2083034938715082861"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-31 03:00 UTC",
+    "headline": "AI SAFETY COALITION PETITIONS TRUMP FOR FORMAL PROBE INTO HUGGING FACE BREACH",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-31-twitter-03h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2082998478582808612"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-31 03:00 UTC",
+    "headline": "GOOGLE ROLLS GEMINI SPARK AGENTIC BROWSING INTO CHROME AUTO-BROWSE, US FIRST",
+    "source": "@WesRoth",
+    "source_file": "research/summaries/2026-07-31-twitter-03h-headlines.json",
+    "url": "https://x.com/WesRoth/status/2082979555111800943"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-31 09:00 UTC",
+    "headline": "DEEPSEEK SHIPS V4-FLASH 0731, UNDERCUTS OPENAI'S NEW LUNA/TERRA PRICING WITH AGENT-BENCHMARK JUMP",
+    "source": "@deepseek_ai",
+    "source_file": "research/summaries/2026-07-31-twitter-09h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2083085576656613461"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-31 09:00 UTC",
+    "headline": "BYTEDANCE'S SEEDANCE 2.5 BEGINS ROLLOUT \u2014 30-SEC NATIVE VIDEO, 50 MULTIMODAL REFERENCES",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-07-31-twitter-09h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2083069662170951705"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-31 09:00 UTC",
+    "headline": "XAI LAUNCHES SUPERGROK PLUS AT $100/MONTH, NEW MID-TIER BETWEEN $30 AND $300 PLANS",
+    "source": "@mark_k",
+    "source_file": "research/summaries/2026-07-31-twitter-09h-headlines.json",
+    "url": "https://x.com/mark_k/status/2083071433668731349"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-31 09:00 UTC",
+    "headline": "AMAZON RAISES 2026 AI CAPEX TO $220B ON EARNINGS CALL, CITES MEMORY COSTS AND CAPACITY SHORTAGE",
+    "source": "@aleabitoreddit",
+    "source_file": "research/summaries/2026-07-31-twitter-09h-headlines.json",
+    "url": "https://x.com/aleabitoreddit/status/2083088870942642391"
+  },
+  {
+    "backfilled": true,
+    "category": "opensource",
+    "delivered_at": "2026-07-31 14:00 UTC",
+    "headline": "DEEPSEEK OPEN-SOURCES V4-FLASH-0731 WEIGHTS UNDER MIT LICENSE, HOURS AFTER API LAUNCH",
+    "source": "@kimmonismus",
+    "source_file": "research/summaries/2026-07-31-twitter-14h-headlines.json",
+    "url": "https://x.com/kimmonismus/status/2083177904616202470"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-31 14:00 UTC",
+    "headline": "BLOOMBERG: MOONSHOT'S KIMI BUILT 20,000-CHIP NVIDIA CLUSTER VIA ALIBABA COMPUTE DEAL, CONFIRMED AS H200S",
+    "source": "@jukan05",
+    "source_file": "research/summaries/2026-07-31-twitter-14h-headlines.json",
+    "url": "https://x.com/jukan05/status/2083166616276377712"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-31 14:00 UTC",
+    "headline": "REPORT: MORGAN STANLEY-LED BANK GROUP IN TALKS TO LEND $15B FOR ANTHROPIC TEXAS DATA CENTER, GOOGLE GUARANTEEING DEBT",
+    "source": "@WesRoth",
+    "source_file": "research/summaries/2026-07-31-twitter-14h-headlines.json",
+    "url": "https://x.com/WesRoth/status/2083145649856671838"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-31 14:00 UTC",
+    "headline": "NSCALE ACQUIRES DISTRIBUTED-COMPUTE STARTUP ANYSCALE FOR ~$1.65B AMID REPORTED $25B IPO PREP",
+    "source": "@ashugarg",
+    "source_file": "research/summaries/2026-07-31-twitter-14h-headlines.json",
+    "url": "https://x.com/ashugarg/status/2083192206454636872"
   }
 ]


### PR DESCRIPTION
Executes the top three items from the six-lens audit. Each was independently re-verified before the change, and each fix was verified against real output rather than by reading code.

## 1. The headline dedupe ledger has been frozen for 28 days

`hourly-twitter.yml` held the only raw `git push origin HEAD:main` left in the repo. The 2026-07-06 repository ruleset (rule 13) rejects those with `GH013` — and the failure path was `::warning::…continuing`, so every cycle since has reported **success** while `research/summaries/twitter-announced-history.json` stayed pinned at `ce2df5de` (2026-07-04, two days before the ruleset landed). Dedupe has been consulting a 28-day-stale ledger, which is exactly the state that lets an already-alerted headline re-alert.

- Push now goes through `.github/actions/safe-push`, same as every other publisher, so it gets the protected-branch PR fallback. It had to leave the send step's `run:` block (composite actions can only be `uses:`), so the send step emits `history_committed` and the push is its own step gated on it — with `!cancelled()` rather than `success()`, because a partially-failed route batch still recorded real deliveries.
- A verify step hard-fails when `pushed != 'true'`. Silently continuing is what hid this for four weeks.
- **Backfill**: 1730 → 2247 records, coverage now 2026-04-27 → 2026-07-31. Two caveats in the commit message — it rebuilds rather than appends (globbing only the gap would have discarded pre-gap history), and the source files are pre-dedupe candidate lists, so it biases toward over-suppression. That is the right side to err on here, since every cycle since 07-04 filtered against a frozen ledger.

## 2. Four documented facts that no longer match the repo

Agents operate this repo from these files, so drift is a production defect. All verified before editing:

| Claim | Reality |
|---|---|
| `CLAUDE.md` — twitter primary lane "uses Fireworks" | SSOT lane `twitter-primary` is `backend: claude` |
| `CLAUDE.md` — `export_wiki_okf.py` under "Validators — all CI-enforced" | `grep -rn okf .github/workflows/` → nothing |
| `docs/headline-dedupe.md` — a **Haiku** step adjudicates | lane `twitter-judge`, `--model opus` → `fallback.native_model` |
| Rule 3 — Cloudflare fronts Railway | it rewrites and blocks; see below |

## 3. Cloudflare is 403ing the AI crawlers the build explicitly allows

Verified 2026-08-01 by direct request:

```
403  ClaudeBot    403  GPTBot    403  CCBot
200  PerplexityBot    200  Googlebot    200  browser
```

The live `/robots.txt` is not the file `postbuild-seo.mjs:1191` builds — Cloudflare prepends a Managed block with `Content-Signal: ai-train=no` and `Disallow: /` for those same agents, while the build emits `Allow: /` for all four. **Zone-level, so this PR cannot fix it** — it documents it in rule 3 and notes that `check_deploy_health.py` sends one fixed UA at one URL and is structurally blind to it. Needs a Cloudflare dashboard change.

## 4. The dispatch prompt was the public article summary

`llms.txt`, `feed.xml` and `/research` described every generative article with `row.prompt` — the internal brief, up to **3,592 characters** on the live site, including `"Argue it."`, `"EVIDENCE DISCIPLINE — this is important"` and a trailing `Tags:` line.

`extractMeta()` already produces a clean 190-char deck/lede, and article pages have always used it for their meta description and JSON-LD — only these three consumers were wrong. Verified against generated output: longest `llms.txt` line **3,592 → 445 chars**, longest `feed.xml` description 240. All 82 articles, no `index.json` contract change.

## Verification

`actionlint` clean · `test_dedupe_headline_alerts.py` 17 ✓ · `test_headline_judge.py` 15 ✓ · `bun run build` green (82 article pages, 82 social cards) · summaries re-checked in `dist/llms.txt` and `dist/feed.xml`

## Not in this PR

A chronic failure surfaced while verifying: `hourly-twitter.yml` has failed **~45% of scheduled runs for at least six days** (4–6 failures/day, 07-26 → 07-31), always at `Fail recovered Claude cycle` — the analyst output fails validation and the deterministic recovery heartbeat publishes instead. That is the fail-closed design working, but the agent path is broken and needs its own investigation. It predates the Opus flip in #1357.

🤖 Generated with [Claude Code](https://claude.com/claude-code)