### PR TITLE
Allow Korean translations to swap protected token order

### DIFF
--- a/scripts/generative_translation_segments.py
+++ b/scripts/generative_translation_segments.py
@@ -9,6 +9,7 @@ by opaque tokens, and reconstructs HTML after validating complete model output.
 from __future__ import annotations
 
 import argparse
+import collections
 import hashlib
 import html
 import json
@@ -373,7 +374,9 @@ def render(source_path: Path, source_sha256: str, result_path: Path, draft_path:
     for segment in reversed(segments):
         translated = translations[segment.id]
         found_tokens = TOKEN_RE.findall(translated)
-        if found_tokens != segment.tokens:
+        # Korean word order may swap two numbers in one clause. Identity
+        # replacement below still maps each token to its source literal.
+        if collections.Counter(found_tokens) != collections.Counter(segment.tokens):
             raise ValueError(
                 f"translation segment {segment.id} changed immutable tokens; "
                 f"expected={segment.tokens}, got={found_tokens}"

--- a/scripts/test_generative_translation.py
+++ b/scripts/test_generative_translation.py
@@ -267,6 +267,55 @@ class TranslationSegmentsTest(unittest.TestCase):
             finally:
                 os.chdir(old_cwd)
 
+    def test_renderer_allows_swapped_token_order(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            source = root / "alpha.ara.md"
+            source.write_text(SOURCE, encoding="utf-8")
+            source_sha = hashlib.sha256(source.read_bytes()).hexdigest()
+            compiled, _ = segments.build_manifest(source, source_sha)
+            extracted = segments.extract_segments(compiled)
+            swapped = next(
+                segment for segment in extracted if len(segment.tokens) >= 2
+            )
+            (root / ".tmp").mkdir()
+            (root / segments.RESULT_PATH).write_text(
+                "".join(
+                    json.dumps(
+                        {
+                            "id": segment.id,
+                            "text": (
+                                " ".join(
+                                    reversed(segments.TOKEN_RE.findall(self._korean_text(segment)))
+                                )
+                                if segment.id == swapped.id
+                                else self._korean_text(segment)
+                            ),
+                        },
+                        ensure_ascii=False,
+                    )
+                    + "\n"
+                    for segment in extracted
+                ),
+                encoding="utf-8",
+            )
+            old_cwd = Path.cwd()
+            try:
+                os.chdir(root)
+                segments.render(
+                    source, source_sha, segments.RESULT_PATH, segments.DRAFT_PATH
+                )
+            finally:
+                os.chdir(old_cwd)
+            self.assertEqual(
+                parity.check_pair(
+                    source,
+                    root / segments.DRAFT_PATH,
+                    allow_localized_number_rendering=True,
+                ),
+                [],
+            )
+
     def test_live_failure_fixture_now_passes_structural_parity(self):
         repo = Path(__file__).resolve().parent.parent
         source = repo / (


### PR DESCRIPTION
## Summary
- NAND reconstruct failed because segment s00071 kept both tokens but reversed them (`⟦ARA0000⟧`, `⟦ARA0001⟧` → swapped).
- Accept the same token multiset in any order. Replacement is still by token identity, so the source literals cannot change.
- Missing or invented tokens still fail.

## Test plan
- [x] `PYTHONPATH=scripts uv run python -m unittest test_generative_translation.TranslationSegmentsTest test_generative_translation.TranslationParityTest`
- [ ] Re-dispatch NAND after merge


Made with [Cursor](https://cursor.com)