### PR TITLE
Auto-dispatch Korean generative translations

### DIFF
--- a/.github/workflows/generative-research.yml
+++ b/.github/workflows/generative-research.yml
@@ -155,6 +155,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      actions: write
       id-token: write
 
     steps:
@@ -3472,9 +3473,20 @@ jobs:
             exit 0
           fi
           FILENAME=$(basename "$(printf '%s\n' "$NEW_FILES" | head -n1)")
-          echo "file=$FILENAME" >> "$GITHUB_OUTPUT"
-          echo "has_file=true" >> "$GITHUB_OUTPUT"
-          echo "Generated: research/generative/$FILENAME"
+          ARTICLE_SLUG=$(jq -er --arg file "$FILENAME" '
+            map(select(.file == $file))
+            | if length == 1 then .[0].slug else error("expected exactly one index row") end
+          ' research/generative/index.json)
+          if [[ ! "$ARTICLE_SLUG" =~ ^[a-z0-9][a-z0-9-]{0,119}$ ]]; then
+            echo "::error::Writer produced an invalid final slug: $ARTICLE_SLUG"
+            exit 1
+          fi
+          {
+            echo "file=$FILENAME"
+            echo "slug=$ARTICLE_SLUG"
+            echo "has_file=true"
+          } >> "$GITHUB_OUTPUT"
+          echo "Generated: research/generative/$FILENAME (slug: $ARTICLE_SLUG)"
 
       # fable-5 and opus-5 are explicit, opt-in model selectors, so provenance
       # must be exact — the whole point of choosing one is knowing which model
@@ -4183,3 +4195,35 @@ jobs:
         env:
           HOOKER_URL: ${{ secrets.HOOKER_URL }}
           HOOKER_TOKEN: ${{ secrets.HOOKER_TOKEN }}
+
+      # Translate only production publications. A workflow_dispatch from a PR
+      # branch remains reviewable on that branch and cannot enqueue a Korean
+      # translation whose canonical English source is not yet on main.
+      #
+      # workflow_dispatch is one of the events GitHub permits a GITHUB_TOKEN
+      # to create. The explicit actions:write permission above is still
+      # required for the dispatch API call.
+      - name: Dispatch Korean translation
+        id: dispatch-translation
+        if: >-
+          always()
+          && steps.outfile.outputs.has_file == 'true'
+          && steps.push.outputs.pushed == 'true'
+          && steps.publish-branch.outputs.branch == github.event.repository.default_branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARTICLE_SLUG: ${{ steps.outfile.outputs.slug }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$ARTICLE_SLUG" =~ ^[a-z0-9][a-z0-9-]{0,119}$ ]]; then
+            echo "::error::Refusing to dispatch an invalid article slug: $ARTICLE_SLUG"
+            exit 1
+          fi
+          gh workflow run translate-generative-research.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "$DEFAULT_BRANCH" \
+            -f "slug=$ARTICLE_SLUG" \
+            -f overwrite=false \
+            -f auto_merge=true
+          echo "::notice::Queued Korean translation for $ARTICLE_SLUG"

--- a/.github/workflows/translate-generative-research.yml
+++ b/.github/workflows/translate-generative-research.yml
@@ -18,10 +18,13 @@ on:
         default: false
         type: boolean
 
-# Serialize every backfill because each one mutates the same index.json row store.
-# safe-push intentionally does not auto-merge nested index conflicts for this lane.
+# Keep duplicate requests for one article serialized without collapsing distinct
+# articles into one pending slot. GitHub retains only one pending run per group,
+# so a global group silently dropped translations during publication bursts. The
+# production self-hosted runner still serializes execution; safe-push intentionally
+# does not auto-merge nested index conflicts for this lane.
 concurrency:
-  group: generative-research-ko-backfill
+  group: generative-research-ko-backfill-${{ inputs.slug }}
   cancel-in-progress: false
 
 jobs:
@@ -79,6 +82,10 @@ jobs:
           GIT_CONFIG_NOSYSTEM: "1"
           GIT_CONFIG_GLOBAL: /dev/null
         with:
+          # A dispatch can wait behind the serialized backlog. Resolve the
+          # branch again at execution time so earlier translation merges are
+          # present in index.json instead of checking out the dispatch-time SHA.
+          ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
           persist-credentials: false
           set-safe-directory: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,7 +304,7 @@ false `deploy-stale` alerts. Do not "fix" any of these omissions.
 |---|---|---|
 | `daily-front-page.yml` | daily `00:30` (after digest) | `research/front-page/YYYY-MM-DD-front-page.png` |
 | `generative-research.yml` | `gen-research` issue label or `workflow_dispatch` with `topic` or `twitter_url` | `research/generative/*.{html,ara.md}` + `index.json` |
-| `translate-generative-research.yml` | manual `workflow_dispatch` with an existing article `slug` | One validated Korean translation revision under `research/generative/`; review PR by default |
+| `translate-generative-research.yml` | automatically dispatched after each generative article reaches `main`; manual `workflow_dispatch` also accepts an existing article `slug` | One validated Korean translation revision under `research/generative/`; automatic runs auto-merge, manual runs use a review PR by default |
 | `research-issue.yml` | issue labeled `research` | `research/issues/{issue-number}-research.md` |
 
 ### Meta (CI, code-review, self-improvement)

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ interesting ones:
 |---|---|---|
 | `daily-front-page.yml` | after a successful daily digest | newspaper PNG + interactive edition |
 | `generative-research.yml` | issue label or dispatch | long-form cited article |
-| `translate-generative-research.yml` | manual dispatch | validated Korean article translation via review PR |
+| `translate-generative-research.yml` | after each production generative article; manual dispatch also available | validated Korean article translation; automatic runs merge after all gates pass |
 | `research-issue.yml` | `research` issue label | report posted back to the issue |
 
 **Keep it honest** — the pipeline watching itself

--- a/data/agent-backends.json
+++ b/data/agent-backends.json
@@ -209,7 +209,7 @@
     "generative-research-ko": {
       "workflow": "translate-generative-research.yml",
       "route": "generative-translation",
-      "notes": "Manual one-slug Korean backfill. The isolated adapter returns one uncommitted draft; trusted host validators and the canonical writer own the immutable artifact pair, index mutation, and review-first publication."
+      "notes": "Automatic one-slug Korean translation after each production generative-research publication, with manual backfill still available. The isolated adapter returns one uncommitted draft; trusted host validators and the canonical writer own the immutable artifact pair, index mutation, and gated publication."
     },
     "twitter-primary": {
       "workflow": "hourly-twitter.yml",

--- a/scripts/test_generative_translation_dispatch.py
+++ b/scripts/test_generative_translation_dispatch.py
@@ -1,0 +1,71 @@
+"""Workflow invariants for automatic Korean generative-research translation."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _workflow(name: str) -> dict:
+    return yaml.safe_load(
+        (REPO_ROOT / ".github" / "workflows" / name).read_text(encoding="utf-8")
+    )
+
+
+class GenerativeTranslationDispatchTest(unittest.TestCase):
+    def test_production_article_dispatches_final_slug_for_auto_merge(self):
+        workflow = _workflow("generative-research.yml")
+        job = workflow["jobs"]["generative-research"]
+        self.assertEqual(job["permissions"]["actions"], "write")
+
+        steps = job["steps"]
+        by_id = {step.get("id"): step for step in steps if step.get("id")}
+        dispatch = by_id["dispatch-translation"]
+        self.assertGreater(steps.index(dispatch), steps.index(by_id["push"]))
+        self.assertNotIn("continue-on-error", dispatch)
+
+        condition = dispatch["if"]
+        self.assertIn("steps.outfile.outputs.has_file == 'true'", condition)
+        self.assertIn("steps.push.outputs.pushed == 'true'", condition)
+        self.assertIn(
+            "steps.publish-branch.outputs.branch == github.event.repository.default_branch",
+            condition,
+        )
+        self.assertEqual(
+            dispatch["env"]["ARTICLE_SLUG"], "${{ steps.outfile.outputs.slug }}"
+        )
+        command = dispatch["run"]
+        self.assertIn("gh workflow run translate-generative-research.yml", command)
+        self.assertIn('--repo "$GITHUB_REPOSITORY"', command)
+        self.assertIn('--ref "$DEFAULT_BRANCH"', command)
+        self.assertIn('-f "slug=$ARTICLE_SLUG"', command)
+        self.assertIn("-f auto_merge=true", command)
+
+        identify = by_id["outfile"]["run"]
+        self.assertIn('map(select(.file == $file))', identify)
+        self.assertIn('echo "slug=$ARTICLE_SLUG"', identify)
+        self.assertIn('} >> "$GITHUB_OUTPUT"', identify)
+
+    def test_distinct_articles_queue_and_read_latest_main(self):
+        workflow = _workflow("translate-generative-research.yml")
+        concurrency = workflow["concurrency"]
+        self.assertIn("${{ inputs.slug }}", concurrency["group"])
+        self.assertIs(concurrency["cancel-in-progress"], False)
+
+        checkout = next(
+            step
+            for step in workflow["jobs"]["translate"]["steps"]
+            if str(step.get("uses", "")).startswith("actions/checkout@")
+        )
+        self.assertEqual(
+            "${{ github.event.repository.default_branch }}", checkout["with"]["ref"]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- dispatch Korean translation after every successful generative article publication to `main`
- use the writer-assigned final slug and auto-merge automatic translations after existing validators pass
- preserve manual review-first backfills while preventing burst traffic from replacing unrelated pending translations
- refresh `main` when a queued translation starts and add workflow contract tests

## Verification
- `actionlint` on both workflows
- 2 automatic-dispatch invariant tests
- 31 generative translation tests
- 81 backend/workflow routing tests
- full 957-test Python suite: 938 passed, 6 skipped; 19 sandbox socket failures rerun separately as 38/38 passing with localhost binding allowed
- backend matrix and generated docs consistency check
- `git diff --check`

## Review notes
- independent internal reviews identified final-slug, default-branch, stale-checkout, and global-concurrency risks; all were addressed
- a proposed unsupported `concurrency.queue` key was rejected by `actionlint` and not used
- external Claude/Cursor review attempts timed out without output; Agy was permission-blocked, so no cross-CLI verdict is claimed