### PR TITLE
Route digest Claude 429s to OpenCode GLM 5.3 Flash

### DIFF
--- a/.github/actions/agent-run/action.yml
+++ b/.github/actions/agent-run/action.yml
@@ -1,5 +1,5 @@
 name: ARA agent run
-description: Run a Claude-Code-compatible agent through native Claude, Fireworks, or Z.ai and optionally require committed output.
+description: Run an agent through native Claude, Fireworks, Z.ai, or an explicitly compatible isolated OpenCode lane fallback and optionally require committed output.
 
 inputs:
   lane:
@@ -7,7 +7,7 @@ inputs:
     required: false
     default: ""
   backend:
-    description: Explicit backend override (claude, fireworks-glm-5p2, zai-glm-5p2, fireworks-deepseek-v4-flash, glm-5p2, deepseek-v4-flash). Bypasses the lane lookup. CI BANS explicit backends in committed workflows (build_backend_matrix.py cross-check) — this input exists only for manual/emergency composite invocation outside CI-checked workflows.
+    description: Explicit agent-run-compatible backend override. Cross-adapter backends require a lane fallback_chain contract and are rejected here. CI bans explicit backends in committed workflows.
     required: false
     default: ""
   claude-code-oauth-token:
@@ -21,8 +21,12 @@ inputs:
     description: Z.ai Coding Plan API key for Z.ai-routed Claude Code runs.
     required: false
     default: ""
+  opencode-api-key:
+    description: OpenCode Go key. Passed only to a lane-explicit isolated OpenCode fallback.
+    required: false
+    default: ""
   fireworks-fallback:
-    description: Fallback policy. claude (default) = walk the ordered fallback.chain from data/agent-backends.json when the requested provider is unavailable; none = strict, the requested backend is the only candidate.
+    description: Fallback policy. claude (default) = walk the lane fallback_chain override when declared, otherwise the global fallback.chain; none = strict, requested backend only.
     required: false
     default: claude
   claude-args:
