### PR TITLE
Retry silent Korean translation attempts

### DIFF
--- a/.github/actions/run-opencode-container/action.yml
+++ b/.github/actions/run-opencode-container/action.yml
@@ -147,6 +147,7 @@ runs:
       shell: bash
       env:
         RUN_MODE: ${{ inputs.mode }}
+        AGENT_LANE: ${{ inputs.lane }}
         ALLOWED_PATHS: ${{ inputs.allowed-paths }}
         RETURN_ARTIFACTS: ${{ inputs.return-artifacts }}
         PROMPT_FILE: ${{ inputs.prompt-file }}
@@ -232,6 +233,12 @@ runs:
         esac
         if [[ ! "$OPENCODE_MODEL_REF" =~ ^[a-z0-9][a-z0-9-]*/[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
           echo "::error::model must be one canonical provider/model ref."
+          exit 1
+        fi
+        if [[ ! "$AGENT_TIMEOUT_MINUTES" =~ ^[0-9]+$ ]] \
+          || [ "$AGENT_TIMEOUT_MINUTES" -lt 1 ] \
+          || [ "$AGENT_TIMEOUT_MINUTES" -gt 240 ]; then
+          echo "::error::timeout-minutes must be an integer from 1 through 240."
           exit 1
         fi
         if [ "$RUN_MODE" = "twitter" ] && [ -z "$ALLOWED_PATHS" ]; then
@@ -672,8 +679,10 @@ runs:
           --env "GIT_COMMITTER_EMAIL=$GIT_USER_EMAIL" \
           --env OPENCODE_MODEL_REF \
           --env AGENT_TIMEOUT_MINUTES \
+          --env AGENT_LANE \
           --env RUN_MODE \
           --env ALLOWED_PATHS \
+          --env RETURN_ARTIFACTS \
           --env "PRE_SHA=$pre_sha" \
           ${extra_args[@]+"${extra_args[@]}"} \
           --volume "$isolated_workspace:/workspace" \
@@ -707,13 +716,78 @@ runs:
               trusted_packed=$(base64 -w0 .git/packed-refs)
             fi
 
-            set +e
-            timeout "${AGENT_TIMEOUT_MINUTES}m" opencode run \
-              -m "$OPENCODE_MODEL_REF" \
-              --auto \
-              "$(cat /tmp/opencode-prompt.md)"
-            agent_status=$?
-            set -e
+            # The Korean translation lane has shown one specific provider
+            # failure mode: opencode exits zero without calling its only
+            # writer tool or creating the required draft. Retry that silent
+            # no-op once, and only that no-op. Both attempts share the original
+            # timeout budget; partial output, nonzero exits, and every other
+            # lane remain single-attempt and fail closed.
+            # OPENCODE_ATTEMPT_LOOP_BEGIN
+            model_budget_seconds=$((AGENT_TIMEOUT_MINUTES * 60))
+            model_started_seconds=$SECONDS
+            attempt_count=0
+            total_chunk_calls=0
+            retry_reason=none
+            artifact_count=0
+            while :; do
+              attempt_count=$((attempt_count + 1))
+              remaining_seconds=$((model_budget_seconds \
+                - (SECONDS - model_started_seconds)))
+              if [ "$remaining_seconds" -le 0 ]; then
+                agent_status=124
+                break
+              fi
+
+              attempt_log="/tmp/opencode-attempt-${attempt_count}.log"
+              rm -f -- "$attempt_log"
+              set +e
+              timeout "${remaining_seconds}s" opencode run \
+                -m "$OPENCODE_MODEL_REF" \
+                --auto \
+                "$(cat /tmp/opencode-prompt.md)" 2>&1 | tee "$attempt_log"
+              agent_status=${PIPESTATUS[0]}
+              set -e
+
+              chunk_calls=$(grep -cF "translation_chunk {" "$attempt_log" || true)
+              if [[ ! "$chunk_calls" =~ ^[0-9]+$ ]]; then
+                echo "could not derive translation_chunk call telemetry" >&2
+                exit 1
+              fi
+              total_chunk_calls=$((total_chunk_calls + chunk_calls))
+              artifact_count=0
+              while IFS= read -r artifact; do
+                [ -z "$artifact" ] && continue
+                if [ -e "$artifact" ] || [ -L "$artifact" ]; then
+                  artifact_count=$((artifact_count + 1))
+                fi
+              done <<< "$RETURN_ARTIFACTS"
+              echo "OpenCode attempt ${attempt_count}: status=${agent_status} translation_chunk_calls=${chunk_calls} artifacts=${artifact_count} remaining_seconds=${remaining_seconds}"
+
+              if [ "$AGENT_LANE" = "generative-research-ko" ] \
+                && [ "$RETURN_ARTIFACTS" = ".tmp/generative-translation.ko.ara.md" ] \
+                && [ "$agent_status" -eq 0 ] \
+                && [ "$artifact_count" -eq 0 ] \
+                && [ "$chunk_calls" -eq 0 ] \
+                && [ "$attempt_count" -eq 1 ]; then
+                retry_reason=zero-artifact-zero-translation-chunk
+                echo "Retrying Korean translation once after a zero-output OpenCode attempt."
+                continue
+              fi
+              break
+            done
+
+            # The model child is gone before this fixed-format file is
+            # replaced. The host still validates every field before logging
+            # it; telemetry never authorizes artifact import or publication.
+            rm -f -- .opencode-attempt-telemetry
+            {
+              printf "attempt_count=%s\n" "$attempt_count"
+              printf "last_agent_status=%s\n" "$agent_status"
+              printf "translation_chunk_calls=%s\n" "$total_chunk_calls"
+              printf "artifact_count=%s\n" "$artifact_count"
+              printf "retry_reason=%s\n" "$retry_reason"
+            } > .opencode-attempt-telemetry
+            # OPENCODE_ATTEMPT_LOOP_END
 
             # This fixed container tail runs after the agent child exits. It
             # restores config/HEAD, removes hooks and object indirections, and
@@ -868,6 +942,42 @@ runs:
           agent_status=$?
         fi
         set -e
+
+        # TRUSTED_ATTEMPT_TELEMETRY_BEGIN
+        telemetry_file="$isolated_workspace/.opencode-attempt-telemetry"
+        if [ ! -f "$telemetry_file" ] || [ -L "$telemetry_file" ] \
+          || [ "$(realpath -- "$telemetry_file")" \
+            != "$(realpath -- "$isolated_workspace")/.opencode-attempt-telemetry" ] \
+          || [ "$(wc -c < "$telemetry_file")" -gt 256 ]; then
+          echo "::error::opencode attempt telemetry is missing, linked, noncanonical, or oversized."
+          exit 1
+        fi
+        telemetry_line_count=$(wc -l < "$telemetry_file")
+        attempt_line=$(sed -n "1p" "$telemetry_file")
+        status_line=$(sed -n "2p" "$telemetry_file")
+        chunk_line=$(sed -n "3p" "$telemetry_file")
+        artifact_line=$(sed -n "4p" "$telemetry_file")
+        reason_line=$(sed -n "5p" "$telemetry_file")
+        if [ "$telemetry_line_count" -ne 5 ] \
+          || [[ ! "$attempt_line" =~ ^attempt_count=([12])$ ]] \
+          || [[ ! "$status_line" =~ ^last_agent_status=([0-9]{1,3})$ ]] \
+          || [[ ! "$chunk_line" =~ ^translation_chunk_calls=([0-9]{1,5})$ ]] \
+          || [[ ! "$artifact_line" =~ ^artifact_count=([0-8])$ ]] \
+          || [[ ! "$reason_line" =~ ^retry_reason=(none|zero-artifact-zero-translation-chunk)$ ]]; then
+          echo "::error::opencode attempt telemetry is malformed."
+          exit 1
+        fi
+        attempt_count=${attempt_line#attempt_count=}
+        last_agent_status=${status_line#last_agent_status=}
+        translation_chunk_calls=${chunk_line#translation_chunk_calls=}
+        artifact_count=${artifact_line#artifact_count=}
+        retry_reason=${reason_line#retry_reason=}
+        if [ "$last_agent_status" -ne "$agent_status" ]; then
+          echo "::error::opencode model status does not match the container exit status."
+          exit 1
+        fi
+        echo "::notice title=OpenCode attempt telemetry::attempts=${attempt_count} last_status=${last_agent_status} translation_chunk_calls=${translation_chunk_calls} artifacts=${artifact_count} retry_reason=${retry_reason}"
+        # TRUSTED_ATTEMPT_TELEMETRY_END
 
         # TRUSTED_IMPORT_GUARD_BEGIN
         RETURN_ARTIFACTS="${RETURN_ARTIFACTS:-}"

--- a/scripts/test_backend_matrix.py
+++ b/scripts/test_backend_matrix.py
@@ -844,6 +844,26 @@ class RoutingInvariants(unittest.TestCase):
         self.assertNotIn('"${trusted_git[@]}" reset --hard', action)
         self.assertIn('tree_mode" != "100644', action)
         self.assertIn("tree_type\" != \"blob", action)
+        # A provider-success/no-output retry is deliberately narrower than
+        # editorial mode: one exact KO lane, one exact draft, one shared
+        # deadline, and no retry after a tool call, artifact, or nonzero exit.
+        self.assertIn('--env AGENT_LANE', action)
+        self.assertIn('--env RETURN_ARTIFACTS', action)
+        self.assertIn(
+            'model_budget_seconds=$((AGENT_TIMEOUT_MINUTES * 60))',
+            action)
+        self.assertIn('model_started_seconds=$SECONDS', action)
+        self.assertIn('(SECONDS - model_started_seconds)', action)
+        self.assertIn('timeout "${remaining_seconds}s" opencode run', action)
+        self.assertIn('[ "$AGENT_LANE" = "generative-research-ko" ]', action)
+        self.assertIn(
+            '[ "$RETURN_ARTIFACTS" = ".tmp/generative-translation.ko.ara.md" ]',
+            action)
+        self.assertIn('[ "$agent_status" -eq 0 ]', action)
+        self.assertIn('[ "$artifact_count" -eq 0 ]', action)
+        self.assertIn('[ "$chunk_calls" -eq 0 ]', action)
+        self.assertIn('[ "$attempt_count" -eq 1 ]', action)
+        self.assertIn("opencode attempt telemetry is malformed", action)
         for name, expected_mode in {
                 "generative-research.yml": "generative",
                 "hourly-twitter.yml": "twitter",
@@ -925,6 +945,155 @@ class RoutingInvariants(unittest.TestCase):
             self.assertEqual(143, proc.wait(timeout=5))
             self.assertIn("rm-end", log.read_text(encoding="utf-8"))
 
+    def test_korean_zero_output_retry_is_bounded_and_fail_closed(self):
+        """Only the exact KO zero-output state gets one shared-budget retry."""
+        action_doc = yaml.safe_load(
+            (REPO_ROOT / ".github/actions/run-opencode-container/action.yml")
+            .read_text(encoding="utf-8")
+        )
+        run = action_doc["runs"]["steps"][0]["run"]
+        loop = run.split("# OPENCODE_ATTEMPT_LOOP_BEGIN", 1)[1].split(
+            "# OPENCODE_ATTEMPT_LOOP_END", 1)[0]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            bin_dir = root / "bin"
+            bin_dir.mkdir()
+            prompt = root / "prompt.md"
+            prompt.write_text("translate\n", encoding="utf-8")
+            loop = loop.replace("/tmp/opencode-prompt.md", str(prompt))
+            loop = loop.replace(
+                'attempt_log="/tmp/opencode-attempt-${attempt_count}.log"',
+                'attempt_log="$PWD/opencode-attempt-${attempt_count}.log"')
+
+            timeout = bin_dir / "timeout"
+            timeout.write_text(
+                "#!/bin/bash\nset -eu\nshift\nexec \"$@\"\n",
+                encoding="utf-8")
+            timeout.chmod(0o755)
+            opencode = bin_dir / "opencode"
+            opencode.write_text(
+                "#!/bin/bash\n"
+                "set -eu\n"
+                "attempt=0\n"
+                "if [ -f \"$OPENCODE_ATTEMPT_FILE\" ]; then "
+                "attempt=$(tr -d '\\r\\n' < \"$OPENCODE_ATTEMPT_FILE\"); fi\n"
+                "attempt=$((attempt + 1))\n"
+                "printf '%s\\n' \"$attempt\" > \"$OPENCODE_ATTEMPT_FILE\"\n"
+                "case \"$OPENCODE_FAKE_BEHAVIOR\" in\n"
+                "  retry-success)\n"
+                "    if [ \"$attempt\" -eq 2 ]; then\n"
+                "      mkdir -p .tmp\n"
+                "      printf 'translated\\n' > .tmp/generative-translation.ko.ara.md\n"
+                "      echo 'translation_chunk {'\n"
+                "    fi\n"
+                "    ;;\n"
+                "  nonzero) exit 9 ;;\n"
+                "  partial)\n"
+                "    mkdir -p .tmp\n"
+                "    printf 'partial\\n' > .tmp/generative-translation.ko.ara.md\n"
+                "    ;;\n"
+                "  no-output) ;;\n"
+                "  *) exit 98 ;;\n"
+                "esac\n",
+                encoding="utf-8")
+            opencode.chmod(0o755)
+
+            def run_case(name: str, lane: str, behavior: str):
+                case_dir = root / name
+                case_dir.mkdir()
+                attempts = case_dir / "attempts"
+                env = {
+                    **os.environ,
+                    "PATH": f"{bin_dir}:/usr/bin:/bin",
+                    "AGENT_TIMEOUT_MINUTES": "1",
+                    "AGENT_LANE": lane,
+                    "RETURN_ARTIFACTS": ".tmp/generative-translation.ko.ara.md",
+                    "OPENCODE_MODEL_REF": "opencode-go/deepseek-v4-flash",
+                    "OPENCODE_ATTEMPT_FILE": str(attempts),
+                    "OPENCODE_FAKE_BEHAVIOR": behavior,
+                }
+                result = subprocess.run(
+                    ["bash", "-c", "set -euo pipefail\n" + loop],
+                    cwd=case_dir, env=env, text=True, capture_output=True,
+                    check=False)
+                return result, attempts.read_text(encoding="utf-8").strip(), (
+                    case_dir / ".opencode-attempt-telemetry").read_text(
+                        encoding="utf-8")
+
+            retry, attempts, telemetry = run_case(
+                "retry", "generative-research-ko", "retry-success")
+            self.assertEqual(0, retry.returncode, retry.stdout + retry.stderr)
+            self.assertEqual("2", attempts)
+            self.assertIn("attempt_count=2", telemetry)
+            self.assertIn("translation_chunk_calls=1", telemetry)
+            self.assertIn("artifact_count=1", telemetry)
+            self.assertIn(
+                "retry_reason=zero-artifact-zero-translation-chunk", telemetry)
+
+            other, attempts, telemetry = run_case(
+                "other-lane", "bluesky-watch", "no-output")
+            self.assertEqual(0, other.returncode, other.stdout + other.stderr)
+            self.assertEqual("1", attempts)
+            self.assertIn("attempt_count=1", telemetry)
+            self.assertIn("retry_reason=none", telemetry)
+
+            failed, attempts, telemetry = run_case(
+                "nonzero", "generative-research-ko", "nonzero")
+            self.assertEqual(0, failed.returncode, failed.stdout + failed.stderr)
+            self.assertEqual("1", attempts)
+            self.assertIn("last_agent_status=9", telemetry)
+            self.assertIn("retry_reason=none", telemetry)
+
+            partial, attempts, telemetry = run_case(
+                "partial", "generative-research-ko", "partial")
+            self.assertEqual(0, partial.returncode, partial.stdout + partial.stderr)
+            self.assertEqual("1", attempts)
+            self.assertIn("artifact_count=1", telemetry)
+            self.assertIn("retry_reason=none", telemetry)
+
+    def test_opencode_attempt_telemetry_is_strictly_validated(self):
+        """Only the fixed five-line numeric/enumerated record is logged."""
+        action_doc = yaml.safe_load(
+            (REPO_ROOT / ".github/actions/run-opencode-container/action.yml")
+            .read_text(encoding="utf-8")
+        )
+        run = action_doc["runs"]["steps"][0]["run"]
+        guard = run.split("# TRUSTED_ATTEMPT_TELEMETRY_BEGIN", 1)[1].split(
+            "# TRUSTED_ATTEMPT_TELEMETRY_END", 1)[0]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            isolated = Path(tmp) / "isolated"
+            isolated.mkdir()
+            telemetry = isolated / ".opencode-attempt-telemetry"
+            telemetry.write_text(
+                "attempt_count=2\n"
+                "last_agent_status=0\n"
+                "translation_chunk_calls=15\n"
+                "artifact_count=1\n"
+                "retry_reason=zero-artifact-zero-translation-chunk\n",
+                encoding="utf-8")
+            valid = subprocess.run(
+                ["bash", "-c", "set -euo pipefail\n" + guard],
+                env={**os.environ, "isolated_workspace": str(isolated),
+                     "agent_status": "0"},
+                text=True, capture_output=True, check=False)
+            self.assertEqual(0, valid.returncode, valid.stdout + valid.stderr)
+            self.assertIn("attempts=2 last_status=0 translation_chunk_calls=15",
+                          valid.stdout)
+
+            telemetry.write_text(
+                telemetry.read_text(encoding="utf-8") + "untrusted=field\n",
+                encoding="utf-8")
+            malformed = subprocess.run(
+                ["bash", "-c", "set -euo pipefail\n" + guard],
+                env={**os.environ, "isolated_workspace": str(isolated),
+                     "agent_status": "0"},
+                text=True, capture_output=True, check=False)
+            self.assertNotEqual(0, malformed.returncode)
+            self.assertIn("attempt telemetry is malformed",
+                          malformed.stdout + malformed.stderr)
+
     def test_editorial_mode_accepts_artifact_only_but_twitter_does_not(self):
         """Bluesky returns a temp section; Twitter still requires commit paths."""
         action_path = (REPO_ROOT / ".github" / "actions" /
@@ -940,6 +1109,7 @@ class RoutingInvariants(unittest.TestCase):
             "RETURN_ARTIFACTS": ".tmp/bluesky-section.md",
             "OPENCODE_CONFIG_REL": ".github/opencode/opencode.json",
             "OPENCODE_MODEL_REF": "opencode-go/deepseek-v4-flash",
+            "AGENT_TIMEOUT_MINUTES": "45",
             "BIRDY_TOOL_LOG_REL": "",
         }
         editorial = subprocess.run(


### PR DESCRIPTION
## Outcome
- retry the Korean translation adapter once only when OpenCode exits 0 with no exact draft and no observed translation_chunk call
- keep both attempts inside the existing 80-minute model budget
- leave all other lanes, nonzero exits, partial drafts, and parity failures single-attempt
- validate fixed-format attempt/status/tool/artifact telemetry on the trusted host before import

## Blast radius
- gated on lane generative-research-ko
- gated on exact artifact .tmp/generative-translation.ko.ara.md
- maximum two attempts
- telemetry never authorizes import or publication

## Evidence
- 70 backend/routing/action tests pass
- backend SSOT/docs check passes
- translate workflow passes actionlint
- extracted composite shell passes bash -n
- git diff --check passes

This targets the silent no-output state observed in Actions run 31494862322.