### PR TITLE
Bind wiki company entities to live market quotes

### DIFF
--- a/.github/workflows/market-quotes.yml
+++ b/.github/workflows/market-quotes.yml
@@ -1,0 +1,89 @@
+name: Market Quotes Refresh
+
+# Keeps research/market/quotes.json fresh so the dashboard's wiki hover can
+# show a price row for entity pages that carry `market` frontmatter.
+#
+# Why a separate lane instead of storing prices on the wiki page: a quote is
+# volatile runtime data and a wiki page is a stable knowledge artifact. Folding
+# prices into research/wiki/index.json would make the committed index
+# non-deterministic and instantly stale, and would churn the wiki's git history
+# every refresh for reasons that have nothing to do with knowledge changing.
+#
+# Symbols are read from research/wiki/index.json, so this lane has no list of
+# its own: adding `market:` to an entity page is the only step needed to start
+# quoting a new company.
+#
+# Deterministic lane: no model involved. Fail-soft per symbol (a failed symbol
+# carries its previous value forward marked `stale`), fail-loud in aggregate
+# (every symbol failing exits 1).
+
+on:
+  schedule:
+    # Every 3 hours at :53 — a deliberately quiet minute slot, away from the
+    # twitter (:07), rss (:30), community (:19), arm (:45) and naver (:47)
+    # lanes so Yahoo fetches don't queue behind a heavier job on the runner.
+    # Not market-hours-aware on purpose: outside a session the last close IS
+    # the current price, and the hover shows `asOf` so a reader can judge.
+    - cron: '53 */3 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: market-quotes
+  cancel-in-progress: true
+
+jobs:
+  refresh:
+    runs-on: [self-hosted, Linux]
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      # The `stock` extra pulls yfinance. It is optional in pyproject.toml
+      # because most lanes don't need it — but here it IS the primary path:
+      # Yahoo's bare urllib endpoint 429s from many IPs, which is exactly the
+      # case yfinance's crumb-cookie handling exists to survive.
+      - name: Install Python dependencies
+        run: uv sync --frozen --extra stock
+
+      - name: Refresh market quotes
+        id: quotes
+        run: uv run --extra stock python scripts/fetch_market_quotes.py
+
+      - name: Commit refreshed quotes
+        id: commit
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- research/market/quotes.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "quotes unchanged; nothing to commit"
+            exit 0
+          fi
+          git add research/market/quotes.json
+          git commit -m "Market quotes refresh $(date -u +'%Y-%m-%d %H:%M UTC')"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Push changes
+        if: steps.commit.outputs.changed == 'true'
+        uses: ./.github/actions/safe-push
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish Hooker workflow telemetry
+        if: always()
+        uses: ./.github/actions/hooker-telemetry
+        with:
+          status: ${{ job.status }}
+          text: "market-quotes committed=${{ steps.commit.outputs.changed }}"
+        env:
+          HOOKER_URL: ${{ secrets.HOOKER_URL }}
+          HOOKER_TOKEN: ${{ secrets.HOOKER_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,6 +229,7 @@ back to host-level `pi --tools ... bash`.
 
 | Workflow | Trigger | Purpose |
 |---|---|---|
+| `market-quotes.yml` | every 3h `:53` | Deterministic refresh of `research/market/quotes.json` from Yahoo for every wiki entity carrying `market` frontmatter — the price row in the wiki hover card and on the entity page. Symbols come from `research/wiki/index.json`, so adding `market:` to a page is the only step needed to quote a new company. Fail-soft per symbol (carries the prior value forward marked `stale`), fail-loud if every symbol fails. Needs the optional `stock` extra — Yahoo's bare urllib path 429s. |
 | `arm-timeline.yml` | every 2h `:45` | Deterministic refresh of `research/arm/timeline.json` so the dashboard's Arm tab renders in prod (the Docker build context has no `.git`/`.github`, so prebuild falls back to this committed file; unrefreshed it ages out of the ±36h window). |
 | `daily-improve.yml` | weekly, Monday `00:17` UTC | Opens improve/YYYY-MM-DD PR with methodology fixes; each run auto-closes prior unmerged `improve/*` PRs. See "Load-bearing rules" for where the IMPROVEMENTS file belongs. |
 | `ci.yml` | push/PR on workflows/dashboard/scripts | actionlint + dashboard build + Python tests on GitHub-hosted runners |
@@ -307,6 +308,7 @@ research/
 ├── front-page/                # daily-front-page.yml (committed PNG + interactive .ara.md/.html edition)
 ├── generative/                # generative-research.yml + Oracle runner (HTML + .ara.md + index.json)
 ├── issues/                    # research-issue.yml
+├── market/                    # market-quotes.yml (quotes.json — live prices for wiki entities carrying `market`)
 ├── models/                    # 24h-model-timeline.yml
 │   ├── tickets/                # persistent set, one .md per shipping artifact
 │   └── <date>-timeline.md      # derived daily diff (created/updated/closed counts)

--- a/dashboard/scripts/prebuild.mjs
+++ b/dashboard/scripts/prebuild.mjs
@@ -28,7 +28,10 @@ const skipLfsPointers = process.env.SKIP_LFS_POINTERS === '1';
 // `wiki` carries research/wiki/ (committed index.json + entities/concepts/themes
 // markdown). The index is built in Python (scripts/build_wiki_index.py) and
 // committed — we only copy it here; we never rebuild it in JS.
-const COPY_DIRS = ['twitter', 'models', 'front-page', 'digest', 'audio', 'generative', 'wiki', 'youtube', 'arm'];
+// `market` carries research/market/quotes.json (market-quotes.yml). Like
+// `arm` it is a single JSON with no date-keyed files, so it stays out of
+// DATE_PATTERNS — it has no per-day artifacts for the freshness rows to key on.
+const COPY_DIRS = ['twitter', 'models', 'front-page', 'digest', 'audio', 'generative', 'wiki', 'youtube', 'arm', 'market'];
 
 // Twitter comparison-lane dirs (hourly-twitter.yml backend tiers). Copied for
 // the A/B side-by-side view but deliberately NOT in COPY_DIRS/DATE_PATTERNS:

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -2297,6 +2297,100 @@ function ensureWikiHover(): void {
   });
   window.addEventListener('scroll', hideWikiHover, true);
 }
