### PR TITLE
Retry zero-commit editorial OpenCode runs

### DIFF
--- a/.github/actions/run-opencode-container/action.yml
+++ b/.github/actions/run-opencode-container/action.yml
@@ -716,12 +716,16 @@ runs:
               trusted_packed=$(base64 -w0 .git/packed-refs)
             fi
 
-            # The Korean translation lane has shown one specific provider
-            # failure mode: opencode exits zero without calling its only
-            # segment tool or creating the required result. Retry that silent
-            # no-op once, and only that no-op. Both attempts share the original
-            # timeout budget; partial output, nonzero exits, and every other
-            # lane remain single-attempt and fail closed.
+            # OpenCode can exit zero without producing required lane output.
+            # output. Retry two exact silent-success shapes once: Korean
+            # translation created neither its segment artifact nor a tool call,
+            # or a commit-producing editorial lane left HEAD at PRE_SHA. Both
+            # attempts share the original timeout budget. Before an editorial
+            # retry, restore the disposable workspace and staged source inputs,
+            # then give the new process a fresh HOME/cache and remove the first
+            # process log. Nonzero exits and successful commits remain
+            # single-attempt; a second editorial no-op becomes an explicit
+            # failure instead of looking like adapter success.
             # OPENCODE_ATTEMPT_LOOP_BEGIN
             #
             # Provider errors that can NEVER recover inside a single run.
@@ -752,6 +756,22 @@ runs:
             total_segment_calls=0
             retry_reason=none
             artifact_count=0
