### PR TITLE
feat(dashboard): add research language menu

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -45,10 +45,38 @@
             <a class="brand-title" id="brandHome" href="/" title="Home">ai-research-arm</a>
           </div>
           <div class="header-actions">
-            <a class="header-link" href="https://github.com/guzus/ai-research-arm" target="_blank" rel="noopener">
+            <a class="header-link" href="https://github.com/guzus/ai-research-arm" target="_blank" rel="noopener" aria-label="View ai-research-arm on GitHub">
               <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
               <span class="header-link-label">guzus/ai-research-arm</span>
             </a>
+            <div class="language-switch" id="languageSwitch">
+              <button
+                class="language-toggle"
+                id="languageToggle"
+                type="button"
+                aria-label="Language: English"
+                aria-haspopup="menu"
+                aria-expanded="false"
+                aria-controls="languageMenu"
+                title="Language / 언어"
+              >
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                  <circle cx="12" cy="12" r="9"/>
+                  <path d="M3 12h18M12 3a14.6 14.6 0 010 18"/>
+                </svg>
+              </button>
+              <div class="language-menu" id="languageMenu" role="menu" aria-label="Research language" hidden>
+                <div class="language-menu-label">Research language</div>
+                <button class="language-option" type="button" role="menuitemradio" data-language="en" aria-checked="true">
+                  <span><strong>English</strong><small>Original</small></span>
+                  <svg class="language-check" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>
+                </button>
+                <button class="language-option" type="button" role="menuitemradio" data-language="ko" aria-checked="false">
+                  <span lang="ko"><strong>한국어</strong><small>번역본</small></span>
+                  <svg class="language-check" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>
+                </button>
+              </div>
+            </div>
           </div>
         </div>
       </header>

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -323,6 +323,8 @@ const calendarEl = document.getElementById('calendar')!;
 const searchInput = document.getElementById('searchInput') as HTMLInputElement;
 const searchCountEl = document.getElementById('searchCount')!;
 const languageSwitch = document.getElementById('languageSwitch');
+const languageToggle = document.getElementById('languageToggle') as HTMLButtonElement | null;
+const languageMenu = document.getElementById('languageMenu');
 
 // ── Path routing ─────────────────────────────────────
 // Format (history API, no hash):
@@ -796,18 +798,32 @@ function hasResearchLanguage(row: GenResearchRow | null, language: ResearchLangu
   return Boolean(row?.translations?.[language]?.file);
 }
 