+// ── Market quotes for the wiki hover ──────────────────
+//
+// research/market/quotes.json is refreshed by market-quotes.yml and keyed by
+// the wiki's `market.symbol`. Loaded LAZILY: the first hover over a page that
+// actually carries `market` triggers it, so a reader who never hovers a listed
+// company never pays for the request. One load per session, and a failure
+// resolves to an empty map so the hover silently falls back to type/title/
+// summary rather than throwing.
+let marketQuotes: Map<string, MarketQuote> | null = null;
+let marketQuotesPromise: Promise<Map<string, MarketQuote>> | null = null;
+
+function loadMarketQuotes(): Promise<Map<string, MarketQuote>> {
+  if (marketQuotes) return Promise.resolve(marketQuotes);
+  if (!marketQuotesPromise) {
+    marketQuotesPromise = fetch(`${DATA_BASE}/market/quotes.json`, { cache: 'no-cache' })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        const map = new Map<string, MarketQuote>();
+        const quotes = data && typeof data === 'object' ? (data as any).quotes : null;
+        if (quotes && typeof quotes === 'object') {
+          for (const [symbol, q] of Object.entries(quotes as Record<string, any>)) {
+            if (q && typeof q.price === 'number') map.set(symbol, q as MarketQuote);
+          }
+        }
+        marketQuotes = map;
+        return map;
+      })
+      .catch(() => {
+        marketQuotes = new Map();
+        return marketQuotes;
+      });
+  }
+  return marketQuotesPromise;
+}
+
+function formatQuoteAsOf(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  // The pipeline writes UTC; readers think in their own timezone.
+  return d.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+}
+
+function marketRowHtml(market: WikiMarket, quote: MarketQuote | undefined): string {
+  const label = escapeHtml(market.symbol);
+  if (!quote) {
+    // Known-listed but unquoted: name the security rather than render an empty
+    // shell or, worse, a fake 0.00. The row still occupies its reserved height,
+    // so filling it in later cannot shift the card.
+    return (
+      '<span class="wiki-hover-market wiki-hover-market--empty">' +
+      '<span class="wiki-hover-market-symbol">' + label + '</span>' +
+      '<span class="wiki-hover-market-note">quote unavailable</span>' +
+      '</span>'
+    );
+  }
+  const hasChange = typeof quote.change === 'number' && typeof quote.changePercent === 'number';
+  const dir = !hasChange ? 'flat' : (quote.change as number) > 0 ? 'up' : (quote.change as number) < 0 ? 'down' : 'flat';
+  const sign = hasChange && (quote.change as number) > 0 ? '+' : '';
+  const price = quote.price.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  const changeBit = hasChange
+    ? '<span class="wiki-hover-market-change">' +
+      escapeHtml(sign + (quote.change as number).toFixed(2)) +
+      ' (' + escapeHtml(sign + (quote.changePercent as number).toFixed(2)) + '%)' +
+      '</span>'
+    : '';
+  const asOf = formatQuoteAsOf(quote.asOf);
+  const meta = [
+    quote.stale ? 'stale' : '',
+    asOf ? `as of ${asOf}` : '',
+    quote.source,
+  ].filter(Boolean).join(' · ');
+  return (
+    '<span class="wiki-hover-market wiki-hover-market--' + dir + (quote.stale ? ' is-stale' : '') + '">' +
+    '<span class="wiki-hover-market-symbol">' + label + '</span>' +
+    '<span class="wiki-hover-market-price">' + escapeHtml(price) + ' ' + escapeHtml(quote.currency) + '</span>' +
+    changeBit +
+    '<span class="wiki-hover-market-note">' + escapeHtml(meta) + '</span>' +
+    '</span>'
+  );
+}
+
+// Which slug the hover is currently showing. An async quote fill must not
+// repaint a card the pointer has already left or moved on from.
+let wikiHoverSlug: string | null = null;
+
+function wikiHoverHtml(page: WikiPage, quote: MarketQuote | undefined): string {
+  return (
+    '<span class="wiki-hover-type">' + escapeHtml(String(page.type)) + '</span>' +
+    '<span class="wiki-hover-title">' + escapeHtml(page.title) + '</span>' +
+    '<span class="wiki-hover-summary">' + escapeHtml(page.summary || '') + '</span>' +
+    (page.market ? marketRowHtml(page.market, quote) : '')
+  );
+}
+
 function showWikiHover(el: HTMLElement): void {
   const slug = el.getAttribute('data-wiki-slug');
   const page = slug ? wikiPageMap.get(slug) : null;
@@ -2306,12 +2400,19 @@ function showWikiHover(el: HTMLElement): void {
     wikiHoverEl.className = 'wiki-hover';
     document.body.appendChild(wikiHoverEl);
   }
-  setSafeContent(
-    wikiHoverEl,
-    '<span class="wiki-hover-type">' + escapeHtml(String(page.type)) + '</span>' +
-    '<span class="wiki-hover-title">' + escapeHtml(page.title) + '</span>' +
-    '<span class="wiki-hover-summary">' + escapeHtml(page.summary || '') + '</span>',
-  );
+  wikiHoverSlug = page.slug;
+  setSafeContent(wikiHoverEl, wikiHoverHtml(page, marketQuotes?.get(page.market?.symbol || '')));
+
+  // Only listed entities trigger the quote load, and only when it isn't
+  // already resolved — the acceptance criterion is that a page without
+  // `market` causes no quote fetch at all.
+  if (page.market && !marketQuotes) {
+    void loadMarketQuotes().then((map) => {
+      if (wikiHoverSlug !== page.slug || !wikiHoverEl) return;
+      if (wikiHoverEl.style.display === 'none') return;
+      setSafeContent(wikiHoverEl, wikiHoverHtml(page, map.get(page.market!.symbol)));
+    });
+  }
   const r = el.getBoundingClientRect();
   const left = Math.max(12, Math.min(r.left, window.innerWidth - 320 - 12));
   wikiHoverEl.style.display = 'block';
@@ -2320,6 +2421,7 @@ function showWikiHover(el: HTMLElement): void {
 }
 function hideWikiHover(): void {
   if (wikiHoverEl) wikiHoverEl.style.display = 'none';
+  wikiHoverSlug = null;
 }
 
 // ── Wiki (LLM Wiki) ───────────────────────────────────
@@ -2341,6 +2443,17 @@ type WikiImage = {
   source_url?: string;
 };
 
+// Public-market IDENTITY only — never a price. Present on entity pages that
+// check_wiki.py validated as listed securities; absent everywhere else, which
+// is what keeps private companies from rendering an empty stock shell.
+type WikiMarket = {
+  ticker: string;
+  exchange: string;
+  symbol: string;          // "EXCHANGE:TICKER" — the join key into quotes.json
+  provider?: string;
+  tradingview_symbol?: string;
+};
+
 type WikiPage = {
   slug: string;
   title: string;
@@ -2352,8 +2465,23 @@ type WikiPage = {
   file: string;            // relative to research/wiki/, e.g. "entities/nebius.md"
   aliases: string[];
   images?: WikiImage[];
+  market?: WikiMarket;
   outbound: string[];      // slugs
   inbound: string[];       // slugs
+};
+
+// research/market/quotes.json, refreshed by market-quotes.yml.
+type MarketQuote = {
+  symbol: string;
+  ticker: string;
+  price: number;
+  change: number | null;
+  changePercent: number | null;
+  currency: string;
+  marketState: string | null;
+  asOf: string;
+  source: string;
+  stale: boolean;
 };
 
 type WikiLogEntry = { date: string; op: string; summary: string };
@@ -2724,8 +2852,48 @@ function wikiKvHtml(page: WikiPage): string {
     page.updated_at ? '<dt>Updated</dt><dd>' + escapeHtml(page.updated_at) + '</dd>' : '',
     page.created_at ? '<dt>Created</dt><dd>' + escapeHtml(page.created_at) + '</dd>' : '',
     '<dt>Links</dt><dd>' + (page.inbound || []).length + ' in · ' + (page.outbound || []).length + ' out</dd>',
+    // Listed entities repeat the quote here, not only in the hover card.
+    // A hover does not exist on touch: tapping a .wiki-mention navigates to
+    // this page, so without this row the market data would be desktop-only.
+    page.market
+      ? '<dt>Market</dt><dd class="wiki-kv-market" data-market-symbol="' +
+        escapeHtml(page.market.symbol) + '">' + escapeHtml(page.market.symbol) + '</dd>'
+      : '',
   ].filter(Boolean).join('');
   return '<dl class="ara-kv">' + rows + '</dl>';
+}
+
+/** Fill any rendered `Market` cells with a quote once quotes.json resolves.
+ * Separate from render so the page paints immediately and a slow or failed
+ * quote leaves the symbol visible rather than an empty cell. */
+function hydrateWikiKvMarket(root: ParentNode = document): void {
+  const cells = [...root.querySelectorAll<HTMLElement>('.wiki-kv-market[data-market-symbol]')];
+  if (!cells.length) return;
+  void loadMarketQuotes().then((map) => {
+    for (const cell of cells) {
+      const symbol = cell.getAttribute('data-market-symbol') || '';
+      const q = map.get(symbol);
+      if (!q) continue;
+      const hasChange = typeof q.change === 'number' && typeof q.changePercent === 'number';
+      const sign = hasChange && (q.change as number) > 0 ? '+' : '';
+      const dir = !hasChange ? 'flat' : (q.change as number) > 0 ? 'up' : (q.change as number) < 0 ? 'down' : 'flat';
+      const price = q.price.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+      const change = hasChange
+        ? ' <span class="wiki-kv-market-change wiki-kv-market-change--' + dir + '">' +
+          escapeHtml(sign + (q.change as number).toFixed(2)) + ' (' +
+          escapeHtml(sign + (q.changePercent as number).toFixed(2)) + '%)</span>'
+        : '';
+      const asOf = formatQuoteAsOf(q.asOf);
+      setSafeContent(
+        cell,
+        escapeHtml(symbol) + ' · <strong>' + escapeHtml(price) + ' ' + escapeHtml(q.currency) + '</strong>' +
+        change +
+        '<span class="wiki-kv-market-note">' +
+        escapeHtml([q.stale ? 'stale' : '', asOf ? 'as of ' + asOf : '', q.source].filter(Boolean).join(' · ')) +
+        '</span>',
+      );
+    }
+  });
 }
 
 /** Internal link to another wiki page (used in lists/backlinks). Always an
@@ -2966,6 +3134,7 @@ function renderWikiPage(page: WikiPage, body: string, signal?: AbortSignal): voi
   if (bodyEl) setSafeWikiContent(bodyEl, bodyHtml);
 
   void hydrateWikiHistory(page, signal ?? new AbortController().signal);
+  hydrateWikiKvMarket();
 }
 
 function renderWikiNotFound(slug: string): void {

--- a/dashboard/src/style.css
+++ b/dashboard/src/style.css
@@ -1356,6 +1356,92 @@ body.search-open { overflow: hidden; }
   color: var(--text-secondary);
 }
 
+/* ── Market quote row in the wiki hover ────────────────
+ * Only rendered for entity pages whose frontmatter carries a validated
+ * `market` block, so a private company never gets an empty stock shell.
+ * min-height reserves the row before the async quote resolves: the card is
+ * positioned against the mention, so growing after paint would visibly shift
+ * it under the pointer.
+ *
+ * Up/down reuses the slope-chart pair (--ara-slope-up/down) rather than the
+ * change-bubble's royal/navy: a share price is the one place readers
+ * genuinely expect the red/green convention, and the slope chart already
+ * establishes it for quantitative series in this system. */
+:root {
+  --ara-slope-up: #1b6d3a;
+  --ara-slope-down: #b3251f;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    /* Lifted for contrast on the dark ground; the light hexes read muddy. */
+    --ara-slope-up: #4ade80;
+    --ara-slope-down: #f87171;
+  }
+}
+
+.wiki-hover-market {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 4px 8px;
+  min-height: 34px;
+  margin-top: 9px;
+  padding-top: 9px;
+  border-top: 1px solid var(--border-light);
+  font-variant-numeric: tabular-nums;
+}
+.wiki-hover-market-symbol {
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--text-tertiary);
+  width: 100%;
+}
+.wiki-hover-market-price {
+  font-size: 0.9rem;
+  font-weight: 650;
+  color: var(--text);
+}
+.wiki-hover-market-change {
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+.wiki-hover-market--up .wiki-hover-market-change { color: var(--ara-slope-up); }
+.wiki-hover-market--down .wiki-hover-market-change { color: var(--ara-slope-down); }
+.wiki-hover-market--flat .wiki-hover-market-change { color: var(--text-secondary); }
+.wiki-hover-market-note {
+  font-size: 0.68rem;
+  color: var(--text-tertiary);
+  width: 100%;
+}
+/* A stale or missing quote stays legible but visibly de-emphasised — the
+ * reader should never mistake a carried-forward price for a live one. */
+.wiki-hover-market.is-stale .wiki-hover-market-price,
+.wiki-hover-market.is-stale .wiki-hover-market-change {
+  opacity: 0.62;
+}
+.wiki-hover-market--empty .wiki-hover-market-note {
+  font-style: italic;
+}
+
+/* Page-level quote (the touch path — no hover exists on a phone). */
+.wiki-kv-market {
+  font-variant-numeric: tabular-nums;
+}
+.wiki-kv-market-change {
+  font-weight: 600;
+  margin-left: 2px;
+}
+.wiki-kv-market-change--up { color: var(--ara-slope-up); }
+.wiki-kv-market-change--down { color: var(--ara-slope-down); }
+.wiki-kv-market-change--flat { color: var(--text-secondary); }
+.wiki-kv-market-note {
+  display: block;
+  font-size: 0.68rem;
+  color: var(--text-tertiary);
+}
+
 .cal-header {
   display: flex;
   align-items: center;

--- a/docs/backend-matrix.md
+++ b/docs/backend-matrix.md
@@ -121,8 +121,9 @@ Reading notes:
 - `daily-front-page.yml`
 - `daily-youtube.yml`
 - `liveness-check.yml`
+- `market-quotes.yml`
 
-_Global ordered fallback chain (SSOT `fallback.chain`): `claude` → `zai-glm-5p2`; native path serves `claude-opus-5`. 30 SSOT lanes (+6 dispatch execution paths) across 26 workflows; 8 workflows run no model._
+_Global ordered fallback chain (SSOT `fallback.chain`): `claude` → `zai-glm-5p2`; native path serves `claude-opus-5`. 30 SSOT lanes (+6 dispatch execution paths) across 27 workflows; 9 workflows run no model._
 
 <!-- END GENERATED BACKEND MATRIX -->
 

--- a/docs/wiki-schema.md
+++ b/docs/wiki-schema.md
@@ -98,6 +98,7 @@ Field reference:
 | `timestamp` | yes | datetime | OKF last-meaningful-change timestamp; use ISO 8601 UTC (`YYYY-MM-DDT00:00:00Z` for date-granular updates); must be `>= created_at`. |
 | `sources` | no | list[map] | Each item is a mapping with `title` (req) and optional `url` (http(s)), `path` (repo-relative), `date` (ISO). No other keys. |
 | `images` | no | list[map] | Visual depictions for the page topic/description. Each item has `url` (req), `alt` (req), and optional `caption`, `credit`, `source_url`. No other keys. |
+| `market` | no | map | **`type: entity` only.** Public-market identity for a listed company. Keys: `ticker` (req), `exchange` (req), `symbol` (req), optional `provider`, `tradingview_symbol`. No other keys. See below. |
 
 Both flow style (`aliases: [a, b]`, `sources: - {title: ...}`) and block style
 parse identically under `yaml.safe_load`; either is accepted.
@@ -124,6 +125,41 @@ Image item schema:
 Images are presentation metadata, not evidence. Keep factual citations in
 `sources` and the body. If an image is generated or illustrative, say that in
 the `caption` or `credit` rather than implying it is documentary evidence.
+
+### `market`
+
+`market` binds an entity page to a **publicly traded security** so the dashboard
+can show a live quote in the wiki hover card. It is optional, valid only on
+`type: entity`, and must be omitted entirely for private companies, products,
+models, people, and every non-company entity.
+
+```yaml
+market:
+  ticker: NVDA
+  exchange: NASDAQ
+  symbol: NASDAQ:NVDA
+  provider: yahoo            # optional
+  tradingview_symbol: NASDAQ:NVDA   # optional
+```
+
+| Key | Req? | Type | Notes |
+|---|---|---|---|
+| `ticker` | yes | string | Uppercase symbol, 1–6 chars, optionally suffixed (`BRK.B`, `005930.KS`). No exchange prefix. |
+| `exchange` | yes | string | Uppercase venue code, e.g. `NASDAQ`, `NYSE`, `KRX`, `HKEX`. |
+| `symbol` | yes | string | `EXCHANGE:TICKER`. Must equal `<exchange>:<ticker>` exactly — the validator cross-checks it, so the three fields cannot silently disagree. |
+| `provider` | no | enum | Quote source. `yahoo` is the only supported value today. |
+| `tradingview_symbol` | no | string | `EXCHANGE:TICKER` for a TradingView handoff, when it differs from `symbol`. |
+
+**Never infer a ticker from `aliases`.** Aliases are resolver/search terms and
+routinely include product names, people, handles, and private-company names that
+collide with real tickers — inferring would produce confident, wrong quotes on
+pages that have nothing to do with a listed security. The binding must be this
+explicit machine field or nothing.
+
+Quote values themselves are never stored on the page: they are volatile runtime
+data fetched separately into `research/market/quotes.json`. A page carries
+identity only, so a stale or failed quote degrades to the ordinary wiki hover
+rather than blocking navigation or content rendering.
 
 After the closing `---`, the body is free-form markdown and **must be
 non-empty**. Use it for the narrative, "why it matters", open questions, and

--- a/research/market/quotes.json
+++ b/research/market/quotes.json
@@ -1,0 +1,161 @@
+{
+  "generated_at": "2026-08-01T12:05:37Z",
+  "quotes": {
+    "NASDAQ:AAPL": {
+      "asOf": "2026-07-31T20:00:01Z",
+      "change": -24.52,
+      "changePercent": -7.3539,
+      "currency": "USD",
+      "marketState": null,
+      "price": 308.91,
+      "source": "yahoo",
+      "stale": false,
+      "symbol": "NASDAQ:AAPL",
+      "ticker": "AAPL"
+    },
+    "NASDAQ:AMZN": {
+      "asOf": "2026-07-31T20:00:01Z",
+      "change": 36.08,
+      "changePercent": 15.3206,
+      "currency": "USD",
+      "marketState": null,
+      "price": 271.58,
+      "source": "yahoo",
+      "stale": false,
+      "symbol": "NASDAQ:AMZN",
+      "ticker": "AMZN"
+    },
+    "NASDAQ:AVGO": {
+      "asOf": "2026-07-31T20:00:01Z",
+      "change": 1.44,
+      "changePercent": 0.3713,
+      "currency": "USD",
+      "marketState": null,
+      "price": 389.28,
+      "source": "yahoo",
+      "stale": false,
+      "symbol": "NASDAQ:AVGO",
+      "ticker": "AVGO"
+    },
+    "NASDAQ:CRWV": {
+      "asOf": "2026-07-31T20:00:01Z",
+      "change": -2.13,
+      "changePercent": -2.8823,
+      "currency": "USD",
+      "marketState": null,
+      "price": 71.77,
+      "source": "yahoo",
+      "stale": false,
+      "symbol": "NASDAQ:CRWV",
+      "ticker": "CRWV"
+    },
+    "NASDAQ:GOOGL": {
+      "asOf": "2026-07-31T20:00:01Z",
+      "change": 22.47,
+      "changePercent": 6.7344,
+      "currency": "USD",
+      "marketState": null,
+      "price": 356.13,
+      "source": "yahoo",
+      "stale": false,
+      "symbol": "NASDAQ:GOOGL",
+      "ticker": "GOOGL"
+    },
+    "NASDAQ:META": {
+      "asOf": "2026-07-31T20:00:01Z",
+      "change": 17.68,
+      "changePercent": 3.28,
+      "currency": "USD",
+      "marketState": null,
+      "price": 556.71,
+      "source": "yahoo",
+      "stale": false,
+      "symbol": "NASDAQ:META",
+      "ticker": "META"
+    },
+    "NASDAQ:MSFT": {
+      "asOf": "2026-07-31T20:00:01Z",
+      "change": 13.62,
+      "changePercent": 3.0193,
+      "currency": "USD",
+      "marketState": null,
+      "price": 464.72,
+      "source": "yahoo",
+      "stale": false,
+      "symbol": "NASDAQ:MSFT",
+      "ticker": "MSFT"
+    },
+    "NASDAQ:MU": {
+      "asOf": "2026-07-31T20:00:00Z",
+      "change": -51.63,
+      "changePercent": -5.9029,
+      "currency": "USD",
+      "marketState": null,
+      "price": 823.03,
+      "source": "yahoo",
+      "stale": false,
+      "symbol": "NASDAQ:MU",
+      "ticker": "MU"
+    },
+    "NASDAQ:NBIS": {
+      "asOf": "2026-07-31T20:00:01Z",
+      "change": 1.98,
+      "changePercent": 1.0508,
+      "currency": "USD",
+      "marketState": null,
+      "price": 190.41,
+      "source": "yahoo",
+      "stale": false,
+      "symbol": "NASDAQ:NBIS",
+      "ticker": "NBIS"
+    },
+    "NASDAQ:NVDA": {
+      "asOf": "2026-07-31T20:00:01Z",
+      "change": 5.71,
+      "changePercent": 2.9276,
+      "currency": "USD",
+      "marketState": null,
+      "price": 200.75,
+      "source": "yahoo",
+      "stale": false,
+      "symbol": "NASDAQ:NVDA",
+      "ticker": "NVDA"
+    },
+    "NYSE:BABA": {
+      "asOf": "2026-07-31T20:02:27Z",
+      "change": 5.93,
+      "changePercent": 5.098,
+      "currency": "USD",
+      "marketState": null,
+      "price": 122.25,
+      "source": "yahoo",
+      "stale": false,
+      "symbol": "NYSE:BABA",
+      "ticker": "BABA"
+    },
+    "NYSE:CRM": {
+      "asOf": "2026-07-31T20:00:03Z",
+      "change": 3.31,
+      "changePercent": 1.8317,
+      "currency": "USD",
+      "marketState": null,
+      "price": 184.02,
+      "source": "yahoo",
+      "stale": false,
+      "symbol": "NYSE:CRM",
+      "ticker": "CRM"
+    },
+    "NYSE:DELL": {
+      "asOf": "2026-07-31T20:04:12Z",
+      "change": 0.56,
+      "changePercent": 0.1383,
+      "currency": "USD",
+      "marketState": null,
+      "price": 405.37,
+      "source": "yahoo",
+      "stale": false,
+      "symbol": "NYSE:DELL",
+      "ticker": "DELL"
+    }
+  }
+}

--- a/research/wiki/entities/alibaba.md
+++ b/research/wiki/entities/alibaba.md
@@ -7,6 +7,11 @@ tags: [china, distillation, litigation, export-control, hyperscaler-china]
 description: Chinese tech conglomerate (Alibaba Cloud, Qwen models) accused by Anthropic of running the largest documented Claude-distillation campaign; confirmed the 2.4T-param Qwen3.8-Max is going open-weight soon, even as it continues fighting a US DoD PLA-linked designation.
 created_at: 2026-07-05
 timestamp: 2026-07-22T00:00:00Z
+market:
+  ticker: BABA
+  exchange: NYSE
+  symbol: NYSE:BABA
+  provider: yahoo
 sources:
   - {title: "ARA daily digest 2026-07-22", path: research/digest/2026-07-22-digest.md}
   - {title: "ARA model ticket — Qwen-Image-3.0 release", path: research/models/tickets/alibaba-qwen-image-3-2026-07.md}

--- a/research/wiki/entities/amazon.md
+++ b/research/wiki/entities/amazon.md
@@ -7,6 +7,11 @@ tags: [hyperscaler, cloud, investor, ai-infrastructure, bedrock]
 description: Hyperscaler, Anthropic's single largest investor, and — per WSJ/Axios reporting — the trigger of the June 2026 Fable 5 / Mythos 5 export crackdown after CEO Andy Jassy briefed Treasury that Amazon researchers had jailbroken the model.
 created_at: 2026-06-14
 timestamp: 2026-07-30T00:00:00Z
+market:
+  ticker: AMZN
+  exchange: NASDAQ
+  symbol: NASDAQ:AMZN
+  provider: yahoo
 sources:
   - {title: "ARA daily digest 2026-07-30", path: research/digest/2026-07-30-digest.md}
   - {title: "ARA model ticket — Amazon Nova frontier reorg", path: research/models/tickets/amazon-nova-frontier-reorg-2026-07.md}

--- a/research/wiki/entities/apple.md
+++ b/research/wiki/entities/apple.md
@@ -7,6 +7,11 @@ tags: [consumer-tech, on-device-ai, apple-intelligence, siri, wwdc]
 description: Consumer-hardware giant whose long-delayed Siri rebuild — reportedly powered by a custom Google Gemini model with a user-selectable "Extensions" layer — is the marquee AI item at WWDC 2026; sued OpenAI (2026-07-12) over alleged hardware trade-secret theft, escalating to legal letters against dozens of OpenAI employees (2026-07-18).
 created_at: 2026-06-08
 timestamp: 2026-07-18T00:00:00Z
+market:
+  ticker: AAPL
+  exchange: NASDAQ
+  symbol: NASDAQ:AAPL
+  provider: yahoo
 sources:
   - {title: "ARA daily digest 2026-07-18", path: research/digest/2026-07-18-digest.md}
   - {title: "ARA daily digest 2026-07-15", path: research/digest/2026-07-15-digest.md}

--- a/research/wiki/entities/broadcom.md
+++ b/research/wiki/entities/broadcom.md
@@ -7,6 +7,11 @@ tags: [ai-infrastructure, semiconductors, custom-asic, private-credit, ai-capex]
 description: Custom AI ASIC vendor and capex sentiment lever; central to Google/Anthropic TPU financing, OpenAI's first custom inference chip (Jalapeño, co-designed with Broadcom), and the June 2026 Broadcom guidance gut-check that erased roughly $320B of market value.
 created_at: 2026-06-17
 timestamp: 2026-06-29T00:00:00Z
+market:
+  ticker: AVGO
+  exchange: NASDAQ
+  symbol: NASDAQ:AVGO
+  provider: yahoo
 sources:
   - {title: "ARA daily digest 2026-06-29", path: research/digest/2026-06-29-digest.md}
   - {title: "ARA model ticket — OpenAI Jalapeño chip", path: research/models/tickets/openai-jalapeno-chip-2026-06.md}

--- a/research/wiki/entities/coreweave.md
+++ b/research/wiki/entities/coreweave.md
@@ -7,6 +7,11 @@ tags: [neocloud, gpu-cloud, ai-infrastructure, take-or-pay]
 description: NASDAQ-listed GPU-as-a-service neocloud with a ~$99B contracted backlog, ~$25B debt, and revenue concentrated in Microsoft, OpenAI, and Meta.
 created_at: 2026-05-24
 timestamp: 2026-05-24T00:00:00Z
+market:
+  ticker: CRWV
+  exchange: NASDAQ
+  symbol: NASDAQ:CRWV
+  provider: yahoo
 sources:
   - {title: "ARA generative research — CoreWeave GPU-as-a-service unit economics", path: research/generative/2026-05-16T103712--coreweave-gpu-as-a-service-unit-economics-and-customer-conce.html}
   - {title: "ARA daily digest 2026-05-20", path: research/digest/2026-05-20-digest.md}

--- a/research/wiki/entities/dell.md
+++ b/research/wiki/entities/dell.md
@@ -7,6 +7,11 @@ tags: [oem, server-vendor, enterprise-ai, capital-markets]
 description: US enterprise-IT OEM; Q1 FY27 (reported 2026-05-29) printed $43.8B revenue (+88% YoY) with AI-Optimized Servers at $16.1B (+757% YoY), $24.4B AI orders booked, FY27 AI-server outlook raised to $60B; stock +32% on the print, the best single day in company history.
 created_at: 2026-06-01
 timestamp: 2026-06-01T00:00:00Z
+market:
+  ticker: DELL
+  exchange: NYSE
+  symbol: NYSE:DELL
+  provider: yahoo
 sources:
   - {title: "ARA daily digest 2026-06-01", path: research/digest/2026-06-01-digest.md}
   - {title: "Dell Q1 FY27 results", date: 2026-05-29}

--- a/research/wiki/entities/google.md
+++ b/research/wiki/entities/google.md
@@ -7,6 +7,11 @@ tags: [hyperscaler, frontier-lab, antitrust, consumer-ai, gemini]
 description: Hyperscaler and frontier-model builder behind Gemini; Q2 2026 revenue hit $119.8B (+24% YoY) with Google Cloud up 82% to $24.77B (2026-07-22), the first hard earnings evidence that its AI-capex guidance is converting into cloud revenue.
 created_at: 2026-07-17
 timestamp: 2026-08-01T00:00:00Z
+market:
+  ticker: GOOGL
+  exchange: NASDAQ
+  symbol: NASDAQ:GOOGL
+  provider: yahoo
 sources:
   - {title: "ARA daily digest 2026-08-01", path: research/digest/2026-08-01-digest.md}
   - {title: "ARA model ticket — Gemini Robotics 2", path: research/models/tickets/google-gemini-robotics-2-2026-07.md}

--- a/research/wiki/entities/meta.md
+++ b/research/wiki/entities/meta.md
@@ -7,6 +7,11 @@ tags: [hyperscaler, frontier-lab, consumer-ai, open-weights, social]
 description: Social-platform hyperscaler and frontier-model builder (Llama); began alerting parents when teens discuss suicide/self-harm with Meta AI (2026-07-17, live in the US/UK/Australia/Canada), its most direct AI-safety product response yet.
 created_at: 2026-06-16
 timestamp: 2026-07-30T00:00:00Z
+market:
+  ticker: META
+  exchange: NASDAQ
+  symbol: NASDAQ:META
+  provider: yahoo
 sources:
   - {title: "ARA daily digest 2026-07-30", path: research/digest/2026-07-30-digest.md}
   - {title: "ARA daily digest 2026-07-17", path: research/digest/2026-07-17-digest.md}

--- a/research/wiki/entities/micron.md
+++ b/research/wiki/entities/micron.md
@@ -7,6 +7,11 @@ tags: [memory, hbm, dram, ai-infrastructure, supply-chain, anthropic]
 description: US memory-chip maker (HBM/DRAM/SSD) that on 2026-06-23 became Anthropic's primary memory supplier under a multi-year supply + co-design pact and participated in Anthropic's Series H — the first named investor in that round.
 created_at: 2026-06-23
 timestamp: 2026-07-12T00:00:00Z
+market:
+  ticker: MU
+  exchange: NASDAQ
+  symbol: NASDAQ:MU
+  provider: yahoo
 sources:
   - {title: "ARA daily digest 2026-07-12", path: research/digest/2026-07-12-digest.md}
   - {title: "ARA daily digest 2026-06-23", path: research/digest/2026-06-23-digest.md}

--- a/research/wiki/entities/microsoft.md
+++ b/research/wiki/entities/microsoft.md
@@ -7,6 +7,11 @@ tags: [hyperscaler, frontier-lab, copilot, azure, foundation-models, custom-sili
 description: Hyperscaler and frontier-model builder; at Build 2026 shipped a full first-party MAI model stack and made Project Polaris the default GitHub Copilot engine; CEO Satya Nadella publicly called Anthropic's Fable "editorially controlled" (2026-07-18) despite Microsoft's $5B stake in Anthropic.
 created_at: 2026-06-03
 timestamp: 2026-07-22T00:00:00Z
+market:
+  ticker: MSFT
+  exchange: NASDAQ
+  symbol: NASDAQ:MSFT
+  provider: yahoo
 sources:
   - {title: "ARA daily digest 2026-07-22", path: research/digest/2026-07-22-digest.md}
   - {title: "ARA daily digest 2026-07-18", path: research/digest/2026-07-18-digest.md}

--- a/research/wiki/entities/nebius.md
+++ b/research/wiki/entities/nebius.md
@@ -7,6 +7,11 @@ tags: [neocloud, gpu-cloud, ai-infrastructure, nvidia-partner]
 description: Amsterdam-based AI cloud ("neocloud") provider spun out of Yandex, scaling GPU capacity for AI training and inference; signed a $1B+ Nvidia GB300 compute deal with Reflection AI through 2029 (2026-07-15), though its stock fell ~5% on the news.
 created_at: 2026-05-24
 timestamp: 2026-07-15T00:00:00Z
+market:
+  ticker: NBIS
+  exchange: NASDAQ
+  symbol: NASDAQ:NBIS
+  provider: yahoo
 sources:
   - {title: "ARA daily digest 2026-07-15", path: research/digest/2026-07-15-digest.md}
   - {title: "ARA daily digest 2026-05-20", path: research/digest/2026-05-20-digest.md}

--- a/research/wiki/entities/nvidia.md
+++ b/research/wiki/entities/nvidia.md
@@ -7,6 +7,11 @@ tags: [gpu, ai-chips, accelerators, open-weights, datacenter, semiconductors]
 description: The dominant AI accelerator supplier; backing Ilya Sutskever's Safe Superintelligence (~$5B, reported 2026-07-28) and reportedly discussing a ~$250B OpenAI Ohio-datacenter financing backstop, on top of the open-weights Nemotron line.
 created_at: 2026-06-05
 timestamp: 2026-07-29T00:00:00Z
+market:
+  ticker: NVDA
+  exchange: NASDAQ
+  symbol: NASDAQ:NVDA
+  provider: yahoo
 sources:
   - {title: "ARA daily digest 2026-07-29", path: research/digest/2026-07-29-digest.md}
   - {title: "ARA model ticket — NVIDIA Taiwan smuggling probe", path: research/models/tickets/nvidia-taiwan-smuggling-probe-2026-07.md}

--- a/research/wiki/entities/salesforce.md
+++ b/research/wiki/entities/salesforce.md
@@ -7,6 +7,11 @@ tags: [enterprise-software, agentic-ai, crm, m-and-a, claude-code]
 description: Enterprise CRM giant betting its AI future on agentic software (Agentforce); acquired AI customer-service platform Fin (formerly Intercom) for $3.6B on 2026-06-15 — the day's largest confirmed AI M&A.
 created_at: 2026-06-16
 timestamp: 2026-06-17T00:00:00Z
+market:
+  ticker: CRM
+  exchange: NYSE
+  symbol: NYSE:CRM
+  provider: yahoo
 sources:
   - {title: "ARA daily digest 2026-06-16", path: research/digest/2026-06-16-digest.md}
   - {title: "Salesforce acquires Fin for $3.6B (CNBC)", url: "https://www.cnbc.com/amp/2026/06/15/salesforce-ai-customer-service-fin-acquistion.html", date: 2026-06-15}

--- a/research/wiki/index.json
+++ b/research/wiki/index.json
@@ -269,7 +269,13 @@
         "gemini-3-6-flash",
         "moonshot-kimi-k3",
         "open-weights"
-      ]
+      ],
+      "market": {
+        "ticker": "BABA",
+        "exchange": "NYSE",
+        "symbol": "NYSE:BABA",
+        "provider": "yahoo"
+      }
     },
     {
       "slug": "amazon",
@@ -308,7 +314,13 @@
         "anthropic",
         "claude-fable-5",
         "federal-ai-policy"
-      ]
+      ],
+      "market": {
+        "ticker": "AMZN",
+        "exchange": "NASDAQ",
+        "symbol": "NASDAQ:AMZN",
+        "provider": "yahoo"
+      }
     },
     {
       "slug": "anthropic",
@@ -452,7 +464,13 @@
       ],
       "inbound": [
         "openai"
-      ]
+      ],
+      "market": {
+        "ticker": "AAPL",
+        "exchange": "NASDAQ",
+        "symbol": "NASDAQ:AAPL",
+        "provider": "yahoo"
+      }
     },
     {
       "slug": "artificial-general-engineer",
@@ -522,7 +540,13 @@
         "gpt-5-6",
         "micron",
         "nvidia"
-      ]
+      ],
+      "market": {
+        "ticker": "AVGO",
+        "exchange": "NASDAQ",
+        "symbol": "NASDAQ:AVGO",
+        "provider": "yahoo"
+      }
     },
     {
       "slug": "california-ai-regulation",
@@ -930,7 +954,13 @@
         "nebius",
         "neocloud",
         "nvidia"
-      ]
+      ],
+      "market": {
+        "ticker": "CRWV",
+        "exchange": "NASDAQ",
+        "symbol": "NASDAQ:CRWV",
+        "provider": "yahoo"
+      }
     },
     {
       "slug": "cursor",
@@ -1100,7 +1130,13 @@
       ],
       "inbound": [
         "ai-capex"
-      ]
+      ],
+      "market": {
+        "ticker": "DELL",
+        "exchange": "NYSE",
+        "symbol": "NYSE:DELL",
+        "provider": "yahoo"
+      }
     },
     {
       "slug": "dynamic-workflows",
@@ -1555,7 +1591,13 @@
         "anthropic",
         "gemini-3-5-pro",
         "gemini-3-6-flash"
-      ]
+      ],
+      "market": {
+        "ticker": "GOOGL",
+        "exchange": "NASDAQ",
+        "symbol": "NASDAQ:GOOGL",
+        "provider": "yahoo"
+      }
     },
     {
       "slug": "gpt-5-6",
@@ -1858,7 +1900,13 @@
         "google",
         "open-weights",
         "openai"
-      ]
+      ],
+      "market": {
+        "ticker": "META",
+        "exchange": "NASDAQ",
+        "symbol": "NASDAQ:META",
+        "provider": "yahoo"
+      }
     },
     {
       "slug": "micron",
@@ -1897,7 +1945,13 @@
         "ai-capex",
         "anthropic",
         "sk-hynix"
-      ]
+      ],
+      "market": {
+        "ticker": "MU",
+        "exchange": "NASDAQ",
+        "symbol": "NASDAQ:MU",
+        "provider": "yahoo"
+      }
     },
     {
       "slug": "microsoft",
@@ -1950,7 +2004,13 @@
         "nvidia",
         "open-weights",
         "openai"
-      ]
+      ],
+      "market": {
+        "ticker": "MSFT",
+        "exchange": "NASDAQ",
+        "symbol": "NASDAQ:MSFT",
+        "provider": "yahoo"
+      }
     },
     {
       "slug": "midjourney",
@@ -2243,7 +2303,13 @@
         "meta",
         "neocloud",
         "nvidia"
-      ]
+      ],
+      "market": {
+        "ticker": "NBIS",
+        "exchange": "NASDAQ",
+        "symbol": "NASDAQ:NBIS",
+        "provider": "yahoo"
+      }
     },
     {
       "slug": "neocloud",
@@ -2396,7 +2462,13 @@
           "credit": "Charbax / Wikimedia Commons (CC BY 3.0)",
           "source_url": "https://commons.wikimedia.org/wiki/File:Nvidia_DGX_Station,_world%27s_most_powerful_desktop,_a_Supercomputer_at_the_office.webm"
         }
