### PR TITLE
Make evidence provenance and producer health explicit

### DIFF
--- a/.github/actions/lane-freshness-alert/action.yml
+++ b/.github/actions/lane-freshness-alert/action.yml
@@ -1,7 +1,8 @@
-name: Lane freshness alert
+name: Lane availability and producer-health alert
 description: >-
-  Check research-lane freshness (git-commit recency vs per-lane cadence) and,
-  on staleness, alert via hooker (relays to Telegram) AND a direct Telegram
+  Check research-lane availability (git-commit recency vs per-lane cadence)
+  separately from producer health (labelled fallback/carry-forward signals) and,
+  on either anomaly, alert via hooker (relays to Telegram) AND a direct Telegram
   fallback, then fail the job. Stdlib Python only, so it runs identically on
   ubuntu-latest and the self-hosted runner. Intended to be invoked from both
   tiers so the watchdog survives whichever tier an outage takes down. The dual
@@ -32,11 +33,22 @@ inputs:
 
 outputs:
   stale:
-    description: "'true' when one or more lanes are stale (lets the caller gate a heartbeat)."
+    description: >-
+      Compatibility alert bit: 'true' when any lane is unavailable, unknown, or
+      producer-degraded. Existing callers use this to gate a healthy heartbeat.
     value: ${{ steps.check.outputs.stale }}
   stale_lanes:
-    description: Comma-separated stale lane names.
+    description: Compatibility alias for comma-separated alerting lane names.
     value: ${{ steps.check.outputs.stale_lanes }}
+  alert_lanes:
+    description: Comma-separated lanes with availability or producer-health alerts.
+    value: ${{ steps.check.outputs.alert_lanes }}
+  unavailable_lanes:
+    description: Comma-separated stale, missing, or availability-unknown lanes.
+    value: ${{ steps.check.outputs.unavailable_lanes }}
+  degraded_lanes:
+    description: Comma-separated lanes whose labelled producer signal is degraded.
+    value: ${{ steps.check.outputs.degraded_lanes }}
 
 runs:
   using: composite
@@ -44,7 +56,7 @@ runs:
     # The script writes stale / stale_lanes / idempotency_key / report to
     # $GITHUB_OUTPUT (registered as this step's outputs) and a table to the
     # job step summary. `|| true` keeps this step green so the alert steps can
-    # still fire on staleness; the explicit "Fail if stale" step (LAST) sets
+    # still fire on an alert; the explicit final fail step sets
     # the job's final red status. (Avoids relying on composite continue-on-error.)
     - name: Check lane freshness
       id: check
@@ -60,9 +72,9 @@ runs:
         [ "$code" -eq 0 ] || [ "$code" -eq 2 ] || exit "$code"
 
     # ── Channel 1: hooker (relays to Telegram) ─────────────────────────────
-    # Idempotency-Key is a per-day hash over the stale set, so the ubuntu-latest
+    # Idempotency-Key is a per-day hash over the alert set, so the ubuntu-latest
     # and self-hosted jobs (and repeat runs the same day) collapse to a single
-    # delivered message; a change in the stale set produces a new key and
+    # delivered message; a change in the alert set produces a new key and
     # re-alerts. continue-on-error so a hooker outage cannot fail the job and
     # cannot prevent the Telegram fallback below from firing.
     - name: Alert via hooker (relays to Telegram)
@@ -74,13 +86,15 @@ runs:
         HOOKER_TOKEN: ${{ inputs.hooker_token }}
         TOPIC: ${{ inputs.topic }}
         STALE_LANES: ${{ steps.check.outputs.stale_lanes }}
+        UNAVAILABLE_LANES: ${{ steps.check.outputs.unavailable_lanes }}
+        DEGRADED_LANES: ${{ steps.check.outputs.degraded_lanes }}
         IDEMPOTENCY_KEY: ${{ steps.check.outputs.idempotency_key }}
         REPO: ${{ github.repository }}
         SERVER: ${{ github.server_url }}
       run: |
         set -euo pipefail
         if [ -z "${HOOKER_URL:-}" ] || [ -z "${HOOKER_TOKEN:-}" ]; then
-          echo "Hooker credentials missing — skipping hooker alert (Telegram fallback + staleness fail still apply)"
+          echo "Hooker credentials missing — skipping hooker alert (Telegram fallback + lane-health fail still apply)"
           exit 0
         fi
         count=$(printf '%s' "$STALE_LANES" | tr ',' '\n' | grep -c . || true)
@@ -88,10 +102,11 @@ runs:
         # since the body uses parse_mode:HTML.
         SAFE_LANES=$(printf '%s' "$STALE_LANES" \
           | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g')
-        TEXT=$(printf 'Stale lanes: %s\n\nThese research lanes have not committed within their expected cadence — likely a workflow outage. Check the GitHub Actions billing/spending limit and the self-hosted runner.' "$SAFE_LANES")
+        TEXT=$(printf 'Alerting lanes: %s\nUnavailable/unknown: %s\nProducer degraded: %s\n\nThe report separates artifact availability from producer health. Investigate the liveness workflow.' \
+          "$SAFE_LANES" "${UNAVAILABLE_LANES:-none}" "${DEGRADED_LANES:-none}")
         ACTIONS_URL="${SERVER%/}/${REPO}/actions/workflows/liveness-check.yml"
         jq -n \
-          --arg title "🚨 ARA pipeline: ${count} lane(s) stale" \
+          --arg title "🚨 ARA pipeline: ${count} lane(s) unhealthy" \
           --arg text "$TEXT" \
           --arg btn "Investigate (Actions)" \
           --arg url "$ACTIONS_URL" \
@@ -125,6 +140,8 @@ runs:
         TELEGRAM_BOT_TOKEN: ${{ inputs.telegram_bot_token }}
         TELEGRAM_CHAT_ID: ${{ inputs.telegram_chat_id }}
         STALE_LANES: ${{ steps.check.outputs.stale_lanes }}
+        UNAVAILABLE_LANES: ${{ steps.check.outputs.unavailable_lanes }}
+        DEGRADED_LANES: ${{ steps.check.outputs.degraded_lanes }}
         REPO: ${{ github.repository }}
         SERVER: ${{ github.server_url }}
         RUN_ID: ${{ github.run_id }}
@@ -139,8 +156,8 @@ runs:
         # Plain text + a Markdown link. Lane names are a controlled allowlist
         # (no Markdown metacharacters), so keeping the body metachar-free is
         # what prevents a silent Telegram parse error under continue-on-error.
-        TEXT=$(printf '🚨 ARA pipeline: %s lane(s) STALE\n\nStale lanes: %s\n\nNo commit within the expected cadence — likely a workflow outage (check GitHub Actions billing/spending limit + the self-hosted runner).\n\n[Investigate](%s)' \
-          "$count" "$STALE_LANES" "$RUN_URL")
+        TEXT=$(printf '🚨 ARA pipeline: %s lane(s) UNHEALTHY\n\nAlerting: %s\nUnavailable/unknown: %s\nProducer degraded: %s\n\n[Investigate](%s)' \
+          "$count" "$STALE_LANES" "${UNAVAILABLE_LANES:-none}" "${DEGRADED_LANES:-none}" "$RUN_URL")
         if curl -sS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
           --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
           --data-urlencode "text=${TEXT}" \
@@ -156,11 +173,11 @@ runs:
     # subsequent steps once one fails without continue-on-error), which is why
     # the alert channels above run first and why the heartbeat is wired in the
     # caller AFTER this action with an `if: stale == 'false'` guard.
-    - name: Fail if stale
+    - name: Fail if lane health alerts
       if: steps.check.outputs.stale == 'true'
       shell: bash
       env:
         STALE_LANES: ${{ steps.check.outputs.stale_lanes }}
       run: |
-        echo "::error::stale lanes: ${STALE_LANES}"
+        echo "::error::lane health alerts: ${STALE_LANES}"
         exit 1

--- a/.github/actions/lane-freshness-alert/action.yml
+++ b/.github/actions/lane-freshness-alert/action.yml
@@ -49,6 +49,9 @@ outputs:
   degraded_lanes:
     description: Comma-separated lanes whose labelled producer signal is degraded.
     value: ${{ steps.check.outputs.degraded_lanes }}
+  producer_unknown_lanes:
+    description: Comma-separated lanes whose configured producer signal cannot be evaluated.
+    value: ${{ steps.check.outputs.producer_unknown_lanes }}
 
 runs:
   using: composite
@@ -88,6 +91,7 @@ runs:
         STALE_LANES: ${{ steps.check.outputs.stale_lanes }}
         UNAVAILABLE_LANES: ${{ steps.check.outputs.unavailable_lanes }}
         DEGRADED_LANES: ${{ steps.check.outputs.degraded_lanes }}
+        PRODUCER_UNKNOWN_LANES: ${{ steps.check.outputs.producer_unknown_lanes }}
         IDEMPOTENCY_KEY: ${{ steps.check.outputs.idempotency_key }}
         REPO: ${{ github.repository }}
         SERVER: ${{ github.server_url }}
@@ -102,8 +106,8 @@ runs:
         # since the body uses parse_mode:HTML.
         SAFE_LANES=$(printf '%s' "$STALE_LANES" \
           | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g')
-        TEXT=$(printf 'Alerting lanes: %s\nUnavailable/unknown: %s\nProducer degraded: %s\n\nThe report separates artifact availability from producer health. Investigate the liveness workflow.' \
-          "$SAFE_LANES" "${UNAVAILABLE_LANES:-none}" "${DEGRADED_LANES:-none}")
+        TEXT=$(printf 'Alerting lanes: %s\nUnavailable/unknown: %s\nProducer degraded: %s\nProducer unknown: %s\n\nThe report separates artifact availability from producer health. Investigate the liveness workflow.' \
+          "$SAFE_LANES" "${UNAVAILABLE_LANES:-none}" "${DEGRADED_LANES:-none}" "${PRODUCER_UNKNOWN_LANES:-none}")
         ACTIONS_URL="${SERVER%/}/${REPO}/actions/workflows/liveness-check.yml"
         jq -n \
           --arg title "🚨 ARA pipeline: ${count} lane(s) unhealthy" \
@@ -142,6 +146,7 @@ runs:
         STALE_LANES: ${{ steps.check.outputs.stale_lanes }}
         UNAVAILABLE_LANES: ${{ steps.check.outputs.unavailable_lanes }}
         DEGRADED_LANES: ${{ steps.check.outputs.degraded_lanes }}
+        PRODUCER_UNKNOWN_LANES: ${{ steps.check.outputs.producer_unknown_lanes }}
         REPO: ${{ github.repository }}
         SERVER: ${{ github.server_url }}
         RUN_ID: ${{ github.run_id }}
@@ -156,8 +161,8 @@ runs:
         # Plain text + a Markdown link. Lane names are a controlled allowlist
         # (no Markdown metacharacters), so keeping the body metachar-free is
         # what prevents a silent Telegram parse error under continue-on-error.
-        TEXT=$(printf '🚨 ARA pipeline: %s lane(s) UNHEALTHY\n\nAlerting: %s\nUnavailable/unknown: %s\nProducer degraded: %s\n\n[Investigate](%s)' \
-          "$count" "$STALE_LANES" "${UNAVAILABLE_LANES:-none}" "${DEGRADED_LANES:-none}" "$RUN_URL")
+        TEXT=$(printf '🚨 ARA pipeline: %s lane(s) UNHEALTHY\n\nAlerting: %s\nUnavailable/unknown: %s\nProducer degraded: %s\nProducer unknown: %s\n\n[Investigate](%s)' \
+          "$count" "$STALE_LANES" "${UNAVAILABLE_LANES:-none}" "${DEGRADED_LANES:-none}" "${PRODUCER_UNKNOWN_LANES:-none}" "$RUN_URL")
         if curl -sS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
           --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
           --data-urlencode "text=${TEXT}" \

--- a/dashboard/scripts/evidence-contract.mjs
+++ b/dashboard/scripts/evidence-contract.mjs
@@ -1,0 +1,19 @@
+export class EvidenceContractError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'EvidenceContractError';
+  }
+}
+
+export function assertClaimReuseContract(claim) {
+  const article = typeof claim?.article === 'string' && claim.article ? claim.article : '<unknown-article>';
+  const key = typeof claim?.key === 'string' && claim.key
+    ? claim.key
+    : `${article}#${claim?.id || '<unknown-claim>'}`;
+  if (typeof claim?.reusable !== 'boolean') {
+    throw new EvidenceContractError(`claim reuse contract: ${key}: reusable must be boolean`);
+  }
+  if (claim.reusable === false && (typeof claim.reuse_block !== 'string' || !claim.reuse_block.trim())) {
+    throw new EvidenceContractError(`claim reuse contract: ${key}: reusable=false requires a non-empty reuse_block`);
+  }
+}

--- a/dashboard/scripts/prebuild.mjs
+++ b/dashboard/scripts/prebuild.mjs
@@ -13,6 +13,7 @@ import { existsSync, readdirSync, mkdirSync, readFileSync, writeFileSync, cpSync
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import * as yaml from 'js-yaml';
+import { assertClaimReuseContract, EvidenceContractError } from './evidence-contract.mjs';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const dashboardDir = dirname(here);
@@ -891,22 +892,25 @@ function buildEvidenceArtifacts() {
     const parsed = JSON.parse(readFileSync(path, 'utf8'));
     publicClaims = (Array.isArray(parsed.claims) ? parsed.claims : [])
       .filter((claim) => claim && typeof claim.claim === 'string' && typeof claim.article === 'string')
-      .map((claim) => ({
-        article: claim.article,
-        article_title: claim.article_title || claim.article,
-        article_created_at: claim.article_created_at || null,
-        key: claim.key || `${claim.article}#${claim.id || 'claim'}`,
-        claim: claim.claim,
-        type: claim.type || 'other',
-        confidence: claim.confidence || 'unknown',
-        risk: claim.risk || null,
-        as_of: claim.as_of || null,
-        reusable: claim.reusable === true,
-        reuse_block: claim.reuse_block || null,
-        source_tiers: Array.isArray(claim.source_tiers) ? claim.source_tiers : [],
-        source_urls: Array.isArray(claim.source_urls) ? claim.source_urls : [],
-        hosts: Array.isArray(claim.hosts) ? claim.hosts : [],
-      }));
+      .map((claim) => {
+        assertClaimReuseContract(claim);
+        return {
+          article: claim.article,
+          article_title: claim.article_title || claim.article,
+          article_created_at: claim.article_created_at || null,
+          key: claim.key || `${claim.article}#${claim.id || 'claim'}`,
+          claim: claim.claim,
+          type: claim.type || 'other',
+          confidence: claim.confidence || 'unknown',
+          risk: claim.risk || null,
+          as_of: claim.as_of || null,
+          reusable: claim.reusable,
+          reuse_block: claim.reuse_block ?? null,
+          source_tiers: Array.isArray(claim.source_tiers) ? claim.source_tiers : [],
+          source_urls: Array.isArray(claim.source_urls) ? claim.source_urls : [],
+          hosts: Array.isArray(claim.hosts) ? claim.hosts : [],
+        };
+      });
     const dir = join(publicResearch, 'claims');
     mkdirSync(dir, { recursive: true });
     writeFileSync(join(dir, 'public.json'), JSON.stringify({ generated_at: new Date().toISOString(), contract: 'evidence-metadata-not-independent-truth', claims: publicClaims }));
@@ -932,6 +936,7 @@ function buildEvidenceArtifacts() {
       });
     }
   } catch (e) {
+    if (e instanceof EvidenceContractError) throw e;
     console.warn('prebuild: public claim evidence skipped:', e?.message || e);
   }
 

