### PR TITLE
Fix Twitter lane broken by birdy v1.0.0 dropping its bundled runtime

### DIFF
--- a/.github/actions/twitter-fetch/action.yml
+++ b/.github/actions/twitter-fetch/action.yml
@@ -96,8 +96,9 @@ runs:
         TMPDIR=$(mktemp -d)
         trap 'rm -rf "$TMPDIR"' EXIT
 
-        # Public repo, no auth needed. Install the whole release layout because
-        # birdy locates the bundled bird runtime next to the birdy binary.
+        # Public repo, no auth needed. Install the whole release layout: through
+        # v0.11.0 birdy shipped a bundled Node `bird/` runtime that it located
+        # next to its own binary, so the layout — not just the binary — mattered.
         curl -fsSL "https://github.com/guzus/birdy/releases/latest/download/${ASSET}" -o "$TMPDIR/$ASSET"
         tar -xzf "$TMPDIR/$ASSET" -C "$TMPDIR"
 
@@ -112,7 +113,18 @@ runs:
         INSTALL_DIR="$HOME/.local/birdy"
         rm -rf "$INSTALL_DIR"
         mkdir -p "$INSTALL_DIR"
-        cp -R "$TMPDIR"/bird "$INSTALL_DIR"/
+        # birdy v1.0.0 (2026-08-07) completed the native-Go rewrite and DROPPED
+        # the bundled runtime: v0.11.0 shipped `bird/dist/...`, v1.x ships only
+        # LICENSE + README + birdy. This `cp` was unconditional, so the major
+        # bump hard-failed every scheduled Twitter run within ~an hour of the
+        # release with `cp: cannot stat '<tmp>/bird': No such file or directory`
+        # — the lane tracks `releases/latest`, so an upstream release reshapes
+        # this step with no commit here. Copy the runtime only if it exists, so
+        # both layouts install; drop this branch once no pinned/rollback release
+        # predates v1.0.0.
+        if [ -d "$TMPDIR/bird" ]; then
+          cp -R "$TMPDIR"/bird "$INSTALL_DIR"/
+        fi
         install -m 755 "$BIN" "$INSTALL_DIR/birdy"
         echo "$INSTALL_DIR" >> "$GITHUB_PATH"
         export PATH="$INSTALL_DIR:$PATH"


### PR DESCRIPTION
## The break

Every scheduled Twitter run has hard-failed at **Fetch twitter snapshot** since ~12:33 UTC on 2026-08-07:

```
cp: cannot stat '/tmp/tmp.gYpsyrqRqb/bird': No such file or directory
```

## Cause is upstream

`.github/actions/twitter-fetch` installs from `guzus/birdy` **`releases/latest`**, so an upstream release can reshape this step with no commit in this repo. That is what happened:

| Release | Published | Tarball contents |
|---|---|---|
| `v0.11.0` | 2026-08-06 11:30Z | `bird/CHANGELOG.md`, `bird/dist/cli.js`, … + `birdy` |
| `v1.0.0` | 2026-08-07 **12:33Z** | `LICENSE`, `README.md`, `birdy` |
| `v1.1.0` | 2026-08-07 14:10Z | same as v1.0.0 |

v1.0.0 completed the native-Go rewrite and dropped the bundled Node runtime that birdy used to locate beside its own binary. `cp -R "$TMPDIR"/bird "$INSTALL_DIR"/` was unconditional, so it fails hard on the new layout.

## Fix

Copy the bundled runtime only when present, so both layouts install. One `if`, no behaviour change on old releases.

Verified by running the extracted installer logic against **both real tarballs**: v0.11.0 copies the runtime, v1.1.0 skips it, `install` succeeds on both.

## Timeline (rules out the recent merge)

- `10:07Z` last green Twitter run (on v0.11.0)
- `12:33Z` **birdy v1.0.0 published**
- `13:17Z` #1793 merged (opencode DeepSeek swap)
- `13:31Z` first Twitter failure
- `16:04Z` second failure

#1793 only touched the opencode tier (case arm, run step, labels) — the failing step is the shared Birdy installer, and the break predates the merge. Both failing jobs are the `claude` primary tier; the `dispatch` job succeeded in both runs.

## Follow-up worth considering

This lane tracks `releases/latest` on a repo you also control, so an upstream release can take out production with no PR here. Pinning to a known-good tag (or having the installer assert the layout it needs with a clear error) would turn this class of break into a deliberate upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)