### PR TITLE
Give each safe-push call its own fallback branch (silent data loss in two lanes)

### DIFF
--- a/.github/actions/safe-push/action.yml
+++ b/.github/actions/safe-push/action.yml
@@ -177,10 +177,33 @@ runs:
             return 1
           fi
 
-          local workflow_part run_part pr_branch title body pr_url
+          local workflow_part run_part step_part pr_branch title body pr_url
           workflow_part="$(sanitize_branch_part "${GITHUB_WORKFLOW:-workflow}")"
           run_part="${GITHUB_RUN_ID:-manual}-${GITHUB_RUN_ATTEMPT:-1}"
-          pr_branch="$(sanitize_branch_part "${PR_BRANCH_PREFIX}/${BRANCH}/${workflow_part}-${run_part}")"
+          # Discriminate by step instance. Run id + attempt alone are IDENTICAL
+          # for two safe-push calls in the same job, and the consequence is
+          # silent data loss, not a visible clash: the second call pushes the
+          # same branch name, `gh pr view <branch>` then resolves the FIRST
+          # call's already-merged PR, so this function reports
+          # pushed=true/pull-request-merged while its own commit never lands.
+          # That is what froze research/summaries/twitter-announced-history.json
+          # and stopped research/audio/ stubs, both since the 2026-07-06
+          # ruleset made this fallback the normal path. GITHUB_ACTION is a
+          # per-step-instance id (e.g. __self_7), fixed across retries within a
+          # call and different between calls, which is exactly the property
+          # needed here.
+          # GITHUB_ACTION should always be set for an action step, but a silent
+          # no-op is precisely the failure this fix exists to kill, so fall
+          # back to a per-job counter rather than trusting it. This function is
+          # called at most once per invocation (it exits immediately after), so
+          # the counter cannot drift across retries of one call.
+          step_part="$(sanitize_branch_part "${GITHUB_ACTION:-}")"
+          if [ -z "$step_part" ]; then
+            local seq_file="${RUNNER_TEMP:-/tmp}/safe-push-call-seq"
+            step_part="call$(( $(cat "$seq_file" 2>/dev/null || echo 0) + 1 ))"
+            printf '%s' "${step_part#call}" > "$seq_file"
+          fi
+          pr_branch="$(sanitize_branch_part "${PR_BRANCH_PREFIX}/${BRANCH}/${workflow_part}-${run_part}-${step_part}")"
           title="$(git log -1 --pretty=%s)"
           body="$(printf '%s\n\n%s\n\n- Run: %s\n- Source ref: %s\n- Target branch: %s\n- Commit: %s' \
             "Automated publish fallback for \`${GITHUB_WORKFLOW:-workflow}\`." \

--- a/.github/workflows/hourly-twitter.yml
+++ b/.github/workflows/hourly-twitter.yml
@@ -1466,6 +1466,9 @@ jobs:
         env:
           PUSHED: ${{ steps.push_history.outputs.pushed }}
           MODE: ${{ steps.push_history.outputs.publication-mode }}
+          HISTORY_FILE: research/summaries/twitter-announced-history.json
+          ANNOUNCED_AT: ${{ steps.datetime.outputs.timestamp }}
+          TARGET_BRANCH: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           echo "publication-mode=$MODE pushed=$PUSHED"
@@ -1476,6 +1479,22 @@ jobs:
                  "Land the open automation/safe-push PR, or re-run this lane."
             exit 1
           fi
+          # Confirm by CONTENT, not by the flag. pushed=true was not enough:
+          # when two safe-push calls in one job generated the same fallback
+          # branch, the second adopted the first's already-merged PR and
+          # reported pushed=true/pull-request-merged while its commit never
+          # landed. This guard is what turns that class of failure from
+          # invisible into red.
+          git fetch -q origin "$TARGET_BRANCH"
+          if ! git show "origin/${TARGET_BRANCH}:${HISTORY_FILE}" \
+               | jq -e --arg ts "$ANNOUNCED_AT" 'any(.[]; .delivered_at == $ts)' >/dev/null; then
+            echo "::error::safe-push reported success (mode=$MODE) but" \
+                 "origin/${TARGET_BRANCH}:${HISTORY_FILE} has no record stamped" \
+                 "'${ANNOUNCED_AT}'. The ledger did NOT land — dedupe will" \
+                 "re-alert already-shipped headlines. Do not trust pushed=true here."
+            exit 1
+          fi
+          echo "Ledger verified on origin/${TARGET_BRANCH}: records stamped ${ANNOUNCED_AT} are present."
 
       # ── Comparison-tier Telegram notification ──────────────────────
       - name: Read summary for Telegram (comparison tiers)

--- a/research/summaries/twitter-announced-history.json
+++ b/research/summaries/twitter-announced-history.json
@@ -20221,5 +20221,185 @@
     "source": "@ashugarg",
     "source_file": "research/summaries/2026-07-31-twitter-14h-headlines.json",
     "url": "https://x.com/ashugarg/status/2083192206454636872"
+  },
+  {
+    "backfilled": true,
+    "category": "breaking",
+    "delivered_at": "2026-07-31 19:00 UTC",
+    "headline": "GOOGLE PULLS GOOGLE EARTH AI IMAGE GENERATOR ONE DAY AFTER LAUNCH OVER FAKED SATELLITE BOMB CRATERS",
+    "source": "@zubiqo",
+    "source_file": "research/summaries/2026-07-31-twitter-19h-headlines.json",
+    "url": "https://x.com/zubiqo/status/2083277367653679294"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-31 19:00 UTC",
+    "headline": "HYPERSCALER 2026 AI CAPEX GUIDANCE HITS 720-745 BILLION DOLLARS \u2014 AMAZON 220B, MICROSOFT 175B, GOOGLE 205B, META 145B",
+    "source": "@aleabitoreddit",
+    "source_file": "research/summaries/2026-07-31-twitter-19h-headlines.json",
+    "url": "https://x.com/aleabitoreddit/status/2083270545320386734"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-31 19:00 UTC",
+    "headline": "DEEPSEEK V4-FLASH-0731 MATCHES GROK 4.5 ON VULNERABILITY DETECTION AT 10X LOWER COST \u2014 INDEPENDENT HARNESS",
+    "source": "@Zaddyzaddy",
+    "source_file": "research/summaries/2026-07-31-twitter-19h-headlines.json",
+    "url": "https://x.com/Zaddyzaddy/status/2083273536387563702"
+  },
+  {
+    "backfilled": true,
+    "category": "opensource",
+    "delivered_at": "2026-07-31 19:00 UTC",
+    "headline": "DEEPSEEK V4-FLASH RUNS LOCALLY IN LOSSLESS 4-BIT ON 168GB RAM, 3-BIT ON 110GB \u2014 HOURS AFTER WEIGHT DROP",
+    "source": "@_akhaliq",
+    "source_file": "research/summaries/2026-07-31-twitter-19h-headlines.json",
+    "url": "https://x.com/_akhaliq/status/2083252616528539787"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-31 19:00 UTC",
+    "headline": "THE INFORMATION: NVIDIA-BACKED REFLECTION AI HAS SHIPPED NO MODEL A YEAR AFTER 800 MILLION DOLLAR BET",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-07-31-twitter-19h-headlines.json",
+    "url": "https://x.com/theinformation/status/2083266487318397361"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-31 19:00 UTC",
+    "headline": "HUGGING FACE CEO ON BREACH WEEK: ATTACKED BY SECRET PROPRIETARY MODELS, DEFENDED WITH AN OPEN ONE",
+    "source": "@HuggingFace",
+    "source_file": "research/summaries/2026-07-31-twitter-19h-headlines.json",
+    "url": "https://x.com/HuggingFace/status/2083204318581207448"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-31 19:00 UTC",
+    "headline": "EU OPENS BIDDING ON SEVEN AI GIGAFACTORIES \u2014 10B EUROS PUBLIC AGAINST 30B TOTAL, AWARDS JULY 2027",
+    "source": "@WesRoth",
+    "source_file": "research/summaries/2026-07-31-twitter-19h-headlines.json",
+    "url": "https://x.com/WesRoth/status/2083190955331477865"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-31 22:00 UTC",
+    "headline": "GOOGLE FOLDS AI STUDIO INTO GEMINI APP \u2014 NO STANDALONE MOBILE CLIENT, APPS TO EMERGE FROM CONVERSATION",
+    "source": "@testingcatalog",
+    "source_file": "research/summaries/2026-07-31-twitter-22h-headlines.json",
+    "url": "https://x.com/testingcatalog/status/2083295051728236693"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-07-31 22:00 UTC",
+    "headline": "WITNESS SAYS GOOGLE 'BRIEFLY' TURNED GOOGLE EARTH INTO A FAKE-IMAGERY GENERATOR \u2014 FIRST EXPERT CONFIRMATION OF PULLBACK",
+    "source": "@SamGregory",
+    "source_file": "research/summaries/2026-07-31-twitter-22h-headlines.json",
+    "url": "https://x.com/SamGregory/status/2083314779699945977"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-07-31 22:00 UTC",
+    "headline": "BLOOMBERG: ALIBABA COMPUTE DEAL FOR ~20,000 NVIDIA CHIPS HELPS POWER MOONSHOT'S KIMI K3",
+    "source": "@BloombergTV",
+    "source_file": "research/summaries/2026-07-31-twitter-22h-headlines.json",
+    "url": "https://x.com/BloombergTV/status/2083313776137314378"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-07-31 22:00 UTC",
+    "headline": "KIMI K3 REPORTED AT 60.4% ON ARC-AGI-2 \u2014 UNVERIFIED, VS INKLING'S VERIFIED 36.5%",
+    "source": "@scaling01",
+    "source_file": "research/summaries/2026-07-31-twitter-22h-headlines.json",
+    "url": "https://x.com/scaling01/status/2083290471212761434"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-31 22:00 UTC",
+    "headline": "THE INFORMATION: OPENAI HIRING HUNDREDS OF FORMER APPLE EMPLOYEES FOR NEW HARDWARE DEVICE FAMILY",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-07-31-twitter-22h-headlines.json",
+    "url": "https://x.com/theinformation/status/2083274133584957454"
+  },
+  {
+    "backfilled": true,
+    "category": "business",
+    "delivered_at": "2026-07-31 22:00 UTC",
+    "headline": "ASCHENBRENNER'S SITUATIONAL AWARENESS SELLS $16B PUBLIC-EQUITY BOOK TO CITADEL, KEEPS ~$10B INCLUDING ANTHROPIC STAKE",
+    "source": "@WesRoth",
+    "source_file": "research/summaries/2026-07-31-twitter-22h-headlines.json",
+    "url": "https://x.com/WesRoth/status/2083115454441062429"
+  },
+  {
+    "backfilled": true,
+    "category": "breaking",
+    "delivered_at": "2026-08-01 03:00 UTC",
+    "headline": "LEAK: OPENAI PREPARING NEW MODEL FAMILY CODENAMED \"ASTRA\" \u2014 PITCHED ON RUNNING MULTIPLE AGENTS",
+    "source": "@scaling01",
+    "source_file": "research/summaries/2026-08-01-twitter-03h-headlines.json",
+    "url": "https://x.com/scaling01/status/2083341678719426615"
+  },
+  {
+    "backfilled": true,
+    "category": "policy",
+    "delivered_at": "2026-08-01 03:00 UTC",
+    "headline": "CURRAN: \"ASTRA\" IS THE SAME UNRELEASED MODEL ALTMAN IS PREVIEWING TO CONGRESS AND THE TRUMP ADMINISTRATION",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-08-01-twitter-03h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2083342854609674546"
+  },
+  {
+    "backfilled": true,
+    "category": "breaking",
+    "delivered_at": "2026-08-01 03:00 UTC",
+    "headline": "ARENA CEO: BOTH OPENAI AND ANTHROPIC MODELS ARE IN \"ESCAPE FROM PRISON\" SCENARIOS \u2014 SANDBOX STORY WIDENS",
+    "source": "@theinformation",
+    "source_file": "research/summaries/2026-08-01-twitter-03h-headlines.json",
+    "url": "https://x.com/theinformation/status/2083319438573543717"
+  },
+  {
+    "backfilled": true,
+    "category": "model",
+    "delivered_at": "2026-08-01 03:00 UTC",
+    "headline": "LMARENA: DEEPSEEK V4-FLASH-HIGH RESHAPES FRONTEND CODE ARENA PARETO FRONTIER",
+    "source": "@AndrewCurran_",
+    "source_file": "research/summaries/2026-08-01-twitter-03h-headlines.json",
+    "url": "https://x.com/AndrewCurran_/status/2083348873238675823"
+  },
+  {
+    "backfilled": true,
+    "category": "opensource",
+    "delivered_at": "2026-08-01 03:00 UTC",
+    "headline": "META'S SOUMITH CHINTALA PUBLISHES OPEN-WEIGHTS PLAN AS 230+ ORGS SIGN OPEN WEIGHTS LETTER",
+    "source": "@soumithchintala",
+    "source_file": "research/summaries/2026-08-01-twitter-03h-headlines.json",
+    "url": "https://x.com/soumithchintala/status/2083341698994688298"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-08-01 03:00 UTC",
+    "headline": "KOREA DRAM EXPORT UNIT PRICE HITS ALL-TIME HIGH AS AI MEMORY SQUEEZE SHOWS UP IN TRADE DATA",
+    "source": "@jukan05",
+    "source_file": "research/summaries/2026-08-01-twitter-03h-headlines.json",
+    "url": "https://x.com/jukan05/status/2083368297534537801"
+  },
+  {
+    "backfilled": true,
+    "category": "infra",
+    "delivered_at": "2026-08-01 03:00 UTC",
+    "headline": "PERPLEXITY REMOTE MCP SERVER GOES LIVE FOR CLAUDE CODE, CURSOR AND VS CODE",
+    "source": "@AravSrinivas",
+    "source_file": "research/summaries/2026-08-01-twitter-03h-headlines.json",
+    "url": "https://x.com/AravSrinivas/status/2083346800375980531"
   }
 ]


### PR DESCRIPTION
**This fixes a bug I shipped in #1359, and a latent one underneath it that is older and worse.**

## The bug

`create_pull_request_fallback()` builds the fallback branch from `GITHUB_RUN_ID` + `GITHUB_RUN_ATTEMPT` and nothing else. Two safe-push calls in the same job therefore generate the **identical** branch name.

That doesn't clash visibly — it loses data silently:

1. Call A pushes `automation/safe-push/main/<wf>-<run>-1`, opens a PR, squash-merges it.
2. Call B pushes the **same** branch name.
3. `gh pr view <branch>` resolves **call A's already-merged PR**, so B takes the "Existing fallback PR" path instead of creating its own.
4. B reports `pushed=true`, `publication-mode=pull-request-merged`. **B's commit never lands.**

Latent since the 2026-07-06 ruleset made the PR fallback the normal path rather than an exception.

## What it has been eating

| Lane | Artifact | Evidence |
|---|---|---|
| `hourly-twitter.yml` | delivered-alert ledger | 3 runs after #1359 delivered **19 headlines**; all 3 green; `origin/main` ledger unchanged. Only one PR per run (#1382), containing only the twitter output files. |
| `daily-digest.yml` | `research/audio/` stubs | Regular through **2026-07-04**, one on 07-25, none since — the same date signature as the ledger freeze. |

I introduced the first by routing the ledger through safe-push in #1359 and shipping a verify step that trusted `pushed`. It reported success three times while nothing landed. The second predates me and affects the flagship digest lane.

## Fix

**Root:** discriminate the branch by step instance — `GITHUB_ACTION` (e.g. `__self_7`), which is fixed across retries within a call and differs between calls. A `RUNNER_TEMP` counter backs it up so an unset variable can't silently reintroduce the collision — a silent no-op is exactly what this fix exists to kill. Verified the two twitter call sites now generate distinct refs (151 and 153 chars, well under the 255-byte limit). **`daily-digest.yml` is fixed by this with no change to that workflow.**

**Defense in depth:** hourly-twitter's verify step now checks **content on the target branch** — that a record stamped with this run's timestamp is actually in the ledger — rather than trusting `pushed`. That flag was `true` while nothing landed, so the guard I shipped in #1359 was worthless. This is the check that would have caught it.

**Data:** re-ran the backfill to absorb the 19 lost headlines (2247 → 2267, coverage through 2026-08-01 03:00 UTC).

## Verification

`actionlint` clean on the workflow · `action.yml` parses · branch-name uniqueness simulated against the real (very long) workflow name · `test_dedupe_headline_alerts` 17 ✓ · `test_backend_matrix` 39 ✓ · `test_workflow_time_convention` 4 ✓

Real confirmation comes from the next `hourly-twitter` run that delivers headlines: the ledger must gain records, and the new content check fails the run loudly if it doesn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)