### PR TITLE
Add confined translation chunk writer

### DIFF
--- a/.github/opencode/translation.json
+++ b/.github/opencode/translation.json
@@ -4,14 +4,11 @@
   "lsp": false,
   "permission": {
     "*": "deny",
-    "edit": {
-      "*": "deny",
-      ".tmp/generative-translation.ko.ara.md": "allow"
-    },
     "read": {
       "*": "deny",
       ".agent-input/source.ara.md": "allow",
       ".agent-input/translation.json": "allow"
-    }
+    },
+    "translation_chunk": "allow"
   }
 }

--- a/.github/workflows/translate-generative-research.yml
+++ b/.github/workflows/translate-generative-research.yml
@@ -123,9 +123,10 @@ jobs:
           mode: editorial
           lane: generative-research-ko
           return-artifacts: ${{ steps.prepare.outputs.draft_path }}
-          # Translation needs two reads and one write. Explicit denies remain
-          # enforced under --auto, so prompt injection cannot gain shell,
-          # network, search, subagent, or broader repository access.
+          # Translation needs two reads and one fixed-destination chunk tool.
+          # Explicit denies remain enforced under --auto, so prompt injection
+          # cannot gain shell, network, search, subagent, edit/write, or
+          # broader repository access.
           opencode-config: .github/opencode/translation.json
           timeout-minutes: '80'
           claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -138,10 +139,14 @@ jobs:
 
             Read `.agent-input/translation.json` first. It gives the exact
             staged `source_path`, `source_type`, and `draft_path`. Read the
-            declared source in full, then write exactly one file at
-            `draft_path`. Tool permissions allow only those two reads and that
-            one write; shell, web, search, subagents, and all other tools are
-            intentionally unavailable.
+            declared source in full. Then call `translation_chunk` repeatedly
+            to build exactly one file at `draft_path`. The first call must use
+            `offset_bytes=0`; every later call must use the exact next offset
+            returned by the prior call. Keep each chunk below 16 KiB and split
+            between complete lines. Do not put the translation in your final
+            response. Tool permissions allow only those two reads and this
+            fixed-destination chunk tool; shell, web, search, subagents,
+            edit/write, and all other tools are intentionally unavailable.
 
             Preserve factual meaning and the complete artifact contract:
             - Keep YAML frontmatter keys, heading levels, ARA directive names,

--- a/.opencode/tools/translation_chunk.ts
+++ b/.opencode/tools/translation_chunk.ts
@@ -1,0 +1,70 @@
+import { constants } from "node:fs"
+import { open } from "node:fs/promises"
+import path from "node:path"
+
+import { tool } from "@opencode-ai/plugin"
+
+const DRAFT_RELATIVE_PATH = ".tmp/generative-translation.ko.ara.md"
+const MAX_CHUNK_BYTES = 16 * 1024
+const MAX_DRAFT_BYTES = 1024 * 1024
+let writeQueue = Promise.resolve()
+
+async function withExclusiveWrite<T>(operation: () => Promise<T>): Promise<T> {
+  let release!: () => void
+  const previous = writeQueue
+  writeQueue = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  await previous
+  try {
+    return await operation()
+  } finally {
+    release()
+  }
+}
+
+export default tool({
+  description:
+    "Append the next UTF-8 chunk of the Korean translation to the one fixed draft. " +
+    "Start with offset_bytes=0, then use the exact next offset returned by each call.",
+  args: {
+    offset_bytes: tool.schema.number().int().nonnegative(),
+    content: tool.schema.string().min(1),
+  },
+  async execute(args, context) {
+    return withExclusiveWrite(async () => {
+      const chunkBytes = Buffer.byteLength(args.content, "utf8")
+      if (chunkBytes > MAX_CHUNK_BYTES) {
+        throw new Error(`chunk exceeds ${MAX_CHUNK_BYTES} UTF-8 bytes`)
+      }
+
+      const draftPath = path.join(context.worktree, DRAFT_RELATIVE_PATH)
+      const flags =
+        args.offset_bytes === 0
+          ? constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW
+          : constants.O_WRONLY | constants.O_APPEND | constants.O_NOFOLLOW
+      const handle = await open(draftPath, flags, 0o600)
+      try {
+        const before = await handle.stat()
+        if (!before.isFile()) throw new Error("translation draft is not a regular file")
+        if (before.size !== args.offset_bytes) {
+          throw new Error(
+            `offset mismatch: draft is ${before.size} bytes, got ${args.offset_bytes}`,
+          )
+        }
+        if (before.size + chunkBytes > MAX_DRAFT_BYTES) {
+          throw new Error(`translation draft exceeds ${MAX_DRAFT_BYTES} bytes`)
+        }
+        await handle.writeFile(args.content, { encoding: "utf8" })
+        await handle.sync()
+        const after = await handle.stat()
+        if (after.size !== before.size + chunkBytes) {
+          throw new Error("translation chunk write was incomplete")
+        }
+        return `Chunk accepted. next offset_bytes=${after.size}`
+      } finally {
+        await handle.close()
+      }
+    })
+  },
+})

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,12 +236,15 @@ boundary for those credentials.
 
 The Korean backfill narrows that container again with
 `.github/opencode/translation.json`: model tools may read only the staged
