### PR TITLE
Restrict Korean translation agent capabilities

### DIFF
--- a/.github/actions/agent-dispatch/action.yml
+++ b/.github/actions/agent-dispatch/action.yml
@@ -53,6 +53,13 @@ inputs:
     description: OpenCode Go key, passed only to the OpenCode adapter.
     required: false
     default: ''
+  opencode-config:
+    description: >-
+      Trusted workspace-relative OpenCode policy. Callers may narrow the
+      default tool surface for a specific lane; the selected model cannot
+      modify this read-only mount.
+    required: false
+    default: .github/opencode/opencode.json
 
 outputs:
   route:
@@ -126,5 +133,6 @@ runs:
         return-artifacts: ${{ inputs.return-artifacts }}
         model: ${{ steps.route.outputs.model_ref }}
         opencode-api-key: ${{ inputs.opencode-api-key }}
+        opencode-config: ${{ inputs.opencode-config }}
         timeout-minutes: ${{ inputs.timeout-minutes }}
         prompt-text: ${{ inputs.prompt-text }}

--- a/.github/actions/run-opencode-container/action.yml
+++ b/.github/actions/run-opencode-container/action.yml
@@ -322,7 +322,10 @@ runs:
           PROMPT_FILE="$staged_prompt"
           printf '%s' "$PROMPT_TEXT" > "$PROMPT_FILE"
         fi
-        if [ ! -f "$GITHUB_WORKSPACE/$OPENCODE_CONFIG_REL" ]; then
+        workspace_root_for_config=$(realpath -- "$GITHUB_WORKSPACE")
+        config_path="$workspace_root_for_config/$OPENCODE_CONFIG_REL"
+        if [ ! -f "$config_path" ] || [ -L "$config_path" ] \
+          || [ "$(realpath -- "$config_path")" != "$config_path" ]; then
           echo "::error::opencode config not found: $OPENCODE_CONFIG_REL"
           exit 1
         fi
@@ -542,6 +545,24 @@ runs:
         fi
         if [ -d "$GITHUB_WORKSPACE/.agent-input" ]; then
           cp -a "$GITHUB_WORKSPACE/.agent-input" "$isolated_workspace/.agent-input"
+        fi
+        # Return artifacts are untracked, so the no-checkout clone does not
+        # carry their parent. Establish the one trusted scratch root before
+        # the model runs; a translation policy can then deny bash entirely.
+        isolated_tmp="$isolated_workspace/.tmp"
+        if [ -e "$isolated_tmp" ] || [ -L "$isolated_tmp" ]; then
+          if [ ! -d "$isolated_tmp" ] || [ -L "$isolated_tmp" ]; then
+            echo "::error::Isolated opencode .tmp root is linked or malformed."
+            exit 1
+          fi
+        else
+          mkdir -- "$isolated_tmp"
+        fi
+        isolated_tmp_parent=$(realpath -- "$(dirname -- "$isolated_tmp")")
+        if [ "$(realpath -- "$isolated_tmp")" \
+          != "$isolated_tmp_parent/$(basename -- "$isolated_tmp")" ]; then
+          echo "::error::Isolated opencode .tmp root is noncanonical."
+          exit 1
         fi
         # TRUSTED_CLONE_SETUP_END
         # Everything the opencode lane families shell out to:

--- a/.github/opencode/translation.json
+++ b/.github/opencode/translation.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "formatter": false,
+  "lsp": false,
+  "permission": {
+    "*": "deny",
+    "edit": {
+      "*": "deny",
+      ".tmp/generative-translation.ko.ara.md": "allow"
+    },
+    "read": {
+      "*": "deny",
+      ".agent-input/source.ara.md": "allow",
+      ".agent-input/translation.json": "allow"
+    }
+  }
+}

--- a/.github/workflows/translate-generative-research.yml
+++ b/.github/workflows/translate-generative-research.yml
@@ -123,6 +123,10 @@ jobs:
           mode: editorial
           lane: generative-research-ko
           return-artifacts: ${{ steps.prepare.outputs.draft_path }}
