### PR TITLE
Raise model-timeline max-turns 60 -> 100

### DIFF
--- a/.github/workflows/24h-model-timeline.yml
+++ b/.github/workflows/24h-model-timeline.yml
@@ -134,8 +134,17 @@ jobs:
           claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           fireworks-api-key: ${{ secrets.FIREWORKS_API_KEY }}
           zai-api-key: ${{ secrets.ZAI_API_KEY }}
+          # max-turns raised 60 -> 100 on 2026-08-16. The ticket store is
+          # persistent and append-only (rule 9), so the per-run read cost
+          # grows with it: at ~186 tickets the CRUD agent started dying on
+          # "Reached maximum number of turns (60)" (run 31871011485) rather
+          # than on any model or credential fault. This is a scope problem,
+          # so it will recur as the store grows -- the durable fix is a
+          # bounded working set, not a bigger number. Wall-clock headroom is
+          # fine: that run burned 60 turns in ~12 min, so 100 lands near
+          # ~20 min against the 90-min timeout above.
           claude-args: |
-            --model opus --max-turns 60 --allowedTools "Read,Write,Edit,Bash(uv:*),Bash(git:*),Bash(ls:*),Bash(cat:*),Bash(grep:*),Bash(jq:*),Bash(curl:*),Task,TodoWrite"
+            --model opus --max-turns 100 --allowedTools "Read,Write,Edit,Bash(uv:*),Bash(git:*),Bash(ls:*),Bash(cat:*),Bash(grep:*),Bash(jq:*),Bash(curl:*),Task,TodoWrite"
           expected-paths: |
             research/models/
           label: Model-ticket Claude CRUD


### PR DESCRIPTION
## What

`24h-model-timeline.yml`: `--max-turns 60` → `--max-turns 100`.

## Why

The `models` lane was one of six reported in the `6 lane(s) STALE` alert, but it is **unrelated to the OpenCode outage** that took the other five. It routes `backend: claude`, and its credential was healthy throughout. It failed with:

```
##[error]Execution failed: Reached maximum number of turns (60)
```

`research/models/tickets/` is a persistent, append-only store (rule 9) — one ticket per shipping artifact, never regenerated. It now holds **186 tickets**, so the per-run read cost grows monotonically with the store. The agent simply ran out of turns before finishing its CRUD pass.

## Headroom

Run `31871011485` burned 60 turns in ~12 minutes. At that rate 100 turns lands near ~20 minutes, against the step's existing `timeout-minutes: 90`. No timeout change needed.

## Caveat

This is a **scope** problem, not a capacity one — it will recur as the store grows. The durable fix is giving the agent a bounded working set rather than a larger turn budget. This unblocks the lane in the meantime.

## Verification

- `actionlint .github/workflows/24h-model-timeline.yml` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)