### PR TITLE
Refresh submission readiness documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,20 +25,21 @@ CODEX_AUTH_JSON=                  # [secret] ChatGPT-managed Codex auth cache
 OPENCODE_API_KEY=                 # [secret] OpenCode Go subscription key (DeepSeek V4 Flash)
 MOONSHOT_API_KEY=                 # [secret] Optional legacy Kimi-only key; not used by this route
 
-# For generative-research backend=cursor-composer-2p5, hourly-twitter
-# backend=cursor-composer-2p5, and cursor-cli-canary.yml. Cursor dashboard
-# API key; no `agent login` step. Production editorial defaults stay on
-# OpenCode until a route selects this profile.
-CURSOR_API_KEY=                   # [secret] Cursor CLI API key (Composer 2.5)
+# For generative-research backend=cursor-grok-4p6-fast, Korean generative
+# translation, and cursor-cli-canary.yml. Cursor dashboard API key; no
+# `agent login` step. Production editorial defaults stay on OpenCode.
+CURSOR_API_KEY=                   # [secret] Cursor CLI API key (Grok 4.6 Fast)
 
 # Alternative / comparison backends. Required only for the DeepSeek-V4-Flash /
 # GLM generative-research paths and the non-Claude Twitter comparison lanes.
 FIREWORKS_API_KEY=               # [secret] Fireworks (DeepSeek V4 Flash + GLM + Kimi)
+ZAI_API_KEY=                     # [secret] Z.ai Coding Plan (GLM 5.2 fallback/canary)
 
-# ─── Twitter / X ingestion (bird CLI) ───────────────────────────────
-# Bare X/Twitter session cookies. The lanes degrade gracefully to empty data
-# when absent, so they are optional for a fork; required to actually pull
-# tweets. These EXPIRE frequently and must be refreshed by hand.
+# ─── Twitter / X ingestion (birdy CLI) ──────────────────────────────
+# Choose one auth route: a non-empty BIRDY_ACCOUNTS JSON array, or both bare
+# cookie values below. Auth setup fails if neither route is complete. Individual
+# fetch failures degrade to empty data. Cookies expire and need refreshing.
+BIRDY_ACCOUNTS=                  # [secret] JSON array of read-only account cookies
 BIRD_AUTH_TOKEN=                 # [secret] X auth_token cookie
 BIRD_CT0=                        # [secret] X ct0 cookie
 
@@ -48,6 +49,10 @@ PERPLEXITY_API_KEY=              # [secret] Perplexity search (optional)
 
 # ─── Audio (digest / article TTS) ───────────────────────────────────
 GEMINI_API_KEY=                  # [secret] Gemini Flash TTS (optional; audio skipped if unset)
+S3_ENDPOINT_URL=                 # [secret] S3-compatible endpoint for generated audio
+S3_BUCKET=                       # [secret] audio bucket name
+S3_ACCESS_KEY_ID=                # [secret] S3 access key (AWS_ACCESS_KEY_ID also accepted)
+S3_SECRET_ACCESS_KEY=            # [secret] S3 secret key (AWS_SECRET_ACCESS_KEY also accepted)
 
 # ─── Telemetry + alerts (all optional; no-op when unset) ────────────
 HOOKER_URL=https://hooker.guzus.xyz   # [config] telemetry endpoint base
@@ -57,9 +62,13 @@ TELEGRAM_CHAT_ID=                # [secret] headline-alert destination chat
 
 # ─── Self-hostable service endpoints (non-secret; override to point at
 #     your own infra instead of the maintainer's example deployment) ──
-# SEC EDGAR requires a contact in the User-Agent; defaults to a project
-# noreply. Set this to your own email if you want SEC to be able to reach you.
+# SEC EDGAR requires a contact in the User-Agent. The scheduled earnings lane
+# reads SEC_CONTACT_EMAIL; research_search.py retains EDGAR_CONTACT_EMAIL for
+# local/on-demand searches. Set both to an address you monitor.
+SEC_CONTACT_EMAIL=ai-research-arm@users.noreply.github.com     # [config]
 EDGAR_CONTACT_EMAIL=ai-research-arm@users.noreply.github.com   # [config]