+          # Translation needs two reads and one write. Explicit denies remain
+          # enforced under --auto, so prompt injection cannot gain shell,
+          # network, search, subagent, or broader repository access.
+          opencode-config: .github/opencode/translation.json
           timeout-minutes: '80'
           claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           fireworks-api-key: ${{ secrets.FIREWORKS_API_KEY }}
@@ -133,8 +137,11 @@ jobs:
             professional Korean. This is translation, not new research.
 
             Read `.agent-input/translation.json` first. It gives the exact
-            `source_path`, `source_type`, and `draft_path`. Read the declared
-            source in full, then write exactly one file at `draft_path`.
+            staged `source_path`, `source_type`, and `draft_path`. Read the
+            declared source in full, then write exactly one file at
+            `draft_path`. Tool permissions allow only those two reads and that
+            one write; shell, web, search, subagents, and all other tools are
+            intentionally unavailable.
 
             Preserve factual meaning and the complete artifact contract:
             - Keep YAML frontmatter keys, heading levels, ARA directive names,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,6 +234,15 @@ process still directly receives its billing key and, on research/Twitter lanes,
 the X cookies while retaining network access, so it is not a secret-exfiltration
 boundary for those credentials.
 
+The Korean backfill narrows that container again with
+`.github/opencode/translation.json`: model tools may read only the staged
+request and staged canonical ARA copy, and may write only the one named `.tmp`
+draft. The policy explicitly denies every other tool under `--auto` and
+disables LSP and formatters; trusted host validators, the canonical writer, and
+exact diff gates remain the only publication path. The OpenCode process still
+needs its own billing key to reach the provider, so this reduces prompt-level
+capabilities but does not make the provider process a secretless boundary.
+
 Until 2026-08-08 opencode had NEITHER: it ran bare on the host with
 `edit`/`bash`/`webfetch` all `allow` plus `--auto`, which auto-approves
 anything not explicitly denied. That mattered because `generative-research.yml`

--- a/scripts/prepare_generative_translation.py
+++ b/scripts/prepare_generative_translation.py
@@ -14,11 +14,15 @@ import hashlib
 import json
 import os
 import re
+import tempfile
 import uuid
 from pathlib import Path
 
 
 SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,119}$")
+AGENT_INPUT_DIR = Path(".agent-input")
+AGENT_SOURCE_PATH = AGENT_INPUT_DIR / "source.ara.md"
+REQUEST_PATH = AGENT_INPUT_DIR / "translation.json"
 
 
 def _regular_file(path: Path, root: Path) -> bool:
@@ -96,6 +100,49 @@ def prepare(repo: Path, slug: str, *, force: bool) -> dict[str, str]:
     }
 
 
+def _atomic_write(path: Path, payload: bytes) -> None:
+    if path.is_symlink() or (path.exists() and not path.is_file()):
+        raise ValueError(f"refusing unsafe staged input path: {path}")
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def stage_agent_request(
+    repo: Path, values: dict[str, str], request_file: str
+) -> dict[str, str]:
+    """Stage the minimum model-visible input under one canonical directory."""
+    if Path(request_file) != REQUEST_PATH:
+        raise ValueError(f"request file must be exactly {REQUEST_PATH.as_posix()!r}")
+    input_dir = repo / AGENT_INPUT_DIR
+    if input_dir.is_symlink() or (input_dir.exists() and not input_dir.is_dir()):
+        raise ValueError(f"refusing unsafe agent input directory: {input_dir}")
+    input_dir.mkdir(exist_ok=True)
+    if input_dir.resolve() != repo.resolve() / AGENT_INPUT_DIR:
+        raise ValueError(f"agent input directory is noncanonical: {input_dir}")
+
+    canonical_source = repo / values["source_path"]
+    source_payload = canonical_source.read_bytes()
+    if hashlib.sha256(source_payload).hexdigest() != values["source_sha256"]:
+        raise ValueError("canonical translation source changed during preflight")
+    _atomic_write(repo / AGENT_SOURCE_PATH, source_payload)
+
+    request_values = dict(values)
+    request_values["source_path"] = AGENT_SOURCE_PATH.as_posix()
+    request_payload = (
+        json.dumps(request_values, ensure_ascii=False, indent=2) + "\n"
+    ).encode("utf-8")
+    _atomic_write(repo / REQUEST_PATH, request_payload)
+    return request_values
+
+
 def _write_github_output(path: Path, values: dict[str, str]) -> None:
     with path.open("a", encoding="utf-8") as out:
         for key, value in values.items():
