### PR TITLE
Include claim evidence in production builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -50,6 +50,10 @@ research/*
 !research/arm/**
 !research/market
 !research/market/**
+# Build-only evidence input. prebuild reads the canonical index to emit the
+# narrowed public claims projection; it does not mirror this directory.
+!research/claims
+!research/claims/**
 # Twitter comparison-lane dirs: prebuild's twitter-ab.json index and the A/B
 # side-by-side view read these. A research dir consumed by prebuild MUST be
 # whitelisted here too — CI never runs the Dockerfile, so a miss ships an

--- a/dashboard/scripts/prebuild.mjs
+++ b/dashboard/scripts/prebuild.mjs
@@ -35,6 +35,11 @@ const skipLfsPointers = process.env.SKIP_LFS_POINTERS === '1';
 // DATE_PATTERNS — it has no per-day artifacts for the freshness rows to key on.
 const COPY_DIRS = ['twitter', 'models', 'front-page', 'digest', 'audio', 'generative', 'wiki', 'wiki-translations', 'youtube', 'arm', 'market'];
 
+// Research directories read during the build but never mirrored wholesale
+// into public/research/. Keep this explicit so the Docker-context contract can
+// verify production has every input without accidentally publishing internals.
+const BUILD_INPUT_DIRS = ['claims'];
+
 // Twitter comparison-lane dirs (hourly-twitter.yml backend tiers). Copied for
 // the A/B side-by-side view but deliberately NOT in COPY_DIRS/DATE_PATTERNS:
 // manifest keys feed the freshness rows, and these lanes run manually/rarely,

--- a/scripts/test_dockerignore_research_dirs.py
+++ b/scripts/test_dockerignore_research_dirs.py
@@ -3,8 +3,9 @@
 
 This closes a gap that CI structurally cannot see. `.dockerignore` excludes
 `research/*` and re-includes specific dirs; `dashboard/scripts/prebuild.mjs`
-copies a list of dirs into `public/research/`. The two lists must agree, but
-nothing enforced it and the failure is SILENT in both directions that matter:
+copies some dirs into `public/research/` and reads other build-only inputs. The
+three lists must agree, but nothing enforced it and the failure is SILENT in
+both directions that matter:
 
   - prebuild skips a missing dir with `if (!existsSync(src)) continue;`
   - CI never builds the Dockerfile (load-bearing rule 3), so the local build
@@ -30,7 +31,8 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 DOCKERIGNORE = REPO_ROOT / ".dockerignore"
 PREBUILD = REPO_ROOT / "dashboard" / "scripts" / "prebuild.mjs"
 
-# `const COPY_DIRS = ['a', 'b', ...];` / `const AB_COMPARISON_LANES = [ ... ];`
+# `const COPY_DIRS = ['a', ...];` / `const BUILD_INPUT_DIRS = ['b', ...];` /
+# `const AB_COMPARISON_LANES = [ ... ];`
 ARRAY_RE = r"const\s+{name}\s*=\s*\[(.*?)\]"
 
 
@@ -74,6 +76,15 @@ class DockerignoreResearchDirsTest(unittest.TestCase):
             f"them, so they are absent from the Railway build context and production will "
             f"404 that data while the local build looks fine. Add `!research/<dir>` and "
             f"`!research/<dir>/**` to .dockerignore.",
+        )
+
+    def test_every_build_input_dir_is_whitelisted(self):
+        missing = [d for d in _js_string_array(self.prebuild, "BUILD_INPUT_DIRS") if d not in self.reincluded]
+        self.assertEqual(
+            [], missing,
+            f"prebuild.mjs reads build-only research/{missing} but .dockerignore does not "
+            f"re-include them, so Railway silently builds incomplete public artifacts. "
+            f"Add `!research/<dir>` and `!research/<dir>/**` to .dockerignore.",
         )
 
     def test_every_ab_comparison_lane_is_whitelisted(self):


### PR DESCRIPTION
## Root cause

Railway successfully deployed PR #3326, but `.dockerignore` excluded `research/claims/`. Dashboard prebuild reads that directory directly, outside `COPY_DIRS`, so production silently emitted zero claim entries and omitted `/research/claims/public.json` while local builds remained healthy.

## Fix

- re-include `research/claims/` as a build-only Docker context input
- declare `BUILD_INPUT_DIRS` separately from public mirror directories, so the canonical claim index is not exposed wholesale
- extend the Docker allowlist regression test to cover build-only prebuild dependencies

## Verification

- Docker allowlist tests: 5 passed
- dashboard production build: 2,168 public claims / 2,721 evidence records
- live semantic probe on the prior deployment correctly failed both evidence contracts
- local Docker smoke unavailable because the Docker daemon is stopped; the PR `production-image` job is the authoritative exact-container check
