### PR TITLE
Default Korean browsers to Korean

### DIFF
--- a/dashboard/scripts/language-default.test.mjs
+++ b/dashboard/scripts/language-default.test.mjs
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { resolveUiLanguage } from '../src/i18n.ts';
+
+test('an explicit saved language overrides browser preferences', () => {
+  assert.equal(resolveUiLanguage('en', ['ko-KR']), 'en');
+  assert.equal(resolveUiLanguage('ko', ['en-US']), 'ko');
+});
+
+test('a first-time Korean browser defaults to Korean', () => {
+  assert.equal(resolveUiLanguage(null, ['ko-KR', 'en-US']), 'ko');
+  assert.equal(resolveUiLanguage(null, ['ko_KR']), 'ko');
+});
+
+test('browser negotiation uses the first supported language', () => {
+  assert.equal(resolveUiLanguage(null, ['ja-JP', 'ko-KR', 'en-US']), 'ko');
+  assert.equal(resolveUiLanguage(null, ['en-US', 'ko-KR']), 'en');
+  assert.equal(resolveUiLanguage(null, ['ja-JP']), 'en');
+});

--- a/dashboard/src/i18n.ts
+++ b/dashboard/src/i18n.ts
@@ -214,6 +214,21 @@ const COPY = {
 export type UiCopyKey = keyof typeof COPY.en;
 type CopyParams = Record<string, string | number>;
 
+/** Resolve the initial UI language without overriding an explicit user choice.
+ * Browser languages are ordered by preference; unsupported locales are skipped
+ * until the first supported base language is found. */
+export function resolveUiLanguage(
+  storedLanguage: string | null,
+  browserLanguages: readonly string[],
+): UiLanguage {
+  if (storedLanguage === 'en' || storedLanguage === 'ko') return storedLanguage;
+  for (const locale of browserLanguages) {
+    const baseLanguage = locale.trim().toLowerCase().split(/[-_]/, 1)[0];
+    if (baseLanguage === 'en' || baseLanguage === 'ko') return baseLanguage;
+  }
+  return 'en';
+}
+
 export function uiText(language: UiLanguage, key: UiCopyKey, params: CopyParams = {}): string {
   const template: string = COPY[language][key];
   return template.replace(/\{(\w+)\}/g, (_, name: string) => String(params[name] ?? `{${name}}`));

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -16,7 +16,7 @@ import { hydrateAgentsTimeline, renderAgentsStudioHtml } from './render/agents';
 import type { ArmTimeline } from './render/agents';
 import { hydratePricing, renderPricing } from './render/pricing';
 import type { ModelPricing } from './render/pricing';
-import { localizeStaticUi, uiText } from './i18n';
+import { localizeStaticUi, resolveUiLanguage, uiText } from './i18n';
 import type { UiCopyKey } from './i18n';
 import { renderTodayHtml } from './render/today';
 import {
@@ -759,11 +759,18 @@ function syncTabUi(): void {
 
 // ── Helpers ───────────────────────────────────────────
 function loadStoredLanguage(): ResearchLanguage {
+  let storedLanguage: string | null = null;
   try {
-    return localStorage.getItem('ara-language') === 'ko' ? 'ko' : 'en';
+    storedLanguage = localStorage.getItem('ara-language');
   } catch {
-    return 'en';
+    // Browser preference still works when storage is unavailable.
   }
+  const browserLanguages = navigator.languages.length
+    ? navigator.languages
+    : navigator.language
+      ? [navigator.language]
+      : [];
+  return resolveUiLanguage(storedLanguage, browserLanguages);
 }
 
 function storeLanguage(language: ResearchLanguage): void {


### PR DESCRIPTION
## Summary
- negotiate the first supported locale from `navigator.languages` on first visit
- default `ko` and `ko-KR` browsers to the Korean UI
- keep a saved English or Korean user choice authoritative
- fall back to English when neither supported locale is present
- add unit coverage for preference ordering and saved-choice precedence

## Verification
- `bun run test` — 17 passed
- `bun run build`
- Korean-browser first visit: no stored value, `lang=ko`, Korean controls, Pretendard loaded
- saved English override persisted across reload despite `navigator.languages = [ko-KR, en-US]`
- desktop and 390x844 mobile: no horizontal overflow

## Review note
External cross-CLI review was unavailable because the only independent local reviewer would transmit the private diff without explicit authorization. The behavior was verified with unit contracts, production build, and browser locale emulation.