### PR TITLE
Skip blank lines in Korean translation JSONL

### DIFF
--- a/scripts/generative_translation_segments.py
+++ b/scripts/generative_translation_segments.py
@@ -294,6 +294,8 @@ def _read_results(path: Path) -> dict[str, str]:
         raise ValueError(f"translation result must be the regular file {RESULT_PATH}")
     translations: dict[str, str] = {}
     for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if not line.strip():
+            continue
         try:
             value = json.loads(line)
         except json.JSONDecodeError as exc:

--- a/scripts/test_generative_translation.py
+++ b/scripts/test_generative_translation.py
@@ -181,6 +181,36 @@ class TranslationSegmentsTest(unittest.TestCase):
             self.assertEqual(manifest["segment_count"], len(extracted))
             self.assertEqual(parity.check_pair(source, draft), [])
 
+    def test_renderer_skips_blank_jsonl_lines(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            source = root / "alpha.ara.md"
+            source.write_text(SOURCE, encoding="utf-8")
+            source_sha = hashlib.sha256(source.read_bytes()).hexdigest()
+            compiled, _ = segments.build_manifest(source, source_sha)
+            extracted = segments.extract_segments(compiled)
+            result = root / segments.RESULT_PATH
+            result.parent.mkdir()
+            rows = [
+                json.dumps(
+                    {"id": segment.id, "text": self._korean_text(segment)},
+                    ensure_ascii=False,
+                )
+                for segment in extracted
+            ]
+            result.write_text("\n\n".join(rows) + "\n\n", encoding="utf-8")
+            old_cwd = Path.cwd()
+            try:
+                os.chdir(root)
+                segments.render(
+                    source, source_sha, segments.RESULT_PATH, segments.DRAFT_PATH
+                )
+            finally:
+                os.chdir(old_cwd)
+            self.assertEqual(
+                parity.check_pair(source, root / segments.DRAFT_PATH), []
+            )
+
     def test_model_manifest_is_compact_json_lines(self):
         repo = Path(__file__).resolve().parent.parent
         source = repo / (


### PR DESCRIPTION
## Summary
- Glassem canary `32025502726` wrote the JSONL (`artifacts=1`) then failed reconstruct: `invalid translation result JSON on line 416: Expecting value`.
- That is an empty line. Skip whitespace-only lines; segment coverage is still exact.

## Test plan
- [x] `test_renderer_skips_blank_jsonl_lines`
- [ ] After merge, re-dispatch `glassem-slips-to-2028-samsung-electro-mechanics-glass-core-s`


Made with [Cursor](https://cursor.com)