### PR TITLE
Skip non-object Korean translation JSONL rows

### DIFF
--- a/scripts/generative_translation_segments.py
+++ b/scripts/generative_translation_segments.py
@@ -295,12 +295,19 @@ def _read_results(path: Path) -> dict[str, str]:
         raise ValueError(f"translation result must be the regular file {RESULT_PATH}")
     translations: dict[str, str] = {}
     for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
-        if not line.strip():
+        stripped = line.strip()
+        # Cursor Write sometimes inserts blank lines or a non-object
+        # separator between valid {"id","text"} rows. Coverage is still
+        # checked after parse, so skipping junk cannot invent a segment.
+        if not stripped or not stripped.startswith("{"):
             continue
         try:
-            value = json.loads(line)
+            value = json.loads(stripped)
         except json.JSONDecodeError as exc:
-            raise ValueError(f"invalid translation result JSON on line {line_no}: {exc}") from exc
+            preview = stripped[:80]
+            raise ValueError(
+                f"invalid translation result JSON on line {line_no}: {exc}; preview={preview!r}"
+            ) from exc
         if not isinstance(value, dict) or set(value) != {"id", "text"}:
             raise ValueError(f"translation result line {line_no} has invalid fields")
         segment_id, text = value["id"], value["text"]

--- a/scripts/test_generative_translation.py
+++ b/scripts/test_generative_translation.py
@@ -181,7 +181,7 @@ class TranslationSegmentsTest(unittest.TestCase):
             self.assertEqual(manifest["segment_count"], len(extracted))
             self.assertEqual(parity.check_pair(source, draft), [])
 
-    def test_renderer_skips_blank_jsonl_lines(self):
+    def test_renderer_skips_blank_and_non_object_jsonl_lines(self):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
             source = root / "alpha.ara.md"
@@ -198,7 +198,10 @@ class TranslationSegmentsTest(unittest.TestCase):
                 )
                 for segment in extracted
             ]
-            result.write_text("\n\n".join(rows) + "\n\n", encoding="utf-8")
+            result.write_text(
+                "\n---\n".join(rows) + "\n\n// trailing note\n",
+                encoding="utf-8",
+            )
             old_cwd = Path.cwd()
             try:
                 os.chdir(root)


### PR DESCRIPTION
## Summary
- NAND reconstruct failed on `invalid translation result JSON on line 235: Expecting value` after the numeric-token strip fix.
- Skip blank lines and any JSONL row that does not start with `{`. Segment coverage is still exact after parse.
- Keep a short preview on real JSON decode errors.

## Test plan
- [x] `PYTHONPATH=scripts uv run python -m unittest test_generative_translation.TranslationSegmentsTest test_generative_translation.TranslationParityTest`
- [ ] Confirm the in-flight NAND retry, then re-queue if it dies on the same junk line


Made with [Cursor](https://cursor.com)