--- a/dashboard/scripts/prebuild.mjs
+++ b/dashboard/scripts/prebuild.mjs
@@ -911,18 +911,24 @@ function buildEvidenceArtifacts() {
     mkdirSync(dir, { recursive: true });
     writeFileSync(join(dir, 'public.json'), JSON.stringify({ generated_at: new Date().toISOString(), contract: 'evidence-metadata-not-independent-truth', claims: publicClaims }));
     for (const claim of publicClaims) {
+      const articleSlug = articleSlugByStem.get(claim.article);
+      // A search result is actionable only when its article route resolves.
+      // The public ledger still retains every claim for article/dossier drawers.
+      if (!articleSlug) continue;
       entries.push({
         id: claim.key,
         type: 'claim',
         title: claim.article_title,
         body: claim.claim,
-        url: `/research/${articleSlugByStem.get(claim.article) || ''}`,
+        url: `/research/${articleSlug}`,
         date: claim.as_of || claim.article_created_at || '',
         confidence: claim.confidence,
         risk: claim.risk || '',
         sourceTier: claim.source_tiers[0] || '',
         sourceTiers: claim.source_tiers,
         language: 'en',
+        reusable: claim.reusable,
+        reuse_block: claim.reuse_block,
       });
     }
   } catch (e) {

--- a/dashboard/scripts/product-intelligence.test.mjs
+++ b/dashboard/scripts/product-intelligence.test.mjs
@@ -13,7 +13,7 @@ test('watchlists are account-free, normalized, bounded, and shareable', async ()
   const mod = await importTs('src/product-intelligence.ts');
   const memory = new Map();
   const storage = { getItem: (key) => memory.get(key) ?? null, setItem: (key, value) => memory.set(key, value) };
-  mod.writeWatchlist({ topics: ['Anthropic', 'anthropic', 'GPU Compute'], lastVisit: '2026-08-29T00:00:00Z' }, storage);
+  mod.writeWatchlist({ topics: ['Anthropic', 'anthropic', 'GPU Compute'] }, storage);
   assert.deepEqual(mod.readWatchlist(storage).topics, ['anthropic', 'gpu-compute']);
   assert.equal(mod.watchlistSharePath(['anthropic', 'gpu-compute'], '/wiki/anthropic', 'ko'), '/wiki/anthropic?watch=anthropic%2Cgpu-compute&lang=ko');
   assert.deepEqual(mod.watchlistFromUrl('?watch=Anthropic,gpu%20compute'), ['anthropic', 'gpu-compute']);
@@ -22,31 +22,61 @@ test('watchlists are account-free, normalized, bounded, and shareable', async ()
 test('evidence search applies trust and language filters before ranking', async () => {
   const mod = await importTs('src/product-intelligence.ts');
   const entries = [
-    { id: 'c1', type: 'claim', title: 'Anthropic revenue', body: 'Primary filing evidence', url: '/', confidence: 'high', sourceTier: 'primary', language: 'en' },
-    { id: 'c2', type: 'claim', title: 'Anthropic rumor', body: 'Secondary report', url: '/', confidence: 'low', sourceTier: 'secondary', language: 'en' },
+    { id: 'c1', type: 'claim', title: 'Anthropic revenue', body: 'Primary filing evidence', url: '/', confidence: 'high', sourceTier: 'primary', language: 'en', reusable: true },
+    { id: 'c2', type: 'claim', title: 'Anthropic rumor', body: 'Secondary report', url: '/', confidence: 'low', sourceTier: 'secondary', language: 'en', reusable: false, reuse_block: 'time-sensitive' },
     { id: 'w1', type: 'wiki', title: '앤스로픽', body: '회사 지식', url: '/', language: 'ko' },
   ];
   assert.deepEqual(mod.searchEvidence(entries, 'anthropic', { confidence: 'high', sourceTier: 'primary' }).map((row) => row.id), ['c1']);
   assert.deepEqual(mod.searchEvidence(entries, '', { language: 'ko' }).map((row) => row.id), ['w1']);
+  const equivalent = [
+    { id: 'blocked', type: 'claim', title: 'Same evidence', body: 'same body', url: '/', confidence: 'high', reusable: false },
+    { id: 'reusable', type: 'claim', title: 'Same evidence', body: 'same body', url: '/', confidence: 'high', reusable: true },
+  ];
+  assert.deepEqual(mod.searchEvidence(equivalent, 'evidence', {}).map((row) => row.id), ['reusable', 'blocked']);
 });
 
-test('What changed DOM exposes reasoning, freshness, watch actions, and RSS without a new tab', async () => {
+test('What changed DOM exposes reasoning, freshness, honest local highlights, and a site-wide feed', async () => {
   globalThis.location = new URL('https://ara.guzus.xyz/');
   const mod = await importTs('src/render/product.ts');
   const html = mod.renderWhatChanged([{
     id: 'x', kind: 'digest', title: 'Model release', summary: 'A concise summary', why: 'It changes cost.', watch: 'Verify adoption.', confidence: 'high', freshness: '2026-08-29', href: '/today/2026-08-29', topics: ['anthropic'], changedAt: '2026-08-29T00:00:00Z',
-  }], { topics: ['anthropic'], lastVisit: '2026-08-28T00:00:00Z' }, 'en');
+  }], { topics: ['anthropic'] }, 'en');
   assert.match(html, /What changed\?/);
   assert.match(html, /Why it matters/);
   assert.match(html, /Watch next/);
-  assert.match(html, /Since your last visit/);
+  assert.doesNotMatch(html, /Since your last visit/);
+  assert.match(html, /only highlight matching cards on this device/);
+  assert.match(html, /Site-wide feed/);
   assert.match(html, /href="\/feed\.xml"/);
   assert.match(html, /data-watch-topic="anthropic"/);
-  const degraded = mod.renderWhatChanged([], { topics: [], lastVisit: null }, 'en', true);
+  const degraded = mod.renderWhatChanged([], { topics: [] }, 'en', true);
   assert.match(degraded, /Degraded mode/);
   assert.match(degraded, /not an editorial ranking/);
   const nav = readFileSync(join(root, 'index.html'), 'utf8');
   assert.equal((nav.match(/class="tab"/g) || []).length, 6);
+});
+
+test('prebuild search contract preserves claim reuse metadata and refuses unresolved article routes', () => {
+  const source = readFileSync(join(root, 'scripts/prebuild.mjs'), 'utf8');
+  assert.match(source, /if \(!articleSlug\) continue/);
+  assert.match(source, /reusable: claim\.reusable/);
+  assert.match(source, /reuse_block: claim\.reuse_block/);
+  assert.doesNotMatch(source, /articleSlugByStem\.get\(claim\.article\) \|\| ''/);
+});
+
+test('runtime global search uses the shared evidence ranker and renders reuse warnings', () => {
+  const source = readFileSync(join(root, 'src/main.ts'), 'utf8');
+  assert.match(source, /const rankedEvidence = searchEvidence\(/);
+  assert.match(source, /evidence-search\.json`, \{ cache: 'no-cache'/);
+  assert.match(source, /Keep language variants as separate evidence records/);
+  assert.match(source, /Reverify live/);
+  assert.match(source, /실시간 재검증 필요/);
+});
+
+test('digest cards do not infer confidence from URL count', () => {
+  const source = readFileSync(join(root, 'src/main.ts'), 'utf8');
+  assert.match(source, /A link count describes sourcing volume, not corroboration quality/);
+  assert.doesNotMatch(source, /sourceCount >= 3 \? 'high'/);
 });
 
 test('reader evidence explicitly denies independent-truth status and shows reverify warnings', async () => {

--- a/dashboard/scripts/product-intelligence.test.mjs
+++ b/dashboard/scripts/product-intelligence.test.mjs
@@ -35,6 +35,15 @@ test('evidence search applies trust and language filters before ranking', async 
   assert.deepEqual(mod.searchEvidence(equivalent, 'evidence', {}).map((row) => row.id), ['reusable', 'blocked']);
 });
 
+test('evidence labels localize stable enums without changing raw semantics', async () => {
+  const mod = await importTs('src/product-intelligence.ts');
+  assert.equal(mod.evidenceEnumLabel('context', 'en'), 'Context');
+  assert.equal(mod.evidenceEnumLabel('context', 'ko'), '맥락');
+  assert.equal(mod.evidenceEnumLabel('high', 'ko'), '높음');
+  assert.equal(mod.evidenceEnumLabel('single-source', 'en'), 'Single source');
+  assert.equal(mod.evidenceEnumLabel('single-source', 'ko'), '단일 출처');
+});
+
 test('What changed DOM exposes reasoning, freshness, honest local highlights, and a site-wide feed', async () => {
   globalThis.location = new URL('https://ara.guzus.xyz/');
   const mod = await importTs('src/render/product.ts');
@@ -87,6 +96,34 @@ test('reader evidence explicitly denies independent-truth status and shows rever
   assert.match(html, /Reverify live/);
   assert.match(html, /As of 2026-08-01/);
   assert.match(html, /target="_blank" rel="noopener noreferrer"/);
+  assert.match(html, />Medium</);
+  assert.match(html, /Risk: Single source/);
+  assert.match(html, /Reverify live · Single source/);
+  const ko = mod.renderEvidenceDrawer([{ article: 'a', article_title: 'A', key: 'a#1', claim: 'A claim', type: 'metric', confidence: 'medium', risk: 'single-source', as_of: '2026-08-01', reusable: false, reuse_block: 'single-source', source_tiers: ['primary'], source_urls: ['https://example.com'] }], { language: 'ko' });
+  assert.match(ko, />중간</);
+  assert.match(ko, /위험: 단일 출처/);
+  assert.match(ko, /실시간 재검증 필요 · 단일 출처/);
+  assert.match(ko, />1차 출처</);
+});
+
+test('brief confidence labels are localized while raw values remain CSS semantics', async () => {
+  globalThis.location = new URL('https://ara.guzus.xyz/');
+  const mod = await importTs('src/render/product.ts');
+  const item = { id: 'x', kind: 'digest', title: 'T', summary: 'S', why: 'W', watch: 'N', confidence: 'context', freshness: '2026-08-29', href: '/', topics: [], changedAt: '2026-08-29T00:00:00Z' };
+  const en = mod.renderWhatChanged([item], { topics: [] }, 'en');
+  const ko = mod.renderWhatChanged([item], { topics: [] }, 'ko');
+  assert.match(en, /evidence-confidence--context">Confidence: Context/);
+  assert.match(ko, /evidence-confidence--context">신뢰: 맥락/);
+});
+
+test('claim reuse projection fails closed on malformed canonical metadata', async () => {
+  const mod = await import('./evidence-contract.mjs');
+  assert.doesNotThrow(() => mod.assertClaimReuseContract({ article: 'a', key: 'a#ok', reusable: true }));
+  assert.doesNotThrow(() => mod.assertClaimReuseContract({ article: 'a', key: 'a#blocked', reusable: false, reuse_block: 'single-source' }));
+  assert.throws(() => mod.assertClaimReuseContract({ article: 'a', key: 'a#missing' }), /a#missing: reusable must be boolean/);
+  assert.throws(() => mod.assertClaimReuseContract({ article: 'a', key: 'a#empty', reusable: false, reuse_block: '  ' }), /a#empty: reusable=false requires a non-empty reuse_block/);
+  const source = readFileSync(join(root, 'scripts/prebuild.mjs'), 'utf8');
+  assert.match(source, /if \(e instanceof EvidenceContractError\) throw e/);
 });
 
 test('product surfaces preserve loading/error paths and mobile containment', () => {

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -26,6 +26,7 @@ import type { BriefItem } from './render/product';
 import {
   claimsForArticle,
   claimsForTopic,
+  evidenceEnumLabel,
   excerptAround,
   normalizeTopic,
   readWatchlist,
@@ -6725,7 +6726,7 @@ async function buildSearchCorpus(): Promise<SearchHit[]> {
     evidenceHits.push({
       type: 'claim',
       title: entry.title,
-      subtitle: [entry.confidence, entry.risk, entry.sourceTier, entry.date].filter(Boolean).join(' · '),
+      subtitle: [entry.confidence, entry.risk, entry.sourceTier].map((value) => evidenceEnumLabel(value, activeLanguage)).concat(entry.date || []).filter(Boolean).join(' · '),
       slug: entry.url,
       hay: `${entry.title} ${entry.body}`.toLowerCase(),
       evidence: entry,
@@ -6753,7 +6754,7 @@ function renderSearchHits(): void {
     '<span class="search-result-title">' + escapeHtml(h.title) + '</span>' +
     (h.subtitle ? '<span class="search-result-sub">' + escapeHtml(h.subtitle) + '</span>' : '') +
     (h.snippet ? '<span class="search-result-snippet">' + escapeHtml(excerptAround(h.snippet, searchInput.value, 180)) + '</span>' : '') +
-    (h.evidence?.reusable === false ? '<span class="search-result-reverify">' + escapeHtml(activeLanguage === 'ko' ? '실시간 재검증 필요' : 'Reverify live') + (h.evidence.reuse_block ? ' · ' + escapeHtml(h.evidence.reuse_block) : '') + '</span>' : '') +
+    (h.evidence?.reusable === false ? '<span class="search-result-reverify">' + escapeHtml(activeLanguage === 'ko' ? '실시간 재검증 필요' : 'Reverify live') + (h.evidence.reuse_block ? ' · ' + escapeHtml(evidenceEnumLabel(h.evidence.reuse_block, activeLanguage)) : '') + '</span>' : '') +
     '</button>',
   ).join('');
   setSafeContent(searchResultsEl, rows);

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -29,6 +29,7 @@ import {
   excerptAround,
   normalizeTopic,
   readWatchlist,
+  searchEvidence,
   textMatchesTopic,
   watchlistFromUrl,
   watchlistSharePath,
@@ -1031,7 +1032,10 @@ async function loadEvidenceSearch(signal?: AbortSignal): Promise<EvidenceSearchE
   if (evidenceSearchPromise) return evidenceSearchPromise;
   evidenceSearchPromise = (async () => {
     try {
-      const response = await fetch(`${DATA_BASE}/evidence-search.json`, { cache: 'force-cache', signal });
+      // Revalidate across deployments so a browser cannot keep the older
+      // schema that omitted claim reuse warnings. The in-session promise
+      // still prevents duplicate downloads of this large artifact.
+      const response = await fetch(`${DATA_BASE}/evidence-search.json`, { cache: 'no-cache', signal });
       if (!response.ok) return [];
       const data = await response.json() as { entries?: EvidenceSearchEntry[] };
       return Array.isArray(data.entries) ? data.entries : [];
@@ -4843,7 +4847,7 @@ async function hydrateWhatChanged(md: string, dateStr: string): Promise<void> {
   );
   for (const [index, section] of sections.slice(0, 3).entries()) {
     const summary = truncateText(cleanPublicLeadText(stripMarkdown(section.body)), 230);
-    const sourceCount = extractUrls(section.body).length;
+    const sourceCount = new Set(extractUrls(section.body)).size;
     items.push({
       id: `digest:${dateStr}:${index}`,
       kind: 'digest',
@@ -4853,7 +4857,9 @@ async function hydrateWhatChanged(md: string, dateStr: string): Promise<void> {
         ? (activeLanguage === 'ko' ? `표시된 대체 다이제스트의 상위 순서입니다. 편집 순위가 아니며 ${sourceCount}개 링크가 있습니다.` : `It appears early in the labelled fallback digest; this is source order, not editorial ranking, with ${sourceCount} linked source${sourceCount === 1 ? '' : 's'}.`)
         : (activeLanguage === 'ko' ? `오늘의 종합 브리프에서 상위 신호로 선정됐습니다. ${sourceCount}개의 링크된 소스가 있습니다.` : `It ranked near the top of today's synthesis and carries ${sourceCount} linked source${sourceCount === 1 ? '' : 's'}.`),
       watch: activeLanguage === 'ko' ? '차기 소스 사이클에서 독립적 확인과 수치 변화를 확인하세요.' : 'Look for independent confirmation and a measurable follow-through in the next source cycle.',
-      confidence: digestDegraded ? 'context' : sourceCount >= 3 ? 'high' : sourceCount ? 'medium' : 'context',
+      // A link count describes sourcing volume, not corroboration quality.
+      // Digest sections remain context until backed by structured claim evidence.
+      confidence: 'context',
       freshness: dateStr,
       href: `/today/${dateStr}`,
       topics: topicSlugs(`${section.title} ${summary}`),
@@ -4912,13 +4918,6 @@ async function hydrateWhatChanged(md: string, dateStr: string): Promise<void> {
   if (first) content.insertBefore(host.firstElementChild!, first);
   else content.appendChild(host.firstElementChild!);
   bindWatchlistActions(content);
-  const priorVisit = watchlist.lastVisit;
-  window.setTimeout(() => {
-    if (watchlist.lastVisit === priorVisit) {
-      watchlist = { ...watchlist, lastVisit: new Date().toISOString() };
-      writeWatchlist(watchlist);
-    }
-  }, 1000);
 }
 
 // ── Generative research ───────────────────────────────
@@ -6702,17 +6701,28 @@ async function buildSearchCorpus(): Promise<SearchHit[]> {
       hay: (c.date + ' ' + c.cycleTime + ' ' + (c.summary || '') + ' ' + (c.storyTitles || []).join(' ')).toLowerCase() });
   }
   const byKey = new Map(hits.filter((hit) => ['research', 'wiki', 'model'].includes(hit.type)).map((hit) => [`${hit.type}:${hit.slug}`, hit]));
+  const enrichedKeys = new Set<string>();
+  const evidenceHits: SearchHit[] = [];
   for (const entry of evidence) {
-    const key = `${entry.type}:${entry.id.replace(/^(?:research|wiki|model):/, '').replace(/:ko$/, '')}`;
+    const key = `${entry.type}:${entry.id.replace(/^(?:research|wiki|model):/, '').replace(/:[a-z]{2}$/i, '')}`;
     const existing = byKey.get(key);
     if (existing) {
-      existing.hay += ` ${entry.body.toLowerCase()}`;
-      existing.evidence = entry;
-      existing.snippet = entry.body;
+      // Keep language variants as separate evidence records so the language
+      // filter and shared ranker operate on the actual indexed document.
+      enrichedKeys.add(key);
+      evidenceHits.push({
+        ...existing,
+        title: entry.title,
+        subtitle: [existing.subtitle, entry.language].filter(Boolean).join(' · '),
+        hay: `${existing.hay} ${entry.title} ${entry.body}`.toLowerCase(),
+        evidence: entry,
+        snippet: entry.body,
+        date: entry.date,
+      });
       continue;
     }
     if (entry.type !== 'claim') continue;
-    hits.push({
+    evidenceHits.push({
       type: 'claim',
       title: entry.title,
       subtitle: [entry.confidence, entry.risk, entry.sourceTier, entry.date].filter(Boolean).join(' · '),
@@ -6723,8 +6733,11 @@ async function buildSearchCorpus(): Promise<SearchHit[]> {
       date: entry.date,
     });
   }
-  searchCorpus = hits;
-  return hits;
+  searchCorpus = [
+    ...hits.filter((hit) => !enrichedKeys.has(`${hit.type}:${hit.slug}`)),
+    ...evidenceHits,
+  ];
+  return searchCorpus;
 }
 
 function renderSearchHits(): void {
@@ -6735,11 +6748,12 @@ function renderSearchHits(): void {
     return;
   }
   const rows = searchHits.map((h, i) =>
-    '<button class="search-result' + (i === searchSel ? ' is-sel' : '') + '" type="button" role="option" data-sr-index="' + i + '">' +
+    '<button class="search-result' + (i === searchSel ? ' is-sel' : '') + (h.evidence?.reusable === false ? ' needs-reverify' : '') + '" type="button" role="option" data-sr-index="' + i + '">' +
     '<span class="search-result-type">' + escapeHtml(uiText(activeLanguage, SEARCH_TYPE_KEY[h.type])) + '</span>' +
     '<span class="search-result-title">' + escapeHtml(h.title) + '</span>' +
     (h.subtitle ? '<span class="search-result-sub">' + escapeHtml(h.subtitle) + '</span>' : '') +
     (h.snippet ? '<span class="search-result-snippet">' + escapeHtml(excerptAround(h.snippet, searchInput.value, 180)) + '</span>' : '') +
+    (h.evidence?.reusable === false ? '<span class="search-result-reverify">' + escapeHtml(activeLanguage === 'ko' ? '실시간 재검증 필요' : 'Reverify live') + (h.evidence.reuse_block ? ' · ' + escapeHtml(h.evidence.reuse_block) : '') + '</span>' : '') +
     '</button>',
   ).join('');
   setSafeContent(searchResultsEl, rows);
@@ -6760,11 +6774,23 @@ async function runGlobalSearch(query: string): Promise<void> {
   const confidenceFilter = (document.getElementById('searchConfidenceFilter') as HTMLSelectElement | null)?.value || '';
   const tierFilter = (document.getElementById('searchTierFilter') as HTMLSelectElement | null)?.value || '';
   const languageFilter = (document.getElementById('searchLanguageFilter') as HTMLSelectElement | null)?.value || '';
-  searchHits = corpus
+  const evidenceHits = corpus.filter((hit): hit is SearchHit & { evidence: EvidenceSearchEntry } => Boolean(hit.evidence));
+  const rankedEvidence = searchEvidence(
+    evidenceHits.map((hit) => hit.evidence),
+    query,
+    {
+      type: typeFilter as EvidenceSearchEntry['type'] || undefined,
+      confidence: confidenceFilter || undefined,
+      sourceTier: tierFilter || undefined,
+      language: languageFilter || undefined,
+    },
+    80,
+  );
+  const legacyHits = corpus
+    .filter((hit) => !hit.evidence)
     .filter((hit) => !typeFilter || hit.type === typeFilter)
-    .filter((hit) => !confidenceFilter || hit.evidence?.confidence === confidenceFilter)
-    .filter((hit) => !tierFilter || hit.evidence?.sourceTier === tierFilter || hit.evidence?.sourceTiers?.includes(tierFilter))
-    .filter((hit) => !languageFilter || hit.evidence?.language === languageFilter)
+    // Evidence-only filters cannot truthfully be applied to legacy digest/Twitter records.
+    .filter(() => !confidenceFilter && !tierFilter && !languageFilter)
     .map((h) => {
       const t = h.title.toLowerCase();
       const score = t.startsWith(q) ? 3 : t.includes(q) ? 2 : h.hay.includes(q) ? 1 : 0;
@@ -6772,8 +6798,17 @@ async function runGlobalSearch(query: string): Promise<void> {
     })
     .filter((x) => x.score > 0)
     .sort((a, b) => b.score - a.score || a.h.title.length - b.h.title.length)
-    .slice(0, 24)
     .map((x) => x.h);
+  const hitByEvidenceId = new Map(evidenceHits.map((hit) => [hit.evidence.id, hit]));
+  const rankedHits = rankedEvidence.flatMap((entry): SearchHit[] => {
+    const hit = hitByEvidenceId.get(entry.id);
+    return hit ? [hit] : [];
+  });
+  searchHits = [
+    ...rankedHits,
+    ...legacyHits,
+  ]
+    .slice(0, 24);
   searchSel = searchHits.length ? 0 : -1;
   if (searchCountEl) searchCountEl.textContent = searchHits.length ? String(searchHits.length) : '';
   renderSearchHits();

--- a/dashboard/src/product-intelligence.ts
+++ b/dashboard/src/product-intelligence.ts
@@ -28,11 +28,12 @@ export type EvidenceSearchEntry = {
   sourceTier?: string;
   sourceTiers?: string[];
   language?: string;
+  reusable?: boolean;
+  reuse_block?: string | null;
 };
 
 export type WatchlistState = {
   topics: string[];
-  lastVisit: string | null;
 };
 
 const WATCHLIST_KEY = 'ara:watchlist:v1';
@@ -42,15 +43,15 @@ export function normalizeTopic(value: string): string {
 }
 
 export function readWatchlist(storage: Storage | null = typeof localStorage === 'undefined' ? null : localStorage): WatchlistState {
-  if (!storage) return { topics: [], lastVisit: null };
+  if (!storage) return { topics: [] };
   try {
     const parsed = JSON.parse(storage.getItem(WATCHLIST_KEY) || '{}') as Partial<WatchlistState>;
     const topics = Array.isArray(parsed.topics)
       ? Array.from(new Set(parsed.topics.map(normalizeTopic).filter(Boolean))).slice(0, 50)
       : [];
-    return { topics, lastVisit: typeof parsed.lastVisit === 'string' ? parsed.lastVisit : null };
+    return { topics };
   } catch {
-    return { topics: [], lastVisit: null };
+    return { topics: [] };
   }
 }
 
@@ -58,7 +59,6 @@ export function writeWatchlist(state: WatchlistState, storage: Storage | null = 
   if (!storage) return;
   storage.setItem(WATCHLIST_KEY, JSON.stringify({
     topics: Array.from(new Set(state.topics.map(normalizeTopic).filter(Boolean))).slice(0, 50),
-    lastVisit: state.lastVisit,
   }));
 }
 
@@ -127,7 +127,13 @@ export function searchEvidence(
       return { entry, score };
     })
     .filter(({ score }) => terms.length === 0 || score > 0)
-    .sort((a, b) => b.score - a.score || (b.entry.date || '').localeCompare(a.entry.date || '') || a.entry.title.localeCompare(b.entry.title))
+    .sort((a, b) =>
+      b.score - a.score ||
+      Number(b.entry.reusable !== false) - Number(a.entry.reusable !== false) ||
+      confidenceRank(b.entry.confidence) - confidenceRank(a.entry.confidence) ||
+      (b.entry.date || '').localeCompare(a.entry.date || '') ||
+      a.entry.title.localeCompare(b.entry.title)
+    )
     .slice(0, limit)
     .map(({ entry }) => entry);
 }

--- a/dashboard/src/product-intelligence.ts
+++ b/dashboard/src/product-intelligence.ts
@@ -38,6 +38,29 @@ export type WatchlistState = {
 
 const WATCHLIST_KEY = 'ara:watchlist:v1';
 
+const EVIDENCE_LABELS: Record<string, { en: string; ko: string }> = {
+  high: { en: 'High', ko: '높음' },
+  medium: { en: 'Medium', ko: '중간' },
+  low: { en: 'Low', ko: '낮음' },
+  context: { en: 'Context', ko: '맥락' },
+  unknown: { en: 'Unknown', ko: '미확인' },
+  stable: { en: 'Stable', ko: '안정적' },
+  volatile: { en: 'Volatile', ko: '변동 가능' },
+  contested: { en: 'Contested', ko: '상충' },
+  'single-source': { en: 'Single source', ko: '단일 출처' },
+  'no-as-of': { en: 'No as-of date', ko: '기준일 없음' },
+  'time-sensitive': { en: 'Time-sensitive', ko: '시점 민감' },
+  primary: { en: 'Primary', ko: '1차 출처' },
+  secondary: { en: 'Secondary', ko: '2차 출처' },
+  academic: { en: 'Academic', ko: '학술' },
+  official: { en: 'Official', ko: '공식' },
+};
+
+export function evidenceEnumLabel(value: string | null | undefined, language: 'en' | 'ko'): string {
+  if (!value) return '';
+  return EVIDENCE_LABELS[value]?.[language] || value.replace(/-/g, ' ');
+}
+
 export function normalizeTopic(value: string): string {
   return value.trim().toLowerCase().replace(/[^a-z0-9-]+/g, '-').replace(/^-+|-+$/g, '');
 }

--- a/dashboard/src/render/product.ts
+++ b/dashboard/src/render/product.ts
@@ -1,5 +1,5 @@
-import { evidenceEnumLabel } from '../product-intelligence';
-import type { PublicClaim, WatchlistState } from '../product-intelligence';
+import { evidenceEnumLabel } from '../product-intelligence.ts';
+import type { PublicClaim, WatchlistState } from '../product-intelligence.ts';
 
 function esc(value: unknown): string {
   return String(value ?? '').replace(/[&<>"']/g, (char) => ({

--- a/dashboard/src/render/product.ts
+++ b/dashboard/src/render/product.ts
@@ -41,15 +41,12 @@ const KIND_LABEL: Record<BriefItem['kind'], { en: string; ko: string }> = {
 export function renderWhatChanged(items: BriefItem[], watchlist: WatchlistState, language: 'en' | 'ko', degraded = false): string {
   const ko = language === 'ko';
   const watched = new Set(watchlist.topics);
-  const lastVisit = watchlist.lastVisit ? Date.parse(watchlist.lastVisit) : NaN;
   const rows = items.map((item) => {
-    const isNew = Number.isFinite(lastVisit) && Date.parse(item.changedAt) > lastVisit;
     const isWatched = item.topics.some((topic) => watched.has(topic));
     return [
-      `<article class="change-card${isNew ? ' is-new' : ''}${isWatched ? ' is-watched' : ''}">`,
+      `<article class="change-card${isWatched ? ' is-watched' : ''}">`,
       '  <div class="change-card-meta">',
       `    <span class="change-kind change-kind--${item.kind}">${esc(KIND_LABEL[item.kind][language])}</span>`,
-      isNew ? `    <span class="change-new">${ko ? '지난 방문 후' : 'Since your last visit'}</span>` : '',
       `    <span class="change-freshness">${esc(item.freshness)}</span>`,
       '  </div>',
       `  <h3><a href="${esc(item.href)}">${esc(item.title)}</a></h3>`,
@@ -69,9 +66,10 @@ export function renderWhatChanged(items: BriefItem[], watchlist: WatchlistState,
     '<section class="what-changed" aria-labelledby="whatChangedTitle">',
     '  <header class="what-changed-head">',
     `    <div><span class="ara-eyebrow">${ko ? '의사결정 브리프' : 'Decision brief'}</span><h2 id="whatChangedTitle">${ko ? '무엇이 바뀌었나' : 'What changed?'}</h2></div>`,
-    `    <div class="watchlist-actions"><a href="/feed.xml" class="watchlist-rss">RSS</a><button type="button" data-share-watchlist>${ko ? '공유' : 'Share watchlist'}</button></div>`,
+    `    <div class="watchlist-actions"><a href="/feed.xml" class="watchlist-rss">${ko ? '사이트 전체 피드' : 'Site-wide feed'}</a><button type="button" data-share-watchlist>${ko ? '관심 표시 공유' : 'Share highlights'}</button></div>`,
     '  </header>',
-    watchlist.topics.length ? `<p class="watchlist-summary">${ko ? '관심 주제' : 'Watching'}: ${esc(watchlist.topics.join(', ').replace(/-/g, ' '))}</p>` : '',
+    watchlist.topics.length ? `<p class="watchlist-summary">${ko ? '이 기기에서 강조 표시' : 'Highlighted on this device'}: ${esc(watchlist.topics.join(', ').replace(/-/g, ' '))}</p>` : '',
+    `<p class="watchlist-note">${ko ? '관심 주제는 이 기기에서 일치하는 카드를 강조할 뿐이며, 구독이나 개인 맞춤 순위가 아닙니다. 피드는 사이트 전체 내용을 제공합니다.' : 'Watched topics only highlight matching cards on this device; they do not subscribe you or personalize ranking. The feed is site-wide.'}</p>`,
     degraded ? `<p class="brief-degraded"><strong>${ko ? '저하 모드' : 'Degraded mode'}.</strong> ${ko ? '오늘의 다이제스트는 모델 종합이 아닌 표시된 결정적 대체 출력입니다. 카드 순서를 편집 우선순위로 해석하지 마세요.' : "Today's digest is a labelled deterministic fallback, not model synthesis. Card order is not an editorial ranking."}</p>` : '',
     `  <div class="change-grid">${rows}</div>`,
     '</section>',

--- a/dashboard/src/render/product.ts
+++ b/dashboard/src/render/product.ts
@@ -1,3 +1,4 @@
+import { evidenceEnumLabel } from '../product-intelligence';
 import type { PublicClaim, WatchlistState } from '../product-intelligence';
 
 function esc(value: unknown): string {
@@ -56,7 +57,7 @@ export function renderWhatChanged(items: BriefItem[], watchlist: WatchlistState,
       `    <div><dt>${ko ? '다음 확인' : 'Watch next'}</dt><dd>${esc(item.watch)}</dd></div>`,
       '  </dl>',
       '  <div class="change-card-foot">',
-      `    <span class="evidence-confidence evidence-confidence--${item.confidence}">${ko ? '신뢰' : 'Confidence'}: ${esc(item.confidence)}</span>`,
+      `    <span class="evidence-confidence evidence-confidence--${item.confidence}">${ko ? '신뢰' : 'Confidence'}: ${esc(evidenceEnumLabel(item.confidence, language))}</span>`,
       item.topics.slice(0, 3).map((topic) => `<button class="watch-chip${watched.has(topic) ? ' is-active' : ''}" type="button" data-watch-topic="${esc(topic)}" aria-pressed="${watched.has(topic)}">${watched.has(topic) ? '★' : '+'} ${esc(topic.replace(/-/g, ' '))}</button>`).join(''),
       '  </div>',
       '</article>',
@@ -84,15 +85,15 @@ export function renderEvidenceDrawer(claims: PublicClaim[], options: { language:
     '<li class="evidence-claim">',
     `  <p>${esc(claim.claim)}</p>`,
     '  <div class="evidence-claim-meta">',
-    `    <span class="evidence-confidence evidence-confidence--${esc(claim.confidence)}">${esc(claim.confidence)}</span>`,
+    `    <span class="evidence-confidence evidence-confidence--${esc(claim.confidence)}">${esc(evidenceEnumLabel(claim.confidence, options.language))}</span>`,
     claim.as_of ? `    <span>${ko ? '기준일' : 'As of'} ${esc(claim.as_of)}</span>` : '',
-    claim.risk ? `    <span>${ko ? '위험' : 'Risk'}: ${esc(claim.risk)}</span>` : '',
+    claim.risk ? `    <span>${ko ? '위험' : 'Risk'}: ${esc(evidenceEnumLabel(claim.risk, options.language))}</span>` : '',
     `    <span>${esc(claim.type)}</span>`,
     '  </div>',
     claim.reusable
       ? `  <div class="evidence-reuse is-reusable">${ko ? '다시 인용 가능한 안정적 근거' : 'Reusable evidence metadata; verify the linked source when stakes are high.'}</div>`
-      : `  <div class="evidence-reuse is-blocked">${ko ? '실시간 재검증 필요' : 'Reverify live'}${claim.reuse_block ? ` · ${esc(claim.reuse_block)}` : ''}</div>`,
-    claim.source_tiers.length ? `  <div class="evidence-tier-list">${claim.source_tiers.map((tier) => `<span>${esc(tier)}</span>`).join('')}</div>` : '',
+      : `  <div class="evidence-reuse is-blocked">${ko ? '실시간 재검증 필요' : 'Reverify live'}${claim.reuse_block ? ` · ${esc(evidenceEnumLabel(claim.reuse_block, options.language))}` : ''}</div>`,
+    claim.source_tiers.length ? `  <div class="evidence-tier-list">${claim.source_tiers.map((tier) => `<span>${esc(evidenceEnumLabel(tier, options.language))}</span>`).join('')}</div>` : '',
     '  <div class="evidence-sources">' + claim.source_urls.slice(0, 4).map((url, index) =>
       `<a href="${safeUrl(url)}" target="_blank" rel="noopener noreferrer">${esc((() => { try { return new URL(url).hostname; } catch { return claim.hosts?.[index] || `source ${index + 1}`; } })())}</a>`
     ).join('') + '</div>',

--- a/dashboard/src/style.css
+++ b/dashboard/src/style.css
@@ -1164,7 +1164,8 @@ body.search-open { overflow: hidden; }
   color: var(--text-secondary);
 }
 .search-result {
-  display: flex;
+  display: grid;
+  grid-template-columns: 56px minmax(0, 1fr) minmax(0, 38%);
   align-items: center;
   gap: 10px;
   width: 100%;
@@ -7357,6 +7358,7 @@ body.tab-pricing .calendar { display: none; }
 .watch-topic-button:focus-visible,
 .watch-chip:focus-visible { outline: 3px solid var(--accent-light); outline-offset: 2px; }
 .watchlist-summary { margin: -8px 0 16px; color: var(--text-secondary); font-size: 0.82rem; }
+.watchlist-note { margin: -8px 0 16px; color: var(--text-tertiary); font-size: 0.74rem; line-height: 1.5; }
 
 .change-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); border-top: 1px solid var(--border); }
 .change-card { min-width: 0; padding: 22px 22px 22px 0; border-bottom: 1px solid var(--border-light); }
@@ -7368,7 +7370,6 @@ body.tab-pricing .calendar { display: none; }
 .evidence-summary { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; }
 .change-card-meta { color: var(--text-tertiary); font-size: 0.72rem; }
 .change-kind { color: var(--accent-warm); font-weight: 700; text-transform: uppercase; letter-spacing: 0.055em; }
-.change-new { padding: 2px 7px; color: var(--on-accent); background: var(--accent); border-radius: 999px; font-weight: 700; }
 .change-freshness { margin-left: auto; }
 .change-card h3 { margin: 9px 0 7px; font-size: 1.12rem; line-height: 1.28; }
 .change-card h3 a { color: inherit; text-decoration-color: var(--accent-light); text-underline-offset: 3px; }
@@ -7428,7 +7429,9 @@ body.tab-pricing .calendar { display: none; }
 .search-filters { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 8px; padding: 10px 14px; border-bottom: 1px solid var(--border-light); }
 .search-filters label { display: grid; gap: 3px; color: var(--text-tertiary); font-size: 0.65rem; text-transform: uppercase; letter-spacing: 0.04em; }
 .search-filters select { width: 100%; min-height: 36px; padding: 5px 8px; color: var(--text); background: var(--bg); border: 1px solid var(--border); border-radius: 7px; text-transform: none; }
-.search-result-snippet { display: block; grid-column: 2; color: var(--text-tertiary); font-size: 0.74rem; line-height: 1.4; }
+.search-result-snippet { display: block; grid-column: 2 / -1; color: var(--text-tertiary); font-size: 0.74rem; line-height: 1.4; }
+.search-result.needs-reverify { box-shadow: inset 3px 0 0 #b45309; }
+.search-result-reverify { display: block; grid-column: 2 / -1; color: #b45309; font-size: 0.7rem; font-weight: 700; }
 
 @media (max-width: 760px) {
   .what-changed-head,

--- a/dashboard/tsconfig.json
+++ b/dashboard/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2020",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,

--- a/data/artifact-slos.json
+++ b/data/artifact-slos.json
@@ -44,6 +44,15 @@
         "scripts/check_lane_content.py"
       ],
       "degraded_policy": "restore-baseline-and-fail",
+      "degraded_signal": {
+        "kind": "commit_subject",
+        "label": "restore-baseline",
+        "pattern": "^Twitter deterministic fallback \\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}(?::\\d{2})? UTC(?: \\(#\\d+\\))?$",
+        "paths": [
+          "research/twitter/[0-9]*.md",
+          "research/twitter/status/*.json"
+        ]
+      },
       "content": {
         "primary_glob": "research/twitter/[0-9]*.md",
         "min_bytes": 600
@@ -90,7 +99,13 @@
       "validators": [
         "scripts/fetch_ai_blogs.py"
       ],
-      "degraded_policy": "partial-source-fail-soft"
+      "degraded_policy": "partial-source-fail-soft",
+      "degraded_signal": {
+        "kind": "text_regex",
+        "label": "partial-source",
+        "path": "research/blogs/[0-9]*.md",
+        "pattern": "(?m)^- Fetch errors: [1-9]\\d*$"
+      }
     },
     {
       "id": "bluesky",
@@ -185,6 +200,11 @@
         "scripts/check_lane_content.py"
       ],
       "degraded_policy": "labelled-deterministic-fallback",
+      "degraded_signal": {
+        "kind": "commit_subject",
+        "label": "deterministic-fallback",
+        "pattern": "^Daily digest deterministic fallback \\d{4}-\\d{2}-\\d{2}(?: \\(#\\d+\\))?$"
+      },
       "content": {
         "primary_glob": "research/digest/[0-9]*-digest.md",
         "min_bytes": 2000
@@ -306,7 +326,15 @@
       "validators": [
         "scripts/fetch_market_quotes.py"
       ],
-      "degraded_policy": "per-symbol-stale-carry-forward"
+      "degraded_policy": "per-symbol-stale-carry-forward",
+      "degraded_signal": {
+        "kind": "json_boolean_any",
+        "label": "carry-forward",
+        "path": "research/market/quotes.json",
+        "selectors": [
+          "quotes.*.stale"
+        ]
+      }
     },
     {
       "id": "model-pricing",
@@ -325,7 +353,16 @@
       "validators": [
         "scripts/fetch_model_pricing.py"
       ],
-      "degraded_policy": "price-live-score-stale"
+      "degraded_policy": "price-live-score-stale",
+      "degraded_signal": {
+        "kind": "json_boolean_any",
+        "label": "carry-forward",
+        "path": "research/market/model-pricing.json",
+        "selectors": [
+          "stale",
+          "capability_stale"
+        ]
+      }
     },
     {
       "id": "gpu-spot",
@@ -344,7 +381,16 @@
       "validators": [
         "scripts/fetch_gpu_spot.py"
       ],
-      "degraded_policy": "per-model-stale-carry-forward"
+      "degraded_policy": "per-model-stale-carry-forward",
+      "degraded_signal": {
+        "kind": "json_boolean_any",
+        "label": "carry-forward",
+        "path": "research/market/gpu-spot.json",
+        "selectors": [
+          "stale",
+          "snapshot.models.*.stale"
+        ]
+      }
     },
     {
       "id": "earnings",

--- a/data/artifact-slos.json
+++ b/data/artifact-slos.json
@@ -45,12 +45,11 @@
       ],
       "degraded_policy": "restore-baseline-and-fail",
       "degraded_signal": {
-        "kind": "commit_subject",
+        "kind": "json_boolean_any",
         "label": "restore-baseline",
-        "pattern": "^Twitter deterministic fallback \\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}(?::\\d{2})? UTC(?: \\(#\\d+\\))?$",
-        "paths": [
-          "research/twitter/[0-9]*.md",
-          "research/twitter/status/*.json"
+        "path": "research/twitter/status/[0-9]*.json",
+        "selectors": [
+          "recovery"
         ]
       },
       "content": {
@@ -201,9 +200,10 @@
       ],
       "degraded_policy": "labelled-deterministic-fallback",
       "degraded_signal": {
-        "kind": "commit_subject",
+        "kind": "text_regex",
         "label": "deterministic-fallback",
-        "pattern": "^Daily digest deterministic fallback \\d{4}-\\d{2}-\\d{2}(?: \\(#\\d+\\))?$"
+        "path": "research/digest/[0-9]*-digest.md",
+        "pattern": "(?m)^> \\*\\*Deterministic fallback digest\\.\\*\\*"
       },
       "content": {
         "primary_glob": "research/digest/[0-9]*-digest.md",

--- a/docs/artifact-slos.md
+++ b/docs/artifact-slos.md
@@ -3,7 +3,9 @@
 `data/artifact-slos.json` is the machine-readable contract for pipeline output.
 Each entry names the producer workflow, exact artifact paths, cadence kind,
 freshness SLO (only for fixed cadence), validators, degraded-output policy, and
-optional content-volume policy.
+optional content-volume policy. Policies that can publish usable-but-degraded
+output also carry an executable `degraded_signal`; the watchdog does not infer
+producer health from prose names.
 
 The distinction between cadence kinds is load-bearing:
 
@@ -17,6 +19,46 @@ Market artifacts use their exact files instead of the shared `research/market/`
 directory, so a healthy quote refresh cannot hide a stale pricing or GPU lane.
 Missing git evidence is `UNKNOWN` and alerts: inability to prove freshness is
 not equivalent to healthy.
+
+Freshness reporting has two independent axes:
+
+- **availability** is `available`, `unavailable`, or `unknown`, derived from
+  path existence and the most recent commit age;
+- **producer state** is `healthy`, `degraded`, or `unknown`, derived only from
+  a registry-declared signal.
+
+This preserves the useful distinction between `available/degraded` (for
+example, today's deterministic digest exists but model synthesis failed) and
+`unavailable/healthy` (the last normal artifact exceeded its SLO). Both alert.
+The legacy JSON `state` (`fresh|stale|missing|unknown`), `stale` action output,
+and `stale_lanes` output remain compatibility fields; `stale` now means the
+same thing as the new aggregate alert bit, so a degraded producer cannot emit
+a false healthy heartbeat. New consumers should use `availability`,
+`producer_state`, `alert_lanes`, `unavailable_lanes`, and `degraded_lanes`.
+
+Supported executable signals are intentionally narrow:
+
+- `commit_subject` uses a lane-specific, fully anchored regular expression.
+  The digest and Twitter recovery subjects are stable workflow contracts;
+  generic commits merely discussing a fallback do not match. A signal may
+  declare broader `paths` than freshness itself, allowing Twitter's recovery
+  status commit to expose restored-baseline degradation without letting that
+  status heartbeat make the public digest look fresh.
+- `json_boolean_any` resolves registry-declared dotted selectors with `*`
+  collection wildcards. Market `stale` flags therefore expose carry-forward
+  directly from their public artifact rather than from a commit-message guess.
+- `text_regex` matches a fully specified producer field in the latest matching
+  artifact. The blog lane's numeric `Fetch errors` summary makes partial-source
+  publication visible without guessing from natural-language article copy.
+
+A configured signal whose git, JSON, or text evidence cannot be read is
+producer-`unknown` and alerts. Exit codes remain `0` for all available/healthy,
+`2` for any availability or producer alert, and `1` for an internal error.
+
+The external production synthetic also validates the semantic JSON contracts
+for `/research/evidence-search.json` and `/research/claims/public.json`.
+It checks stable keys/types—including boolean `reusable` provenance on claim
+entries—without coupling liveness to mutable editorial copy, counts, or order.
 
 Scheduled `safe-push` calls are strict by default. Direct publication, a
 successfully merged fallback PR, and a genuine no-op pass. A branch-only or

--- a/docs/artifact-slos.md
+++ b/docs/artifact-slos.md
@@ -35,21 +35,27 @@ and `stale_lanes` output remain compatibility fields; `stale` now means the
 same thing as the new aggregate alert bit, so a degraded producer cannot emit
 a false healthy heartbeat. New consumers should use `availability`,
 `producer_state`, `alert_lanes`, `unavailable_lanes`, and `degraded_lanes`.
+Producer-signal uncertainty is separately listed in `producer_unknown_lanes`,
+so an `available/unknown` lane can never disappear between the availability
+and degraded bucket lists.
 
 Supported executable signals are intentionally narrow:
 
-- `commit_subject` uses a lane-specific, fully anchored regular expression.
-  The digest and Twitter recovery subjects are stable workflow contracts;
-  generic commits merely discussing a fallback do not match. A signal may
-  declare broader `paths` than freshness itself, allowing Twitter's recovery
-  status commit to expose restored-baseline degradation without letting that
-  status heartbeat make the public digest look fresh.
+- `commit_subject` is available for lane-specific, fully anchored workflow
+  contracts, but current fallback state uses durable artifact markers so a
+  later audio/spoken-script commit cannot mask a degraded digest.
 - `json_boolean_any` resolves registry-declared dotted selectors with `*`
   collection wildcards. Market `stale` flags therefore expose carry-forward
   directly from their public artifact rather than from a commit-message guess.
 - `text_regex` matches a fully specified producer field in the latest matching
-  artifact. The blog lane's numeric `Fetch errors` summary makes partial-source
+  artifact. The digest fallback banner persists across same-path audio updates;
+  the blog lane's numeric `Fetch errors` summary makes partial-source
   publication visible without guessing from natural-language article copy.
+
+Twitter restore-baseline state comes from the latest status artifact's boolean
+`recovery` field. Status remains broader producer-health evidence only: it is
+not added to `freshness_paths`, so a recovery heartbeat cannot make an unchanged
+public digest available.
 
 A configured signal whose git, JSON, or text evidence cannot be read is
 producer-`unknown` and alerts. Exit codes remain `0` for all available/healthy,

--- a/scripts/artifact_slos.py
+++ b/scripts/artifact_slos.py
@@ -4,12 +4,22 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_REGISTRY = REPO_ROOT / "data" / "artifact-slos.json"
 CADENCE_KINDS = {"interval", "daily", "event", "on_demand"}
+DEGRADED_SIGNAL_KINDS = {"commit_subject", "json_boolean_any", "text_regex"}
+PUBLISHED_DEGRADED_POLICIES = {
+    "restore-baseline-and-fail",
+    "partial-source-fail-soft",
+    "labelled-deterministic-fallback",
+    "per-symbol-stale-carry-forward",
+    "price-live-score-stale",
+    "per-model-stale-carry-forward",
+}
 
 
 def load_registry(path: Path | str = DEFAULT_REGISTRY) -> list[dict[str, Any]]:
@@ -37,6 +47,51 @@ def load_registry(path: Path | str = DEFAULT_REGISTRY) -> list[dict[str, Any]]:
                 raise ValueError(f"{source}: {artifact_id} {field} must be a string list")
         if not isinstance(entry["degraded_policy"], str) or not entry["degraded_policy"]:
             raise ValueError(f"{source}: {artifact_id} degraded_policy must be a non-empty string")
+        signal = entry.get("degraded_signal")
+        if entry["degraded_policy"] in PUBLISHED_DEGRADED_POLICIES and signal is None:
+            raise ValueError(
+                f"{source}: {artifact_id} policy {entry['degraded_policy']!r} "
+                "can publish degraded output and needs degraded_signal"
+            )
+        if signal is not None:
+            if not isinstance(signal, dict) or signal.get("kind") not in DEGRADED_SIGNAL_KINDS:
+                raise ValueError(f"{source}: {artifact_id} has invalid degraded_signal kind")
+            if not isinstance(signal.get("label"), str) or not signal["label"]:
+                raise ValueError(f"{source}: {artifact_id} degraded_signal needs a non-empty label")
+            if signal["kind"] in {"commit_subject", "text_regex"}:
+                pattern = signal.get("pattern")
+                if not isinstance(pattern, str) or not pattern:
+                    raise ValueError(f"{source}: {artifact_id} regex signal needs pattern")
+                try:
+                    re.compile(pattern)
+                except re.error as exc:
+                    raise ValueError(
+                        f"{source}: {artifact_id} degraded_signal pattern is invalid: {exc}"
+                    ) from exc
+                paths = signal.get("paths")
+                if paths is not None and (
+                    not isinstance(paths, list)
+                    or not paths
+                    or not all(isinstance(value, str) and value for value in paths)
+                ):
+                    raise ValueError(
+                        f"{source}: {artifact_id} degraded_signal paths must be a string list"
+                    )
+                if signal["kind"] == "text_regex" and (
+                    not isinstance(signal.get("path"), str) or not signal["path"]
+                ):
+                    raise ValueError(f"{source}: {artifact_id} text_regex signal needs path")
+            else:
+                path = signal.get("path")
+                selectors = signal.get("selectors")
+                if not isinstance(path, str) or not path:
+                    raise ValueError(f"{source}: {artifact_id} json_boolean_any signal needs path")
+                if not isinstance(selectors, list) or not selectors or not all(
+                    isinstance(value, str) and value for value in selectors
+                ):
+                    raise ValueError(
+                        f"{source}: {artifact_id} json_boolean_any signal needs selectors[]"
+                    )
         cadence = entry.get("cadence")
         if not isinstance(cadence, dict) or cadence.get("kind") not in CADENCE_KINDS:
             raise ValueError(f"{source}: {artifact_id} has invalid cadence")

--- a/scripts/check_lane_freshness.py
+++ b/scripts/check_lane_freshness.py
@@ -21,8 +21,8 @@ out with `fetch-depth: 0` (a shallow clone makes `git log` unreliable;
 we warn when we detect one).
 
 Exit codes:
-  0  every lane is fresh
-  2  one or more lanes are stale or their directory is missing (alert)
+  0  every artifact is available and every producer is healthy
+  2  one or more availability/producer states alert
   1  internal error (e.g. not a git repository)
 
 Per-lane thresholds are tuned to each lane's schedule (see CLAUDE.md
@@ -36,6 +36,7 @@ import argparse
 import glob
 import json
 import os
+import re
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -57,11 +58,21 @@ LANE_THRESHOLDS_HOURS: dict[str, float] = {
 LANE_FRESHNESS_PATHS: dict[str, tuple[str, ...]] = {
     entry["id"]: tuple(entry["freshness_paths"]) for entry in _FRESHNESS_ENTRIES
 }
+LANE_DEGRADED_SIGNALS: dict[str, dict[str, object]] = {
+    entry["id"]: entry["degraded_signal"]
+    for entry in _FRESHNESS_ENTRIES
+    if isinstance(entry.get("degraded_signal"), dict)
+}
 
 FRESH = "fresh"
 STALE = "stale"
 MISSING = "missing"
 UNKNOWN = "unknown"
+
+AVAILABLE = "available"
+UNAVAILABLE = "unavailable"
+HEALTHY = "healthy"
+DEGRADED = "degraded"
 
 # States that should trigger an alert.
 # UNKNOWN means the watchdog cannot prove freshness (commonly truncated git
@@ -76,10 +87,20 @@ class LaneStatus:
     threshold_hours: float
     age_hours: Optional[float]
     state: str
+    producer_state: str = HEALTHY
+    degraded_reason: Optional[str] = None
+
+    @property
+    def availability(self) -> str:
+        if self.state == FRESH:
+            return AVAILABLE
+        if self.state in {STALE, MISSING}:
+            return UNAVAILABLE
+        return UNKNOWN
 
     @property
     def alerting(self) -> bool:
-        return self.state in ALERTING_STATES
+        return self.state in ALERTING_STATES or self.producer_state != HEALTHY
 
 
 def _git(args: list[str], repo_root: str) -> Optional[str]:
@@ -124,6 +145,90 @@ def lane_age_hours(lane: str, now_epoch: int, repo_root: str) -> Optional[float]
     return (now_epoch - commit_epoch) / 3600.0
 
 
+def _select_values(value: object, selector: str) -> list[object]:
+    """Resolve a deliberately small dotted selector with ``*`` wildcards.
+
+    This is not JSONPath: keeping the grammar to object keys plus collection
+    wildcard makes registry signals deterministic and easy to validate.
+    """
+    values = [value]
+    for part in selector.split("."):
+        next_values: list[object] = []
+        for current in values:
+            if part == "*":
+                if isinstance(current, dict):
+                    next_values.extend(current.values())
+                elif isinstance(current, list):
+                    next_values.extend(current)
+            elif isinstance(current, dict) and part in current:
+                next_values.append(current[part])
+        values = next_values
+    return values
+
+
+def lane_producer_health(lane: str, repo_root: str) -> tuple[str, Optional[str]]:
+    """Return producer health independently of artifact availability.
+
+    A lane without an executable degraded signal is healthy by construction:
+    its policy fails closed and therefore cannot publish a labelled degraded
+    artifact. Configured signals are strict. Missing git/JSON evidence is
+    UNKNOWN and alerts rather than silently claiming producer health.
+    """
+    signal = LANE_DEGRADED_SIGNALS.get(lane)
+    if not signal:
+        return HEALTHY, None
+    label = str(signal["label"])
+    kind = signal["kind"]
+    if kind == "commit_subject":
+        configured_paths = signal.get("paths")
+        paths = (
+            tuple(str(path) for path in configured_paths)
+            if isinstance(configured_paths, list)
+            else LANE_FRESHNESS_PATHS.get(lane, (f"research/{lane}",))
+        )
+        subject = _git(["log", "-1", "--format=%s", "--", *paths], repo_root)
+        if subject is None:
+            return UNKNOWN, f"{label}: commit subject unavailable"
+        if re.fullmatch(str(signal["pattern"]), subject):
+            return DEGRADED, f"{label}: {subject}"
+        return HEALTHY, None
+    if kind == "json_boolean_any":
+        relative_path = str(signal["path"])
+        try:
+            with open(os.path.join(repo_root, relative_path), encoding="utf-8") as handle:
+                payload = json.load(handle)
+        except (OSError, json.JSONDecodeError) as exc:
+            return UNKNOWN, f"{label}: cannot read {relative_path}: {type(exc).__name__}"
+        observed = False
+        for selector in signal["selectors"]:  # validated by artifact_slos
+            values = _select_values(payload, str(selector))
+            if not values:
+                continue
+            observed = True
+            if any(not isinstance(value, bool) for value in values):
+                return UNKNOWN, f"{label}: {relative_path} {selector} is not boolean"
+            if any(value is True for value in values):
+                return DEGRADED, f"{label}: {relative_path} {selector}=true"
+        if not observed:
+            return UNKNOWN, f"{label}: {relative_path} selectors matched no values"
+        return HEALTHY, None
+    if kind == "text_regex":
+        relative_glob = str(signal["path"])
+        matches = sorted(glob.glob(os.path.join(repo_root, relative_glob)))
+        if not matches:
+            return UNKNOWN, f"{label}: no file matches {relative_glob}"
+        latest = matches[-1]
+        try:
+            with open(latest, encoding="utf-8") as handle:
+                text = handle.read()
+        except OSError as exc:
+            return UNKNOWN, f"{label}: cannot read {relative_glob}: {type(exc).__name__}"
+        if re.search(str(signal["pattern"]), text):
+            return DEGRADED, f"{label}: {os.path.relpath(latest, repo_root)}"
+        return HEALTHY, None
+    return UNKNOWN, f"unsupported degraded signal kind: {kind}"
+
+
 def classify(age_hours: Optional[float], threshold_hours: float, dir_exists: bool) -> str:
     if not dir_exists:
         return MISSING
@@ -139,6 +244,7 @@ def evaluate(
     *,
     age_fn: Callable[[str, int, str], Optional[float]] = lane_age_hours,
     dir_exists_fn: Callable[[str, str], bool] = lane_dir_exists,
+    producer_fn: Callable[[str, str], tuple[str, Optional[str]]] = lane_producer_health,
 ) -> list[LaneStatus]:
     """Evaluate every configured lane. age_fn/dir_exists_fn are injectable
     so the logic can be unit-tested without a real repository."""
@@ -146,7 +252,17 @@ def evaluate(
     for lane, threshold in thresholds.items():
         exists = dir_exists_fn(lane, repo_root)
         age = age_fn(lane, now_epoch, repo_root) if exists else None
-        results.append(LaneStatus(lane, threshold, age, classify(age, threshold, exists)))
+        producer_state, reason = producer_fn(lane, repo_root) if exists else (UNKNOWN, None)
+        results.append(
+            LaneStatus(
+                lane,
+                threshold,
+                age,
+                classify(age, threshold, exists),
+                producer_state,
+                reason,
+            )
+        )
     return results
 
 
@@ -159,50 +275,62 @@ def _fmt_age(age_hours: Optional[float]) -> str:
 
 
 def format_report(statuses: list[LaneStatus]) -> str:
-    """Human/markdown-friendly table. Stale and missing lanes first."""
+    """Human/markdown-friendly table. Alerting lanes first."""
     icon = {FRESH: "✅", STALE: "🔴", MISSING: "❓", UNKNOWN: "⚠️"}
     order = {STALE: 0, MISSING: 1, UNKNOWN: 2, FRESH: 3}
-    rows = sorted(statuses, key=lambda s: (order[s.state], s.lane))
-    lines = ["| lane | state | age | threshold |", "|---|---|---|---|"]
+    rows = sorted(statuses, key=lambda s: (not s.alerting, order[s.state], s.lane))
+    lines = [
+        "| lane | availability | producer | legacy state | age | threshold | detail |",
+        "|---|---|---|---|---|---|---|",
+    ]
     for s in rows:
+        detail = (s.degraded_reason or "-").replace("|", "\\|")
         lines.append(
-            f"| `{s.lane}` | {icon[s.state]} {s.state} "
-            f"| {_fmt_age(s.age_hours)} | {s.threshold_hours:g}h |"
+            f"| `{s.lane}` | {icon[s.state]} {s.availability} | {s.producer_state} "
+            f"| {s.state} | {_fmt_age(s.age_hours)} | {s.threshold_hours:g}h | {detail} |"
         )
     return "\n".join(lines)
 
 
-def idempotency_key(stale_lanes: list[str], now: datetime) -> str:
-    """Stable per-day key over the stale set, so the same outage reported
+def idempotency_key(alert_lanes: list[str], now: datetime) -> str:
+    """Stable per-day key over the alert set, so the same outage reported
     by both the ubuntu-latest and self-hosted watchdog jobs (and by repeat
     runs the same day) collapses to a single delivered alert. A change in
-    the stale set (escalation) produces a new key."""
+    the alert set (escalation) produces a new key."""
     date = now.strftime("%Y-%m-%d")
-    part = "-".join(sorted(stale_lanes)) if stale_lanes else "none"
+    part = "-".join(sorted(alert_lanes)) if alert_lanes else "none"
     return f"lane-freshness-{date}-{part}"
 
 
-def _emit_github_output(stale_lanes: list[str], report: str, key: str) -> None:
+def _emit_github_output(statuses: list[LaneStatus], report: str, key: str) -> None:
     out_path = os.environ.get("GITHUB_OUTPUT")
     if not out_path:
         return
-    stale = "true" if stale_lanes else "false"
+    alert_lanes = sorted(s.lane for s in statuses if s.alerting)
+    unavailable_lanes = sorted(s.lane for s in statuses if s.availability != AVAILABLE)
+    degraded_lanes = sorted(s.lane for s in statuses if s.producer_state == DEGRADED)
+    # `stale` remains the compatibility alert bit consumed by existing actions.
+    stale = "true" if alert_lanes else "false"
     delim = "__ARA_REPORT_EOF__"
     with open(out_path, "a", encoding="utf-8") as fh:
         fh.write(f"stale={stale}\n")
-        fh.write(f"stale_lanes={','.join(sorted(stale_lanes))}\n")
+        fh.write(f"stale_lanes={','.join(alert_lanes)}\n")
+        fh.write(f"alert={stale}\n")
+        fh.write(f"alert_lanes={','.join(alert_lanes)}\n")
+        fh.write(f"unavailable_lanes={','.join(unavailable_lanes)}\n")
+        fh.write(f"degraded_lanes={','.join(degraded_lanes)}\n")
         fh.write(f"idempotency_key={key}\n")
         fh.write(f"report<<{delim}\n{report}\n{delim}\n")
 
 
-def _emit_step_summary(report: str, stale_lanes: list[str]) -> None:
+def _emit_step_summary(report: str, alert_lanes: list[str]) -> None:
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
     if not summary_path:
         return
     header = (
-        f"### 🔴 Pipeline freshness: {len(stale_lanes)} lane(s) alerting\n\n"
-        if stale_lanes
-        else "### ✅ Pipeline freshness: all lanes fresh\n\n"
+        f"### 🔴 Pipeline health: {len(alert_lanes)} lane(s) alerting\n\n"
+        if alert_lanes
+        else "### ✅ Pipeline health: all artifacts available, producers healthy\n\n"
     )
     with open(summary_path, "a", encoding="utf-8") as fh:
         fh.write(header + report + "\n")
@@ -249,21 +377,29 @@ def main(argv: Optional[list[str]] = None) -> int:
         )
 
     statuses = evaluate(LANE_THRESHOLDS_HOURS, now_epoch, repo_root)
-    stale_lanes = [s.lane for s in statuses if s.alerting]
+    alert_lanes = [s.lane for s in statuses if s.alerting]
+    unavailable_lanes = [s.lane for s in statuses if s.availability != AVAILABLE]
+    degraded_lanes = [s.lane for s in statuses if s.producer_state == DEGRADED]
     report = format_report(statuses)
-    key = idempotency_key(stale_lanes, now_dt)
+    key = idempotency_key(alert_lanes, now_dt)
 
     if args.json:
         print(
             json.dumps(
                 {
                     "now": now_dt.isoformat(),
-                    "stale_lanes": sorted(stale_lanes),
+                    "stale_lanes": sorted(alert_lanes),
+                    "alert_lanes": sorted(alert_lanes),
+                    "unavailable_lanes": sorted(unavailable_lanes),
+                    "degraded_lanes": sorted(degraded_lanes),
                     "idempotency_key": key,
                     "lanes": [
                         {
                             "lane": s.lane,
                             "state": s.state,
+                            "availability": s.availability,
+                            "producer_state": s.producer_state,
+                            "degraded_reason": s.degraded_reason,
                             "age_hours": s.age_hours,
                             "threshold_hours": s.threshold_hours,
                         }
@@ -276,13 +412,13 @@ def main(argv: Optional[list[str]] = None) -> int:
     else:
         print(report)
 
-    _emit_github_output(stale_lanes, report, key)
-    _emit_step_summary(report, stale_lanes)
+    _emit_github_output(statuses, report, key)
+    _emit_step_summary(report, alert_lanes)
 
-    if stale_lanes:
-        print(f"\n::error::stale lanes detected: {', '.join(sorted(stale_lanes))}", file=sys.stderr)
+    if alert_lanes:
+        print(f"\n::error::lane health alerts: {', '.join(sorted(alert_lanes))}", file=sys.stderr)
         return 2
-    print("\nall lanes fresh", file=sys.stderr)
+    print("\nall artifacts available; all producers healthy", file=sys.stderr)
     return 0
 
 

--- a/scripts/check_lane_freshness.py
+++ b/scripts/check_lane_freshness.py
@@ -193,12 +193,17 @@ def lane_producer_health(lane: str, repo_root: str) -> tuple[str, Optional[str]]
             return DEGRADED, f"{label}: {subject}"
         return HEALTHY, None
     if kind == "json_boolean_any":
-        relative_path = str(signal["path"])
+        relative_glob = str(signal["path"])
+        matches = sorted(glob.glob(os.path.join(repo_root, relative_glob)))
+        if not matches:
+            return UNKNOWN, f"{label}: no file matches {relative_glob}"
+        artifact_path = matches[-1]
+        display_path = os.path.relpath(artifact_path, repo_root)
         try:
-            with open(os.path.join(repo_root, relative_path), encoding="utf-8") as handle:
+            with open(artifact_path, encoding="utf-8") as handle:
                 payload = json.load(handle)
         except (OSError, json.JSONDecodeError) as exc:
-            return UNKNOWN, f"{label}: cannot read {relative_path}: {type(exc).__name__}"
+            return UNKNOWN, f"{label}: cannot read {display_path}: {type(exc).__name__}"
         observed = False
         for selector in signal["selectors"]:  # validated by artifact_slos
             values = _select_values(payload, str(selector))
@@ -206,11 +211,11 @@ def lane_producer_health(lane: str, repo_root: str) -> tuple[str, Optional[str]]
                 continue
             observed = True
             if any(not isinstance(value, bool) for value in values):
-                return UNKNOWN, f"{label}: {relative_path} {selector} is not boolean"
+                return UNKNOWN, f"{label}: {display_path} {selector} is not boolean"
             if any(value is True for value in values):
-                return DEGRADED, f"{label}: {relative_path} {selector}=true"
+                return DEGRADED, f"{label}: {display_path} {selector}=true"
         if not observed:
-            return UNKNOWN, f"{label}: {relative_path} selectors matched no values"
+            return UNKNOWN, f"{label}: {display_path} selectors matched no values"
         return HEALTHY, None
     if kind == "text_regex":
         relative_glob = str(signal["path"])
@@ -309,6 +314,7 @@ def _emit_github_output(statuses: list[LaneStatus], report: str, key: str) -> No
     alert_lanes = sorted(s.lane for s in statuses if s.alerting)
     unavailable_lanes = sorted(s.lane for s in statuses if s.availability != AVAILABLE)
     degraded_lanes = sorted(s.lane for s in statuses if s.producer_state == DEGRADED)
+    producer_unknown_lanes = sorted(s.lane for s in statuses if s.producer_state == UNKNOWN)
     # `stale` remains the compatibility alert bit consumed by existing actions.
     stale = "true" if alert_lanes else "false"
     delim = "__ARA_REPORT_EOF__"
@@ -319,6 +325,7 @@ def _emit_github_output(statuses: list[LaneStatus], report: str, key: str) -> No
         fh.write(f"alert_lanes={','.join(alert_lanes)}\n")
         fh.write(f"unavailable_lanes={','.join(unavailable_lanes)}\n")
         fh.write(f"degraded_lanes={','.join(degraded_lanes)}\n")
+        fh.write(f"producer_unknown_lanes={','.join(producer_unknown_lanes)}\n")
         fh.write(f"idempotency_key={key}\n")
         fh.write(f"report<<{delim}\n{report}\n{delim}\n")
 
@@ -380,6 +387,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     alert_lanes = [s.lane for s in statuses if s.alerting]
     unavailable_lanes = [s.lane for s in statuses if s.availability != AVAILABLE]
     degraded_lanes = [s.lane for s in statuses if s.producer_state == DEGRADED]
+    producer_unknown_lanes = [s.lane for s in statuses if s.producer_state == UNKNOWN]
     report = format_report(statuses)
     key = idempotency_key(alert_lanes, now_dt)
 
@@ -392,6 +400,7 @@ def main(argv: Optional[list[str]] = None) -> int:
                     "alert_lanes": sorted(alert_lanes),
                     "unavailable_lanes": sorted(unavailable_lanes),
                     "degraded_lanes": sorted(degraded_lanes),
+                    "producer_unknown_lanes": sorted(producer_unknown_lanes),
                     "idempotency_key": key,
                     "lanes": [
                         {

--- a/scripts/check_production_surface.py
+++ b/scripts/check_production_surface.py
@@ -29,7 +29,9 @@ from typing import Callable, Iterable, Optional
 
 DEFAULT_BASE_URL = "https://ara.guzus.xyz"
 DEFAULT_TIMEOUT_SECONDS = 15.0
-MAX_BODY_BYTES = 1_000_000
+# evidence-search.json is intentionally a lazy-loaded full-text corpus. Read
+# the whole semantic contract (rather than validating a truncated prefix).
+MAX_BODY_BYTES = 16_000_000
 
 BROWSER_UA = "ara-production-synthetic/1.0 (+https://github.com/guzus/ai-research-arm)"
 
@@ -42,6 +44,7 @@ class Probe:
     expected_status: int = 200
     content_type_prefix: str = ""
     body_contains: str = ""
+    json_contract: str = ""
     required_headers: tuple[tuple[str, str], ...] = ()
 
 
@@ -50,6 +53,7 @@ class Response:
     status: int
     headers: dict[str, str]
     body: str
+    truncated: bool = False
 
 
 @dataclass
@@ -78,6 +82,18 @@ ROUTE_PROBES: tuple[Probe, ...] = (
     Probe("research", "/research", content_type_prefix="text/html", body_contains="<title", required_headers=HTML_HEADERS),
     Probe("wiki", "/wiki", content_type_prefix="text/html", body_contains="<title", required_headers=HTML_HEADERS),
     Probe("manifest", "/research/manifest.json", content_type_prefix="application/json", body_contains='"generatedAt"'),
+    Probe(
+        "evidence-search-contract",
+        "/research/evidence-search.json",
+        content_type_prefix="application/json",
+        json_contract="evidence-search-v1",
+    ),
+    Probe(
+        "public-claims-contract",
+        "/research/claims/public.json",
+        content_type_prefix="application/json",
+        json_contract="public-claims-v1",
+    ),
     Probe("robots", "/robots.txt", content_type_prefix="text/plain", body_contains="User-agent:"),
     # Caddy currently serves both generated XML artifacts as text/xml. Pin the
     # observed edge contract so a type change is reviewed rather than ignored.
@@ -112,13 +128,15 @@ def fetch(probe: Probe, base_url: str, timeout: float = DEFAULT_TIMEOUT_SECONDS)
     )
     try:
         with urllib.request.urlopen(request, timeout=timeout) as response:
-            body = response.read(MAX_BODY_BYTES).decode("utf-8", "replace")
+            raw = response.read(MAX_BODY_BYTES + 1)
+            body = raw[:MAX_BODY_BYTES].decode("utf-8", "replace")
             headers = {str(k).lower(): str(v) for k, v in response.headers.items()}
-            return Response(int(response.status), headers, body)
+            return Response(int(response.status), headers, body, len(raw) > MAX_BODY_BYTES)
     except urllib.error.HTTPError as exc:
-        body = exc.read(MAX_BODY_BYTES).decode("utf-8", "replace")
+        raw = exc.read(MAX_BODY_BYTES + 1)
+        body = raw[:MAX_BODY_BYTES].decode("utf-8", "replace")
         headers = {str(k).lower(): str(v) for k, v in exc.headers.items()}
-        return Response(int(exc.code), headers, body)
+        return Response(int(exc.code), headers, body, len(raw) > MAX_BODY_BYTES)
 
 
 def evaluate_response(probe: Probe, response: Response) -> Result:
@@ -128,13 +146,90 @@ def evaluate_response(probe: Probe, response: Response) -> Result:
         actual = response.headers.get("content-type", "")
         if not actual.lower().startswith(probe.content_type_prefix.lower()):
             return Result(probe.name, probe.path, "failed", f"content-type {actual!r}, expected prefix {probe.content_type_prefix!r}", response.status)
+    if response.truncated:
+        return Result(
+            probe.name,
+            probe.path,
+            "failed",
+            f"body exceeds semantic-check limit of {MAX_BODY_BYTES} bytes",
+            response.status,
+        )
     if probe.body_contains and probe.body_contains.lower() not in response.body.lower():
         return Result(probe.name, probe.path, "failed", f"body missing marker {probe.body_contains!r}", response.status)
+    if probe.json_contract:
+        problem = validate_json_contract(probe.json_contract, response.body)
+        if problem:
+            return Result(
+                probe.name,
+                probe.path,
+                "failed",
+                f"JSON contract {probe.json_contract}: {problem}",
+                response.status,
+            )
     for header, marker in probe.required_headers:
         actual = response.headers.get(header, "")
         if marker.lower() not in actual.lower():
             return Result(probe.name, probe.path, "failed", f"header {header}={actual!r} missing {marker!r}", response.status)
     return Result(probe.name, probe.path, "healthy", f"HTTP {response.status}", response.status)
+
+
+def _object_array(payload: object, key: str) -> tuple[Optional[list[object]], Optional[str]]:
+    if not isinstance(payload, dict):
+        return None, "$ must be an object"
+    if key not in payload:
+        return None, f"$.{key} is missing"
+    values = payload[key]
+    if not isinstance(values, list):
+        return None, f"$.{key} must be an array"
+    return values, None
+
+
+def validate_json_contract(contract: str, body: str) -> Optional[str]:
+    """Return a precise schema violation, or None for a valid payload.
+
+    These checks pin stable public semantics, not generated counts, copy, or
+    ordering. That catches a SPA fallback or provenance regression without
+    paging when editorial content naturally changes.
+    """
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError as exc:
+        return f"$ is not valid JSON ({exc.msg} at line {exc.lineno} column {exc.colno})"
+
+    if contract == "evidence-search-v1":
+        entries, problem = _object_array(payload, "entries")
+        if problem:
+            return problem
+        for index, entry in enumerate(entries or []):
+            path = f"$.entries[{index}]"
+            if not isinstance(entry, dict):
+                return f"{path} must be an object"
+            if not isinstance(entry.get("type"), str) or not entry["type"]:
+                return f"{path}.type must be a non-empty string"
+            if entry["type"] == "claim":
+                if not isinstance(entry.get("reusable"), bool):
+                    return f"{path}.reusable must be a boolean for claim entries"
+                for key in ("id", "title", "body", "url"):
+                    if not isinstance(entry.get(key), str) or not entry[key]:
+                        return f"{path}.{key} must be a non-empty string for claim entries"
+        return None
+
+    if contract == "public-claims-v1":
+        claims, problem = _object_array(payload, "claims")
+        if problem:
+            return problem
+        for index, claim in enumerate(claims or []):
+            path = f"$.claims[{index}]"
+            if not isinstance(claim, dict):
+                return f"{path} must be an object"
+            if not isinstance(claim.get("reusable"), bool):
+                return f"{path}.reusable must be a boolean"
+            for key in ("article", "claim"):
+                if not isinstance(claim.get(key), str) or not claim[key]:
+                    return f"{path}.{key} must be a non-empty string"
+        return None
+
+    return f"unsupported contract {contract!r}"
 
 
 def run_probe(

--- a/scripts/check_production_surface.py
+++ b/scripts/check_production_surface.py
@@ -200,6 +200,7 @@ def validate_json_contract(contract: str, body: str) -> Optional[str]:
         entries, problem = _object_array(payload, "entries")
         if problem:
             return problem
+        claim_count = 0
         for index, entry in enumerate(entries or []):
             path = f"$.entries[{index}]"
             if not isinstance(entry, dict):
@@ -207,23 +208,36 @@ def validate_json_contract(contract: str, body: str) -> Optional[str]:
             if not isinstance(entry.get("type"), str) or not entry["type"]:
                 return f"{path}.type must be a non-empty string"
             if entry["type"] == "claim":
+                claim_count += 1
                 if not isinstance(entry.get("reusable"), bool):
                     return f"{path}.reusable must be a boolean for claim entries"
+                if entry["reusable"] is False and (
+                    not isinstance(entry.get("reuse_block"), str) or not entry["reuse_block"].strip()
+                ):
+                    return f"{path}.reuse_block must be a non-empty string when reusable=false"
                 for key in ("id", "title", "body", "url"):
                     if not isinstance(entry.get(key), str) or not entry[key]:
                         return f"{path}.{key} must be a non-empty string for claim entries"
+        if claim_count == 0:
+            return "$.entries must contain at least one claim entry"
         return None
 
     if contract == "public-claims-v1":
         claims, problem = _object_array(payload, "claims")
         if problem:
             return problem
+        if not claims:
+            return "$.claims must contain at least one claim"
         for index, claim in enumerate(claims or []):
             path = f"$.claims[{index}]"
             if not isinstance(claim, dict):
                 return f"{path} must be an object"
             if not isinstance(claim.get("reusable"), bool):
                 return f"{path}.reusable must be a boolean"
+            if claim["reusable"] is False and (
+                not isinstance(claim.get("reuse_block"), str) or not claim["reuse_block"].strip()
+            ):
+                return f"{path}.reuse_block must be a non-empty string when reusable=false"
             for key in ("article", "claim"):
                 if not isinstance(claim.get(key), str) or not claim[key]:
                     return f"{path}.{key} must be a non-empty string"

--- a/scripts/test_artifact_slos.py
+++ b/scripts/test_artifact_slos.py
@@ -40,6 +40,16 @@ class ArtifactSloRegistryTest(unittest.TestCase):
         self.assertEqual(set(freshness.LANE_THRESHOLDS_HOURS), expected)
         self.assertEqual(set(content.LANE_SPECS), {e["id"] for e in artifact_slos.content_entries()})
 
+    def test_every_publishable_degraded_policy_has_an_executable_signal(self):
+        for entry in self.entries:
+            if entry["degraded_policy"] in artifact_slos.PUBLISHED_DEGRADED_POLICIES:
+                self.assertIn("degraded_signal", entry, entry["id"])
+                self.assertIn(
+                    entry["degraded_signal"]["kind"],
+                    artifact_slos.DEGRADED_SIGNAL_KINDS,
+                    entry["id"],
+                )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_check_lane_freshness.py
+++ b/scripts/test_check_lane_freshness.py
@@ -5,7 +5,9 @@ import shutil
 import subprocess
 import tempfile
 import unittest
+from pathlib import Path
 from datetime import datetime, timezone
+from unittest import mock
 
 import check_lane_freshness as clf
 
@@ -33,6 +35,16 @@ class ClassifyTest(unittest.TestCase):
         # boundary: equal age is not yet stale
         self.assertEqual(clf.classify(30.0, 30, dir_exists=True), clf.FRESH)
 
+    def test_availability_and_producer_are_independent(self):
+        fresh_fallback = clf.LaneStatus("digest", 30, 1, clf.FRESH, clf.DEGRADED)
+        stale_normal = clf.LaneStatus("rss", 8, 9, clf.STALE, clf.HEALTHY)
+        self.assertEqual((fresh_fallback.availability, fresh_fallback.producer_state),
+                         (clf.AVAILABLE, clf.DEGRADED))
+        self.assertEqual((stale_normal.availability, stale_normal.producer_state),
+                         (clf.UNAVAILABLE, clf.HEALTHY))
+        self.assertTrue(fresh_fallback.alerting)
+        self.assertTrue(stale_normal.alerting)
+
 
 class EvaluateTest(unittest.TestCase):
     def _evaluate_with(self, ages, present):
@@ -50,6 +62,7 @@ class EvaluateTest(unittest.TestCase):
             repo_root="/nonexistent",
             age_fn=age_fn,
             dir_exists_fn=dir_exists_fn,
+            producer_fn=lambda lane, repo: (clf.HEALTHY, None),
         )
 
     def test_mixed_states(self):
@@ -116,6 +129,87 @@ class IdempotencyKeyTest(unittest.TestCase):
         self.assertNotEqual(a, b)
 
 
+class ProducerSignalTest(unittest.TestCase):
+    def test_json_carry_forward_is_degraded_and_parse_failure_unknown(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "artifact.json"
+            path.write_text('{"rows":{"a":{"stale":true},"b":{"stale":false}}}')
+            signal = {
+                "kind": "json_boolean_any",
+                "label": "carry-forward",
+                "path": "artifact.json",
+                "selectors": ["rows.*.stale"],
+            }
+            with mock.patch.dict(clf.LANE_DEGRADED_SIGNALS, {"test": signal}, clear=True):
+                state, reason = clf.lane_producer_health("test", tmp)
+                self.assertEqual(state, clf.DEGRADED)
+                self.assertIn("rows.*.stale=true", reason)
+                path.write_text("not-json")
+                state, reason = clf.lane_producer_health("test", tmp)
+                self.assertEqual(state, clf.UNKNOWN)
+                self.assertIn("JSONDecodeError", reason)
+
+    def test_json_all_false_is_healthy(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "artifact.json").write_text('{"rows":[{"stale":false}]}')
+            signal = {
+                "kind": "json_boolean_any",
+                "label": "carry-forward",
+                "path": "artifact.json",
+                "selectors": ["rows.*.stale"],
+            }
+            with mock.patch.dict(clf.LANE_DEGRADED_SIGNALS, {"test": signal}, clear=True):
+                self.assertEqual(clf.lane_producer_health("test", tmp), (clf.HEALTHY, None))
+
+    def test_missing_or_non_boolean_json_signal_is_unknown(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp, "artifact.json")
+            signal = {
+                "kind": "json_boolean_any", "label": "carry-forward",
+                "path": "artifact.json", "selectors": ["stale"],
+            }
+            with mock.patch.dict(clf.LANE_DEGRADED_SIGNALS, {"test": signal}, clear=True):
+                path.write_text("{}")
+                self.assertEqual(clf.lane_producer_health("test", tmp)[0], clf.UNKNOWN)
+                path.write_text('{"stale":"false"}')
+                self.assertEqual(clf.lane_producer_health("test", tmp)[0], clf.UNKNOWN)
+
+    def test_text_regex_reads_latest_labelled_artifact_only(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            lane = Path(tmp, "lane")
+            lane.mkdir()
+            Path(lane, "2026-01-01.md").write_text("- Fetch errors: 9\n")
+            Path(lane, "2026-01-02.md").write_text("- Fetch errors: 0\n")
+            signal = {
+                "kind": "text_regex", "label": "partial-source",
+                "path": "lane/[0-9]*.md", "pattern": r"(?m)^- Fetch errors: [1-9]\d*$",
+            }
+            with mock.patch.dict(clf.LANE_DEGRADED_SIGNALS, {"test": signal}, clear=True):
+                self.assertEqual(clf.lane_producer_health("test", tmp), (clf.HEALTHY, None))
+                Path(lane, "2026-01-02.md").write_text("- Fetch errors: 1\n")
+                self.assertEqual(clf.lane_producer_health("test", tmp)[0], clf.DEGRADED)
+
+
+class GithubOutputTest(unittest.TestCase):
+    def test_legacy_and_two_axis_outputs_share_alert_semantics(self):
+        statuses = [
+            clf.LaneStatus("normal", 8, 1, clf.FRESH, clf.HEALTHY),
+            clf.LaneStatus("fallback", 30, 1, clf.FRESH, clf.DEGRADED, "fallback"),
+            clf.LaneStatus("late", 8, 9, clf.STALE, clf.HEALTHY),
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp) / "output"
+            with mock.patch.dict(os.environ, {"GITHUB_OUTPUT": str(output)}):
+                clf._emit_github_output(statuses, "report", "key")
+            values = output.read_text()
+        self.assertIn("stale=true\n", values)
+        self.assertIn("alert=true\n", values)
+        self.assertIn("stale_lanes=fallback,late\n", values)
+        self.assertIn("alert_lanes=fallback,late\n", values)
+        self.assertIn("unavailable_lanes=late\n", values)
+        self.assertIn("degraded_lanes=fallback\n", values)
+
+
 @unittest.skipIf(shutil.which("git") is None, "git not available")
 class GitIntegrationTest(unittest.TestCase):
     """Exercises the real `git log` path with deterministic backdated commits."""
@@ -136,7 +230,7 @@ class GitIntegrationTest(unittest.TestCase):
         subprocess.run(["git", *args], cwd=self.repo, check=True,
                        capture_output=True, text=True, env=env)
 
-    def _commit_lane(self, lane, iso_date):
+    def _commit_lane(self, lane, iso_date, message=None):
         d = os.path.join(self.repo, "research", lane)
         os.makedirs(d, exist_ok=True)
         with open(os.path.join(d, "2026-01-01.md"), "a", encoding="utf-8") as fh:
@@ -144,7 +238,7 @@ class GitIntegrationTest(unittest.TestCase):
         self._git("add", "-A")
         # Pin both author and committer date so %ct is deterministic.
         self._git(
-            "commit", "-q", "-m", f"{lane} {iso_date}",
+            "commit", "-q", "-m", message or f"{lane} {iso_date}",
             env_extra={"GIT_AUTHOR_DATE": iso_date, "GIT_COMMITTER_DATE": iso_date},
         )
 
@@ -177,6 +271,29 @@ class GitIntegrationTest(unittest.TestCase):
         now_epoch = int(datetime(2026, 5, 28, 6, 0, tzinfo=timezone.utc).timestamp())
         statuses = clf.evaluate({"bluesky": 30}, now_epoch, self.repo)
         self.assertEqual(statuses[0].state, clf.MISSING)
+
+    def test_fresh_labelled_fallback_is_available_but_degraded(self):
+        self._commit_lane(
+            "digest",
+            "2026-05-28T05:00:00Z",
+            "Daily digest deterministic fallback 2026-05-28 (#42)",
+        )
+        now_epoch = int(datetime(2026, 5, 28, 6, 0, tzinfo=timezone.utc).timestamp())
+        statuses = clf.evaluate({"digest": 30}, now_epoch, self.repo)
+        self.assertEqual(len(statuses), 1)
+        status = statuses[0]
+        self.assertEqual(status.state, clf.FRESH)
+        self.assertEqual(status.availability, clf.AVAILABLE)
+        self.assertEqual(status.producer_state, clf.DEGRADED)
+        self.assertTrue(status.alerting)
+
+    def test_generic_fallback_words_do_not_match_labelled_signal(self):
+        self._commit_lane(
+            "digest",
+            "2026-05-28T05:00:00Z",
+            "Fix deterministic fallback digest parser (#42)",
+        )
+        self.assertEqual(clf.lane_producer_health("digest", self.repo), (clf.HEALTHY, None))
 
 
 if __name__ == "__main__":

--- a/scripts/test_check_lane_freshness.py
+++ b/scripts/test_check_lane_freshness.py
@@ -196,6 +196,7 @@ class GithubOutputTest(unittest.TestCase):
             clf.LaneStatus("normal", 8, 1, clf.FRESH, clf.HEALTHY),
             clf.LaneStatus("fallback", 30, 1, clf.FRESH, clf.DEGRADED, "fallback"),
             clf.LaneStatus("late", 8, 9, clf.STALE, clf.HEALTHY),
+            clf.LaneStatus("uncertain", 8, 1, clf.FRESH, clf.UNKNOWN, "unreadable"),
         ]
         with tempfile.TemporaryDirectory() as tmp:
             output = Path(tmp) / "output"
@@ -204,10 +205,11 @@ class GithubOutputTest(unittest.TestCase):
             values = output.read_text()
         self.assertIn("stale=true\n", values)
         self.assertIn("alert=true\n", values)
-        self.assertIn("stale_lanes=fallback,late\n", values)
-        self.assertIn("alert_lanes=fallback,late\n", values)
+        self.assertIn("stale_lanes=fallback,late,uncertain\n", values)
+        self.assertIn("alert_lanes=fallback,late,uncertain\n", values)
         self.assertIn("unavailable_lanes=late\n", values)
         self.assertIn("degraded_lanes=fallback\n", values)
+        self.assertIn("producer_unknown_lanes=uncertain\n", values)
 
 
 @unittest.skipIf(shutil.which("git") is None, "git not available")
@@ -273,10 +275,19 @@ class GitIntegrationTest(unittest.TestCase):
         self.assertEqual(statuses[0].state, clf.MISSING)
 
     def test_fresh_labelled_fallback_is_available_but_degraded(self):
-        self._commit_lane(
-            "digest",
-            "2026-05-28T05:00:00Z",
-            "Daily digest deterministic fallback 2026-05-28 (#42)",
+        path = Path(self.repo, "research", "digest", "2026-05-28-digest.md")
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            "# Digest\n\n> **Deterministic fallback digest.** Model synthesis failed.\n",
+            encoding="utf-8",
+        )
+        self._git("add", "-A")
+        self._git(
+            "commit", "-q", "-m", "Daily digest deterministic fallback 2026-05-28 (#42)",
+            env_extra={
+                "GIT_AUTHOR_DATE": "2026-05-28T05:00:00Z",
+                "GIT_COMMITTER_DATE": "2026-05-28T05:00:00Z",
+            },
         )
         now_epoch = int(datetime(2026, 5, 28, 6, 0, tzinfo=timezone.utc).timestamp())
         statuses = clf.evaluate({"digest": 30}, now_epoch, self.repo)
@@ -287,13 +298,48 @@ class GitIntegrationTest(unittest.TestCase):
         self.assertEqual(status.producer_state, clf.DEGRADED)
         self.assertTrue(status.alerting)
 
-    def test_generic_fallback_words_do_not_match_labelled_signal(self):
-        self._commit_lane(
-            "digest",
-            "2026-05-28T05:00:00Z",
-            "Fix deterministic fallback digest parser (#42)",
-        )
+    def test_generic_fallback_words_do_not_match_durable_banner(self):
+        path = Path(self.repo, "research", "digest", "2026-05-28-digest.md")
+        path.parent.mkdir(parents=True)
+        path.write_text("# Digest\n\nDiscussion of deterministic fallback behavior.\n")
+        self._git("add", "-A")
+        self._git("commit", "-q", "-m", "Fix deterministic fallback digest parser (#42)")
         self.assertEqual(clf.lane_producer_health("digest", self.repo), (clf.HEALTHY, None))
+
+    def test_digest_banner_survives_later_same_path_spoken_commit_until_replaced(self):
+        path = Path(self.repo, "research", "digest", "2026-05-28-digest.md")
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            "# Digest\n\n> **Deterministic fallback digest.** The model path failed.\n",
+            encoding="utf-8",
+        )
+        self._git("add", "-A")
+        self._git("commit", "-q", "-m", "Daily digest deterministic fallback 2026-05-28")
+        self.assertEqual(clf.lane_producer_health("digest", self.repo)[0], clf.DEGRADED)
+
+        path.write_text(path.read_text() + "\n<!-- spoken script generated -->\n", encoding="utf-8")
+        self._git("add", "-A")
+        self._git("commit", "-q", "-m", "Add digest spoken script metadata")
+        self.assertEqual(clf.lane_producer_health("digest", self.repo)[0], clf.DEGRADED)
+
+        path.write_text("# Digest\n\nModel-authored synthesis.\n", encoding="utf-8")
+        self._git("add", "-A")
+        self._git("commit", "-q", "-m", "Daily digest 2026-05-28")
+        self.assertEqual(clf.lane_producer_health("digest", self.repo), (clf.HEALTHY, None))
+
+    def test_twitter_recovery_status_survives_unrelated_public_path_commit(self):
+        status = Path(self.repo, "research", "twitter", "status", "2026-05-28-06h.json")
+        status.parent.mkdir(parents=True)
+        status.write_text('{"recovery":true}', encoding="utf-8")
+        self._git("add", "-A")
+        self._git("commit", "-q", "-m", "Twitter deterministic fallback 2026-05-28 06:00 UTC")
+        self.assertEqual(clf.lane_producer_health("twitter", self.repo)[0], clf.DEGRADED)
+
+        digest = Path(self.repo, "research", "twitter", "2026-05-28.md")
+        digest.write_text("# existing digest\n<!-- spoken metadata -->\n", encoding="utf-8")
+        self._git("add", "-A")
+        self._git("commit", "-q", "-m", "Update Twitter spoken metadata")
+        self.assertEqual(clf.lane_producer_health("twitter", self.repo)[0], clf.DEGRADED)
 
 
 if __name__ == "__main__":

--- a/scripts/test_check_production_surface.py
+++ b/scripts/test_check_production_surface.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import json
 import unittest
 
 import check_production_surface as cps
@@ -36,6 +37,42 @@ class ResponseEvaluationTest(unittest.TestCase):
         probe = cps.Probe("blocked", "/", expected_status=403)
         self.assertFalse(cps.evaluate_response(probe, cps.Response(403, {}, "blocked")).failed)
 
+    def test_evidence_contract_requires_boolean_reusable_on_claim_entries(self):
+        probe = cps.Probe("evidence", "/evidence.json", json_contract="evidence-search-v1")
+        good = {"entries": [
+            {"type": "research"},
+            {"type": "claim", "id": "a#c1", "title": "A", "body": "Claim", "url": "/research/a", "reusable": False},
+        ]}
+        self.assertFalse(cps.evaluate_response(probe, cps.Response(200, {}, json.dumps(good))).failed)
+
+        bad = {"entries": [{"type": "claim", "id": "a#c1", "title": "A", "body": "Claim", "url": "/research/a"}]}
+        result = cps.evaluate_response(probe, cps.Response(200, {}, json.dumps(bad)))
+        self.assertTrue(result.failed)
+        self.assertIn("$.entries[0].reusable", result.detail)
+
+    def test_public_claim_contract_reports_exact_index_and_key(self):
+        probe = cps.Probe("claims", "/claims.json", json_contract="public-claims-v1")
+        good = {"claims": [{"article": "a", "claim": "Evidence", "reusable": True}]}
+        self.assertFalse(cps.evaluate_response(probe, cps.Response(200, {}, json.dumps(good))).failed)
+
+        bad = {"claims": [{"article": "a", "claim": "Evidence", "reusable": "yes"}]}
+        result = cps.evaluate_response(probe, cps.Response(200, {}, json.dumps(bad)))
+        self.assertTrue(result.failed)
+        self.assertIn("$.claims[0].reusable", result.detail)
+
+    def test_json_contract_rejects_spa_html_and_wrong_array_key(self):
+        probe = cps.Probe("evidence", "/evidence.json", json_contract="evidence-search-v1")
+        invalid = cps.evaluate_response(probe, cps.Response(200, {}, "<html>app</html>"))
+        self.assertIn("not valid JSON", invalid.detail)
+        wrong = cps.evaluate_response(probe, cps.Response(200, {}, '{"claims":[]}'))
+        self.assertIn("$.entries is missing", wrong.detail)
+
+    def test_truncated_semantic_payload_fails_explicitly(self):
+        probe = cps.Probe("evidence", "/evidence.json", json_contract="evidence-search-v1")
+        result = cps.evaluate_response(probe, cps.Response(200, {}, '{"entries":[]}', True))
+        self.assertTrue(result.failed)
+        self.assertIn("exceeds semantic-check limit", result.detail)
+
 
 class EvaluateTest(unittest.TestCase):
     def test_fetch_exception_is_a_failed_result(self):
@@ -50,6 +87,7 @@ class EvaluateTest(unittest.TestCase):
         names = {probe.name for probe in cps.DEFAULT_PROBES}
         self.assertTrue({"home", "today", "twitter", "models", "research", "wiki"} <= names)
         self.assertTrue({"manifest", "robots", "sitemap", "feed", "llms", "real-404"} <= names)
+        self.assertTrue({"evidence-search-contract", "public-claims-contract"} <= names)
         self.assertTrue({"ua-googlebot", "ua-perplexity", "ua-claudebot-policy", "ua-gptbot-policy", "ua-ccbot-policy"} <= names)
 
 

--- a/scripts/test_check_production_surface.py
+++ b/scripts/test_check_production_surface.py
@@ -41,7 +41,7 @@ class ResponseEvaluationTest(unittest.TestCase):
         probe = cps.Probe("evidence", "/evidence.json", json_contract="evidence-search-v1")
         good = {"entries": [
             {"type": "research"},
-            {"type": "claim", "id": "a#c1", "title": "A", "body": "Claim", "url": "/research/a", "reusable": False},
+            {"type": "claim", "id": "a#c1", "title": "A", "body": "Claim", "url": "/research/a", "reusable": False, "reuse_block": "Reverify live"},
         ]}
         self.assertFalse(cps.evaluate_response(probe, cps.Response(200, {}, json.dumps(good))).failed)
 
@@ -59,6 +59,39 @@ class ResponseEvaluationTest(unittest.TestCase):
         result = cps.evaluate_response(probe, cps.Response(200, {}, json.dumps(bad)))
         self.assertTrue(result.failed)
         self.assertIn("$.claims[0].reusable", result.detail)
+
+    def test_claim_contracts_reject_empty_collections_and_missing_reuse_reason(self):
+        evidence = cps.Probe("evidence", "/evidence.json", json_contract="evidence-search-v1")
+        result = cps.evaluate_response(evidence, cps.Response(200, {}, '{"entries":[]}'))
+        self.assertIn("at least one claim entry", result.detail)
+        no_claims = '{"entries":[{"type":"research"}]}'
+        self.assertIn(
+            "at least one claim entry",
+            cps.evaluate_response(evidence, cps.Response(200, {}, no_claims)).detail,
+        )
+        missing_reason = {
+            "entries": [{
+                "type": "claim", "id": "a#c1", "title": "A", "body": "Claim",
+                "url": "/research/a", "reusable": False, "reuse_block": "",
+            }]
+        }
+        self.assertIn(
+            "$.entries[0].reuse_block",
+            cps.evaluate_response(evidence, cps.Response(200, {}, json.dumps(missing_reason))).detail,
+        )
+
+        claims = cps.Probe("claims", "/claims.json", json_contract="public-claims-v1")
+        self.assertIn(
+            "at least one claim",
+            cps.evaluate_response(claims, cps.Response(200, {}, '{"claims":[]}')).detail,
+        )
+        public_missing_reason = {
+            "claims": [{"article": "a", "claim": "Claim", "reusable": False}]
+        }
+        self.assertIn(
+            "$.claims[0].reuse_block",
+            cps.evaluate_response(claims, cps.Response(200, {}, json.dumps(public_missing_reason))).detail,
+        )
 
     def test_json_contract_rejects_spa_html_and_wrong_array_key(self):
         probe = cps.Probe("evidence", "/evidence.json", json_contract="evidence-search-v1")


### PR DESCRIPTION
## Summary
- expose evidence reuse eligibility and revalidation reasons in the generated contract and bilingual dashboard search
- replace misleading confidence and personalization copy with deterministic context and device-local watch behavior
- split surface availability from producer degradation, preserve legacy fields, and keep digest fallback degradation durable
- add strict semantic production probes for evidence-search and public-claims artifacts

## Verification
- bun test — 31 passed
- bun run typecheck
- bun run build
- Python suite — 973 passed, 6 skipped
- actionlint
- desktop/mobile browser QA in English and Korean, including reusable and blocked evidence search states

## Review
An independent reviewer found four issues: digest degradation could be masked by a later commit, empty evidence arrays passed validation, producer-unknown state was omitted from legacy alerts, and Korean evidence enums remained raw. All four were fixed with regression coverage. A Grok CLI audit also inspected the diff but exhausted its turn limit; its synthesis continuation returned no findings before hanging.