### PR TITLE
Strip leftover Korean number tokens as wholes

### DIFF
--- a/scripts/check_generative_translation.py
+++ b/scripts/check_generative_translation.py
@@ -212,10 +212,13 @@ def check_pair(
                 "localized number rendering is only valid for ARA-to-HTML comparisons"
             )
         elif not _localized_integer_additions_are_safe(source_numbers, target_raw):
+            missing = sorted((source_numbers - target_numbers).elements())
+            extra = sorted((target_numbers - source_numbers).elements())
             errors.append(
                 "source numeric-token multiset was not preserved or target added "
                 "a non-localized numeric token"
             )
+            errors.append(f"numeric-token diff missing={missing} extra={extra}")
     elif source_numbers != target_numbers:
         errors.append("numeric-token multiset changed")
     if source.name.endswith(".ara.md") and translation.name.endswith(".ara.md"):

--- a/scripts/generative_translation_segments.py
+++ b/scripts/generative_translation_segments.py
@@ -32,6 +32,7 @@ ATTR_RE = re.compile(
 WORD_RE = re.compile(r"[A-Za-z][A-Za-z'-]*")
 TOKEN_RE = re.compile(r"\u27e6ARA\d{4}\u27e7")
 LOCALIZED_INTEGER_RE = re.compile(r"(?<![0-9.,+\-−$€£₩¥])[0-9]+(?=[가-힣])")
+NUMBER_DEBRIS_RE = re.compile(r"[$€£₩¥%×]+")
 EXCLUDED_TAGS = frozenset({"code", "pre", "script", "style"})
 TRANSLATABLE_ATTRS = frozenset(
     {
@@ -312,12 +313,14 @@ def _read_results(path: Path) -> dict[str, str]:
 
 
 def strip_unsafe_digits(text: str) -> str:
-    """Drop invented digits while keeping opaque tokens and 9일/3배 forms.
+    """Drop leftover numeric literals while keeping tokens and 9일/3배 forms.
 
     Cursor writes a finished JSONL; unlike the OpenCode segment tool it does
     not reject leftover $2.5 / 30% / 2026 copies mid-flight. Those leftovers
-    are not source literals (those are already ⟦ARA####⟧ tokens), so stripping
-    them is safer than failing a finished translation.
+    are not source literals (those are already ⟦ARA####⟧ tokens). Strip the
+    whole NUMBER_RE match — not just the digits — so leftover `$` / `%` / `.`
+    cannot glue onto a restored token and change the numeric-token multiset
+    (`2.5` becoming `$2.5`).
     """
     pieces = TOKEN_RE.split(text)
     tokens = TOKEN_RE.findall(text)
@@ -326,13 +329,18 @@ def strip_unsafe_digits(text: str) -> str:
         out: list[str] = []
         cursor = 0
         while cursor < len(piece):
-            match = LOCALIZED_INTEGER_RE.match(piece, cursor)
-            if match:
-                out.append(match.group(0))
-                cursor = match.end()
+            localized = LOCALIZED_INTEGER_RE.match(piece, cursor)
+            if localized:
+                out.append(localized.group(0))
+                cursor = localized.end()
                 continue
-            if piece[cursor].isdigit():
-                cursor += 1
+            leftover = NUMBER_RE.match(piece, cursor)
+            if leftover:
+                cursor = leftover.end()
+                continue
+            debris = NUMBER_DEBRIS_RE.match(piece, cursor)
+            if debris:
+                cursor = debris.end()
                 continue
             out.append(piece[cursor])
             cursor += 1

--- a/scripts/test_generative_translation.py
+++ b/scripts/test_generative_translation.py
@@ -300,8 +300,13 @@ class TranslationSegmentsTest(unittest.TestCase):
         token = "⟦ARA0007⟧"
         self.assertEqual(
             segments.strip_unsafe_digits(f"{token} 1차 9일 $1,000 30% 2.5 42"),
-            f"{token} 1차 9일 $, % . ",
+            f"{token} 1차 9일    ",
         )
+        # Leftover currency/percent/dot must not remain to glue onto the
+        # restored token and change 2.5 into $2.5 or 25 into 25%.
+        self.assertEqual(segments.strip_unsafe_digits(f"${token}"), token)
+        self.assertEqual(segments.strip_unsafe_digits(f"{token}%"), token)
+        self.assertEqual(segments.strip_unsafe_digits(f"$2.5{token}"), token)
 
     def test_renderer_allows_korean_integer_forms_and_strips_unsafe_numbers(self):
         with tempfile.TemporaryDirectory() as td:
@@ -337,7 +342,7 @@ class TranslationSegmentsTest(unittest.TestCase):
                 segments.render(
                     source, source_sha, segments.RESULT_PATH, segments.DRAFT_PATH
                 )
-                for leftover in (" $1,000", " -30%", " 2.5×", " 42"):
+                for leftover in (" $1,000", " -30%", " 2.5×", " 42", "$2.5", "$", "%"):
                     with self.subTest(leftover=leftover):
                         write_rows(leftover)
                         segments.render(
@@ -346,10 +351,17 @@ class TranslationSegmentsTest(unittest.TestCase):
                             segments.RESULT_PATH,
                             segments.DRAFT_PATH,
                         )
+                        draft = (root / segments.DRAFT_PATH).read_text(encoding="utf-8")
                         self.assertEqual(
-                            parity.check_pair(source, root / segments.DRAFT_PATH),
+                            parity.check_pair(
+                                source,
+                                root / segments.DRAFT_PATH,
+                                allow_localized_number_rendering=True,
+                            ),
                             [],
                         )
+                        self.assertNotIn("$$", draft)
+                        self.assertNotIn("$12%", draft)
             finally:
                 os.chdir(old_cwd)
 


### PR DESCRIPTION
## Summary
- Digit-by-digit leftover stripping left `$` / `%` / `.` debris that glued onto restored source literals (`2.5` became `$2.5`) and failed the translation numeric-token check after reconstruct succeeded.
- Strip the whole leftover `NUMBER_RE` match plus orphan currency/percent signs; keep `⟦ARA####⟧` tokens and `9일` / `3배` forms.
- Print missing/extra numeric tokens when parity still fails so the next NAND-style miss is diagnosable.

## Test plan
- [x] `PYTHONPATH=scripts uv run python -m unittest scripts.test_generative_translation.TranslationSegmentsTest scripts.test_generative_translation.TranslationParityTest`
- [ ] Re-dispatch `turning-nand-into-a-dram-tier-cufile-scada-and-the-2027-100m` after merge


Made with [Cursor](https://cursor.com)