### PR TITLE
Pin production image versions and normalize MIT license

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM oven/bun:1-alpine AS build
+# Keep the contest/release SBOM reproducible. The tag documents the human-
+# readable version while the digest prevents it from moving underneath us.
+FROM oven/bun:1.4.0-alpine@sha256:07235578f79ef8c6f97d94aee7938e76f5cdba5f21ae5dbfdd3d3d38058437eb AS build
 
 WORKDIR /app
 
@@ -18,9 +20,7 @@ COPY research ./research
 
 RUN cd dashboard && SKIP_LFS_POINTERS=1 bun run build
 
-FROM oven/bun:1-alpine AS runtime
-
-RUN apk add --no-cache caddy
+FROM caddy:2.11.4-alpine@sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95ab7c14d58648 AS runtime
 
 ENV PORT=8080
 

--- a/LICENSE
+++ b/LICENSE
@@ -19,16 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
----
-
-NOTE ON SCOPE: This MIT license covers the SOURCE CODE of this repository
-(scripts, workflows, the dashboard application, and documentation). It does
-NOT relicense the contents of `research/`, which are automated excerpts,
-summaries, and reproductions of third-party material (news articles, posts
-from X/Twitter, Hacker News, Reddit, Bluesky, arXiv, and similar sources).
-Those artifacts remain the property of their original authors and are included
-here only as the generated output of the pipeline. If you reuse anything under
-`research/`, you are responsible for complying with the original sources'
-terms (including the X/Twitter Terms of Service and the copyright of each
-publisher). See the "License" section of README.md for details.


### PR DESCRIPTION
## Summary
- replace floating `oven/bun:1-alpine` with Bun 1.4.0 / Alpine 3.22.5 pinned by multi-arch digest
- use the official Caddy 2.11.4 / Alpine 3.23.5 runtime image pinned by multi-arch digest
- restore `LICENSE` to the canonical MIT text so GitHub can detect it; the existing README License section retains the `research/` content carve-out

## Verification
- `bun run test` (20/20 passed)
- `SKIP_LFS_POINTERS=1 bun run build`
- Docker Hub OCI manifests/configs checked for both pinned digests

## Operational note
Railway watches `main`; merging this PR triggers the production rebuild for ara.guzus.xyz.