### PR TITLE
Compact Korean translation segment input

### DIFF
--- a/.github/opencode/translation.json
+++ b/.github/opencode/translation.json
@@ -6,7 +6,6 @@
     "*": "deny",
     "read": {
       "*": "deny",
-      ".agent-input/translation.json": "allow",
       ".agent-input/translation-segments.json": "allow"
     },
     "translation_segment": "allow"

--- a/.github/workflows/translate-generative-research.yml
+++ b/.github/workflows/translate-generative-research.yml
@@ -134,7 +134,7 @@ jobs:
           mode: editorial
           lane: generative-research-ko
           return-artifacts: ${{ steps.prepare.outputs.result_path }}
-          # Translation needs two reads and one fixed-destination segment tool.
+          # Translation needs one compact read and one fixed-destination segment tool.
           # Explicit denies remain enforced under --auto, so prompt injection
           # cannot gain shell, network, search, subagent, edit/write, or
           # broader repository access.
@@ -148,13 +148,17 @@ jobs:
             Translate one existing ARA generative-research article into natural,
             professional Korean. This is translation, not new research.
 
-            Read `.agent-input/translation.json`, then read
-            `.agent-input/translation-segments.json` in full. Translate every
-            segment's `text` into Korean and submit batches with
-            `translation_segment`. Preserve every opaque token such as
+            Read `.agent-input/translation-segments.json`. It is compact JSON
+            Lines: the first line is a header; every later line is
+            `[segment_id, source_text, internal_flag]`. Translate each
+            `source_text` into Korean and submit `{id, text}` batches with
+            `translation_segment` immediately after reading the rows. Do not
+            draft a full document or final-answer translation. If the read is
+            paginated, submit the current page before reading the next page.
+            Preserve every opaque token such as
             `⟦ARA0000⟧` exactly once and in its original order. Submit each
             segment id exactly once. Do not put translations in your final
-            response. Tool permissions allow only those two reads and this
+            response. Tool permissions allow only this read and the
             fixed-destination segment tool; shell, web, search, subagents,
             edit/write, and all other tools are intentionally unavailable.
 

--- a/.opencode/tools/translation_segment.ts
+++ b/.opencode/tools/translation_segment.ts
@@ -32,7 +32,38 @@ type Manifest = { version: number; segment_count: number; segments: ManifestSegm
 
 async function loadManifest(worktree: string): Promise<Manifest> {
   const raw = await readFile(path.join(worktree, MANIFEST_RELATIVE_PATH), "utf8")
-  const manifest = JSON.parse(raw) as Manifest
+  const lines = raw.trimEnd().split("\n")
+  const header = JSON.parse(lines.shift() ?? "null") as {
+    version?: unknown
+    segment_count?: unknown
+  } | null
+  const segments: ManifestSegment[] = []
+  const ids = new Set<string>()
+  for (const line of lines) {
+    const row = JSON.parse(line) as unknown
+    if (
+      !Array.isArray(row) ||
+      row.length !== 3 ||
+      typeof row[0] !== "string" ||
+      !/^s\d{5}$/.test(row[0]) ||
+      typeof row[1] !== "string" ||
+      (row[2] !== 0 && row[2] !== 1) ||
+      ids.has(row[0])
+    ) {
+      throw new Error("translation segment manifest row is malformed")
+    }
+    ids.add(row[0])
+    segments.push({
+      id: row[0],
+      tokens: row[1].match(TOKEN_RE) ?? [],
+      forbid_commas: row[2] === 1,
+    })
+  }
+  const manifest: Manifest = {
+    version: Number(header?.version),
+    segment_count: Number(header?.segment_count),
+    segments,
+  }
   if (
     manifest.version !== 1 ||
     !Number.isInteger(manifest.segment_count) ||

--- a/scripts/generative_translation_segments.py
+++ b/scripts/generative_translation_segments.py
@@ -263,10 +263,28 @@ def write_manifest(source_path: Path, source_sha256: str, manifest_path: Path) -
     if manifest_path != MANIFEST_PATH:
         raise ValueError(f"manifest path must be exactly {MANIFEST_PATH}")
     _, manifest = build_manifest(source_path, source_sha256)
-    _atomic_write(
-        manifest_path,
-        json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+    lines = [
+        json.dumps(
+            {
+                "version": manifest["version"],
+                "segment_count": manifest["segment_count"],
+            },
+            separators=(",", ":"),
+        )
+    ]
+    lines.extend(
+        json.dumps(
+            [
+                segment["id"],
+                segment["text"],
+                1 if segment["forbid_commas"] else 0,
+            ],
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+        for segment in manifest["segments"]
     )
+    _atomic_write(manifest_path, "\n".join(lines) + "\n")
     return manifest
 
 

--- a/scripts/test_backend_matrix.py
+++ b/scripts/test_backend_matrix.py
@@ -198,7 +198,6 @@ class RoutingInvariants(unittest.TestCase):
         self.assertEqual(
             {
                 "*": "deny",
-                ".agent-input/translation.json": "allow",
                 ".agent-input/translation-segments.json": "allow",
             },
             policy["read"],

--- a/scripts/test_generative_translation.py
+++ b/scripts/test_generative_translation.py
@@ -181,6 +181,31 @@ class TranslationSegmentsTest(unittest.TestCase):
             self.assertEqual(manifest["segment_count"], len(extracted))
             self.assertEqual(parity.check_pair(source, draft), [])
 
+    def test_model_manifest_is_compact_json_lines(self):
+        repo = Path(__file__).resolve().parent.parent
+        source = repo / (
+            "research/generative/2026-08-11T084945--"
+            "eu-ai-act-article-50-2-claude-s-text-watermark-the-six-signa.ara.md"
+        )
+        source_sha = hashlib.sha256(source.read_bytes()).hexdigest()
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / ".agent-input").mkdir()
+            old_cwd = Path.cwd()
+            try:
+                os.chdir(root)
+                manifest = segments.write_manifest(
+                    source, source_sha, segments.MANIFEST_PATH
+                )
+            finally:
+                os.chdir(old_cwd)
+            payload = (root / segments.MANIFEST_PATH).read_text(encoding="utf-8")
+            lines = payload.splitlines()
+            self.assertEqual(len(lines), manifest["segment_count"] + 1)
+            self.assertEqual(json.loads(lines[0])["segment_count"], 438)
+            self.assertEqual(len(json.loads(lines[1])), 3)
+            self.assertLess(len(payload.encode("utf-8")), 65_000)
+
     def test_renderer_rejects_missing_or_changed_tokens(self):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)


### PR DESCRIPTION
## Outcome

Fixes the Korean backfill workflow's zero-artifact failure by replacing the 106 KB duplicated model manifest with compact JSONL and instructing the model to submit translated segments page-by-page.

## Blast radius

The model can read only the compact segment manifest and can write only through the fixed-destination translation tool. It cannot read source metadata, use shell/network/search/subagents, edit arbitrary files, or publish. The trusted host still reconstructs and validates the article before publication.

## Evidence

- Actual OpenCode Go / DeepSeek V4 Flash canary read the compact manifest, invoked the custom tool, recovered from a rejected token reordering, and submitted all expected segments.
- Exact previously failing article fixture: 438 segments, manifest below 65 KB.
- 25 focused translation tests passed.
- 70 backend/routing security tests passed.
- Full 893-test suite passed (6 skipped).
- actionlint and git diff checks passed.

Independent CLI review was attempted earlier: Claude lacked login, Agy could not read in headless mode, and OpenCode timed out without a verdict; the live provider canary and repository tests supplied direct evidence instead.