### PR TITLE
Stop denying all Cursor writes on Korean translation

### DIFF
--- a/.github/actions/run-cursor-container/action.yml
+++ b/.github/actions/run-cursor-container/action.yml
@@ -798,16 +798,6 @@ runs:
               done
               wait "$agent_pid"
               agent_status=$?
-              # Flush the attempt log after the child exits. tail --pid
-              # can miss a fully-buffered write that lands as the process
-              # dies (canary 31998429963: status=0 but the token never
-              # reached OUTPUT_FILE). Canary needs that text on stdout
-              # for the token assert; failures need it for diagnosis.
-              # Production successes stay single-streamed.
-              if [ "$RUN_MODE" = "canary" ] || [ "$agent_status" -ne 0 ]; then
-                echo "Cursor attempt ${attempt_count} log (status=${agent_status}):"
-                cat -- "$attempt_log" || true
-              fi
               # Tear the streamer down explicitly rather than trusting
               # `tail --pid` to notice; an unreaped tail keeps this step
               # stdout open and would hang the job it was meant to shorten.
@@ -828,6 +818,18 @@ runs:
                   artifact_count=$((artifact_count + 1))
                 fi
               done <<< "$RETURN_ARTIFACTS"
+              # Flush the attempt log after the child exits. tail --pid
+              # can miss a fully-buffered write that lands as the process
+              # dies (canary 31998429963: status=0 but the token never
+              # reached OUTPUT_FILE). Canary needs that text on stdout
+              # for the token assert; failures and zero-artifact exits
+              # need it for diagnosis. Production successes stay
+              # single-streamed.
+              if [ "$RUN_MODE" = "canary" ] || [ "$agent_status" -ne 0 ] \
+                || [ "$artifact_count" -eq 0 ]; then
+                echo "Cursor attempt ${attempt_count} log (status=${agent_status}):"
+                cat -- "$attempt_log" || true
+              fi
               echo "Cursor attempt ${attempt_count}: status=${agent_status} translation_segment_calls=${segment_calls} artifacts=${artifact_count} remaining_seconds=${remaining_seconds}"
 
               if [ "$AGENT_LANE" = "generative-research-ko" ] \

--- a/.github/cursor/translation.json
+++ b/.github/cursor/translation.json
@@ -9,11 +9,19 @@
       "Read(.tmp/**/*)",
       "Read(.github/cursor/**/*)",
       "Write(.tmp/generative-translation.ko.ara.md)",
-      "Write(.tmp/generative-translation.ko.segments.jsonl)"
+      "Write(.tmp/generative-translation.ko.segments.jsonl)",
+      "Write(.tmp/**/*)"
     ],
     "deny": [
       "Shell(*)",
-      "Write(*)",
+      "Write(.env*)",
+      "Write(.git/**/*)",
+      "Write(.github/**/*)",
+      "Write(research/**/*)",
+      "Write(data/**/*)",
+      "Write(scripts/**/*)",
+      "Write(dashboard/**/*)",
+      "Write(docs/**/*)",
       "WebFetch(*)",
       "Mcp(*)"
     ]

--- a/.github/workflows/translate-generative-research.yml
+++ b/.github/workflows/translate-generative-research.yml
@@ -150,16 +150,21 @@ jobs:
             Translate one existing ARA generative-research article into natural,
             professional Korean. This is translation, not new research.
 
+            The run fails unless
+            `.tmp/generative-translation.ko.segments.jsonl` exists as a
+            regular file before you stop. A chat-only translation is a
+            failed run. Use the Write tool on that exact path.
+
             Read `.agent-input/translation-segments.json`. It is compact JSON
             Lines: the first line is a header; every later line is
             `[segment_id, source_text, internal_flag]`. Translate each
             `source_text` into Korean. Submit `{id, text}` objects only.
             If `translation_segment` exists, submit batches with that tool
-            immediately after reading the rows. Otherwise append one JSON
+            immediately after reading the rows. Otherwise Write one JSON
             object per line to exactly
             `.tmp/generative-translation.ko.segments.jsonl`. Do not
             draft a full document or final-answer translation. If the read is
-            paginated, submit the current page before reading the next page.
+            paginated, Write the current page before reading the next page.
             Preserve every opaque token such as
             `⟦ARA0000⟧` exactly once and in its original order. Submit each
             segment id exactly once. Never invent an opaque token; a row may

--- a/scripts/test_backend_matrix.py
+++ b/scripts/test_backend_matrix.py
@@ -1116,7 +1116,7 @@ class RoutingInvariants(unittest.TestCase):
             action)
         self.assertIn(
             'if [ "$RUN_MODE" = "canary" ] || [ "$agent_status" -ne 0 ] \\',
-        )
+            action)
         self.assertIn(
             '[ "$artifact_count" -eq 0 ]; then',
             action)

--- a/scripts/test_backend_matrix.py
+++ b/scripts/test_backend_matrix.py
@@ -268,15 +268,32 @@ class RoutingInvariants(unittest.TestCase):
             )
         )
         self.assertEqual(
-            ["Shell(*)", "Write(*)", "WebFetch(*)", "Mcp(*)"],
+            [
+                "Shell(*)",
+                "Write(.env*)",
+                "Write(.git/**/*)",
+                "Write(.github/**/*)",
+                "Write(research/**/*)",
+                "Write(data/**/*)",
+                "Write(scripts/**/*)",
+                "Write(dashboard/**/*)",
+                "Write(docs/**/*)",
+                "WebFetch(*)",
+                "Mcp(*)",
+            ],
             cursor_policy["permissions"]["deny"],
         )
+        self.assertNotIn("Write(*)", cursor_policy["permissions"]["deny"])
         self.assertIn(
             "Read(.agent-input/translation-segments.json)",
             cursor_policy["permissions"]["allow"],
         )
         self.assertIn(
             "Write(.tmp/generative-translation.ko.segments.jsonl)",
+            cursor_policy["permissions"]["allow"],
+        )
+        self.assertIn(
+            "Write(.tmp/**/*)",
             cursor_policy["permissions"]["allow"],
         )
 
@@ -1098,7 +1115,10 @@ class RoutingInvariants(unittest.TestCase):
             'cp -- "$CURSOR_CONFIG_DIR/cli-config.json" "$HOME/.cursor/cli-config.json"',
             action)
         self.assertIn(
-            'if [ "$RUN_MODE" = "canary" ] || [ "$agent_status" -ne 0 ]; then',
+            'if [ "$RUN_MODE" = "canary" ] || [ "$agent_status" -ne 0 ] \\',
+        )
+        self.assertIn(
+            '[ "$artifact_count" -eq 0 ]; then',
             action)
         self.assertIn('cat -- "$attempt_log"', action)
         self.assertIn("HOME=/tmp/cursor-home", action)


### PR DESCRIPTION
## Summary
- Korean canary `32008449084` failed after two 11-minute Cursor attempts: exit 0, `artifacts=0`, no `.tmp/generative-translation.ko.segments.jsonl`.
- `Write(*)` in `.github/cursor/translation.json` deny likely blocked the specific `.tmp` allow. Mirror the production pattern: allow `.tmp/**`, deny checkout-sensitive writes only.
- Flush the attempt log on zero-artifact exits so the next miss is diagnosable.

## Test plan
- [x] Korean policy + bash-parse + cross-check tests
- [ ] After merge, re-dispatch:

```bash
gh workflow run translate-generative-research.yml --ref main \
  -f slug="grok-4-6-at-2-6-vs-fable-5-max-10-50-does-the-frontier-repri" \
  -f overwrite=false -f auto_merge=false
```


Made with [Cursor](https://cursor.com)