-request and staged canonical ARA copy, and may write only the one named `.tmp`
-draft. The policy explicitly denies every other tool under `--auto` and
-disables LSP and formatters; trusted host validators, the canonical writer, and
-exact diff gates remain the only publication path. The OpenCode process still
-needs its own billing key to reach the provider, so this reduces prompt-level
-capabilities but does not make the provider process a secretless boundary.
+request and staged canonical ARA copy. Long translations cross the output-token
+limit through `.opencode/tools/translation_chunk.ts`, which accepts no path,
+writes only the one named `.tmp` draft, caps each chunk and the total file, and
+requires an exact monotonic byte offset. Built-in edit/write remain denied. The
+policy explicitly denies every other tool under `--auto` and disables LSP and
+formatters; trusted host validators, the canonical writer, and exact diff gates
+remain the only publication path. The OpenCode process still needs its own
+billing key to reach the provider, so this reduces prompt-level capabilities
+but does not make the provider process a secretless boundary.
 
 Until 2026-08-08 opencode had NEITHER: it ran bare on the host with
 `edit`/`bash`/`webfetch` all `allow` plus `--auto`, which auto-approves

--- a/scripts/test_backend_matrix.py
+++ b/scripts/test_backend_matrix.py
@@ -204,12 +204,25 @@ class RoutingInvariants(unittest.TestCase):
             policy["read"],
         )
         self.assertEqual(
-            {
-                "*": "deny",
-                ".tmp/generative-translation.ko.ara.md": "allow",
-            },
-            policy["edit"],
+            "allow",
+            policy["translation_chunk"],
         )
+        self.assertNotIn("edit", policy)
+
+        chunk_tool = (
+            REPO_ROOT / ".opencode/tools/translation_chunk.ts"
+        ).read_text(encoding="utf-8")
+        self.assertIn(
+            'const DRAFT_RELATIVE_PATH = ".tmp/generative-translation.ko.ara.md"',
+            chunk_tool,
+        )
+        self.assertIn("constants.O_NOFOLLOW", chunk_tool)
+        self.assertIn("withExclusiveWrite", chunk_tool)
+        self.assertIn("before.size !== args.offset_bytes", chunk_tool)
+        self.assertIn("MAX_CHUNK_BYTES = 16 * 1024", chunk_tool)
+        self.assertIn("MAX_DRAFT_BYTES = 1024 * 1024", chunk_tool)
+        self.assertNotIn("filePath:", chunk_tool)
+        self.assertNotIn("path:", chunk_tool)
 
     def test_global_fallback_chain_shape(self):
         self.assertEqual(self.fallback["harness"], "agent-run")


### PR DESCRIPTION
## Summary

- replace the built-in whole-file write with a translation-only chunk tool whose destination is hard-coded
- cap chunks at 16 KiB and the completed draft at 1 MiB
- require exact monotonic UTF-8 byte offsets and serialize concurrent calls
- use no-follow file descriptors and keep built-in edit/write, shell, network, search, and subagents denied

This addresses the hardened smoke-run failure: the 68 KB translation cannot fit safely in one model tool call, while restoring shell would unnecessarily widen the blast radius.

## Verification

- `uv run python scripts/test_generative_translation.py` (19 tests)
- `uv run python scripts/test_backend_matrix.py` (68 tests)
- `uv run python scripts/build_backend_matrix.py --check`
- `actionlint .github/workflows/translate-generative-research.yml`
- `bun build .opencode/tools/translation_chunk.ts --external @opencode-ai/plugin --target bun`
- executable writer checks: sequential UTF-8 offsets, concurrent same-offset rejection, symlink refusal, and oversized-chunk refusal
- `git diff --check`

## Review evidence

An independent Codex review found the original concurrent-call race; the writer now serializes calls so the stale second offset fails before it writes. Claude was not logged in and Agy could not start in its sandbox.