-      ]
+      ],
+      "market": {
+        "ticker": "NVDA",
+        "exchange": "NASDAQ",
+        "symbol": "NASDAQ:NVDA",
+        "provider": "yahoo"
+      }
     },
     {
       "slug": "open-weights",
@@ -2771,7 +2843,13 @@
         "anthropic",
         "nvidia",
         "openai"
-      ]
+      ],
+      "market": {
+        "ticker": "CRM",
+        "exchange": "NYSE",
+        "symbol": "NYSE:CRM",
+        "provider": "yahoo"
+      }
     },
     {
       "slug": "sk-hynix",

--- a/scripts/build_wiki_index.py
+++ b/scripts/build_wiki_index.py
@@ -22,7 +22,7 @@ index.json shape:
     {
       "pages": [
         {slug, title, type, tags, summary, created_at, updated_at,
-         file, aliases, images?, outbound, inbound}
+         file, aliases, images?, market?, outbound, inbound}
       ],
       "resolver": { "<name-or-alias lowercased>": "<slug>" },
       "recent_log": [ {date, op, summary} ]   # newest first
@@ -73,6 +73,7 @@ def _page_extra_fields(path: Path) -> dict[str, Any]:
         "created_at": _isoformat(data.get("created_at")),
         "timestamp": _isoformat(data.get("timestamp") or data.get("updated_at")),
         "images": cw.normalize_images(data.get("images")),
+        "market": cw.normalize_market(data.get("market")),
     }
 
 