-function syncLanguageUi(row: GenResearchRow | null = null): void {
-  if (!languageSwitch) return;  // language toggle removed (English-only for now)
+function syncLanguageUi(_row: GenResearchRow | null = null): void {
+  if (!languageSwitch) return;
+  document.documentElement.lang = activeLanguage;
   languageSwitch.querySelectorAll<HTMLButtonElement>('[data-language]').forEach((btn) => {
     const language = btn.dataset.language as ResearchLanguage;
-    const available = !row || hasResearchLanguage(row, language);
-    btn.classList.toggle('active', language === activeLanguage);
-    btn.classList.toggle('unavailable', !available);
-    btn.setAttribute('aria-pressed', String(language === activeLanguage));
-    btn.title = available
-      ? (language === 'ko' ? 'Show Korean' : 'Show English')
-      : 'Korean version has not been published for this article';
+    btn.setAttribute('aria-checked', String(language === activeLanguage));
   });
+  if (languageToggle) {
+    const label = activeLanguage === 'ko' ? '한국어' : 'English';
+    languageToggle.setAttribute('aria-label', `Language: ${label}`);
+  }
+}
+
+function setLanguageMenuOpen(open: boolean, focusSelected = false): void {
+  if (!languageMenu || !languageToggle) return;
+  languageMenu.hidden = !open;
+  languageToggle.setAttribute('aria-expanded', String(open));
+  if (open && focusSelected) {
+    languageMenu.querySelector<HTMLButtonElement>('[aria-checked="true"]')?.focus();
+  }
+}
+
+function languageMenuOptions(): HTMLButtonElement[] {
+  return languageMenu
+    ? Array.from(languageMenu.querySelectorAll<HTMLButtonElement>('[data-language]'))
+    : [];
 }
 
 function languageFallbackNote(row: GenResearchRow): string {
@@ -6490,16 +6506,51 @@ searchInput.addEventListener('input', () => {
   searchDebounceId = window.setTimeout(() => { void runGlobalSearch(searchInput.value); }, 120);
 });
 
-languageSwitch?.addEventListener('click', (e) => {
+languageToggle?.addEventListener('click', () => {
+  setLanguageMenuOpen(languageMenu?.hasAttribute('hidden') ?? true, true);
+});
+
+languageToggle?.addEventListener('keydown', (e) => {
+  if (e.key === 'ArrowDown') {
+    e.preventDefault();
+    setLanguageMenuOpen(true, true);
+  }
+});
+
+languageMenu?.addEventListener('click', (e) => {
   const btn = (e.target as HTMLElement).closest('[data-language]') as HTMLButtonElement | null;
   if (!btn) return;
   const language = btn.dataset.language === 'ko' ? 'ko' : 'en';
+  setLanguageMenuOpen(false);
+  languageToggle?.focus();
   if (language === activeLanguage) return;
   activeLanguage = language;
   storeLanguage(activeLanguage);
   researchDocCache = null;
   syncLanguageUi(selectedSlug ? findResearchRow(selectedSlug) : null);
-  load();
+  void load();
+});
+
+languageMenu?.addEventListener('keydown', (e) => {
+  const options = languageMenuOptions();
+  const current = options.indexOf(document.activeElement as HTMLButtonElement);
+  if (e.key === 'Escape') {
+    e.preventDefault();
+    setLanguageMenuOpen(false);
+    languageToggle?.focus();
+  } else if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+    e.preventDefault();
+    const direction = e.key === 'ArrowDown' ? 1 : -1;
+    options[(current + direction + options.length) % options.length]?.focus();
+  } else if (e.key === 'Home' || e.key === 'End') {
+    e.preventDefault();
+    options[e.key === 'Home' ? 0 : options.length - 1]?.focus();
+  }
+});
+
+document.addEventListener('click', (e) => {
+  if (languageMenu?.hidden || languageSwitch?.contains(e.target as Node)) return;
+  setLanguageMenuOpen(false);
 });
 
 // Retry button + research index navigation (event delegation on content)

--- a/dashboard/src/style.css
+++ b/dashboard/src/style.css
@@ -258,50 +258,110 @@ body.has-digest-player .app {
 }
 
 .language-switch {
-  display: inline-flex;
-  align-items: center;
-  gap: 2px;
-  padding: 2px;
-  background: var(--bg);
-  border: 1px solid var(--border);
-  border-radius: 9px;
-  box-shadow: var(--shadow-sm);
+  position: relative;
   flex-shrink: 0;
 }
 
-.language-btn {
-  min-width: 34px;
-  height: 26px;
-  padding: 0 8px;
-  border: 0;
-  border-radius: 7px;
-  background: transparent;
+.language-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  background: var(--bg);
   color: var(--text-secondary);
-  font-family: var(--font);
-  font-size: 0.72rem;
-  font-weight: 650;
-  line-height: 1;
   cursor: pointer;
-  transition: background 0.12s, color 0.12s, opacity 0.12s;
+  box-shadow: var(--shadow-sm);
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
 }
 
-.language-btn:hover {
+.language-toggle:hover,
+.language-toggle[aria-expanded="true"] {
   color: var(--text);
+  background: var(--bg-hover);
+  border-color: var(--text-tertiary);
+}
+
+.language-toggle:focus-visible,
+.language-option:focus-visible {
+  outline: 2px solid var(--accent-warm);
+  outline-offset: 2px;
+}
+
+.language-menu {
+  position: absolute;
+  z-index: 1400;
+  top: calc(100% + 8px);
+  right: 0;
+  width: 206px;
+  padding: 6px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--bg);
+  box-shadow: var(--shadow-lg);
+}
+
+.language-menu[hidden] {
+  display: none;
+}
+
+.language-menu-label {
+  padding: 7px 10px 6px;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.language-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  min-height: 48px;
+  padding: 7px 10px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text);
+  font-family: var(--font);
+  text-align: left;
+  cursor: pointer;
+}
+
+.language-option:hover,
+.language-option:focus-visible {
   background: var(--bg-hover);
 }
 
-.language-btn.active {
-  background: var(--accent);
-  color: var(--on-accent);
+.language-option > span {
+  display: grid;
+  gap: 2px;
 }
 
-.language-btn.unavailable:not(.active) {
-  opacity: 0.42;
+.language-option strong {
+  font-size: 0.84rem;
+  font-weight: 650;
 }
 
-.language-btn:focus-visible {
-  outline: 2px solid var(--accent-warm);
-  outline-offset: 2px;
+.language-option small {
+  color: var(--text);
+  font-size: 0.72rem;
+  font-weight: 500;
+}
+
+.language-check {
+  color: var(--accent);
+  opacity: 0;
+}
+
+.language-option[aria-checked="true"] .language-check {
+  opacity: 1;
 }
 
 .header-link {
@@ -386,6 +446,11 @@ body.has-digest-player .app {
 
   .header-link-label {
     display: none;
+  }
+
+  .language-toggle {
+    width: 40px;
+    height: 40px;
   }
 
 }


### PR DESCRIPTION
## Summary
- add a globe language control to the top-right header
- let readers select English or 한국어 and persist the preference
- load Korean research variants where available and retain the existing fallback notice elsewhere
- support keyboard navigation, Escape dismissal, outside-click dismissal, and mobile layout

## Verification
- `bun run typecheck`
- `bun run test` (13 passed)
- `bun run build`
- browser-tested translated article switching and reload persistence
- browser-tested untranslated article fallback
- browser-tested 1440×900 and 390×844; no horizontal overflow
- axe audit of the new control: 0 violations