### PR TITLE
Link generative research alerts to site articles

### DIFF
--- a/.github/workflows/generative-research.yml
+++ b/.github/workflows/generative-research.yml
@@ -3997,7 +3997,6 @@ jobs:
           TG_REQUESTED_BACKEND: ${{ steps.params.outputs.backend }}
           TG_USED_FALLBACK: ${{ steps.effective.outputs.used_fallback }}
           TG_FILE: ${{ steps.outfile.outputs.file }}
-          TG_REPO: ${{ github.repository }}
           GH_RUN_ID: ${{ github.run_id }}
           GH_RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
@@ -4006,7 +4005,22 @@ jobs:
             echo "Hooker credentials missing — skipping notification"
             exit 0
           fi
-          ARTICLE_URL="https://github.com/${TG_REPO}/blob/main/research/generative/${TG_FILE}"
+          SITE_ORIGIN="${ARA_SITE_ORIGIN:-https://ara.guzus.xyz}"
+          ARTICLE_SLUG=$(jq -r --arg file "$TG_FILE" '
+            map(select(.file == $file)) | last | .slug // empty
+          ' research/generative/index.json)
+          if [ -z "$ARTICLE_SLUG" ]; then
+            stem="${TG_FILE%.html}"
+            if [[ "$stem" == *--* ]]; then
+              ARTICLE_SLUG="${stem#*--}"
+            fi
+          fi
+          if [ -n "$ARTICLE_SLUG" ]; then
+            ARTICLE_URL="${SITE_ORIGIN%/}/research/${ARTICLE_SLUG}"
+          else
+            echo "::warning::Could not resolve article slug for ${TG_FILE}; linking to research index"
+            ARTICLE_URL="${SITE_ORIGIN%/}/research"
+          fi
           BODY=$(printf '📝 Topic: %s\n🤖 Backend: %s' "${TG_TOPIC}" "${TG_BACKEND}")
           if [ "${TG_USED_FALLBACK:-false}" = "true" ]; then
             BODY=$(printf '%s (requested %s; fireworks-fallback)' "$BODY" "${TG_REQUESTED_BACKEND}")
@@ -4021,7 +4035,7 @@ jobs:
               priority: 3,
               tags: ["ara", "generative-research"],
               parse_mode: "HTML",
-              reply_markup: { inline_keyboard: [[{ text: "View on GitHub", url: $url }]] }
+              reply_markup: { inline_keyboard: [[{ text: "Read on ARA", url: $url }]] }
             }')
           curl -fsS --max-time 30 -X POST "${HOOKER_URL%/}/publish/ara-research" \
             -H "Authorization: Bearer ${HOOKER_TOKEN}" \


### PR DESCRIPTION
## What

The generative-research Telegram alert linked to the raw HTML file on GitHub. It now links to the published article on ara.guzus.xyz, and the button reads **"Read on ARA"** instead of "View on GitHub".

Slug resolution: `research/generative/index.json` by `file`, falling back to parsing the `<timestamp>--<slug>.html` filename stem, falling back to `/research` with a workflow warning. Origin is overridable via `ARA_SITE_ORIGIN`.

## Verification

- All **88** entries in `research/generative/index.json` carry a `slug` — the primary lookup path is never the fallback in practice.
- `dashboard/src/main.ts:347` routes `/research/<slug>`, so the URL shape is the one the SPA actually serves.
- Live check with a browser UA (per CLAUDE.md rule 3, Cloudflare 403s ClaudeBot at the edge):
  - `https://ara.guzus.xyz/research/comfyui-company` → **200**
  - `https://ara.guzus.xyz/research` (the fallback) → **200**

Workflow-only change; no script or dashboard code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)