### PR TITLE
Tell Cursor Korean translation not to invent raw digits

### DIFF
--- a/.github/workflows/translate-generative-research.yml
+++ b/.github/workflows/translate-generative-research.yml
@@ -176,6 +176,10 @@ jobs:
 
             Trusted code owns the document structure and immutable literals:
             - Never translate, remove, reorder, duplicate, or alter opaque tokens.
+            - Do not invent raw digits. Source numbers are already opaque
+              tokens. The only allowed untokenized digits are an integer
+              glued to Hangul (`9일`, `3배`). Never write `$1,000`, `2.5`,
+              `30%`, `2026`, or any other bare number.
             - Translate reader-facing prose, headings, labels, captions,
               callouts, quotations, and reference titles into idiomatic Korean.
             - Do not browse, research, add claims, add sources, drop sections,


### PR DESCRIPTION
## Summary
- Second Korean canary (`32010925978`) got past Cursor: `artifacts=1`, no retry.
- Host `render()` failed: `translation segment s00060 added an unsafe localized numeric token`.
- Spell the existing host rule in the prompt: no raw digits except an integer glued to Hangul (`9일`, `3배`).

## Test plan
- [ ] After merge, re-dispatch the same slug.


Made with [Cursor](https://cursor.com)