### PR TITLE
Keep last copy of duplicated Korean translation segments

### DIFF
--- a/scripts/generative_translation_segments.py
+++ b/scripts/generative_translation_segments.py
@@ -362,8 +362,6 @@ def _read_results(path: Path) -> dict[str, str]:
             segment_id, text = value["id"], value["text"]
             if not isinstance(segment_id, str) or not isinstance(text, str) or not text.strip():
                 raise ValueError(f"translation result line {line_no} has invalid id/text")
-            if segment_id in translations:
-                raise ValueError(f"duplicate translation segment: {segment_id}")
             translations[segment_id] = text
     return translations
 

--- a/scripts/test_generative_translation.py
+++ b/scripts/test_generative_translation.py
@@ -210,7 +210,7 @@ class TranslationSegmentsTest(unittest.TestCase):
                 + inner["text"][8:]
                 + '"}'
             )
-            body = [leaked, glued, quoted, *rows[4:]]
+            body = [leaked, glued, quoted, rows[3], *rows[4:]]
             result.write_text("\n".join(body) + "\n", encoding="utf-8")
             old_cwd = Path.cwd()
             try:


### PR DESCRIPTION
## Summary
- Google reorg reconstruct failed on \`duplicate translation segment: s00453\`.
- Last write wins for a repeated id. Segment coverage is still exact after parse.

## Test plan
- [x] Salvage JSONL unit test now includes a repeated id
- [ ] Re-dispatch google reorg after merge if the in-flight retry misses this SHA


Made with [Cursor](https://cursor.com)