### PR TITLE
Bound the OpenCode preflight step with timeout-minutes

### DIFF
--- a/.github/workflows/generative-research.yml
+++ b/.github/workflows/generative-research.yml
@@ -1989,6 +1989,13 @@ jobs:
       - name: Resolve and preflight OpenCode route
         if: steps.effective.outputs.backend == 'opencode-deepseek-v4-flash'
         id: opencode-route
+        # The curl below is bounded (--max-time 60 --retry 2 --retry-delay 5,
+        # so ~190s worst case), but a bounded curl is not a bounded STEP: on
+        # 2026-08-16 this step wedged for 3h and, because this repo has a
+        # single self-hosted runner, head-of-line blocked 10 queued runs —
+        # including gpu-spot/model-pricing/blogs, which never touch OpenCode.
+        # Every sibling agent step carries timeout-minutes; this one must too.
+        timeout-minutes: 5
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           MOONSHOT_API_KEY: ${{ secrets.MOONSHOT_API_KEY }}


### PR DESCRIPTION
## What

Adds `timeout-minutes: 5` to the `Resolve and preflight OpenCode route` step in `generative-research.yml`.

## Why

The preflight `curl` is already bounded (`--max-time 60 --retry 2 --retry-delay 5`, ~190s worst case) — but **a bounded curl is not a bounded step**.

On 2026-08-16 that step wedged for **3 hours**. This repo has exactly one self-hosted runner (`gunux-guzus-ai-research-arm`), so the wedge head-of-line blocked 10 queued runs behind it, including `gpu-spot`, `model-pricing`, `daily-ai-blogs` and `blog-subscriptions` — lanes with no OpenCode involvement at all. A provider-side hang in one optional backend became a repo-wide pipeline stall.

Every sibling agent step in this workflow already carries `timeout-minutes: 90`; this one carried none. 5 minutes is ~1.5× the curl's own worst case, so it fails fast without flaking on a legitimate retry.

Found while investigating the `6 lane(s) STALE` alert (arxiv, bluesky, community, models, rss, wiki).

## Verification

- `actionlint .github/workflows/generative-research.yml` → clean.
- The wedged run (`31933073668`) was cancelled manually to drain the queue; with this change that path self-recovers in 5 minutes instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)