### PR TITLE
site: add /privacy page for the ARA Daily iOS app

### DIFF
--- a/dashboard/public/privacy/index.html
+++ b/dashboard/public/privacy/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Privacy Policy — ARA Daily</title>
+<style>body{font:17px/1.6 -apple-system,system-ui,Georgia,serif;max-width:40rem;margin:4rem auto;padding:0 1.25rem;color:#1a1a1a}h1{font-size:1.8rem}h2{font-size:1.15rem;margin-top:2rem}code{background:#f2f2f2;padding:.1em .3em}</style></head>
+<body>
+<h1>Privacy Policy — ARA Daily (iOS)</h1>
+<p><em>Effective 2026-08-28</em></p>
+<p>ARA Daily is a reader for AI Research Arm, an open-source pipeline that publishes an AI news digest, a live-news feed and research articles at <a href="https://ara.guzus.xyz">ara.guzus.xyz</a>.</p>
+<h2>Data we collect</h2>
+<p><strong>None.</strong> The app has no accounts, no analytics, no advertising and no tracking. It does not collect, store or transmit personal information.</p>
+<h2>Network requests</h2>
+<p>The app downloads publicly published content from <code>ara.guzus.xyz</code> and audio files from <code>s3.guzus.xyz</code>. These servers receive the standard technical information any web request carries (your IP address, request time and the file requested), which is used only to serve the content and for ordinary server logs.</p>
+<h2>On-device data</h2>
+<p>Your language and notification preferences, and which editions you have already seen, are stored only on your device and never leave it. Notifications are generated on your device from published content; no push server receives information about you.</p>
+<h2>Third parties</h2>
+<p>Links inside articles open in your browser and are subject to those sites' policies.</p>
+<h2>Contact</h2>
+<p>Questions: <a href="https://github.com/guzus/ai-research-arm/issues">github.com/guzus/ai-research-arm/issues</a></p>
+</body></html>


### PR DESCRIPTION
Static privacy policy at https://ara.guzus.xyz/privacy/ required for the App Store listing of the ARA Daily iOS reader (guzus/ara-ios). No data collected; documents the two content hosts the app reads from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)