@@ -75,7 +79,7 @@ outputs:
     description: Resolved native Claude model (what the `--model opus` alias serves on the native path — the native-model input, else the SSOT's global fallback.native_model).
     value: ${{ steps.select.outputs.native-model }}
   execution-file:
-    description: Path to the Claude Code execution transcript JSON reported by whichever provider step ran (empty when the run step failed before reporting one). Callers that need it after a later agent-run call in the same job must copy it immediately — the underlying action reuses the same RUNNER_TEMP path.
+    description: Path to the Claude Code execution transcript JSON reported by a Claude-compatible child (intentionally empty for isolated OpenCode). Callers that need it after a later agent-run call in the same job must copy it immediately.
     value: ${{ steps.run-claude.outputs.execution_file || steps.run-claude-bots.outputs.execution_file || steps.run-fireworks.outputs.execution_file || steps.run-fireworks-bots.outputs.execution_file || steps.run-zai.outputs.execution_file || steps.run-zai-bots.outputs.execution_file }}
   changed:
     description: "true when expected-paths were provided and changed"
@@ -100,8 +104,9 @@ runs:
 
     # Routing SSOT: scripts/select_backend.py resolves the lane's backend
     # from data/agent-backends.json, probes the requested provider, and on
-    # unavailability walks the ordered fallback.chain — first available
-    # candidate wins. Strict lanes / fireworks-fallback=none skip the chain.
+    # unavailability walks the explicit lane fallback_chain override when
+    # present, otherwise the ordered global fallback.chain. Strict lanes /
+    # fireworks-fallback=none skip both chains.
     # No input at all is a hard error — never a silent default.
     - name: Select backend (SSOT lane + ordered fallback chain)
       id: select
@@ -113,9 +118,10 @@ runs:
         FALLBACK_POLICY: ${{ inputs.fireworks-fallback }}
         FIREWORKS_API_KEY: ${{ inputs.fireworks-api-key }}
         ZAI_API_KEY: ${{ inputs.zai-api-key }}
-        # The claude probe needs the OAuth token to tell "credential dead"
-        # (401/403 → walk the chain) from "credential fine". Without it the
-        # probe reports the native path down and every lane reroutes.
+        OPENCODE_API_KEY: ${{ inputs.opencode-api-key }}
+        # The Claude OAuth preflight marks 401/403 auth rejection and a 429
+        # run-scoped rate limit unavailable (non-strict → walk the chain).
+        # Without the token the native path is also unavailable.
         CLAUDE_CODE_OAUTH_TOKEN: ${{ inputs.claude-code-oauth-token }}
       run: |
         set -euo pipefail
@@ -136,8 +142,47 @@ runs:
         fi
         python3 scripts/select_backend.py "${args[@]}"
 
+    - name: Resolve isolated editorial path contract
+      id: isolated-contract
+      if: steps.select.outputs.provider == 'opencode-go'
+      shell: bash
+      env:
+        EXPECTED_PATHS: ${{ inputs.expected-paths }}
+        ALLOWED_PATHS: ${{ inputs.allowed-paths }}
+      run: |
+        set -euo pipefail
+        paths="$ALLOWED_PATHS"
+        if [ -z "$paths" ]; then
+          paths="$EXPECTED_PATHS"
+        fi
+        if [ -z "$paths" ]; then
+          echo "::error::An isolated OpenCode fallback requires expected-paths or allowed-paths."
+          exit 1
+        fi
+        {
+          echo "paths<<__ISOLATED_ALLOWED_PATHS__"
+          echo "$paths"
+          echo "__ISOLATED_ALLOWED_PATHS__"
+        } >> "$GITHUB_OUTPUT"
+
     - name: Setup Claude sandbox
+      if: steps.select.outputs.provider != 'opencode-go'
       uses: ./.github/actions/setup-claude-sandbox
+
+    # Cross-adapter fallback is opt-in per lane in the routing SSOT. The
+    # isolated child receives the exact caller prompt and output path contract,
+    # and imports only one validated commit back into the host checkout.
+    - name: Run agent with isolated OpenCode
+      id: run-opencode
+      if: steps.select.outputs.provider == 'opencode-go'
+      uses: ./.github/actions/run-opencode-container
+      with:
+        mode: editorial
+        lane: ${{ inputs.lane }}
+        allowed-paths: ${{ steps.isolated-contract.outputs.paths }}
+        model: ${{ steps.select.outputs.provider }}/${{ steps.select.outputs.model-id }}
+        opencode-api-key: ${{ inputs.opencode-api-key }}
+        prompt-text: ${{ inputs.prompt }}
 
     # Native-Claude runs (requested backend=claude or Fireworks fallback)
     # serve the resolved native model (native-model input, else the SSOT's

--- a/.github/workflows/daily-digest.yml
+++ b/.github/workflows/daily-digest.yml
@@ -335,12 +335,18 @@ jobs:
           claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           fireworks-api-key: ${{ secrets.FIREWORKS_API_KEY }}
           zai-api-key: ${{ secrets.ZAI_API_KEY }}
+          # Lane-scoped authorization: only this compatibility-tested digest
+          # call can select the isolated OpenCode fallback.
+          opencode-api-key: ${{ secrets.OPENCODE_API_KEY }}
           claude-args: |
             --model opus --allowedTools "Glob,Read,Write,Edit,Bash(git:*),Bash(jq:*),Bash(python3:*),Bash(test:*),Bash(ls:*),Bash(cat:*),Bash(head:*),Bash(wc:*),Bash(mkdir:*),Bash(rg:*),Bash(printf:*),Bash(touch:*)"
           expected-paths: |
-            research/digest/
-            research/summaries/
-          label: Daily digest Claude local-source synthesizer
+            research/digest/${{ steps.date.outputs.date }}-digest.md
+            research/summaries/${{ steps.date.outputs.date }}-digest-summary.txt
+          allowed-paths: |
+            research/digest/${{ steps.date.outputs.date }}-digest.md
+            research/summaries/${{ steps.date.outputs.date }}-digest-summary.txt
+          label: Daily digest local-source synthesizer
           prompt: |
             You are the AI News Editor. Create a comprehensive DAILY DIGEST.
 
@@ -494,8 +500,7 @@ jobs:
       # commit (mid-run tool/API error) would otherwise strand the content:
       # floor ok → fallback skipped → require-output red → wiki-ingest/
       # front-page starve. Commit exactly this workflow's expected output
-      # paths (research/digest/ + research/summaries/ — both are .md/.txt/
-      # .json only, no LFS-filtered media). On a clean tree (re-dispatch on
+      # files only. On a clean tree (re-dispatch on
       # a healthy day) this is a no-op, so the fallback's overwrite
       # protection and honest-red semantics are unchanged.
       - name: Commit recovered agent digest output
@@ -504,12 +509,14 @@ jobs:
           DATE: ${{ steps.date.outputs.date }}
         run: |
           set -euo pipefail
-          if [ -z "$(git status --porcelain -- research/digest/ research/summaries/)" ]; then
+          DIGEST_FILE="research/digest/${DATE}-digest.md"
+          SUMMARY_FILE="research/summaries/${DATE}-digest-summary.txt"
+          if [ -z "$(git status --porcelain -- "$DIGEST_FILE" "$SUMMARY_FILE")" ]; then
             echo "No uncommitted digest-lane changes — nothing to recover."
             exit 0
           fi
           echo "::notice::Floor-passing digest output found uncommitted in the working tree (agent likely died before its commit step); committing it."
-          git add research/digest/ research/summaries/
+          git add "$DIGEST_FILE" "$SUMMARY_FILE"
           git commit -m "Daily digest ${DATE} (recovered uncommitted agent output)" || echo "No recovered digest changes"
 
       - name: Check for fresh digest output
@@ -600,6 +607,19 @@ jobs:
           base-sha: ${{ steps.digest-output-base.outputs.sha }}
           expected-paths: |
             research/digest/
+          label: Daily digest workflow output
+
+      # The synthesis composite is intentionally continue-on-error so the
+      # deterministic recovery can run. Independently prove that every commit
+      # since the pre-agent base stayed inside today's two publication files
+      # before any later safe-push step can publish it.
+      - name: Require digest diff scope
+        uses: ./.github/actions/require-diff-scope
+        with:
+          base-sha: ${{ steps.digest-output-base.outputs.sha }}
+          allowed-paths: |
+            research/digest/${{ steps.date.outputs.date }}-digest.md
+            research/summaries/${{ steps.date.outputs.date }}-digest-summary.txt
           label: Daily digest workflow output
 
       - name: Classify digest publication state

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ short pointer plus the few genuinely agent-specific notes.
   Reference: https://code.claude.com/docs/en/github-actions
   (action repo: https://github.com/anthropics/claude-code-action)
 
-- **GLM-5.2 is the preferred fallback for Claude-harness content lanes.** The
+- **GLM-5.2 is the default fallback for Claude-harness content lanes.** The
   editorial dispatcher uses two strict isolated routes: OpenCode
   `opencode-go/glm-5.3-flash` for RSS/community/Bluesky and Cursor Grok 4.6 Fast
   for arXiv/wiki. Known
@@ -44,7 +44,10 @@ short pointer plus the few genuinely agent-specific notes.
   host-checkout `agent-run` profiles cannot be selected by this route. `agent-run`
   probes the requested provider and walks the ordered `fallback.chain` from
   `data/agent-backends.json` when it is unavailable (currently native Claude →
-  Z.ai GLM); lanes marked `"strict": true` and `fireworks-fallback:
+  Z.ai GLM). The local-source `digest-synthesis-fallback` lane is the explicit
+  exception: its lane-local chain replaces the global chain with isolated
+  OpenCode `opencode-go/glm-5.3-flash`, and Claude HTTP 429 selects that
+  adapter before execution. Lanes marked `"strict": true` and `fireworks-fallback:
   none` runs never fall back. Set `expected-paths` in `agent-run`, or call
   `.github/actions/require-output` after deterministic commit steps, so green
   no-op runs do not leave the freshness watchdog stale. RSS, HN/Reddit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -691,12 +691,16 @@ output or break the pipeline. Read them before editing.
     (a) **`fallback.chain` spans ≥2 providers** — CI-enforced by
     `test_backend_matrix.test_global_fallback_chain_shape`. Claude leads
     (it is what the prompts are tuned against); it must not also terminate.
-    (b) **`probe_claude()` is auth-only** — down on 401/403, up on
-    200/429/5xx/network fault. Both sides are empirically pinned: a dead
-    token answers `401 "OAuth access token is invalid."`, while a *live*
-    subscription token answers the same raw 1-token ping with **429**. So
-    treating non-200 as down would reroute a healthy fleet off Claude
-    permanently. It must send
+    (b) **`probe_claude()` is a narrow run-availability preflight** — down
+    on 401/403 auth rejection and on HTTP 429. A 429 proves the subscription
+    token is alive but also proves Claude cannot serve this run. The local-source
+    digest lane has an explicit compatibility-tested `fallback_chain` override,
+    so it runs the same prompt through isolated OpenCode GLM 5.3 Flash; if that
+    adapter is unavailable it fails into the existing deterministic recovery.
+    Unrelated non-strict agent-run lanes retain the global Z.ai secondary.
+    HTTP 400, 5xx, and network faults remain fail-open because this
+    tiny probe does not mechanically prove the full Claude Code path is down.
+    It must send
     `authorization: Bearer` + the oauth beta header and **never**
     `x-api-key` (which makes the API reject a *good* OAuth token with
     `401 invalid x-api-key`). `agent-run` must keep passing

--- a/data/agent-backends.json
+++ b/data/agent-backends.json
@@ -41,7 +41,7 @@
       "model": "",
       "display_name": "Claude",
       "aliases": [],
-      "notes": "Native Anthropic through claude-code-action OAuth; the served model is fallback.native_model (the --model opus alias resolves to it). Always considered available."
+      "notes": "Native Anthropic through claude-code-action OAuth; the served model is fallback.native_model (the --model opus alias resolves to it). The preflight marks 401/403 auth rejection and HTTP 429 rate limiting unavailable for the current run. Ordinary non-strict lanes continue to the global Z.ai secondary; digest-synthesis-fallback uses its explicit isolated OpenCode lane override."
     },
     "claude-opus-5": {
       "adapter": "dispatch-default",
@@ -96,7 +96,7 @@
         "opencode-glm",
         "glm-5.3-flash-opencode"
       ],
-      "notes": "OpenCode CLI inside run-opencode-container, authenticated by OPENCODE_API_KEY and pinned to the official opencode-go/glm-5.3-flash model id. Primary strict profile for the shared research-editorial route; not selectable by agent-run."
+      "notes": "OpenCode CLI inside run-opencode-container, authenticated by OPENCODE_API_KEY and pinned to the official opencode-go/glm-5.3-flash model id. Primary strict profile for the shared research-editorial route and the explicit isolated fallback for digest-synthesis-fallback; it is never a member of the global host-checkout fallback chain."
     },
     "zai-glm-5p2": {
       "adapter": "agent-run",
@@ -154,7 +154,7 @@
       "zai-glm-5p2"
     ],
     "native_model": "claude-opus-5",
-    "notes": "ORDERED fallback chain, globally applied to every non-strict agent-run lane. When the lane's requested provider probe fails, scripts/select_backend.py walks this chain in order (skipping the already-failed requested backend if it reappears) and runs the first candidate whose provider is available. Native Claude leads the chain and serves `native_model`. Z.ai GLM-5.2 is the second link, added after the 2026-07-24 outage: the chain was [\"claude\"] only AND probe_claude() hardcoded \"always available\", so an expired CLAUDE_CODE_OAUTH_TOKEN took down every agent lane in the fleet at once with no route out (instant is_error, 1 turn, $0 cost) while ZAI_API_KEY sat configured and healthy. probe_claude() now reports down only on an explicit 401/403 credential rejection, so a rate limit, 5xx, or network blip still keeps the fleet on Claude. Lanes with \"strict\": true (zai-canary, the comparison tiers) never walk the chain — unavailability fails the run. `native_model` is the model served whenever the native claude path runs (also what the --model opus alias resolves to); raised from claude-sonnet-5 to claude-opus-5 on 2026-08-01, so every non-strict agent lane and the twitter-ab claude leg now run Opus 5 on the same OAuth subscription."
+    "notes": "ORDERED fallback chain, applied to non-strict agent-run lanes that do not declare a lane.fallback_chain override. Native Claude leads and serves `native_model`; Z.ai GLM-5.2 is the global secondary. Cross-adapter fallbacks are never inferred globally: only lanes with an explicit compatibility-tested fallback_chain may enter an isolated adapter, and that lane chain replaces rather than extends the global chain. The intentionally narrow Claude 400/5xx/network fail-open behavior is unchanged. Strict lanes never walk either chain."
   },
   "lanes": {
     "rss": {
@@ -187,7 +187,10 @@
       "workflow": "daily-digest.yml",
       "harness": "agent-run",
       "backend": "claude",
-      "notes": "Local-source digest synthesis when MCP keys are absent."
+      "fallback_chain": [
+        "opencode-glm-5p3-flash"
+      ],
+      "notes": "Local-source digest synthesis when MCP keys are absent. Its committed research/digest/ + research/summaries/ contract and local-only prompt are compatible with isolated OpenCode editorial mode, so Claude unavailability uses OpenCode GLM 5.3 Flash instead of the global Z.ai chain."
     },
     "digest-audio-script": {
       "workflow": "daily-digest.yml",

--- a/docs/backend-matrix.md
+++ b/docs/backend-matrix.md
@@ -32,10 +32,16 @@ Fallback is an ORDERED CHAIN, SSOT-defined: the top-level `fallback.chain`
 lists backend selectors tried in order. At run time `scripts/select_backend.py`
 walks `[lane's backend] + chain` (deduplicated — a failed primary isn't
 retried from the chain), probes each candidate's provider (fireworks =
-preflight request, zai = Z.ai endpoint probe, claude = always available),
-and runs the first available candidate. Keeping `claude` terminal in the
-chain guarantees selection succeeds whenever the OAuth token exists — a
-unit test pins this invariant. Lanes marked `"strict": true` (zai-canary)
+preflight request, zai = Z.ai endpoint probe, claude = OAuth preflight),
+and runs the first available candidate. Claude 401/403 auth rejection or
+HTTP 429 rate limiting advances ordinary non-strict callers to Z.ai; the
+local-source digest lane explicitly overrides that chain with isolated
+OpenCode GLM 5.3 Flash because its local prompt and exact two-file commit
+contract are adapter-compatible. A lane override replaces the global chain,
+so OpenCode failure reaches the existing deterministic digest recovery rather
+than silently changing provenance again. HTTP 400, 5xx, and network faults
+retain the narrow fail-open behavior. Lanes marked
+`"strict": true` (zai-canary)
 and runs with `fireworks-fallback: none` never walk the chain: requested
 backend or hard fail. The `backends` profile table (selector → provider /
 model / aliases) also lives in the SSOT file — the action has no routing