+            retry_commit_editorial=false
+            retry_agent_input_tree=""
+            if [ "${RUN_MODE:-}" = "editorial" ] \
+              && [ -n "${ALLOWED_PATHS:-}" ] \
+              && [ -z "${RETURN_ARTIFACTS:-}" ]; then
+              retry_commit_editorial=true
+              if [ -d .agent-input ]; then
+                retry_index=$(mktemp /tmp/opencode-retry-index.XXXXXX)
+                rm -f -- "$retry_index"
+                GIT_INDEX_FILE="$retry_index" git read-tree --empty
+                GIT_INDEX_FILE="$retry_index" git add -f -- .agent-input
+                retry_agent_input_tree=$(GIT_INDEX_FILE="$retry_index" \
+                  git write-tree)
+                rm -f -- "$retry_index"
+              fi
+            fi
             while :; do
               attempt_count=$((attempt_count + 1))
               remaining_seconds=$((model_budget_seconds \
@@ -763,13 +783,22 @@ runs:
 
               attempt_log="/tmp/opencode-attempt-${attempt_count}.log"
               rm -f -- "$attempt_log"
+              attempt_home="/tmp/opencode-home-attempt-${attempt_count}"
+              rm -rf -- "$attempt_home"
+              mkdir -p "$attempt_home"
               set +e
               # --print-logs puts opencode provider errors on stderr so a
               # dead route is visible in the job log instead of silent. The
               # run is backgrounded (rather than piped through tee) purely so
               # we hold its PID and can abort early; `tail --pid` reproduces
               # the old live-streaming behaviour and exits with the run.
-              timeout "${remaining_seconds}s" opencode run \
+              HOME="$attempt_home" \
+                XDG_CONFIG_HOME="$attempt_home/.config" \
+                XDG_DATA_HOME="$attempt_home/.local/share" \
+                XDG_CACHE_HOME="$attempt_home/.cache" \
+                UV_CACHE_DIR="$attempt_home/.cache/uv" \
+                UV_PYTHON_INSTALL_DIR="$attempt_home/.local/uv-python" \
+                timeout "${remaining_seconds}s" opencode run \
                 -m "$OPENCODE_MODEL_REF" \
                 --auto \
                 --print-logs --log-level ERROR \
@@ -821,6 +850,36 @@ runs:
                 fi
               done <<< "$RETURN_ARTIFACTS"
               echo "OpenCode attempt ${attempt_count}: status=${agent_status} translation_segment_calls=${segment_calls} artifacts=${artifact_count} remaining_seconds=${remaining_seconds}"
+
+              attempt_post_sha=""
+              if [ "$retry_commit_editorial" = "true" ]; then
+                attempt_post_sha=$(git rev-parse HEAD)
+              fi
+              if [ "$retry_commit_editorial" = "true" ] \
+                && [ "$agent_status" -eq 0 ] \
+                && [ "$attempt_post_sha" = "$PRE_SHA" ]; then
+                if [ "$attempt_count" -eq 1 ]; then
+                  retry_reason=zero-commit-editorial
+                  echo "Retrying editorial OpenCode once after a zero-commit successful attempt."
+                  git reset --hard "$PRE_SHA"
+                  git clean -ffdx
+                  mkdir -p .tmp
+                  if [ -n "$retry_agent_input_tree" ]; then
+                    retry_index=$(mktemp /tmp/opencode-retry-index.XXXXXX)
+                    rm -f -- "$retry_index"
+                    GIT_INDEX_FILE="$retry_index" git read-tree \
+                      "$retry_agent_input_tree"
+                    GIT_INDEX_FILE="$retry_index" git checkout-index \
+                      --all --force --prefix="$PWD/"
+                    rm -f -- "$retry_index"
+                  fi
+                  rm -rf -- "$attempt_home"
+                  rm -f -- "$attempt_log"
+                  continue
+                fi
+                echo "::error::Editorial OpenCode exited successfully twice without committing output."
+                agent_status=86
+              fi
 
               if [ "$AGENT_LANE" = "generative-research-ko" ] \
                 && [ "$RETURN_ARTIFACTS" = ".tmp/generative-translation.ko.segments.jsonl" ] \
@@ -1022,7 +1081,7 @@ runs:
           || [[ ! "$status_line" =~ ^last_agent_status=([0-9]{1,3})$ ]] \
           || [[ ! "$segment_line" =~ ^translation_segment_calls=([0-9]{1,5})$ ]] \
           || [[ ! "$artifact_line" =~ ^artifact_count=([0-8])$ ]] \
-          || [[ ! "$reason_line" =~ ^retry_reason=(none|zero-artifact-zero-translation-segment)$ ]]; then
+          || [[ ! "$reason_line" =~ ^retry_reason=(none|zero-artifact-zero-translation-segment|zero-commit-editorial)$ ]]; then
           echo "::error::opencode attempt telemetry is malformed."
           exit 1
         fi

--- a/scripts/test_backend_matrix.py
+++ b/scripts/test_backend_matrix.py
@@ -1456,6 +1456,183 @@ class RoutingInvariants(unittest.TestCase):
             self.assertIn("artifact_count=1", telemetry)
             self.assertIn("retry_reason=none", telemetry)
 
+    def test_editorial_zero_commit_retry_is_clean_bounded_and_fail_closed(self):
+        """Commit editorials retry one clean-workspace no-op, then fail."""
+        action_doc = yaml.safe_load(
+            (REPO_ROOT / ".github/actions/run-opencode-container/action.yml")
+            .read_text(encoding="utf-8")
+        )
+        run = action_doc["runs"]["steps"][0]["run"]
+        self.assertEqual(2, run.count('exit "$agent_status"'))
+        loop = run.split("# OPENCODE_ATTEMPT_LOOP_BEGIN", 1)[1].split(
+            "# OPENCODE_ATTEMPT_LOOP_END", 1)[0]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            bin_dir = root / "bin"
+            bin_dir.mkdir()
+            prompt = root / "prompt.md"
+            prompt.write_text("curate arxiv\n", encoding="utf-8")
+            loop = loop.replace("/tmp/opencode-prompt.md", str(prompt))
+            loop = loop.replace(
+                'attempt_log="/tmp/opencode-attempt-${attempt_count}.log"',
+                'attempt_log="$PWD/opencode-attempt-${attempt_count}.log"')
+
+            timeout = bin_dir / "timeout"
+            timeout.write_text(
+                "#!/bin/bash\nset -eu\nshift\nexec \"$@\"\n",
+                encoding="utf-8")
+            timeout.chmod(0o755)
+            opencode = bin_dir / "opencode"
+            opencode.write_text(
+                "#!/bin/bash\n"
+                "set -eu\n"
+                "attempt=0\n"
+                "if [ -f \"$OPENCODE_ATTEMPT_FILE\" ]; then "
+                "attempt=$(tr -d '\\r\\n' < \"$OPENCODE_ATTEMPT_FILE\"); fi\n"
+                "attempt=$((attempt + 1))\n"
+                "printf '%s\\n' \"$attempt\" > \"$OPENCODE_ATTEMPT_FILE\"\n"
+                "write_commit() {\n"
+                "  mkdir -p research/arxiv\n"
+                "  printf 'papers\\n' > research/arxiv/2026-08-26-papers.md\n"
+                "  git add research/arxiv/2026-08-26-papers.md\n"
+                "  git commit -qm 'arXiv papers'\n"
+                "}\n"
+                "case \"$OPENCODE_FAKE_BEHAVIOR\" in\n"
+                "  retry-commit) [ \"$attempt\" -eq 2 ] && write_commit || : ;;\n"
+                "  dirty-retry)\n"
+                "    if [ \"$attempt\" -eq 1 ]; then\n"
+                "      mkdir -p research/arxiv\n"
+                "      printf 'partial\\n' > research/arxiv/2026-08-26-papers.md\n"
+                "    else\n"
+                "      [ ! -e research/arxiv/2026-08-26-papers.md ] || exit 97\n"
+                "      write_commit\n"
+                "    fi\n"
+                "    ;;\n"
+                "  first-commit) write_commit ;;\n"
+                "  mutate-input)\n"
+                "    if [ \"$attempt\" -eq 1 ]; then\n"
+                "      printf 'changed\\n' > .agent-input/source.txt\n"
+                "    else\n"
+                "      grep -qx 'source' .agent-input/source.txt || exit 96\n"
+                "      write_commit\n"
+                "    fi\n"
+                "    ;;\n"
+                "  nonzero) exit 9 ;;\n"
+                "  no-output) ;;\n"
+                "  *) exit 98 ;;\n"
+                "esac\n",
+                encoding="utf-8")
+            opencode.chmod(0o755)
+
+            def run_case(name: str, behavior: str, *, mode: str = "editorial",
+                         allowed_paths: str = (
+                             "research/arxiv/2026-08-26-papers.md"),
+                         return_artifacts: str = ""):
+                case_dir = root / name
+                case_dir.mkdir()
+                subprocess.run(["git", "init", "-q"], cwd=case_dir,
+                               check=True)
+                subprocess.run(["git", "config", "user.name", "Test"],
+                               cwd=case_dir, check=True)
+                subprocess.run(["git", "config", "user.email", "test@example.com"],
+                               cwd=case_dir, check=True)
+                (case_dir / "seed.txt").write_text("seed\n", encoding="utf-8")
+                agent_input = case_dir / ".agent-input"
+                agent_input.mkdir()
+                (agent_input / "source.txt").write_text(
+                    "source\n", encoding="utf-8")
+                subprocess.run(["git", "add", "seed.txt"], cwd=case_dir,
+                               check=True)
+                subprocess.run(["git", "commit", "-qm", "seed"],
+                               cwd=case_dir, check=True)
+                pre_sha = subprocess.check_output(
+                    ["git", "rev-parse", "HEAD"], cwd=case_dir,
+                    text=True).strip()
+                attempts = root / f"{name}-attempts"
+                env = {
+                    **os.environ,
+                    "PATH": f"{bin_dir}:/usr/bin:/bin",
+                    "AGENT_TIMEOUT_MINUTES": "1",
+                    "AGENT_LANE": "arxiv",
+                    "RUN_MODE": mode,
+                    "ALLOWED_PATHS": allowed_paths,
+                    "RETURN_ARTIFACTS": return_artifacts,
+                    "PRE_SHA": pre_sha,
+                    "OPENCODE_MODEL_REF": "opencode-go/deepseek-v4-flash",
+                    "OPENCODE_ATTEMPT_FILE": str(attempts),
+                    "OPENCODE_FAKE_BEHAVIOR": behavior,
+                }
+                result = subprocess.run(
+                    ["bash", "-c", (
+                        "set -euo pipefail\n" + loop
+                        + '\nexit "$agent_status"\n')],
+                    cwd=case_dir, env=env, text=True, capture_output=True,
+                    check=False)
+                telemetry = (case_dir / ".opencode-attempt-telemetry").read_text(
+                    encoding="utf-8")
+                count = attempts.read_text(encoding="utf-8").strip()
+                return result, count, telemetry
+
+            retried, attempts, telemetry = run_case("retry", "retry-commit")
+            self.assertEqual(0, retried.returncode,
+                             retried.stdout + retried.stderr)
+            self.assertEqual("2", attempts)
+            self.assertIn("attempt_count=2", telemetry)
+            self.assertIn("last_agent_status=0", telemetry)
+            self.assertIn("retry_reason=zero-commit-editorial", telemetry)
+
+            cleaned, attempts, telemetry = run_case("clean", "dirty-retry")
+            self.assertEqual(0, cleaned.returncode,
+                             cleaned.stdout + cleaned.stderr)
+            self.assertEqual("2", attempts)
+            self.assertIn("last_agent_status=0", telemetry)
+
+            exhausted, attempts, telemetry = run_case("exhausted", "no-output")
+            self.assertEqual(86, exhausted.returncode,
+                             exhausted.stdout + exhausted.stderr)
+            self.assertEqual("2", attempts)
+            self.assertIn("last_agent_status=86", telemetry)
+            self.assertIn("retry_reason=zero-commit-editorial", telemetry)
+            self.assertIn("exited successfully twice without committing output",
+                          exhausted.stdout)
+
+            committed, attempts, telemetry = run_case(
+                "first-commit", "first-commit")
+            self.assertEqual(0, committed.returncode,
+                             committed.stdout + committed.stderr)
+            self.assertEqual("1", attempts)
+            self.assertIn("retry_reason=none", telemetry)
+
+            failed, attempts, telemetry = run_case("nonzero", "nonzero")
+            self.assertEqual(9, failed.returncode, failed.stdout + failed.stderr)
+            self.assertEqual("1", attempts)
+            self.assertIn("last_agent_status=9", telemetry)
+            self.assertIn("retry_reason=none", telemetry)
+
+            artifact_only, attempts, telemetry = run_case(
+                "artifact-only", "no-output", allowed_paths="",
+                return_artifacts=".tmp/bluesky-section.md")
+            self.assertEqual(0, artifact_only.returncode,
+                             artifact_only.stdout + artifact_only.stderr)
+            self.assertEqual("1", attempts)
+            self.assertIn("retry_reason=none", telemetry)
+
+            generative, attempts, telemetry = run_case(
+                "generative", "no-output", mode="generative")
+            self.assertEqual(0, generative.returncode,
+                             generative.stdout + generative.stderr)
+            self.assertEqual("1", attempts)
+            self.assertIn("retry_reason=none", telemetry)
+
+            restored, attempts, telemetry = run_case(
+                "mutated-input", "mutate-input")
+            self.assertEqual(0, restored.returncode,
+                             restored.stdout + restored.stderr)
+            self.assertEqual("2", attempts)
+            self.assertIn("last_agent_status=0", telemetry)
+            self.assertIn("retry_reason=zero-commit-editorial", telemetry)
+
     def test_opencode_attempt_telemetry_is_strictly_validated(self):
         """Only the fixed five-line numeric/enumerated record is logged."""
         action_doc = yaml.safe_load(


### PR DESCRIPTION
Summary:
- retry commit-required editorial OpenCode once after exit 0 with unchanged HEAD
- restore tracked, untracked, and staged source input state before retry
- isolate retry process HOME/cache and fail a second no-op with status 86
- preserve artifact-only, Korean translation, committed, and nonzero behavior

Verification:
- backend contract suite: 79 tests passed
- actionlint passed
- backend routing matrix check passed
- independent repository review reconciled