@@ -117,11 +164,7 @@ def main(argv: list[str] | None = None) -> int:
 
     repo = Path(args.repo_root).resolve()
     values = prepare(repo, args.slug, force=args.force == "true")
-    request_path = repo / args.request_file
-    request_path.parent.mkdir(parents=True, exist_ok=True)
-    if request_path.is_symlink():
-        raise SystemExit(f"refusing linked request path: {request_path}")
-    request_path.write_text(json.dumps(values, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    stage_agent_request(repo, values, args.request_file)
     (repo / ".tmp").mkdir(exist_ok=True)
     output_path = Path(args.github_output or os.environ.get("GITHUB_OUTPUT", ""))
     if str(output_path):

--- a/scripts/test_backend_matrix.py
+++ b/scripts/test_backend_matrix.py
@@ -157,6 +157,8 @@ class RoutingInvariants(unittest.TestCase):
         self.assertEqual("./.github/actions/run-opencode-container", child["uses"])
         self.assertEqual("${{ inputs.opencode-api-key }}",
                          child["with"]["opencode-api-key"])
+        self.assertEqual("${{ inputs.opencode-config }}",
+                         child["with"]["opencode-config"])
         rendered_child = json.dumps(child, sort_keys=True)
         for secret_input in ("claude-code-oauth-token", "fireworks-api-key",
                              "zai-api-key"):
@@ -168,6 +170,46 @@ class RoutingInvariants(unittest.TestCase):
         self.assertIs(adapter["editorial_contract"], True)
         self.assertEqual({"opencode-go": "opencode-api-key"},
                          adapter["provider_credentials"])
+
+    def test_korean_translation_dispatch_uses_capability_minimized_policy(self):
+        workflow = yaml.safe_load(
+            (REPO_ROOT / ".github/workflows/translate-generative-research.yml")
+            .read_text(encoding="utf-8")
+        )
+        dispatch = next(
+            step
+            for step in workflow["jobs"]["translate"]["steps"]
+            if step.get("uses") == "./.github/actions/agent-dispatch"
+        )
+        self.assertEqual(
+            ".github/opencode/translation.json",
+            dispatch["with"].get("opencode-config"),
+        )
+
+        policy = json.loads(
+            (REPO_ROOT / ".github/opencode/translation.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        self.assertIs(False, policy["formatter"])
+        self.assertIs(False, policy["lsp"])
+        policy = policy["permission"]
+        self.assertEqual("deny", policy["*"])
+        self.assertEqual(
+            {
+                "*": "deny",
+                ".agent-input/source.ara.md": "allow",
+                ".agent-input/translation.json": "allow",
+            },
+            policy["read"],
+        )
+        self.assertEqual(
+            {
+                "*": "deny",
+                ".tmp/generative-translation.ko.ara.md": "allow",
+            },
+            policy["edit"],
+        )
 
     def test_global_fallback_chain_shape(self):
         self.assertEqual(self.fallback["harness"], "agent-run")
@@ -643,14 +685,15 @@ class RoutingInvariants(unittest.TestCase):
                                 .read_text(encoding="utf-8"))
         self.assertNotIn("model", production)
         self.assertNotIn("provider", production)
-        for name in ("opencode.json", "opencode-canary.json"):
+        for name in ("opencode.json", "opencode-canary.json", "translation.json"):
             cfg = json.loads((REPO_ROOT / ".github" / "opencode" / name)
                              .read_text(encoding="utf-8"))
             # opencode REJECTS unknown top-level keys ("Unrecognized key:
             # $comment"), which breaks config injection for the whole lane.
             # Keep revert notes in the workflows and docs, never in here.
             self.assertLessEqual(set(cfg) - {"$schema", "model", "provider",
-                                             "permission", "agent", "mcp"}, set(),
+                                             "permission", "agent", "mcp",
+                                             "formatter", "lsp"}, set(),
                                  f"{name}: unknown top-level key rejected by opencode")
 
     def test_opencode_twitter_tier_labels_name_the_served_model(self):
@@ -754,6 +797,8 @@ class RoutingInvariants(unittest.TestCase):
         self.assertIn("scripts/build_opencode_config.py", action)
         self.assertIn('--volume "$generated_opencode_config:/tmp/opencode.generated.json:ro"', action)
         self.assertIn("--env OPENCODE_CONFIG=/tmp/opencode.generated.json", action)
+        self.assertIn('[ ! -f "$config_path" ] || [ -L "$config_path" ]', action)
+        self.assertIn('mkdir -- "$isolated_tmp"', action)
         self.assertIn('trap \'exit 143\' TERM', action)
         self.assertIn('trap \'exit 130\' INT', action)
         self.assertIn("trap '' TERM INT", action)

--- a/scripts/test_generative_translation.py
+++ b/scripts/test_generative_translation.py
@@ -115,6 +115,41 @@ class TranslationPreparationTest(unittest.TestCase):
                 with self.subTest(slug=slug), self.assertRaises(ValueError):
                     prepare.prepare(root, slug, force=False)
 
+    def test_stages_only_a_copy_and_model_visible_paths(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            gen, _ = seed_repo(root)
+            values = prepare.prepare(root, "alpha", force=False)
+            request = prepare.stage_agent_request(
+                root, values, ".agent-input/translation.json"
+            )
+
+            staged = root / request["source_path"]
+            canonical = gen / "2026-01-01T000000--alpha.ara.md"
+            self.assertEqual(".agent-input/source.ara.md", request["source_path"])
+            self.assertEqual(canonical.read_bytes(), staged.read_bytes())
+            self.assertEqual(
+                request,
+                json.loads((root / ".agent-input/translation.json").read_text()),
+            )
+            self.assertNotIn(values["source_path"], json.dumps(request))
+
+    def test_rejects_noncanonical_request_or_linked_input_directory(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            seed_repo(root)
+            values = prepare.prepare(root, "alpha", force=False)
+            with self.assertRaisesRegex(ValueError, "request file must be exactly"):
+                prepare.stage_agent_request(root, values, ".tmp/request.json")
+
+            outside = root / "outside"
+            outside.mkdir()
+            (root / ".agent-input").symlink_to(outside, target_is_directory=True)
+            with self.assertRaisesRegex(ValueError, "unsafe agent input directory"):
+                prepare.stage_agent_request(
+                    root, values, ".agent-input/translation.json"
+                )
+
 
 class TranslationParityTest(unittest.TestCase):
     def test_faithful_korean_translation_passes(self):


### PR DESCRIPTION
## Summary

- stage only a copy of the canonical source plus the translation request for the model
- apply a translation-specific OpenCode policy that allows exactly two reads and one draft write
- explicitly deny shell, web/search, subagents, broad repository reads, and other tools; disable LSP and formatters
- validate the selected policy and isolated scratch path in the trusted host harness

The trusted parity validator, canonical writer, exact three-path diff gates, and review-first publication path remain unchanged.

## Verification

- `uv run python scripts/test_generative_translation.py` (19 tests)
- `uv run python scripts/test_backend_matrix.py` (68 tests)
- `uv run python scripts/build_backend_matrix.py --check`
- `actionlint .github/workflows/translate-generative-research.yml`
- resolved the generated policy with `opencode --pure debug config`
- `git diff --check`

## Residual boundary

The OpenCode process still needs its own provider billing key and provider network access. This change minimizes model tool capabilities; it does not turn the provider process into a secretless network boundary.