@@ -135,6 +136,11 @@ def build_index(wiki_dir: Path) -> dict[str, Any]:
         }
         if extra["images"]:
             doc["images"] = extra["images"]
+        # Identity only — never a quote. Live prices are volatile runtime data
+        # fetched into research/market/quotes.json; folding them in here would
+        # make the committed index non-deterministic and instantly stale.
+        if extra["market"]:
+            doc["market"] = extra["market"]
         page_docs.append(doc)
 
     return {

--- a/scripts/check_wiki.py
+++ b/scripts/check_wiki.py
@@ -42,6 +42,19 @@ URL_RE = re.compile(r"^https?://\S+$")
 IMAGE_URL_RE = re.compile(r"^(https?://\S+|/(?!/)\S+)$")
 IMAGE_SVG_RE = re.compile(r"\.svg(?:$|[?#])", re.IGNORECASE)
 IMAGE_FIELDS = {"url", "alt", "caption", "credit", "source_url"}
+# ORDERED, and normalize_market must iterate this tuple rather than the set
+# below: index.json preserves insertion order, so iterating a set makes the
+# emitted key order vary with PYTHONHASHSEED and the committed index flaps
+# between runs. build_wiki_index.py --check catches it, but only after the
+# damage is committed.
+MARKET_KEYS = ("ticker", "exchange", "symbol", "provider", "tradingview_symbol")
+MARKET_FIELDS = set(MARKET_KEYS)
+MARKET_REQUIRED = ("ticker", "exchange", "symbol")
+# Ticker allows a dotted suffix (BRK.B) and a numeric+venue form (005930.KS).
+MARKET_TICKER_RE = re.compile(r"^[A-Z0-9]{1,6}(\.[A-Z]{1,3})?$")
+MARKET_EXCHANGE_RE = re.compile(r"^[A-Z]{2,10}$")
+MARKET_SYMBOL_RE = re.compile(r"^[A-Z]{2,10}:[A-Z0-9]{1,6}(\.[A-Z]{1,3})?$")
+MARKET_PROVIDERS = {"yahoo"}
 # [[slug]] or [[slug|Display Label]]. The target is everything up to an
 # optional '|'. We capture the raw target and strip/validate it afterwards.
 WIKILINK_RE = re.compile(r"\[\[([^\[\]]+?)\]\]")
@@ -314,6 +327,86 @@ def _check_images(val: Any, path: Path, report: Report) -> None:
                 report.fail(path, "images", f"item {i} source_url must be http(s)://... ({source_url!r})")
 
 
+def normalize_market(value: Any) -> dict[str, str]:
+    """Return normalized market metadata for validated-ish frontmatter.
+
+    Same contract as normalize_images: the validator is the authority on
+    failures, so this is deliberately forgiving and simply drops anything
+    incomplete. Returns {} when there is no usable identity, which is what
+    keeps `market` out of index.json for the overwhelming majority of pages.
+    """
+    if not isinstance(value, dict):
+        return {}
+    out: dict[str, str] = {}
+    for key in MARKET_KEYS:  # ordered tuple, NOT the set — see MARKET_KEYS
+        val = value.get(key)
+        if isinstance(val, str) and val.strip():
+            out[key] = val.strip()
+    if not all(k in out for k in MARKET_REQUIRED):
+        return {}
+    return out
+
+
+def _check_market(val: Any, type_: Any, path: Path, report: Report) -> None:
+    """Optional public-market identity. Entity-only, strict, never inferred.
+
+    Strictness is the point: a wrong ticker renders a confident, wrong price
+    on a page about something else entirely. Every field is exact-matched, and
+    `symbol` is cross-checked against ticker+exchange so the three cannot
+    silently disagree after a hand edit.
+    """
+    if not isinstance(val, dict):
+        report.fail(path, "market", "must be a mapping")
+        return
+    if not val:
+        report.fail(path, "market", "must be omitted entirely rather than an empty mapping")
+        return
+    if type_ != "entity":
+        report.fail(
+            path,
+            "market",
+            f"is only valid on type: entity (got {type_!r}) — concepts and themes are not securities",
+        )
+        return
+
+    extra = set(val) - MARKET_FIELDS
+    if extra:
+        report.fail(path, "market", f"has unknown keys {sorted(extra)} (allowed: {sorted(MARKET_FIELDS)})")
+
+    for key in MARKET_REQUIRED:
+        if key not in val or val[key] is None:
+            report.fail(path, "market", f"missing required key {key!r}")
+
+    ticker = _single_line_str(val.get("ticker"), path, "market", report, required=True)
+    exchange = _single_line_str(val.get("exchange"), path, "market", report, required=True)
+    symbol = _single_line_str(val.get("symbol"), path, "market", report, required=True)
+
+    if ticker and not MARKET_TICKER_RE.match(ticker):
+        report.fail(path, "market", f"ticker must be uppercase 1-6 chars with an optional .SUFFIX ({ticker!r})")
+    if exchange and not MARKET_EXCHANGE_RE.match(exchange):
+        report.fail(path, "market", f"exchange must be an uppercase venue code, 2-10 chars ({exchange!r})")
+    if symbol and not MARKET_SYMBOL_RE.match(symbol):
+        report.fail(path, "market", f"symbol must be EXCHANGE:TICKER ({symbol!r})")
+    if ticker and exchange and symbol and symbol != f"{exchange}:{ticker}":
+        report.fail(
+            path,
+            "market",
+            f"symbol {symbol!r} must equal '{exchange}:{ticker}' — ticker/exchange/symbol disagree",
+        )
+
+    provider = val.get("provider")
+    if provider is not None:
+        provider_s = _single_line_str(provider, path, "market", report, required=False)
+        if provider_s and provider_s not in MARKET_PROVIDERS:
+            report.fail(path, "market", f"provider must be one of {sorted(MARKET_PROVIDERS)} ({provider_s!r})")
+
+    tv = val.get("tradingview_symbol")
+    if tv is not None:
+        tv_s = _single_line_str(tv, path, "market", report, required=False)
+        if tv_s and not MARKET_SYMBOL_RE.match(tv_s):
+            report.fail(path, "market", f"tradingview_symbol must be EXCHANGE:TICKER ({tv_s!r})")
+
+
 def extract_wikilinks(body: str) -> list[str]:
     """Return raw link targets from [[...]] in `body`, skipping fenced code.
 
@@ -420,6 +513,8 @@ def load_page(path: Path, report: Report) -> Page | None:
         _check_sources(data["sources"], path, report)
     if "images" in data and data["images"] is not None:
         _check_images(data["images"], path, report)
+    if "market" in data and data["market"] is not None:
+        _check_market(data["market"], type_, path, report)
 
     if not body.strip():
         report.fail(path, "body", "body must not be empty — write markdown under the frontmatter")

--- a/scripts/fetch_market_quotes.py
+++ b/scripts/fetch_market_quotes.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Refresh research/market/quotes.json for wiki entities that carry `market`.
+
+The wiki stores market IDENTITY (ticker/exchange/symbol); prices are volatile
+runtime data and live here instead, so a stale quote can never make a wiki page
+stale. The dashboard reads this file once per session to put a price row in the
+wiki hover card.
+
+Symbols come from research/wiki/index.json, so this script has no list of its
+own to drift: adding `market:` to an entity page and regenerating the index is
+the only step needed to start quoting a new company.
+
+Usage:
+  uv run --extra stock python scripts/fetch_market_quotes.py
+  uv run --extra stock python scripts/fetch_market_quotes.py --dry-run
+  uv run --extra stock python scripts/fetch_market_quotes.py --max-age-hours 48
+
+Output contract (research/market/quotes.json):
+
+    {
+      "generated_at": "2026-08-01T10:04:00Z",
+      "quotes": {
+        "NASDAQ:NVDA": {
+          "symbol": "NASDAQ:NVDA", "ticker": "NVDA",
+          "price": 200.75, "change": 3.91, "changePercent": 1.99,
+          "currency": "USD", "marketState": "REGULAR"|null,
+          "asOf": "2026-08-01T20:00:01Z", "source": "yahoo", "stale": false
+        }
+      }
+    }
+
+Keys are the wiki's `market.symbol`, so the dashboard joins on one field.
+
+Failure policy is fail-soft per symbol and fail-loud in aggregate. A symbol that
+cannot be refreshed keeps its previous entry marked `stale: true` (a known-old
+price with an honest asOf beats a blank row); a symbol that has never been
+fetched is simply absent. But if EVERY symbol fails, that is an environment
+problem — a 429 wall, no network, a dead dependency — and exit 1 makes it
+visible rather than silently publishing a fully stale file. Same reasoning as
+postbuild-seo.mjs's all-social-cards-failed guard.
+
+Change is computed from the last two daily closes rather than any provider
+"previousClose" field: Yahoo exposes previousClose, chartPreviousClose and
+fast_info.previous_close, and on 2026-08-01 those returned 195.04, 206.84 and
+196.839 for the same ticker. Differencing the series we already fetched is
+self-consistent and matches what a reader would compute by hand.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WIKI_INDEX = REPO_ROOT / "research" / "wiki" / "index.json"
+DEFAULT_OUT = REPO_ROOT / "research" / "market" / "quotes.json"
+DEFAULT_MAX_AGE_HOURS = 24
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def load_symbols(index_path: Path) -> list[dict[str, str]]:
+    """Return [{symbol, ticker, provider}] for every entity carrying `market`.
+
+    Deduplicated by symbol: two pages may legitimately reference one security.
+    """
+    try:
+        data = json.loads(index_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"ERROR: cannot read {index_path}: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc
+
+    seen: dict[str, dict[str, str]] = {}
+    for page in data.get("pages") or []:
+        market = page.get("market")
+        if not isinstance(market, dict):
+            continue
+        symbol, ticker = market.get("symbol"), market.get("ticker")
+        if not symbol or not ticker:
+            continue
+        seen.setdefault(symbol, {
+            "symbol": symbol,
+            "ticker": ticker,
+            "provider": market.get("provider") or "yahoo",
+        })
+    return [seen[k] for k in sorted(seen)]
+
+
+def _closes_via_yfinance(ticker: str) -> tuple[list[float], str, int | None, str | None]:
+    import yfinance as yf  # local import — optional `stock` extra
+
+    t = yf.Ticker(ticker)
+    hist = t.history(period="5d", interval="1d", auto_adjust=False)
+    if hist.empty:
+        raise ValueError(f"yfinance returned empty history for {ticker}")
+    closes = [float(c) for c in hist["Close"] if c == c]  # drop NaN
+    if not closes:
+        raise ValueError(f"yfinance returned no usable closes for {ticker}")
+    meta = t.history_metadata or {}
+    currency = str(meta.get("currency") or "USD")
+    as_of = meta.get("regularMarketTime")
+    market_state = meta.get("marketState")
+    return closes, currency, (int(as_of) if as_of else None), (str(market_state) if market_state else None)
+
+
+def _closes_via_urllib(ticker: str) -> tuple[list[float], str, int | None, str | None]:
+    """Fallback when the optional `stock` extra is not installed.
+
+    Yahoo 429s this path from many IPs (see stock_prices.py) — that is exactly
+    why it is the fallback and not the primary.
+    """
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    import stock_prices as sp  # type: ignore
+
+    result = sp.fetch_chart(ticker, "5d", "1d")
+    closes, _labels = sp.extract_series(result, "1d")
+    if not closes:
+        raise ValueError(f"no closes for {ticker}")
+    meta = result.get("meta") or {}
+    return (
+        closes,
+        str(meta.get("currency") or "USD"),
+        meta.get("regularMarketTime"),
+        (str(meta.get("marketState")) if meta.get("marketState") else None),
+    )
+
+
+def fetch_quote(entry: dict[str, str]) -> dict[str, Any]:
+    """Fetch one symbol. Raises on failure; the caller decides fail-soft policy."""
+    ticker = entry["ticker"]
+    try:
+        closes, currency, as_of_epoch, market_state = _closes_via_yfinance(ticker)
+        source = "yahoo"
+    except ImportError:
+        closes, currency, as_of_epoch, market_state = _closes_via_urllib(ticker)
+        source = "yahoo"
+
+    price = round(closes[-1], 4)
+    # A single close means no prior session to difference against — emit the
+    # price with a null change rather than a fabricated 0.00 (+0.00%).
+    if len(closes) >= 2 and closes[-2]:
+        change = round(price - closes[-2], 4)
+        change_percent = round((price - closes[-2]) / closes[-2] * 100, 4)
+    else:
+        change = None
+        change_percent = None
+
+    as_of = _iso(datetime.fromtimestamp(as_of_epoch, tz=timezone.utc)) if as_of_epoch else _iso(_utc_now())
+    return {
+        "symbol": entry["symbol"],
+        "ticker": ticker,
+        "price": price,
+        "change": change,
+        "changePercent": change_percent,
+        "currency": currency,
+        "marketState": market_state,
+        "asOf": as_of,
+        "source": source,
+        "stale": False,
+    }
+
+
+def _load_previous(out_path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(out_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    quotes = data.get("quotes")
+    return quotes if isinstance(quotes, dict) else {}
+
+
+def _mark_stale(prev: dict[str, Any], max_age: timedelta, now: datetime) -> dict[str, Any] | None:
+    """Carry a previous quote forward as stale, or drop it once it is too old.
+
+    A price from an hour ago labelled as such is useful; one from last month
+    presented next to a company name is misinformation.
+    """
+    as_of = prev.get("asOf")
+    if not isinstance(as_of, str):
+        return None
+    try:
+        parsed = datetime.strptime(as_of, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+    if now - parsed > max_age:
+        return None
+    carried = dict(prev)
+    carried["stale"] = True
+    return carried
+
+
+def write_atomic(out_path: Path, payload: dict[str, Any]) -> None:
+    """Temp file in the same dir + os.replace (load-bearing rule 8): a
+    half-written quotes.json must never reach the dashboard prebuild."""
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = out_path.with_suffix(out_path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp, out_path)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--index", type=Path, default=WIKI_INDEX)
+    ap.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    ap.add_argument("--max-age-hours", type=int, default=DEFAULT_MAX_AGE_HOURS,
+                    help="Drop a carried-forward stale quote older than this (default 24).")
+    ap.add_argument("--dry-run", action="store_true", help="Print the payload; write nothing.")
+    args = ap.parse_args(argv)
+
+    entries = load_symbols(args.index)
+    if not entries:
+        print("No wiki entities carry `market` — nothing to quote.")
+        return 0
+
+    now = _utc_now()
+    previous = _load_previous(args.out)
+    max_age = timedelta(hours=args.max_age_hours)
+
+    quotes: dict[str, Any] = {}
+    failures: list[str] = []
+    for entry in entries:
+        symbol = entry["symbol"]
+        try:
+            quotes[symbol] = fetch_quote(entry)
+        except Exception as exc:  # noqa: BLE001 — boundary: any provider fault is fail-soft
+            failures.append(f"{symbol}: {type(exc).__name__}: {exc}")
+            carried = _mark_stale(previous.get(symbol) or {}, max_age, now)
+            if carried:
+                quotes[symbol] = carried
+
+    for line in failures:
+        print(f"WARN {line}", file=sys.stderr)
+
+    fresh = sum(1 for q in quotes.values() if not q.get("stale"))
+    print(f"{fresh} fresh, {len(quotes) - fresh} carried-stale, {len(failures)} failed, of {len(entries)} symbol(s)")
+
+    if fresh == 0:
+        print(
+            "ERROR: every symbol failed to refresh — treat as an environment problem "
+            "(rate limit, network, missing `stock` extra), not per-symbol noise.",
+            file=sys.stderr,
+        )
+        return 1
+
+    payload = {"generated_at": _iso(now), "quotes": quotes}
+    if args.dry_run:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+    write_atomic(args.out, payload)
+    print(f"wrote {args.out} ({len(quotes)} quote(s))")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_wiki.py
+++ b/scripts/test_wiki.py
@@ -329,6 +329,94 @@ class FrontmatterFailureTest(unittest.TestCase):
         self.assertIn("images", fail_fields(report))
 
 
+    # --- market (public-market identity) ------------------------------------
+    #
+    # Strictness matters more here than anywhere else in the schema: a wrong
+    # ticker renders a confident, WRONG share price on a page about something
+    # else. Each case below is a way that could happen.
+
+    def _market_page(self, market_yaml: str, type_: str = "entity", subdir: str = "entities"):
+        def build(root):
+            p = root / subdir / "alpha.md"
+            p.write_text(
+                f"---\nslug: alpha\ntitle: Alpha\ntype: {type_}\ndescription: x\n"
+                "created_at: 2026-05-24\ntimestamp: 2026-05-24\n"
+                f"{market_yaml}---\n\nBody.\n",
+                encoding="utf-8",
+            )
+            kwargs = {"entities": ["alpha"]} if subdir == "entities" \
+                else {"concepts": ["alpha"]} if subdir == "concepts" \
+                else {"themes": ["alpha"]}
+            write_index(root, **kwargs)
+
+        return self._one_page_report(build)
+
+    def test_valid_market_on_public_company_passes(self):
+        report = self._market_page(
+            "market:\n  ticker: NVDA\n  exchange: NASDAQ\n  symbol: NASDAQ:NVDA\n"
+            "  provider: yahoo\n  tradingview_symbol: NASDAQ:NVDA\n"
+        )
+        self.assertTrue(report.ok(), fail_fields(report))
+
+    def test_private_company_without_market_passes(self):
+        # The common case: no market key at all. Must not be required.
+        report = self._market_page("")
+        self.assertTrue(report.ok(), fail_fields(report))
+
+    def test_market_symbol_disagreeing_with_ticker_exchange_fails(self):
+        # The dangerous hand-edit: someone updates ticker but not symbol.
+        report = self._market_page(
+            "market:\n  ticker: AMD\n  exchange: NASDAQ\n  symbol: NASDAQ:NVDA\n"
+        )
+        self.assertFalse(report.ok())
+        self.assertIn("market", fail_fields(report))
+
+    def test_market_malformed_symbol_fails(self):
+        report = self._market_page(
+            "market:\n  ticker: NVDA\n  exchange: NASDAQ\n  symbol: nvda\n"
+        )
+        self.assertFalse(report.ok())
+        self.assertIn("market", fail_fields(report))
+
+    def test_market_missing_required_key_fails(self):
+        report = self._market_page("market:\n  ticker: NVDA\n")
+        self.assertFalse(report.ok())
+        self.assertIn("market", fail_fields(report))
+
+    def test_market_unknown_key_fails(self):
+        report = self._market_page(
+            "market:\n  ticker: NVDA\n  exchange: NASDAQ\n  symbol: NASDAQ:NVDA\n  price: 900\n"
+        )
+        self.assertFalse(report.ok())
+        self.assertIn("market", fail_fields(report))
+
+    def test_market_unknown_provider_fails(self):
+        report = self._market_page(
+            "market:\n  ticker: NVDA\n  exchange: NASDAQ\n  symbol: NASDAQ:NVDA\n  provider: bloomberg\n"
+        )
+        self.assertFalse(report.ok())
+        self.assertIn("market", fail_fields(report))
+
+    def test_market_on_concept_fails(self):
+        report = self._market_page(
+            "market:\n  ticker: NVDA\n  exchange: NASDAQ\n  symbol: NASDAQ:NVDA\n",
+            type_="concept",
+            subdir="concepts",
+        )
+        self.assertFalse(report.ok())
+        self.assertIn("market", fail_fields(report))
+
+    def test_market_on_theme_fails(self):
+        report = self._market_page(
+            "market:\n  ticker: NVDA\n  exchange: NASDAQ\n  symbol: NASDAQ:NVDA\n",
+            type_="theme",
+            subdir="themes",
+        )
+        self.assertFalse(report.ok())
+        self.assertIn("market", fail_fields(report))
+
+
+
 # --- check_wiki: corpus-level failure modes ---------------------------------
 
 


### PR DESCRIPTION
Closes #140.

Hovering a company mention now answers both of the issue's questions at once: what this company is in the ARA wiki, and — if it's listed — what the market read is.

## The binding is explicit, never inferred

`aliases` routinely contain product names, people, handles and private-company names that collide with real tickers, so inferring a ticker from them would render confident, **wrong** prices on pages that have nothing to do with a security. Entity pages carry an optional `market` block or nothing at all:

```yaml
market:
  ticker: NVDA
  exchange: NASDAQ
  symbol: NASDAQ:NVDA
  provider: yahoo
```

## Page stores identity, not price

| | Where | Why |
|---|---|---|
| Identity | `research/wiki/entities/*.md` → `index.json` | Stable knowledge artifact |
| Price | `research/market/quotes.json` (new `market-quotes.yml`, every 3h) | Volatile runtime data |

Folding quotes into `index.json` would make the committed index non-deterministic, instantly stale, and would churn the wiki's git history every refresh for reasons unrelated to knowledge changing. Symbols are read **from** the wiki index, so the quote lane has no list of its own to drift — adding `market:` to a page is the only step needed to quote a new company.

## Validation (rule 10: doc + validator in lockstep)

Entity-only, allowed keys, ticker/exchange/symbol regexes, provider enum, and a cross-check that `symbol` equals `exchange:ticker` so a hand edit can't leave the three disagreeing. **Nine tests**: valid public company, private company with no field, symbol/ticker disagreement, malformed symbol, missing key, unknown key, unknown provider, and `market` on a concept and on a theme.

## Failure behavior

- **Per symbol: fail-soft.** A failure carries the previous value forward marked `stale`, dropped once older than `--max-age-hours` (default 24). A known-old price with an honest `asOf` beats a blank row; a month-old one next to a company name is misinformation.
- **In aggregate: fail-loud.** Every symbol failing exits 1 — that's a rate-limit/network/dependency problem, not per-symbol noise. Same reasoning as `postbuild-seo.mjs`'s all-cards-failed guard.
- **Change is computed from the last two daily closes**, not any provider `previousClose`. Yahoo exposes `previousClose`, `chartPreviousClose` and `fast_info.previous_close`, which returned **195.04, 206.84 and 196.839 for the same ticker** on 2026-08-01. Differencing the series we already fetched is self-consistent and matches what a reader would compute by hand.

## Dashboard

`quotes.json` loads **lazily** on the first hover over a page that actually carries `market`, once per session; a failure resolves to an empty map so the hover falls back to type/title/summary rather than throwing. The row reserves its height so the async fill can't shift a card positioned under the pointer.

It also renders on the **entity page itself**, not only in the hover. Touch devices have no hover — tapping a `.wiki-mention` navigates to the page, so a hover-only treatment would have made this desktop-exclusive, which the issue explicitly rules out.

## A bug worth recording

`normalize_market` first iterated `MARKET_FIELDS`, a **set** — so emitted key order varied with `PYTHONHASHSEED` and `index.json` flapped between runs. `build_wiki_index.py --check` caught it. It now iterates an ordered tuple, verified stable across five separate processes.

## Verification — every acceptance criterion, in a browser

| Criterion | Result |
|---|---|
| Public-company hover shows type/title/summary + price, change, %, source, as-of | ✅ `NASDAQ:NVDA · 200.75 USD · +5.71 (+2.93%) · as of Aug 1, 05:00 AM · yahoo` |
| Private-company hover unchanged, no empty stock shell | ✅ Anthropic: `hasMarketRow: false` |
| **No quote fetch for entities without `market`** | ✅ `quotes.json` requests: 0 on load, 0 after hovering Anthropic, 1 after hovering NVIDIA |
| Click still routes to `/wiki/<slug>` | ✅ unchanged |
| Mobile not hover-dependent | ✅ 390×844: `NASDAQ:NVDA · 200.75 USD +5.71 (+2.93%)` on the page |
| `check_wiki.py` / `build_wiki_index.py --check` | ✅ 73 pages valid, index up to date |
| `bun run build` | ✅ |

Plus `test_wiki.py` (45), `test_backend_matrix.py` (39), `test_workflow_time_convention.py` (4), `actionlint` clean on the new workflow, and `docs/backend-matrix.md` regenerated (the new workflow made it stale).

## Seeds

13 US-listed companies. Non-US primaries (SK Hynix on KRX) are deliberately left unmapped rather than guessed — Yahoo needs a venue suffix (`000660.KS`) that the current `symbol` shape doesn't carry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)