+# YouTube signal API. Point this at your own compatible tuber deployment.
+TUBER_API_BASE=https://tuber-api.guzus.xyz                     # [config]
 # Where the daily digest/article MP3s are hosted (producer + consumer).
 AUDIO_BASE_URL=https://s3.guzus.xyz/obj-ai-research-arm        # [config] (workflows)
 VITE_AUDIO_BASE_URL=https://s3.guzus.xyz/obj-ai-research-arm   # [config] (dashboard build)

--- a/README.md
+++ b/README.md
@@ -5,19 +5,22 @@
 **The AI newspaper that writes itself.** Every few hours, a fleet of LLM agents
 reads the AI firehose — Twitter/X, RSS, Hacker News, Reddit, Bluesky, arXiv,
 expert blogs, YouTube. Every night it writes the paper: a synthesized digest, a
-rendered front page, a model-release timeline, a compounding wiki. Every week
-it opens a pull request to improve its own methodology. The only human in the
-loop reviews the PRs.
+rendered front page, a model-release timeline, a compounding wiki. Every week it
+audits its own methodology and may open a review PR. Humans review code and
+methodology changes; routine publication PRs merge automatically after their
+scope and output contracts pass.
 
 [![CI](https://github.com/guzus/ai-research-arm/actions/workflows/ci.yml/badge.svg)](https://github.com/guzus/ai-research-arm/actions/workflows/ci.yml)
 [![Live dashboard](https://img.shields.io/badge/live-ara.guzus.xyz-1f6feb)](https://ara.guzus.xyz)
 [![License: MIT](https://img.shields.io/badge/license-MIT-2ea44f)](LICENSE)
 [![Commit activity](https://img.shields.io/github/commit-activity/w/guzus/ai-research-arm?label=commits)](https://github.com/guzus/ai-research-arm/commits/main)
 
-Running unattended since January 2026: **23 GitHub Actions workflows** have
-committed **1,400+ research artifacts** — 110+ daily digests, 60+ long-form
-cited articles, a 115-ticket model-release timeline, and a 58-page wiki — all
-deployed continuously to **[ara.guzus.xyz](https://ara.guzus.xyz)**.
+Running unattended since January 2026. As of 2026-08-19, **32 GitHub Actions
+workflow files** orchestrate the pipeline, and the repository contains **5,700+
+files under `research/`** — 152 daily digests, 109 rendered front pages, 101
+generative-research archive entries, 186 model-release tickets, and a 93-page
+wiki. Public outputs deploy continuously to
+**[ara.guzus.xyz](https://ara.guzus.xyz)**.
 
 📖 [Why this is open source](https://guzus.substack.com/p/open-sourcing-ai-research-arm-ara) ·
 [What's changed since the post](docs/since-the-open-sourcing-post.md) ·
@@ -29,15 +32,15 @@ deployed continuously to **[ara.guzus.xyz](https://ara.guzus.xyz)**.
 ![Today's Front Page](research/front-page/2026-08-19-front-page.png)
 <!-- FRONT_PAGE_END -->
 
-> 🗞️ Rendered every day at 00:30 UTC from the digest — deterministic SVG→PNG,
-> no model in the render path. [Interactive edition](https://ara.guzus.xyz/frontpage) ·
+> 🗞️ Rendered after each successful daily digest — deterministic SVG→PNG, no
+> model in the render path. [Interactive edition](https://ara.guzus.xyz/frontpage) ·
 > [archive](research/front-page/)
 
 ## What it publishes
 
 | Output | Cadence | Live | Source of truth |
 |---|---|---|---|
-| 🗞️ **Front page** — the day's digest as a newspaper | daily 00:30 | [/frontpage](https://ara.guzus.xyz/frontpage) | [`research/front-page/`](research/front-page/) |
+| 🗞️ **Front page** — the day's digest as a newspaper | after a successful daily digest | [/frontpage](https://ara.guzus.xyz/frontpage) | [`research/front-page/`](research/front-page/) |
 | 📰 **Daily digest** — all-source synthesis, with TTS audio | daily 00:00 | [/today](https://ara.guzus.xyz/today) | [`research/digest/`](research/digest/) |
 | 🎫 **Model timeline** — one CRUD'd ticket per release, funding round, or legal fight | daily | [/models](https://ara.guzus.xyz/models) | [`research/models/tickets/`](research/models/tickets/) |
 | 📚 **LLM wiki** — compounding knowledge base; one page per entity, concept, theme | daily, post-digest | [/wiki](https://ara.guzus.xyz/wiki) | [`research/wiki/`](research/wiki/) |
@@ -52,17 +55,17 @@ supply-chain-risk label"* — [browse all](https://ara.guzus.xyz/research).
 
 ## Quickstart (no accounts needed)
 
-Prerequisites: [Bun](https://bun.sh) and [Git LFS](https://git-lfs.com) — the
-committed front-page images are stored with Git LFS, so a `git clone` with
-git-lfs installed hydrates them automatically (the dashboard prebuild fails on
-unhydrated LFS pointers).
+Prerequisites: Node.js 22.12+ and [Bun](https://bun.sh). The current checkout
+contains no Git LFS objects; the committed sample data and front-page images
+build from a normal clone.
 
 The dashboard builds and runs against the sample research data already
 committed in this repo — no API keys or secrets required:
 
 ```bash
 cd dashboard
-bun install
+bun install --frozen-lockfile
+bun run test         # dashboard data, Korean UI, rendering, and SEO contracts
 bun run dev          # local dev server at http://localhost:5173
 # or: bun run build  # production build into dashboard/dist/
 ```
@@ -70,7 +73,7 @@ bun run dev          # local dev server at http://localhost:5173
 Python tooling is stdlib-first and managed with [uv](https://docs.astral.sh/uv/):
 
 ```bash
-uv sync --all-extras
+uv sync --frozen --all-extras
 uv run python -m unittest discover -s scripts -p 'test_*.py'
 ```
 
@@ -79,8 +82,9 @@ infrastructure — see [What you can run vs. what needs accounts](#what-you-can-
 
 ## Architecture
 
-Read → synthesize → publish → improve. Every artifact at every stage is a git
-commit, so the entire history of the pipeline's "mind" is diffable.
+Read → synthesize → publish → improve. Published text, indexes, and front-page
+artifacts are committed to git, so their history is diffable. Transient inputs,
+Telegram delivery, and S3-hosted audio are explicit exceptions.
 
 ```mermaid
 flowchart TB
@@ -95,7 +99,7 @@ flowchart TB
         YouTube["▶️ YouTube<br/><i>daily</i>"]
     end
 
-    read --> store[("📁 research/<br/>every artifact is a git commit")]
+    read --> store[("📁 research/<br/>versioned publication record")]
 
     subgraph synth["🧠 SYNTHESIZE — daily"]
         Digest["📰 Daily digest<br/><i>00:00 UTC · + TTS audio</i>"]
@@ -123,16 +127,16 @@ flowchart TB
     Front --> Site
     Gen --> Site
 
-    Improve["🔄 IMPROVE — weekly<br/><i>reads its own output, opens a PR</i>"]
+    Improve["🔄 IMPROVE — weekly<br/><i>audits output, proposes scoped fixes</i>"]
     Site -.-> Improve
     Improve -.-> read
 ```
 
 The dashboard is a Vite + Bun + TypeScript SPA. On every push to `main`,
 Railway rebuilds the root [`Dockerfile`](Dockerfile) (bun build → Caddy serve,
-behind Cloudflare); `dashboard/scripts/prebuild.mjs` copies `research/` into
-the site before Vite runs. There is no deploy workflow — publishing research
-*is* deploying.
+behind Cloudflare); `dashboard/scripts/prebuild.mjs` copies the dashboard's
+selected committed output directories into the site before Vite runs. There is
+no deploy workflow — publishing research *is* deploying.
 
 ## Backend routing
 
@@ -191,11 +195,11 @@ _Generated from [`data/agent-backends.json`](data/agent-backends.json) — fallb
 |--------|--------|-----------|
 | **Twitter/X** | Birdy read-only multi-fetch (reviewed account manifest + 7 searches) | Every 3 hours |
 | **RSS feeds** | Direct XML fetch (OpenAI, Anthropic, DeepMind, TechCrunch, …) | Every 2 hours |
-| **Hacker News** | MCP server | Every 4 hours |
+| **Hacker News** | Algolia HN Search API | Every 4 hours |
 | **Reddit** | RSS feeds (r/MachineLearning, r/LocalLLaMA, r/artificial) | Every 4 hours |
 | **Expert blogs** | Curated KOL/researcher/operator feed registry; selected feeds also emit GUID-deduplicated Telegram alerts | Every 6 hours (subscriptions every 2 hours) |
 | **Bluesky** | Public API | Daily |
-| **arXiv** | MCP + RSS | Daily |
+| **arXiv** | Direct Atom API (plus RSS in the RSS lane) | Daily |
 | **YouTube** | tuber API discovery + read-only summaries/transcripts | Daily |
 | **Web search** | Exa/Perplexity MCP (optional) | On demand |
 
@@ -207,7 +211,7 @@ is strong. Contract: [`docs/twitter-account-curation.md`](docs/twitter-account-c
 
 ## Workflows
 
-All 27 workflows live in [`.github/workflows/`](.github/workflows/). The
+All 32 workflows live in [`.github/workflows/`](.github/workflows/). The
 interesting ones:
 
 **Aggregate** — raw signal in, markdown out
@@ -238,69 +242,44 @@ interesting ones:
 
 | Workflow | Trigger | Output |
 |---|---|---|
-| `daily-front-page.yml` | daily 00:30 UTC | newspaper PNG + interactive edition |
+| `daily-front-page.yml` | after a successful daily digest | newspaper PNG + interactive edition |
 | `generative-research.yml` | issue label or dispatch | long-form cited article |
+| `translate-generative-research.yml` | manual dispatch | validated Korean article translation via review PR |
 | `research-issue.yml` | `research` issue label | report posted back to the issue |
 
 **Keep it honest** — the pipeline watching itself
 
 | Workflow | Trigger | Purpose |
 |---|---|---|
-| `daily-improve.yml` | weekly Mon | reads its own output, opens a methodology PR |
+| `daily-improve.yml` | weekly Mon | audits output; opens a methodology PR when it finds a scoped change |
 | `liveness-check.yml` | scheduled | per-lane freshness watchdog, runs on *both* runner tiers |
-| `auto-rerun-on-runner-loss.yml` | on failure | re-runs jobs whose ephemeral worker vanished (loop-capped) |
-| `ci.yml` | push/PR | actionlint + dashboard build + Python tests |
+| `auto-rerun-on-runner-loss.yml` | on failure | re-runs jobs whose runner vanished (loop-capped) |
+| `ci.yml` | push/PR | actionlint + dashboard tests/typecheck/build + Python tests and data validators |
 | `claude.yml` / `claude-code-review.yml` | `@claude` / PR | interactive agent + automated review |
 
-<details>
-<summary>📅 Daily schedule as a Gantt chart</summary>
-
-```mermaid
-gantt
-    title Daily Workflow Schedule (UTC)
-    dateFormat HH:mm
-    axisFormat %H:%M
-
-    section Every 2h
-    RSS Feeds           :crit, 00:30, 2h
-
-    section Every 3h
-    Twitter/X           :active, 00:07, 3h
-
-    section Every 4h
-    Community (HN+Reddit) :00:19, 4h
-
-    section Every 6h
-    Expert Blogs        :00:13, 6h
-
-    section Twice Daily
-    AI News Research    :08:23, 1h
-
-    section Daily
-    YouTube Signal      :23:20, 1h
-    Bluesky             :00:11, 1h
-    arXiv Papers        :06:13, 1h
-    Daily Digest        :00:00, 1h
-    Self-Improve        :milestone, 00:17, 0h
-```
-
-</details>
+Exact cron expressions and event dependencies live in the workflow YAML; the
+tables above describe cadence without duplicating a second schedule that can
+drift.
 
 ## Research on demand
 
-Three ways to commission work from the pipeline:
+Three ways maintainers and trusted collaborators can commission work from the
+pipeline:
 
-**1. Issue → research report.** Open a GitHub issue, add the `research` label.
-The agent acknowledges it, researches with web search + MCP tools, commits a
-report to `research/issues/`, and posts the findings back on the issue.
+**1. Issue → research report.** A repository owner, member, or collaborator
+opens an issue and adds the `research` label. The agent acknowledges it,
+researches with web search + MCP tools, commits a report to `research/issues/`,
+and posts the findings back on the issue.
 
-**2. Topic → published article.** Label an issue `gen-research` or dispatch
-`generative-research.yml` with a `topic`. The agent researches primary
-sources, writes in the [ARA DSL](ARA_DSL.md) (a validated component language
-— see [Component catalog](COMPONENTS.md)), and publishes through a single
-writer path that re-validates everything before commit. Defaults to GLM 5.2
-via Fireworks; `backend=claude|codex|opencode-deepseek-v4-flash|deepseek-v4-flash`
-selects other providers ([details](docs/generative-research-backends.md)).
+**2. Topic → published article.** A trusted issue author uses the
+`gen-research` label, or a maintainer dispatches `generative-research.yml` with
+a `topic`. The agent researches primary sources, writes in the
+[ARA DSL](ARA_DSL.md) (a validated component language — see
+[Component catalog](COMPONENTS.md)), and publishes through a single writer
+path that re-validates everything before commit. The SSOT default is DeepSeek
+V4 Flash via OpenCode Go; explicit selectors also expose native Claude, Codex,
+Cursor, and Fireworks routes
+([details](docs/generative-research-backends.md)).
 
 **3. Tweet → verified article.** Give it just a tweet URL — it reads the
 thread, infers the underlying research question, then verifies the claims
@@ -317,28 +296,31 @@ The interesting engineering is less "call an LLM" and more "survive every way
 this can break":
 
 - **Fail-closed publishing.** Scheduled editorial lanes must prove fresh
-  Claude-authored output. If the agent path writes nothing or produces
-  sub-floor content, the workflow goes red instead of publishing a
-  model-free fallback summary.
+  agent-authored output. If the agent path writes nothing or produces
+  sub-floor content, the workflow goes red. The daily digest is the deliberate
+  exception: it may publish a clearly labelled deterministic fallback rather
+  than leave the front page blank.
 - **Output contracts.** Agent lanes must *prove* their work:
   [`require-output`](.github/actions/require-output) asserts the expected
   artifacts changed, and [`require-diff-scope`](.github/actions/require-diff-scope)
   asserts nothing outside the declared paths was committed.
-- **Sandboxed agents.** Claude Code runs under a fail-closed bubblewrap policy
-  ([`.claude/settings.json`](.claude/settings.json)) — no host credentials, no
-  unsandboxed shell. Comparison lanes on other harnesses run in containers.
-- **Provider failover.** One SSOT file routes every lane across
-  Fireworks / Z.ai / Anthropic / Codex with an ordered fallback chain — and CI
-  fails if docs or workflows drift from it.
+- **Sandboxed agents.** Native Claude lanes use a fail-closed bubblewrap policy
+  ([`.claude/settings.json`](.claude/settings.json)). OpenCode and Cursor lanes
+  run as non-root users in locked-down containers and import only validated
+  output from disposable clones.
+- **Provider routing.** One SSOT maps lanes across OpenCode, Cursor, Fireworks,
+  Z.ai, Anthropic, and Codex, including strict routes and ordered fallbacks —
+  and CI fails if the generated docs or workflow mirrors drift from it.
 - **Watchdogs that outlive the fleet.** Freshness checks run on both runner
   tiers so an outage on either still alerts; a loop-safe auto-rerunner
-  recovers jobs whose ephemeral Cloud Run worker vanished mid-run.
+  recovers jobs whose runner vanished mid-run.
 - **CRUD, not regenerate.** The model timeline and wiki are persistent stores
   with immutable slugs and append-only history, schema-validated on every PR
-  — knowledge compounds instead of being rewritten nightly.
+  that changes them — knowledge compounds instead of being rewritten nightly.
 - **Self-improvement with review.** The weekly improve lane reads the
-  pipeline's own output and opens PRs — it can propose anything, but a human
-  merges.
+  pipeline's own output and may open a scoped methodology PR; it makes no
+  change when the evidence does not justify one, and a human decides whether
+  to merge proposals.
 
 ## What you can run vs. what needs accounts
 
@@ -350,9 +332,9 @@ is included for transparency rather than turnkey reuse.
 - The **dashboard** — builds and serves from the sample data committed under
   `research/` (see [Quickstart](#quickstart-no-accounts-needed)).
 - The **Python tooling + tests** — stdlib-first, `uv`-managed; validators and
-  unit tests run offline.
+  unit tests need no service accounts after dependencies are installed.
 
-**Needs your own credentials (drop-in):**
+**Needs your own credentials and compatible runners/services:**
 - **Claude / Codex / OpenCode / Cursor / Fireworks / Z.ai backends** — set
   `CLAUDE_CODE_OAUTH_TOKEN`, `CODEX_AUTH_JSON`, `OPENCODE_API_KEY`,
   `CURSOR_API_KEY`, `FIREWORKS_API_KEY`, or `ZAI_API_KEY` for the
@@ -361,14 +343,17 @@ is included for transparency rather than turnkey reuse.
   authenticates the opencode CLI with a plain env-var key against the
   OpenCode Go subscription; the Cursor lane authenticates the official
   `agent` CLI with `CURSOR_API_KEY`.
-- **Twitter/X lanes** — supply your own `BIRD_AUTH_TOKEN` / `BIRD_CT0` cookies
-  (they expire often; lanes degrade to empty data without them).
+- **Twitter/X lanes** — supply either `BIRDY_ACCOUNTS` or both
+  `BIRD_AUTH_TOKEN` / `BIRD_CT0` cookies. Auth setup fails fast if neither
+  route is complete; after setup, individual fetch errors degrade to empty
+  data so one expired account does not crash the whole aggregation pass.
 - **Exa / Perplexity** search enrichment and **Gemini** TTS are optional.
 
 **Maintainer-specific (swap or disable to self-host):**
-- **Runners:** nearly every workflow targets a private self-hosted Cloud Run
-  fleet (`runs-on: [self-hosted, Linux]`); on a fork those jobs queue until you
-  point them at your own runners (or change `runs-on`).
+- **Runners:** nearly every workflow targets the maintainer's private
+  self-hosted Linux runner (`runs-on: [self-hosted, Linux]`); on a fork those
+  jobs queue until you register your own runner (or change `runs-on`). The old
+  Cloud Run fleet is paused rollback infrastructure, not the production path.
 - **Services:** `hooker.guzus.xyz` (telemetry — no-ops if `HOOKER_URL` is
   unset), `tuber-api.guzus.xyz` (YouTube signal — no public equivalent), and
   `s3.guzus.xyz` (audio hosting). Override the non-secret endpoints via the env
@@ -378,25 +363,26 @@ is included for transparency rather than turnkey reuse.
   `ara.guzus.xyz` is the maintainer's domain. The static dashboard shell also
   embeds a Google Analytics tag in `dashboard/index.html` — remove it on a fork.
 - **Sibling repos** `../oracle` and `../runner` referenced in the docs are
-  private and not required for the default Claude/Codex/Fireworks paths.
+  private and not required for the no-account Quickstart or hosted-provider
+  workflows.
 
 ### Secrets
 
 All credentials are injected via GitHub Actions secrets (or a local `.env`,
-which is gitignored) — see [`.env.example`](.env.example) for the full
-annotated list. None are needed for the
+which is gitignored) — see [`.env.example`](.env.example) for the common local
+settings and service overrides. None are needed for the
 [Quickstart](#quickstart-no-accounts-needed).
 
 | Secret | Required for | Description |
 |--------|--------------|-------------|
 | `CLAUDE_CODE_OAUTH_TOKEN` | native-Claude lanes, fallback path, reserved dispatcher plumbing | Claude Code auth; current host-checkout agent-run is incompatible with the editorial dispatcher |
-| `FIREWORKS_API_KEY` | Fireworks profiles, comparison lanes, reserved dispatcher plumbing | Anthropic-compatible Fireworks endpoint; prewired for a future isolated adapter, not selectable through agent-run today |
-| `ZAI_API_KEY` | Z.ai GLM 5.2 lanes, reserved dispatcher plumbing | Z.ai Coding Plan; prewired for a future isolated adapter |
+| `FIREWORKS_API_KEY` | Fireworks generative and comparison routes | Anthropic-compatible Fireworks endpoint for explicit model routes and comparison lanes |
+| `ZAI_API_KEY` | Z.ai GLM 5.2 lanes and fallback chain | Z.ai Coding Plan key; current second provider in the global fallback chain and used by Z.ai canaries/comparison lanes |
 | `CODEX_AUTH_JSON` | `generative-research backend=codex` | file-backed ChatGPT Codex auth from `codex login`; treat like a password |
 | `OPENCODE_API_KEY` | OpenCode profiles, direct comparison/canary paths, dispatcher route plumbing | OpenCode Go key. The five editorial lanes use it while their shared route selects the current strict OpenCode profile; then they share its plan caps. |
 | `CURSOR_API_KEY` | Cursor CLI profiles, direct comparison/canary paths, dispatcher route plumbing | Cursor dashboard API key. Prewired so an SSOT-only switch to `cursor-grok-4p6-fast` needs no workflow edit. Production defaults stay on OpenCode. |
 | `BIRD_AUTH_TOKEN` / `BIRD_CT0` | Twitter/X lanes | X cookies (read-only use; expire often) |
-| `BIRDY_ACCOUNTS` | optional | multi-account rotation JSON; every account forced read-only |
+| `BIRDY_ACCOUNTS` | alternative to cookie pair | multi-account rotation JSON; every account forced read-only |
 | `GEMINI_API_KEY` | digest/article audio | price-performant TTS |
 | `EXA_API_KEY` / `PERPLEXITY_API_KEY` | optional | neural + cited web search via MCP |
 | `TELEGRAM_BOT_TOKEN` / `TELEGRAM_CHAT_ID` | blog alerts, digests, liveness escalation | delivery channel |
@@ -406,20 +392,25 @@ annotated list. None are needed for the
 
 ```
 research/
+├── arm/            # dashboard-facing agent timeline
 ├── arxiv/          # daily papers
+├── audio/          # zero-byte date stubs; generated audio lives on S3
 ├── blogs/          # expert-blog digests
 ├── bluesky/        # supplemental commentary
 ├── community/      # HN + Reddit digests
+├── claims/         # cross-article verified-claim index
 ├── digest/         # the daily synthesis (+ audio stubs; mp3s on S3)
 ├── earnings/       # AI-issuer earnings events from SEC EDGAR (per event, not per day)
 ├── front-page/     # newspaper PNG + interactive edition
-├── generative/     # long-form articles (.html + .ara.md + index.json)
+├── generative/     # long-form articles, translations, claim ledgers, and index
 ├── issues/         # on-demand issue research
+├── market/         # deterministic GPU and model-price datasets
 ├── models/tickets/ # persistent model-release tickets
 ├── rss/            # raw-signal digests
 ├── summaries/      # Telegram digests + alert/subscription ledgers
 ├── twitter/        # 3-hourly reports
 ├── wiki/           # the compounding knowledge base
+├── wiki-translations/ko/ # validated Korean wiki mirrors
 └── youtube/        # tuber signal lane
 ```
 
@@ -432,7 +423,7 @@ research/
 | [`CLAUDE.md`](CLAUDE.md) | The operator's manual — load-bearing rules, lane contracts, failure modes |
 | [`ARA_DSL.md`](ARA_DSL.md) + [`ARA_CATALOG.json`](ARA_CATALOG.json) + [`COMPONENTS.md`](COMPONENTS.md) | The article component language: source format, machine catalog, human reference — kept in lockstep by CI |
 | [`data/agent-backends.json`](data/agent-backends.json) | Single source of truth for model routing + fallback chains |
-| [`scripts/`](scripts/) | 87 stdlib-first Python tools: validators, deterministic fallbacks, dedup gates, renderers |
+| [`scripts/`](scripts/) | 109 Python modules: 65 implementation tools and 44 test modules, plus the JavaScript front-page renderer |
 | [`docs/`](docs/) | Contracts and deep dives: [backend matrix](docs/backend-matrix.md), [model tickets](docs/model-tickets.md), [wiki schema](docs/wiki-schema.md), [headline dedup](docs/headline-dedupe.md), [AI industry map](docs/ai-industry-map.md), [OKF export](docs/okf.md) |
 | [`dashboard/`](dashboard/) | Vite + Bun + TypeScript SPA behind ara.guzus.xyz |
 | [`prompts/`](prompts/) | Agent prompts for the scheduled lanes |


### PR DESCRIPTION
## Summary
- refresh dated repository/output metrics and current workflow behavior
- make the no-account Quickstart reproducible with locked Bun and uv installs
- align backend, runner, schedule, source, and trusted-trigger documentation with the live contracts
- document the current environment variables used by hosted-provider and self-hosted paths

## Verification
- bun install --frozen-lockfile
- bun run test (20/20)
- bun run build (101 research pages, 152 digests, 109 front pages, 93 wiki pages)
- uv sync --frozen --all-extras
- uv run python scripts/build_backend_matrix.py --check
- git diff --check
- fresh-clone review verified no Git LFS objects/pointers

## Scope
License and privacy/analytics policy are intentionally unchanged.