### PR TITLE
Repair Cursor Twitter Cycle-summary misses before publish

### DIFF
--- a/.github/actions/render-twitter-prompt/action.yml
+++ b/.github/actions/render-twitter-prompt/action.yml
@@ -262,12 +262,27 @@ runs:
             headlines_section = ""
 
         # final_step — what to verify and how to commit.
+        validate_cmd = (
+            "Then run and fix until exit 0:\n"
+            f"uv run python scripts/validate_twitter_public_output.py "
+            f"--backend {backend} --status-file {status_file} "
+            f"--digest-file {output_dir}/{date}.md "
+            f"--summary-file {summaries_dir}/{date}-{summary_slug}-{hour}h-summary.txt "
+            f"--headlines-file {summaries_dir}/{date}-{summary_slug}-{hour}h-headlines.json "
+            f"--date {date} --hour {hour} --generated-at \"{ts}\" "
+            f"--run-id {run_id} --run-attempt {run_attempt}\n"
+            "A published section must contain this exact line:\n"
+            "**Cycle summary**: <1-2 sentences>\n"
+            "`**Cycle Summary**:` (capital S) or a missing line fails the host validator."
+        )
         if "headlines" in features:
             final_step = (
                 "STEP 4 — Verify status, summary, and headlines files exist before committing.\n"
                 "When status is `published`, also verify the same-hour digest section exists.\n"
                 "When status is `no_update`, verify that public section is absent and headlines\n"
-                "is `[]`. Then commit:\n"
+                "is `[]`.\n"
+                f"{validate_cmd}\n"
+                "Then commit:\n"
                 f"git add {output_dir}/ {summaries_dir}/\n"
                 f"git commit -m \"{commit_prefix} {ts}\" || echo \"No changes\"\n"
                 "\n"
@@ -277,7 +292,9 @@ runs:
             final_step = (
                 "STEP 3 — Verify status and summary files exist before committing. When status\n"
                 "is `published`, also verify the digest section exists; for `no_update`, verify\n"
-                "the public same-hour section is absent. Then commit:\n"
+                "the public same-hour section is absent.\n"
+                f"{validate_cmd}\n"
+                "Then commit:\n"
                 f"git add {output_dir}/ {summaries_dir}/\n"
                 f"git commit -m \"{commit_prefix} {ts}\" || echo \"No changes\""
             )

--- a/.github/workflows/hourly-twitter.yml
+++ b/.github/workflows/hourly-twitter.yml
@@ -919,6 +919,7 @@ jobs:
           fi
 
       - name: Process tweets with Cursor CLI + Composer 2.5 (cursor-composer-2p5 tier)
+        id: twitter-cursor-agent
         if: steps.backend.outputs.name == 'cursor-composer-2p5'
         uses: ./.github/actions/run-cursor-container
         with:
@@ -932,6 +933,118 @@ jobs:
           model: cursor/composer-2.5
           cursor-api-key: ${{ secrets.CURSOR_API_KEY }}
           timeout-minutes: '45'
+          mount-bird-snapshot: 'true'
+          bird-auth-token: ${{ secrets.BIRD_AUTH_TOKEN }}
+          bird-ct0: ${{ secrets.BIRD_CT0 }}
+          birdy-tool-log-path: .twitter-input/birdy-tool-log.jsonl
+
+      # One repair turn, same model, fail-closed. Comparison lanes do not get
+      # a deterministic composer (PR #303). The blocking Validate step below
+      # still gates push if this repair also misses the contract.
+      - name: Repair Cursor Twitter contract once
+        id: repair_cursor_twitter
+        if: steps.backend.outputs.name == 'cursor-composer-2p5'
+        env:
+          BACKEND: ${{ steps.backend.outputs.name }}
+          DATE: ${{ steps.datetime.outputs.date }}
+          HOUR: ${{ steps.datetime.outputs.hour }}
+          TIMESTAMP: ${{ steps.datetime.outputs.timestamp }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          DIGEST_FILE: ${{ steps.const.outputs.digest_file }}
+          STATUS_FILE: ${{ steps.const.outputs.status_file }}
+          SUMMARY_FILE: ${{ steps.const.outputs.summary_file }}
+          HEADLINES_FILE: ${{ steps.const.outputs.headlines_file }}
+          OUTPUT_DIR: ${{ steps.const.outputs.output_dir }}
+          COMMIT_PREFIX: ${{ steps.const.outputs.commit_prefix }}
+          REPAIR_PROMPT: ${{ runner.temp }}/cursor-twitter-repair.md
+        run: |
+          set -euo pipefail
+          needed=false
+          if uv run python scripts/validate_twitter_public_output.py \
+            --backend "$BACKEND" \
+            --status-file "$STATUS_FILE" \
+            --digest-file "$DIGEST_FILE" \
+            --summary-file "$SUMMARY_FILE" \
+            --headlines-file "$HEADLINES_FILE" \
+            --date "$DATE" \
+            --hour "$HOUR" \
+            --generated-at "$TIMESTAMP" \
+            --run-id "$RUN_ID" \
+            --run-attempt "$RUN_ATTEMPT" \
+            > /tmp/cursor-twitter-validate.out 2>&1; then
+            cat /tmp/cursor-twitter-validate.out
+          else
+            needed=true
+            echo "::warning::Cursor Twitter contract failed; one repair turn will run"
+            cat /tmp/cursor-twitter-validate.out
+            python3 - <<'PY'
+          import os
+          from pathlib import Path
+
+          err = Path("/tmp/cursor-twitter-validate.out").read_text(encoding="utf-8")
+          hour = os.environ["HOUR"]
+          digest = os.environ["DIGEST_FILE"]
+          status = os.environ["STATUS_FILE"]
+          summary = os.environ["SUMMARY_FILE"]
+          headlines = os.environ["HEADLINES_FILE"]
+          output_dir = os.environ["OUTPUT_DIR"]
+          prefix = os.environ["COMMIT_PREFIX"]
+          ts = os.environ["TIMESTAMP"]
+          backend = os.environ["BACKEND"]
+          date = os.environ["DATE"]
+          run_id = os.environ["RUN_ID"]
+          run_attempt = os.environ["RUN_ATTEMPT"]
+          # Concatenate the validator dump so braces in the section preview
+          # cannot break an f-string.
+          text = (
+              "The previous Cursor Twitter turn wrote artifacts that failed\n"
+              "scripts/validate_twitter_public_output.py.\n\n"
+              "Validator output:\n"
+              + err
+              + "\n\n"
+              "Repair ONLY the existing files. Do not start a new brief from scratch unless\n"
+              "a required file is missing.\n\n"
+              f"If status is published, the same-hour section under `## {hour}:00 UTC` MUST\n"
+              "contain this exact line on its own line (lowercase s in summary):\n\n"
+              "**Cycle summary**: <1-2 sentences naming the concrete developments>\n\n"
+              "`**Cycle Summary**:` (capital S), `Cycle summary:` without bold, HTML\n"
+              "<strong>, or a blank value all fail.\n\n"
+              "Then run this exact command and fix until it exits 0:\n\n"
+              "uv run python scripts/validate_twitter_public_output.py \\\n"
+              f"  --backend {backend} \\\n"
+              f"  --status-file {status} \\\n"
+              f"  --digest-file {digest} \\\n"
+              f"  --summary-file {summary} \\\n"
+              f"  --headlines-file {headlines} \\\n"
+              f"  --date {date} \\\n"
+              f"  --hour {hour} \\\n"
+              f"  --generated-at \"{ts}\" \\\n"
+              f"  --run-id {run_id} \\\n"
+              f"  --run-attempt {run_attempt}\n\n"
+              "Commit only the allowed paths:\n\n"
+              f"git add {output_dir}/ research/summaries/\n"
+              f"git commit -m \"{prefix} {ts}\" || echo \"No changes\"\n"
+          )
+          Path(os.environ["REPAIR_PROMPT"]).write_text(text, encoding="utf-8")
+          PY
+          fi
+          echo "needed=${needed}" >> "$GITHUB_OUTPUT"
+
+      - name: Re-run Cursor CLI to repair Twitter contract
+        if: steps.repair_cursor_twitter.outputs.needed == 'true'
+        uses: ./.github/actions/run-cursor-container
+        with:
+          mode: twitter
+          allowed-paths: |
+            ${{ steps.const.outputs.digest_file }}
+            ${{ steps.const.outputs.status_file }}
+            ${{ steps.const.outputs.summary_file }}
+            ${{ steps.const.outputs.headlines_file }}
+          prompt-file: ${{ runner.temp }}/cursor-twitter-repair.md
+          model: cursor/composer-2.5
+          cursor-api-key: ${{ secrets.CURSOR_API_KEY }}
+          timeout-minutes: '20'
           mount-bird-snapshot: 'true'
           bird-auth-token: ${{ secrets.BIRD_AUTH_TOKEN }}
           bird-ct0: ${{ secrets.BIRD_CT0 }}

--- a/prompts/twitter-analyst.md
+++ b/prompts/twitter-analyst.md
@@ -91,6 +91,11 @@ section. Otherwise append the new section at the end. Start a new file with:
 
 **Cycle summary**: [1-2 sentences naming the concrete developments in this cycle.]
 
+The Cycle summary line is load-bearing and exact. The host validator
+requires this regex on its own line: `**Cycle summary**: <non-empty text>`.
+`**Cycle Summary**:` (capital S), unbolded `Cycle summary:`, HTML
+`<strong>`, or a blank value all fail the run and discard the brief.
+
 ### Top stories
 
 Use this Twitter component shape for every Top Story. The folded card is

--- a/scripts/test_backend_matrix.py
+++ b/scripts/test_backend_matrix.py
@@ -1211,6 +1211,44 @@ class RoutingInvariants(unittest.TestCase):
                 self.assertNotIn(other, line.lower(),
                                  f"{field} names {other} but the tier serves {family}")
 
+    def test_cursor_twitter_repairs_contract_once(self):
+        workflow_path = (REPO_ROOT / ".github" / "workflows" /
+                         "hourly-twitter.yml")
+        workflow = workflow_path.read_text(encoding="utf-8")
+        doc = yaml.safe_load(workflow)
+        steps = doc["jobs"]["twitter"]["steps"]
+        names = [step.get("name") for step in steps]
+        process = next(i for i, name in enumerate(names)
+                       if name == "Process tweets with Cursor CLI + Composer 2.5 "
+                       "(cursor-composer-2p5 tier)")
+        repair = next(i for i, name in enumerate(names)
+                      if name == "Repair Cursor Twitter contract once")
+        rerun = next(i for i, name in enumerate(names)
+                     if name == "Re-run Cursor CLI to repair Twitter contract")
+        validate = next(i for i, name in enumerate(names)
+                        if name == "Validate Twitter signal-only public output")
+        self.assertLess(process, repair)
+        self.assertLess(repair, rerun)
+        self.assertLess(rerun, validate)
+        self.assertIn("validate_twitter_public_output.py", steps[repair]["run"])
+        self.assertNotIn("deterministic_twitter_digest.py", steps[repair]["run"])
+        self.assertEqual(
+            steps[rerun].get("uses"),
+            "./.github/actions/run-cursor-container",
+        )
+        self.assertEqual((steps[rerun].get("with") or {}).get("mode"), "twitter")
+        self.assertIn("validate_twitter_public_output.py",
+                      (REPO_ROOT / ".github" / "actions" /
+                       "render-twitter-prompt" / "action.yml")
+                      .read_text(encoding="utf-8"))
+        self.assertIn("**Cycle summary**:",
+                      (REPO_ROOT / "prompts" / "twitter-analyst.md")
+                      .read_text(encoding="utf-8"))
+        self.assertNotIn("deterministic_twitter_digest.py",
+                         workflow[workflow.index("Repair Cursor Twitter"):
+                                  workflow.index(
+                                      "Validate Twitter signal-only public output")])
+
     def test_all_dispatch_callers_prewire_cursor_credential(self):
         for obs in self.obs.values():
             for step in obs.dispatch_steps:

--- a/scripts/test_validate_twitter_public_output.py
+++ b/scripts/test_validate_twitter_public_output.py
@@ -89,6 +89,40 @@ class ValidateTwitterPublicOutputTest(unittest.TestCase):
         with self.assertRaisesRegex(ContractError, "no story card"):
             self.validate()
 
+    def test_rejects_missing_cycle_summary_includes_section_preview(self) -> None:
+        self.write_status("published", 1)
+        self.summary.write_text("Meta released Muse Spark 1.1.\n", encoding="utf-8")
+        self.digest.write_text(
+            "## 10:00 UTC\n\n"
+            "### Top stories\n"
+            "<article class=\"twitter-story\">"
+            "<h3 class=\"twitter-story-title\">Muse Spark 1.1</h3>"
+            "<p class=\"twitter-story-lead\">Meta released the model.</p>"
+            "<a class=\"twitter-source-chip\" href=\"https://x.com/AIatMeta/status/122\">@AIatMeta</a>"
+            "</article>\n",
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(ContractError, r"section preview:\n## 10:00 UTC") as ctx:
+            self.validate()
+        self.assertIn("exact line: **Cycle summary**: <text>", str(ctx.exception))
+        self.assertIn("twitter-story-title", str(ctx.exception))
+
+    def test_rejects_capital_s_cycle_summary(self) -> None:
+        self.write_status("published", 1)
+        self.summary.write_text("Meta released Muse Spark 1.1.\n", encoding="utf-8")
+        self.digest.write_text(
+            "## 10:00 UTC\n\n"
+            "**Cycle Summary**: Meta released Muse Spark 1.1.\n\n"
+            "<article class=\"twitter-story\">"
+            "<h3 class=\"twitter-story-title\">Muse Spark 1.1</h3>"
+            "<p class=\"twitter-story-lead\">Meta released the model.</p>"
+            "<a class=\"twitter-source-chip\" href=\"https://x.com/AIatMeta/status/122\">@AIatMeta</a>"
+            "</article>\n",
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(ContractError, r"\*\*Cycle Summary\*\*"):
+            self.validate()
+
     def test_rejects_empty_story_shell(self) -> None:
         self.write_status("published", 1)
         self.summary.write_text("Meta released Muse Spark 1.1.\n", encoding="utf-8")

--- a/scripts/validate_twitter_public_output.py
+++ b/scripts/validate_twitter_public_output.py
@@ -80,6 +80,19 @@ def cycle_sections(text: str, hour: str) -> list[str]:
     return sections
 
 
+def _section_preview(section: str, *, max_lines: int = 12, max_chars: int = 800) -> str:
+    """Keep just enough of a failing section for the next operator to see the miss."""
+    lines = section.splitlines()
+    preview = "\n".join(lines[:max_lines])
+    truncated = len(lines) > max_lines
+    if len(preview) > max_chars:
+        preview = preview[:max_chars]
+        truncated = True
+    if truncated:
+        preview += "\n..."
+    return preview
+
+
 def public_item_count(section: str) -> int:
     section = HTML_COMMENT_RE.sub("", section)
 
@@ -187,7 +200,11 @@ def validate(
             re.MULTILINE,
         )
         if summary_match is None:
-            raise ContractError("published section requires a non-empty Cycle summary")
+            raise ContractError(
+                "published section requires a non-empty Cycle summary "
+                "(exact line: **Cycle summary**: <text>)\n"
+                f"section preview:\n{_section_preview(section)}"
+            )
         filler = FILLER_RE.search(section)
         if filler is not None:
             raise ContractError(f"public section contains operational/no-news filler: {filler.group(0)!r}")


### PR DESCRIPTION
## Summary
- Composer 2.5 wrote a published Twitter brief that failed `validate_twitter_public_output.py` because it lacked the exact `**Cycle summary**:` line; the host then discarded the turn with no section preview.
- The validator now prints a section snippet, the shared prompt tells every backend to run the validator before commit, and Cursor gets one isolated same-model repair turn (still fail-closed — no deterministic composer).
- Re-dispatch `hourly-twitter.yml` `backend=cursor-composer-2p5` after merge.

## Test plan
- [x] `uv run python -m unittest test_validate_twitter_public_output` (includes missing / capital-S Cycle summary cases)
- [x] `test_cursor_twitter_repairs_contract_once` plus Cursor sandbox / bash-lc / deterministic-fallback invariants
- [x] `scripts/build_backend_matrix.py --check`
- [ ] CI green on this PR
- [ ] After squash-merge: `gh workflow run hourly-twitter.yml --ref main -f backend=cursor-composer-2p5`


Made with [Cursor](https://cursor.com)