@@ -84,7 +90,7 @@ Reading notes:
 | daily-improve | `daily-improve.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
 | digest-audio-script | `daily-digest.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2`; then `deterministic_daily_digest.py` |
 | digest-synthesis | `daily-digest.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2`; then `deterministic_daily_digest.py` |
-| digest-synthesis-fallback | `daily-digest.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2`; then `deterministic_daily_digest.py` |
+| digest-synthesis-fallback | `daily-digest.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `opencode-glm-5p3-flash`; then `deterministic_daily_digest.py` |
 | generative-research-claude (+1 retry step) | `generative-research.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
 | generative-research-default | `generative-research.yml` | dispatch default (runtime SSOT) | (per chosen backend) | default: `claude-opus-5` | (per chosen backend) | workflow-level `fireworks_fallback` input (default `claude`) |
 | generative-research-ko (route:generative-translation) | `translate-generative-research.yml` | agent-dispatch → Cursor CLI (runtime SSOT) | Grok 4.6 Fast via Cursor CLI | `cursor-grok-4.6-high-fast` | `CURSOR_API_KEY` | hard fail (route fallback=none) |
@@ -135,6 +141,8 @@ Reading notes:
 - `production-synthetic.yml`
 
 _Global ordered fallback chain (SSOT `fallback.chain`): `claude` → `zai-glm-5p2`; native path serves `claude-opus-5`. 31 SSOT lanes (+10 dispatch execution paths) across 34 workflows; 14 workflows run no model._
+
+_Explicit lane fallback overrides (replace, never extend, the global chain): `digest-synthesis-fallback`: `opencode-glm-5p3-flash`._
 
 <!-- END GENERATED BACKEND MATRIX -->
 

--- a/scripts/build_backend_matrix.py
+++ b/scripts/build_backend_matrix.py
@@ -164,6 +164,13 @@ REQUIRED_AGENT_RUN_SECRETS = {
     "fireworks-api-key": "FIREWORKS_API_KEY",
     "zai-api-key": "ZAI_API_KEY",
 }
+OPTIONAL_AGENT_RUN_SECRETS = {
+    "opencode-api-key": "OPENCODE_API_KEY",
+}
+AGENT_RUN_SECRET_INPUTS = {
+    **REQUIRED_AGENT_RUN_SECRETS,
+    **OPTIONAL_AGENT_RUN_SECRETS,
+}
 REQUIRED_DISPATCH_SECRETS = {
     **REQUIRED_AGENT_RUN_SECRETS,
     "opencode-api-key": "OPENCODE_API_KEY",
@@ -476,7 +483,7 @@ def observe_workflow(wf_path: Path) -> Observation:
                 ))
 
             elif uses == "./.github/actions/agent-run":
-                secrets = {k: first_secret(with_block.get(k)) for k in REQUIRED_AGENT_RUN_SECRETS}
+                secrets = {k: first_secret(with_block.get(k)) for k in AGENT_RUN_SECRET_INPUTS}
                 step_id = str(step.get("id", "")).strip()
                 lane = str(with_block.get("lane", "")).strip()
                 if step_id and lane:
@@ -732,6 +739,36 @@ def cross_check(lanes: dict[str, dict], observations: dict[str, Observation],
                               "must not lie about tier placement")
             if "strict" in lane and not isinstance(lane.get("strict"), bool):
                 errors.append(f"lane '{step.lane}': strict must be a boolean")
+            lane_chain = lane.get("fallback_chain", [])
+            if not isinstance(lane_chain, list):
+                errors.append(f"lane '{step.lane}': fallback_chain must be a list")
+                lane_chain = []
+            if lane.get("strict") and lane_chain:
+                errors.append(f"lane '{step.lane}': strict lanes cannot declare fallback_chain")
+            seen_lane_fallbacks: set[str] = set()
+            for candidate in lane_chain:
+                candidate_profile = profiles.get(str(candidate))
+                if candidate_profile is None:
+                    errors.append(f"lane '{step.lane}': fallback_chain entry '{candidate}' "
+                                  "is not in the backends table")
+                    continue
+                if candidate_profile.normalized in seen_lane_fallbacks:
+                    errors.append(f"lane '{step.lane}': fallback_chain entry '{candidate}' "
+                                  "duplicates an earlier candidate")
+                seen_lane_fallbacks.add(candidate_profile.normalized)
+                if candidate_profile.adapter not in {"agent-run", "opencode"}:
+                    errors.append(f"lane '{step.lane}': fallback backend '{candidate}' uses "
+                                  f"unsupported adapter '{candidate_profile.adapter}'")
+                if candidate_profile.adapter == "opencode":
+                    adapter = adapters.get("opencode", {})
+                    if adapter.get("isolated_workspace") is not True \
+                      or adapter.get("editorial_contract") is not True:
+                        errors.append(f"lane '{step.lane}': OpenCode fallback lacks the "
+                                      "isolated editorial capability contract")
+                    expected = OPTIONAL_AGENT_RUN_SECRETS["opencode-api-key"]
+                    if step.secrets.get("opencode-api-key") != expected:
+                        errors.append(f"{label}: lane fallback requires opencode-api-key: "
+                                      f"secrets.{expected}")
             for input_name, expected in REQUIRED_AGENT_RUN_SECRETS.items():
                 if step.secrets.get(input_name) != expected:
                     errors.append(f"{label}: must pass {input_name}: secrets.{expected} — "
@@ -907,9 +944,9 @@ def build_rows(lanes: dict[str, dict], observations: dict[str, Observation],
             script = obs.det_job_wide[0]
         return f"; then `{script}`" if script else ""
 
-    def render_chain(requested: str) -> str:
+    def render_chain(requested: str, effective_chain: list[str] | None = None) -> str:
         parts = []
-        for entry in chain:
+        for entry in (chain if effective_chain is None else effective_chain):
             profile = profiles.get(str(entry))
             if profile is None or profile.normalized == requested:
                 continue  # select_backend skips the already-failed requested backend
@@ -985,7 +1022,11 @@ def build_rows(lanes: dict[str, dict], observations: dict[str, Observation],
             elif setting == "none":
                 fallback = "hard fail (`fireworks-fallback: none`)"
             else:
-                fallback = render_chain(profile.normalized if profile else backend)
+                lane_chain = [str(entry) for entry in lane.get("fallback_chain", [])]
+                fallback = render_chain(
+                    profile.normalized if profile else backend,
+                    lane_chain if lane_chain else None,
+                )
             tier = step.tier if step else ""
             fallback += det_suffix(obs, key, tier)
             lane_label = key + (f" (tier:{tier})" if tier else "") + pinned
@@ -1283,6 +1324,14 @@ def build_generated_blocks() -> tuple[str, str]:
                  f"native path serves `{native_fallback}`. {len(lanes)} SSOT lanes "
                  f"(+{len(rows) - len(lanes)} dispatch execution paths) across "
                  f"{len(workflow_files())} workflows; {len(no_model)} workflows run no model._")
+    lane_overrides = [
+        f"`{key}`: " + " → ".join(f"`{entry}`" for entry in lane["fallback_chain"])
+        for key, lane in sorted(lanes.items()) if lane.get("fallback_chain")
+    ]
+    if lane_overrides:
+        lines.append("")
+        lines.append("_Explicit lane fallback overrides (replace, never extend, the global chain): "
+                     + "; ".join(lane_overrides) + "._")
     lines.append("")
     lines.append(END_MARKER)
 

--- a/scripts/select_backend.py
+++ b/scripts/select_backend.py
@@ -7,21 +7,27 @@ fallback chain), probes each candidate's provider for availability, and
 emits the first available candidate to $GITHUB_OUTPUT. Called by
 `.github/actions/agent-run` as the single backend-selection step.
 
-Candidate order: [requested backend] + fallback.chain, deduplicated (a
-zai-primary lane whose chain starts with the same zai backend skips it).
+Candidate order: [requested backend] + either lane.fallback_chain (when
+declared) OR fallback.chain, deduplicated. A lane-local chain overrides the
+global chain because it is the explicit compatibility boundary for a
+cross-adapter fallback; the global chain remains agent-run-native.
 Probes: fireworks → tiny /v1/messages preflight (reuses
 check_fireworks_backend); zai → same-shape probe against the Z.ai
-Anthropic-compatible endpoint; claude → OAuth-token auth probe against
-api.anthropic.com that is UNAVAILABLE only on an explicit credential
-rejection (401/403) and available on anything else.
+Anthropic-compatible endpoint; claude → OAuth-token preflight against
+api.anthropic.com that is UNAVAILABLE on an explicit credential rejection
+(401/403) or a run-scoped rate limit (429), and available on anything else;
+opencode-go is available when its isolated-adapter credential is configured.
 
 Why the claude probe is auth-only (2026-07-24 incident): this probe used
 to hardcode "always available", so when CLAUDE_CODE_OAUTH_TOKEN expired
 every agent lane in the fleet died instantly (is_error, 1 turn, $0) with
 no route out — the chain could not move past a backend it always believed
-was up. It stays deliberately narrow in the other direction too: a 429,
-5xx, or network blip must NOT reroute a healthy fleet away from Claude,
-so only a real auth rejection counts as down.
+was up. A 429 proves the credential is alive but also proves Claude cannot
+serve this run, so the compatible local-source digest lane first continues to
+isolated OpenCode GLM 5.3 Flash. Other lanes retain the global Z.ai chain. The probe remains
+deliberately narrow for 400, 5xx, and network faults: those inconclusive
+responses keep the existing fail-open behavior rather than broadening the
+reroute policy.
 
 Strictness: `--fallback-policy none` or a lane with `"strict": true`
 disables the chain — the requested backend is the only candidate and its
@@ -118,7 +124,7 @@ def probe_zai(model: str) -> tuple[bool, str]:
 
 
 def probe_claude(model: str) -> tuple[bool, str]:
-    """Report the native Claude OAuth path down ONLY on a credential rejection.
+    """Report Claude down on auth rejection or a run-scoped rate limit.
 
     The Claude Code OAuth token authenticates with `authorization: Bearer`
     plus the oauth beta header. It must NOT be sent as `x-api-key` — the
@@ -127,9 +133,12 @@ def probe_claude(model: str) -> tuple[bool, str]:
     how a naive reuse of request_preflight() would strand the whole fleet
     on the fallback backend. Hence a dedicated request here.
 
-    A healthy token typically answers this 1-token ping with 200 or 429
-    (subscription tokens are rate-limited on raw API pings); both mean
-    "credential is alive". Only 401/403 mean the token itself is dead.
+    A 429 means the credential is alive, but availability is the ability to
+    serve this run, not merely authenticate. Non-strict callers should walk
+    to Z.ai instead of selecting a Claude path known to be throttled. Only
+    401/403 and 429 are classified unavailable; 400, 5xx, and network faults
+    retain the existing fail-open behavior because this narrow preflight does
+    not prove the full Claude Code path is unavailable in those cases.
     """
     token = os.environ.get("CLAUDE_CODE_OAUTH_TOKEN", "").strip()
     if not token:
@@ -143,13 +152,30 @@ def probe_claude(model: str) -> tuple[bool, str]:
         return True, f"native path (OAuth probe inconclusive: {redact(str(exc))})"
     if status in (401, 403):
         return False, f"HTTP {status}: {extract_message(status, body)}"
+    if status == 429:
+        return False, f"HTTP 429: rate limited for this run: {extract_message(status, body)}"
     return True, f"native path (claude-code-action OAuth; probe HTTP {status})"
+
+
+def probe_opencode(model: str) -> tuple[bool, str]:
+    """Check only whether the isolated OpenCode adapter can authenticate.
+
+    OpenCode Go does not expose a stable provider preflight endpoint here.
+    The isolated container owns runtime/provider error handling, including
+    fatal usage-limit detection. Selection therefore treats a configured key
+    as available and never exposes it to any non-OpenCode child action.
+    """
+    api_key = os.environ.get("OPENCODE_API_KEY", "").strip()
+    if not api_key:
+        return False, "OPENCODE_API_KEY is not configured"
+    return True, "isolated OpenCode credential configured"
 
 
 PROBES = {
     "fireworks": probe_fireworks,
     "zai": probe_zai,
     "claude": probe_claude,
+    "opencode-go": probe_opencode,
 }
 
 
@@ -198,10 +224,17 @@ def main_with_args(argv: list[str] | None = None) -> int:
         return config_error(f"{args.file} has no 'backends' profile table")
 
     strict = args.fallback_policy == "none"
+    lane_fallback_chain: list[str] = []
     if args.backend:
         requested = normalize(args.backend, backends)
         if requested is None:
             return config_error(f"unknown backend selector '{args.backend}'")
+        adapter = str(backends[requested].get("adapter", "agent-run"))
+        if adapter != "agent-run":
+            return config_error(
+                f"explicit backend '{requested}' uses adapter '{adapter}'; "
+                "cross-adapter execution requires a lane fallback_chain contract"
+            )
     elif args.lane:
         lane = lanes.get(args.lane)
         if lane is None:
@@ -217,10 +250,23 @@ def main_with_args(argv: list[str] | None = None) -> int:
                                 "in the backends table")
         if lane.get("strict"):
             strict = True
+        raw_lane_chain = lane.get("fallback_chain", [])
+        if not isinstance(raw_lane_chain, list):
+            return config_error(f"lane '{args.lane}' fallback_chain must be a list")
+        lane_fallback_chain = [str(entry) for entry in raw_lane_chain]
     else:
         return config_error("one of --lane or --backend is required")
 
-    chain: list[str] = [] if strict else list(fallback.get("chain") or [])
+    # An explicit lane chain is an OVERRIDE, not a prefix. Compatibility was
+    # proven for that lane's prompt/input/output boundary only; silently
+    # continuing into the host-checkout global chain after it fails would
+    # change provenance again and hide the isolated-adapter failure.
+    if strict:
+        chain: list[str] = []
+    elif lane_fallback_chain:
+        chain = lane_fallback_chain
+    else:
+        chain = list(fallback.get("chain") or [])
     candidates: list[str] = []
     for selector in [requested, *chain]:
         key = normalize(str(selector), backends)
@@ -246,7 +292,8 @@ def main_with_args(argv: list[str] | None = None) -> int:
     if chosen is None:
         print(f"::error::no available backend: walked {len(candidates)} candidate(s) "
               f"({', '.join(candidates)}) and every provider probe failed. "
-              "Fix the providers or extend fallback.chain in data/agent-backends.json.",
+              "Fix the providers or the selected lane/global fallback chain in "
+              "data/agent-backends.json.",
               file=sys.stderr)
         return 1
 

--- a/scripts/test_backend_matrix.py
+++ b/scripts/test_backend_matrix.py
@@ -386,6 +386,83 @@ class RoutingInvariants(unittest.TestCase):
         self.assertEqual(len(chain), len(set(chain)), "chain has duplicates")
         self.assertTrue(self.fallback["native_model"])
 
+    def test_local_digest_has_the_only_cross_adapter_lane_override(self):
+        overrides = {
+            key: lane["fallback_chain"]
+            for key, lane in self.lanes.items() if lane.get("fallback_chain")
+        }
+        self.assertEqual(
+            {"digest-synthesis-fallback": ["opencode-glm-5p3-flash"]},
+            overrides,
+        )
+        # The lane override replaces this global chain; it never appends Z.ai
+        # as a third provenance hop.
+        self.assertEqual(["claude", "zai-glm-5p2"], self.fallback["chain"])
+
+        local_step = next(
+            step for step in self.obs["daily-digest.yml"].agent_run
+            if step.lane == "digest-synthesis-fallback"
+        )
+        self.assertEqual("OPENCODE_API_KEY",
+                         local_step.secrets["opencode-api-key"])
+        other_steps = [
+            step for obs in self.obs.values() for step in obs.agent_run
+            if step.lane != "digest-synthesis-fallback"
+        ]
+        self.assertTrue(all(not step.secrets.get("opencode-api-key")
+                            for step in other_steps))
+
+    def test_agent_run_scopes_isolated_opencode_child_contract(self):
+        action = yaml.safe_load(
+            (REPO_ROOT / ".github/actions/agent-run/action.yml").read_text()
+        )
+        steps = action["runs"]["steps"]
+        child = next(
+            step for step in steps
+            if step.get("uses") == "./.github/actions/run-opencode-container"
+        )
+        self.assertEqual("steps.select.outputs.provider == 'opencode-go'",
+                         child.get("if"))
+        self.assertEqual("editorial", child["with"]["mode"])
+        self.assertEqual("${{ inputs.prompt }}", child["with"]["prompt-text"])
+        self.assertEqual("${{ steps.isolated-contract.outputs.paths }}",
+                         child["with"]["allowed-paths"])
+        self.assertEqual("${{ inputs.opencode-api-key }}",
+                         child["with"]["opencode-api-key"])
+        rendered = json.dumps(child, sort_keys=True)
+        for secret_input in ("claude-code-oauth-token", "fireworks-api-key",
+                             "zai-api-key"):
+            self.assertNotIn(secret_input, rendered)
+
+        execution_output = action["outputs"]["execution-file"]["value"]
+        self.assertNotIn("run-opencode", execution_output)
+
+    def test_local_digest_exact_paths_and_post_recovery_scope_gate(self):
+        workflow = yaml.safe_load(
+            (REPO_ROOT / ".github/workflows/daily-digest.yml").read_text()
+        )
+        steps = workflow["jobs"]["daily-digest"]["steps"]
+        local = next(step for step in steps
+                     if step.get("id") == "digest-agent-local")
+        dated_paths = (
+            "research/digest/${{ steps.date.outputs.date }}-digest.md\n"
+            "research/summaries/${{ steps.date.outputs.date }}-digest-summary.txt"
+        )
+        self.assertEqual(dated_paths, local["with"]["expected-paths"].strip())
+        self.assertEqual(dated_paths, local["with"]["allowed-paths"].strip())
+
+        recovery = next(step for step in steps
+                        if step.get("name") == "Commit recovered agent digest output")
+        self.assertIn('git add "$DIGEST_FILE" "$SUMMARY_FILE"', recovery["run"])
+        self.assertNotIn("git add research/digest/ research/summaries/", recovery["run"])
+
+        scope = next(step for step in steps
+                     if step.get("uses") == "./.github/actions/require-diff-scope"
+                     and step.get("name") == "Require digest diff scope")
+        self.assertEqual("${{ steps.digest-output-base.outputs.sha }}",
+                         scope["with"]["base-sha"])
+        self.assertEqual(dated_paths, scope["with"]["allowed-paths"].strip())
+
     def test_every_agent_run_lane_backend_has_a_profile(self):
         for key, lane in self.lanes.items():
             if lane.get("harness") == "agent-run":

--- a/scripts/test_select_backend.py
+++ b/scripts/test_select_backend.py
@@ -24,6 +24,12 @@ def fake_data(chain, lanes=None):
                                   "aliases": ["glm-5p2", "glm"]},
             "zai-glm-5p2": {"provider": "zai", "model": "glm-5.2",
                             "display_name": "GLM 5.2 via Z.ai", "aliases": ["zai"]},
+            "opencode-glm-5p3-flash": {
+                "adapter": "opencode",
+                "provider": "opencode-go", "model": "glm-5.3-flash",
+                "display_name": "GLM 5.3 Flash via OpenCode Go",
+                "aliases": ["opencode-glm"],
+            },
         },
         "fallback": {"harness": "agent-run", "chain": chain,
                      "native_model": "claude-sonnet-5"},
@@ -77,6 +83,75 @@ class SelectBackendTest(unittest.TestCase):
         self.assertEqual(out["backend"], "zai-glm-5p2")
         self.assertEqual(out["provider"], "zai")
         self.assertEqual(out["used-fallback"], "true")
+
+    def test_claude_429_uses_lane_local_opencode_before_global_zai(self):
+        lanes = {
+            "digest": {"workflow": "daily-digest.yml", "harness": "agent-run",
+                       "backend": "claude",
+                       "fallback_chain": ["opencode-glm-5p3-flash"]},
+        }
+        self.set_availability(zai=True, **{"opencode-go": True})
+        with unittest.mock.patch.dict(
+                os.environ, {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-oat01-test"}), \
+                unittest.mock.patch.object(
+                    select_backend, "request_oauth_preflight",
+                    return_value=(429, '{"error":{"message":"rate limit exceeded"}}')):
+            code, out, log = self.run_select(
+                "--lane", "digest", chain=("claude", "zai-glm-5p2"), lanes=lanes)
+
+        self.assertEqual(code, 0)
+        self.assertEqual(out["backend"], "opencode-glm-5p3-flash")
+        self.assertEqual(out["provider"], "opencode-go")
+        self.assertEqual(out["used-fallback"], "true")
+        self.assertIn("rate limited for this run", log)
+
+    def test_claude_429_does_not_cross_strict_lane_boundary(self):
+        lanes = {
+            "digest": {"workflow": "daily-digest.yml", "harness": "agent-run",
+                       "backend": "claude",
+                       "fallback_chain": ["opencode-glm-5p3-flash"]},
+        }
+        self.set_availability(zai=True, **{"opencode-go": True})
+        with unittest.mock.patch.dict(
+                os.environ, {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-oat01-test"}), \
+                unittest.mock.patch.object(
+                    select_backend, "request_oauth_preflight",
+                    return_value=(429, '{"error":{"message":"rate limit exceeded"}}')):
+            code, out, log = self.run_select(
+                "--lane", "digest", "--fallback-policy", "none",
+                chain=("claude", "zai-glm-5p2"), lanes=lanes)
+
+        self.assertEqual(code, 1)
+        self.assertNotIn("backend", out)
+        self.assertIn("rate limited for this run", log)
+        self.assertNotIn("candidate opencode-glm-5p3-flash", log)
+        self.assertNotIn("candidate zai-glm-5p2", log)
+
+    def test_lane_override_does_not_continue_to_global_zai(self):
+        lanes = {
+            "digest": {"workflow": "daily-digest.yml", "harness": "agent-run",
+                       "backend": "claude",
+                       "fallback_chain": ["opencode-glm-5p3-flash"]},
+        }
+        self.set_availability(zai=True, **{"opencode-go": False})
+        with unittest.mock.patch.dict(
+                os.environ, {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-oat01-test"}), \
+                unittest.mock.patch.object(
+                    select_backend, "request_oauth_preflight", return_value=(429, "{}")):
+            code, out, log = self.run_select(
+                "--lane", "digest", chain=("claude", "zai-glm-5p2"), lanes=lanes)
+
+        self.assertEqual(code, 1)
+        self.assertNotIn("backend", out)
+        self.assertIn("candidate opencode-glm-5p3-flash", log)
+        self.assertNotIn("candidate zai-glm-5p2", log)
+
+    def test_explicit_cross_adapter_override_requires_lane_contract(self):
+        code, out, log = self.run_select(
+            "--backend", "opencode-glm", chain=("claude", "zai-glm-5p2"))
+        self.assertEqual(code, 2)
+        self.assertNotIn("backend", out)
+        self.assertIn("requires a lane fallback_chain contract", log)
 
     def test_chain_skips_unavailable_middle_candidate(self):
         self.set_availability(fireworks=False, zai=False, claude=True)
@@ -146,7 +221,8 @@ class ProbeClaudeTest(unittest.TestCase):
     probe_claude used to hardcode "always available", so an expired
     CLAUDE_CODE_OAUTH_TOKEN killed every agent lane with no route out.
     The replacement must be sharp in BOTH directions: down on a real
-    credential rejection, up on anything else.
+    credential rejection or a run-scoped 429, without broadening other
+    inconclusive failures into reroutes.
     """
 
     def setUp(self):
@@ -168,11 +244,16 @@ class ProbeClaudeTest(unittest.TestCase):
                 self.assertFalse(available)
                 self.assertIn(str(status), reason)
 
-    def test_healthy_and_non_auth_failures_keep_claude_up(self):
-        # 429 is what a live subscription OAuth token actually answers a raw
-        # 1-token API ping with — it must never be read as "credential dead",
-        # or a healthy fleet reroutes itself off Claude wholesale.
-        for status in (200, 429, 400, 500, 529):
+    def test_rate_limit_marks_claude_unavailable_for_this_run(self):
+        self.stub(429, '{"error":{"message":"rate limit exceeded"}}')
+        available, reason = select_backend.probe_claude("claude-sonnet-5")
+        self.assertFalse(available)
+        self.assertIn("rate limited for this run", reason)
+
+    def test_healthy_and_inconclusive_non_auth_failures_keep_claude_up(self):
+        # Preserve the old narrow behavior for shapes this preflight cannot
+        # mechanically prove will prevent Claude Code from serving the run.
+        for status in (200, 400, 500, 529):
             with self.subTest(status=status):
                 self.stub(status)
                 available, _ = select_backend.probe_claude("claude-sonnet-5")
@@ -227,6 +308,21 @@ class ProbeClaudeTest(unittest.TestCase):
         self.assertEqual(
             captured["headers"]["anthropic-beta"],
             select_backend.ANTHROPIC_OAUTH_BETA)
+
+
+class ProbeOpenCodeTest(unittest.TestCase):
+    def test_requires_scoped_credential(self):
+        with unittest.mock.patch.dict(os.environ, {}, clear=True):
+            available, reason = select_backend.probe_opencode("glm-5.3-flash")
+        self.assertFalse(available)
+        self.assertIn("not configured", reason)
+
+    def test_configured_credential_is_available_without_network_probe(self):
+        with unittest.mock.patch.dict(
+                os.environ, {"OPENCODE_API_KEY": "test-key"}, clear=True):
+            available, reason = select_backend.probe_opencode("glm-5.3-flash")
+        self.assertTrue(available)
+        self.assertIn("isolated OpenCode", reason)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Behavior
- classify Claude OAuth preflight HTTP 429 as unavailable for the current run
- give only `digest-synthesis-fallback` a lane-local secondary: isolated OpenCode Go `glm-5.3-flash`
- replace rather than extend the global chain, so this lane never silently reaches Z.ai
- keep strict lanes strict and unrelated lanes on the existing global Claude -> Z.ai chain
- constrain OpenCode and recovery commits to the exact dated digest + summary files
- reject committed out-of-scope changes before any later push

## Verification
- `python3 scripts/test_select_backend.py` — 24 passed
- `uv run python scripts/test_backend_matrix.py` — 84 passed
- focused isolated adapter/SSOT/workflow contract tests — passed
- `actionlint .github/workflows/daily-digest.yml`
- `uv run python scripts/build_backend_matrix.py --check`
- `git diff --check`

## Review
Independent in-thread reviewer confirmed lane-specific preselection is safer than a post-Claude retry because OpenCode starts from a clean isolated checkout. Claude CLI review timed out and agy could not acquire read permission; neither was counted as a successful external review.