### PR TITLE
Reject new digits in Korean translations

### DIFF
--- a/.github/workflows/translate-generative-research.yml
+++ b/.github/workflows/translate-generative-research.yml
@@ -157,7 +157,9 @@ jobs:
             paginated, submit the current page before reading the next page.
             Preserve every opaque token such as
             `⟦ARA0000⟧` exactly once and in its original order. Submit each
-            segment id exactly once. Do not put translations in your final
+            segment id exactly once. Do not introduce Arabic digits outside
+            opaque tokens; spell source quantities such as "nine" in Korean.
+            Do not put translations in your final
             response. Tool permissions allow only this read and the
             fixed-destination segment tool; shell, web, search, subagents,
             edit/write, and all other tools are intentionally unavailable.

--- a/.opencode/tools/translation_segment.ts
+++ b/.opencode/tools/translation_segment.ts
@@ -77,7 +77,7 @@ async function loadManifest(worktree: string): Promise<Manifest> {
 
 export default tool({
   description:
-    "Submit Korean translations for fixed text segment ids. Opaque ARA tokens must remain exact and ordered.",
+    "Submit Korean translations for fixed text segment ids. Opaque ARA tokens must remain exact and ordered; do not add digits outside them.",
   args: {
     segments: tool.schema
       .array(
@@ -109,6 +109,12 @@ export default tool({
         const actualTokens = segment.text.match(TOKEN_RE) ?? []
         if (JSON.stringify(actualTokens) !== JSON.stringify(expected.tokens)) {
           throw new Error(`immutable token mismatch for ${segment.id}`)
+        }
+        const proseWithoutTokens = segment.text.replace(TOKEN_RE, "")
+        if (/[0-9]/.test(proseWithoutTokens)) {
+          throw new Error(
+            `unprotected numeric digit in ${segment.id}; spell the quantity in Korean`,
+          )
         }
         if (expected.forbid_commas && segment.text.includes(",")) {
           throw new Error(`unprotected list separator in ${segment.id}`)

--- a/scripts/generative_translation_segments.py
+++ b/scripts/generative_translation_segments.py
@@ -329,6 +329,11 @@ def render(source_path: Path, source_sha256: str, result_path: Path, draft_path:
                 f"translation segment {segment.id} changed immutable tokens; "
                 f"expected={segment.tokens}, got={found_tokens}"
             )
+        prose_without_tokens = TOKEN_RE.sub("", translated)
+        if re.search(r"[0-9]", prose_without_tokens):
+            raise ValueError(
+                f"translation segment {segment.id} added an unprotected numeric digit"
+            )
         if segment.forbid_commas and "," in translated:
             raise ValueError(
                 f"translation segment {segment.id} added an unprotected list separator"

--- a/scripts/test_backend_matrix.py
+++ b/scripts/test_backend_matrix.py
@@ -220,6 +220,7 @@ class RoutingInvariants(unittest.TestCase):
         self.assertIn("MAX_TEXT_BYTES = 16 * 1024", segment_tool)
         self.assertIn("MAX_RESULT_BYTES = 1024 * 1024", segment_tool)
         self.assertIn("immutable token mismatch", segment_tool)
+        self.assertIn("unprotected numeric digit", segment_tool)
         self.assertIn("duplicate translation segment", segment_tool)
         self.assertIn("unprotected list separator", segment_tool)
         self.assertNotIn("filePath:", segment_tool)

--- a/scripts/test_generative_translation.py
+++ b/scripts/test_generative_translation.py
@@ -266,6 +266,40 @@ class TranslationSegmentsTest(unittest.TestCase):
                 os.chdir(old_cwd)
             self.assertEqual(parity.check_pair(source, root / segments.DRAFT_PATH), [])
 
+    def test_renderer_rejects_new_digits_outside_source_tokens(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            source = root / "alpha.ara.md"
+            source.write_text(SOURCE, encoding="utf-8")
+            source_sha = hashlib.sha256(source.read_bytes()).hexdigest()
+            compiled, _ = segments.build_manifest(source, source_sha)
+            extracted = segments.extract_segments(compiled)
+            (root / ".tmp").mkdir()
+            (root / segments.RESULT_PATH).write_text(
+                "".join(
+                    json.dumps(
+                        {
+                            "id": segment.id,
+                            "text": self._korean_text(segment)
+                            + (" 9일" if segment.id == extracted[0].id else ""),
+                        },
+                        ensure_ascii=False,
+                    )
+                    + "\n"
+                    for segment in extracted
+                ),
+                encoding="utf-8",
+            )
+            old_cwd = Path.cwd()
+            try:
+                os.chdir(root)
+                with self.assertRaisesRegex(ValueError, "unprotected numeric digit"):
+                    segments.render(
+                        source, source_sha, segments.RESULT_PATH, segments.DRAFT_PATH
+                    )
+            finally:
+                os.chdir(old_cwd)
+
     def test_renderer_rejects_unprotected_list_separator(self):
         source_raw = """---
 title: Allocation mix


### PR DESCRIPTION
## Outcome

Makes the translation tool reject Arabic digits that were not present as protected source tokens. This directly fixes run 31595217209, where faithful numeric literals were preserved but spelled-out English quantities were rendered as new digits: nine days became 9일 and thirtyfold became 30배.

The model receives the rejection immediately and can retry with Korean words; trusted reconstruction enforces the same rule before parity validation.

## Evidence

- 26 translation tests passed, including the new host-side rejection fixture.
- 70 routing/security tests passed and assert the tool guard exists.
- Full 894-test suite passed (6 skipped).
- Workflow actionlint and diff checks passed.
- The preceding live run completed all 438 tool segments and reconstructed safely; it failed before commit/push only on this precise numeric invariant.