### PR TITLE
Whitelist research/market in .dockerignore, and gate the prebuild coupling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -46,10 +46,16 @@ research/*
 !research/youtube/**
 !research/arm
 !research/arm/**
+!research/market
+!research/market/**
 # Twitter comparison-lane dirs: prebuild's twitter-ab.json index and the A/B
 # side-by-side view read these. A research dir consumed by prebuild MUST be
 # whitelisted here too — CI never runs the Dockerfile, so a miss ships an
 # empty index to prod silently (same failure mode as the 2026-07 Arm tab).
+# This is now GATED, not just documented: scripts/test_dockerignore_research_dirs.py
+# fails when prebuild's COPY_DIRS/AB_COMPARISON_LANES and these !research/
+# lines disagree. It was added after `market` slipped through on 2026-08-01
+# and 404'd in production while the local build passed.
 !research/twitter-opencode-kimi
 !research/twitter-opencode-kimi/**
 !research/twitter-zai

--- a/scripts/test_dockerignore_research_dirs.py
+++ b/scripts/test_dockerignore_research_dirs.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Every research dir prebuild copies must be whitelisted in .dockerignore.
+
+This closes a gap that CI structurally cannot see. `.dockerignore` excludes
+`research/*` and re-includes specific dirs; `dashboard/scripts/prebuild.mjs`
+copies a list of dirs into `public/research/`. The two lists must agree, but
+nothing enforced it and the failure is SILENT in both directions that matter:
+
+  - prebuild skips a missing dir with `if (!existsSync(src)) continue;`
+  - CI never builds the Dockerfile (load-bearing rule 3), so the local build
+    is always fine — the miss only appears in production
+
+Observed 2026-08-01: `market` was added to COPY_DIRS for the wiki hover quote
+row and the dashboard build passed locally, but `research/market/` was absent
+from the Docker context, so ara.guzus.xyz served 404 for
+/research/market/quotes.json. The .dockerignore comment warns about exactly
+this ("A research dir consumed by prebuild MUST be whitelisted here too") —
+a comment is not a gate, so this is the gate.
+
+Run: uv run python scripts/test_dockerignore_research_dirs.py
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOCKERIGNORE = REPO_ROOT / ".dockerignore"
+PREBUILD = REPO_ROOT / "dashboard" / "scripts" / "prebuild.mjs"
+
+# `const COPY_DIRS = ['a', 'b', ...];` / `const AB_COMPARISON_LANES = [ ... ];`
+ARRAY_RE = r"const\s+{name}\s*=\s*\[(.*?)\]"
+
+
+def _js_string_array(source: str, name: str) -> list[str]:
+    match = re.search(ARRAY_RE.format(name=name), source, re.DOTALL)
+    if not match:
+        raise AssertionError(
+            f"could not find `const {name} = [...]` in {PREBUILD} — the parser and "
+            "the file have drifted; fix this test rather than deleting it"
+        )
+    return re.findall(r"'([^']+)'", match.group(1))
+
+
+def _dockerignore_reincludes(text: str) -> set[str]:
+    """Return dir names re-included via `!research/<name>` lines."""
+    out: set[str] = set()
+    for line in text.splitlines():
+        line = line.strip()
+        m = re.fullmatch(r"!research/([A-Za-z0-9._-]+)", line)
+        if m:
+            out.add(m.group(1))
+    return out
+
+
+class DockerignoreResearchDirsTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.prebuild = PREBUILD.read_text(encoding="utf-8")
+        cls.dockerignore = DOCKERIGNORE.read_text(encoding="utf-8")
+        cls.reincluded = _dockerignore_reincludes(cls.dockerignore)
+
+    def test_research_is_excluded_by_default(self):
+        # The allowlist only means anything if the blanket exclude is present.
+        self.assertIn("research/*", self.dockerignore.splitlines())
+
+    def test_every_copy_dir_is_whitelisted(self):
+        missing = [d for d in _js_string_array(self.prebuild, "COPY_DIRS") if d not in self.reincluded]
+        self.assertEqual(
+            [], missing,
+            f"prebuild.mjs copies research/{missing} but .dockerignore does not re-include "
+            f"them, so they are absent from the Railway build context and production will "
+            f"404 that data while the local build looks fine. Add `!research/<dir>` and "
+            f"`!research/<dir>/**` to .dockerignore.",
+        )
+
+    def test_every_ab_comparison_lane_is_whitelisted(self):
+        lanes = _js_string_array(self.prebuild, "AB_COMPARISON_LANES")
+        missing = [d for d in lanes if d not in self.reincluded]
+        self.assertEqual([], missing, f"A/B lanes missing from .dockerignore: {missing}")
+
+    def test_recursive_glob_accompanies_each_reinclude(self):
+        # `!research/foo` alone re-includes the directory entry but not its
+        # contents; the `/**` line is what actually ships the files.
+        lines = {l.strip() for l in self.dockerignore.splitlines()}
+        for name in sorted(self.reincluded):
+            self.assertIn(
+                f"!research/{name}/**", lines,
+                f"`!research/{name}` has no matching `!research/{name}/**`, so the "
+                f"directory is re-included but its files are still excluded",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
**Production regression from #1407, caught by checking prod rather than trusting the local build.**

## What broke

`https://ara.guzus.xyz/research/market/quotes.json` → **404**, while the same file built and served fine locally.

`.dockerignore` excludes `research/*` and re-includes specific dirs. #1407 added `market` to prebuild's `COPY_DIRS` but not to that allowlist, so the Railway build context had no `research/market/` and prebuild skipped it silently:

```js
if (!existsSync(src)) continue;
```

The rest of #1407 deployed correctly — prod already serves the new wiki index with all 13 `market` entries — so the hover degrades to the ordinary card rather than breaking. Nothing throws; the quote row just never appears in production.

## Why the local build couldn't catch it

Nothing outside Docker applies `.dockerignore`, and **CI never builds the Dockerfile** (load-bearing rule 3). So the only environment that could observe this was production. That's the same asymmetry behind the 2026-07 empty Arm tab.

The `.dockerignore` comment already warned about precisely this:

> A research dir consumed by prebuild MUST be whitelisted here too — CI never runs the Dockerfile, so a miss ships an empty index to prod silently (same failure mode as the 2026-07 Arm tab).

A comment is not a gate. It did not stop me.

## The gate

`scripts/test_dockerignore_research_dirs.py` asserts:

- every `COPY_DIRS` entry has a `!research/<dir>` line
- every `AB_COMPARISON_LANES` entry does too
- each re-include has a matching `!research/<dir>/**` (without it the dir is re-included but its *files* stay excluded)
- the blanket `research/*` exclude is still present — the allowlist means nothing without it

**Verified it fails on the pre-fix state**, with the message pointing at the fix:

```
+ ['market'] : prebuild.mjs copies research/['market'] but .dockerignore does not
re-include them, so they are absent from the Railway build context and production
will 404 that data while the local build looks fine.
```

A test that has never seen the bug it claims to catch isn't evidence, so I reverted the fix, watched it fail, and restored.

CI runs `unittest discover -s scripts -p 'test_*.py'`, so this is gated on every PR with no workflow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)