### PR TITLE
Route Twitter Claude 429s to OpenCode GLM

### DIFF
--- a/.github/workflows/hourly-twitter.yml
+++ b/.github/workflows/hourly-twitter.yml
@@ -510,6 +510,7 @@ jobs:
           claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           fireworks-api-key: ${{ secrets.FIREWORKS_API_KEY }}
           zai-api-key: ${{ secrets.ZAI_API_KEY }}
+          opencode-api-key: ${{ secrets.OPENCODE_API_KEY }}
           claude-args: |
             --model opus --allowedTools "Read,Write,Edit,MultiEdit,Bash(git:*),Bash(birdy-fast:*),Bash(curl:*),Bash(jq:*),Bash(python3:*),Bash(python:*),Bash(node:*),Bash(ls:*),Bash(cat:*),Bash(head:*),Bash(test:*),Bash(wc:*),Bash(mkdir:*),Bash(sed:*),Bash(rg:*),Bash(printf:*),Bash(touch:*)"
           expected-paths: |
@@ -536,6 +537,7 @@ jobs:
           claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           fireworks-api-key: ${{ secrets.FIREWORKS_API_KEY }}
           zai-api-key: ${{ secrets.ZAI_API_KEY }}
+          opencode-api-key: ${{ secrets.OPENCODE_API_KEY }}
           claude-args: |
             --model opus --max-turns 40 --allowedTools "Read,Write,Edit,MultiEdit,Bash(git:*),Bash(jq:*),Bash(python3:*),Bash(python:*),Bash(node:*),Bash(test:*),Bash(ls:*),Bash(cat:*),Bash(head:*),Bash(wc:*),Bash(mkdir:*),Bash(sed:*),Bash(rg:*),Bash(printf:*),Bash(touch:*)"
           expected-paths: |

--- a/data/agent-backends.json
+++ b/data/agent-backends.json
@@ -219,14 +219,20 @@
       "tier": "claude",
       "harness": "agent-run",
       "backend": "claude",
-      "notes": "Primary 3h Twitter/X processor (tier slot named 'claude' for historical reasons)."
+      "fallback_chain": [
+        "opencode-glm-5p3-flash"
+      ],
+      "notes": "Primary 3h Twitter/X processor (tier slot named 'claude' for historical reasons). Its local snapshot prompt and research/twitter/ + research/summaries/ write contract are compatible with isolated OpenCode editorial mode, so Claude unavailability uses OpenCode GLM 5.3 Flash instead of publishing a deterministic recovery heartbeat."
     },
     "twitter-primary-repair": {
       "workflow": "hourly-twitter.yml",
       "tier": "claude",
       "harness": "agent-run",
       "backend": "claude",
-      "notes": "Claude-only repair writer for the primary Twitter/X tier when the first Claude pass returns without required files."
+      "fallback_chain": [
+        "opencode-glm-5p3-flash"
+      ],
+      "notes": "Repair writer for the primary Twitter/X tier when the first pass returns without required files. It shares the primary lane's isolated OpenCode GLM 5.3 Flash fallback and exact output contract."
     },
     "twitter-judge": {
       "workflow": "hourly-twitter.yml",

--- a/docs/backend-matrix.md
+++ b/docs/backend-matrix.md
@@ -107,8 +107,8 @@ Reading notes:
 | twitter-deepseek-pi (tier:deepseek-pi) | `hourly-twitter.yml` | pi · run-pi-container (CI-enforced mirror) | fireworks (pi built-in) | `accounts/fireworks/models/deepseek-v4-flash` | `FIREWORKS_API_KEY` | — |
 | twitter-fireworks-pi (tier:fireworks-pi) | `hourly-twitter.yml` | pi · run-pi-container (CI-enforced mirror) | fireworks (pi built-in) | `accounts/fireworks/models/kimi-k2p7` | `FIREWORKS_API_KEY` | — |
 | twitter-judge (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2` |
-| twitter-primary (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2`; then `deterministic_twitter_digest.py` |
-| twitter-primary-repair (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2` |
+| twitter-primary (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `opencode-glm-5p3-flash`; then `deterministic_twitter_digest.py` |
+| twitter-primary-repair (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `opencode-glm-5p3-flash` |
 | twitter-zai (tier:zai-glm-5p2) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Z.ai | `glm-5.2` | `ZAI_API_KEY` | hard fail (strict — never walks the chain) |
 | wiki-ingest (route:research-editorial-secondary) | `wiki-ingest.yml` | agent-dispatch → Cursor CLI (runtime SSOT) | Grok 4.6 Fast via Cursor CLI | `cursor-grok-4.6-high-fast` | `CURSOR_API_KEY` | hard fail (route fallback=none) |
 | zai-canary · PINNED | `zai-claude-code-canary.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Z.ai | `glm-5.2` | `ZAI_API_KEY` | hard fail (strict — never walks the chain) |
@@ -142,7 +142,7 @@ Reading notes:
 
 _Global ordered fallback chain (SSOT `fallback.chain`): `claude` → `zai-glm-5p2`; native path serves `claude-opus-5`. 31 SSOT lanes (+10 dispatch execution paths) across 34 workflows; 14 workflows run no model._
 
-_Explicit lane fallback overrides (replace, never extend, the global chain): `digest-synthesis-fallback`: `opencode-glm-5p3-flash`._
+_Explicit lane fallback overrides (replace, never extend, the global chain): `digest-synthesis-fallback`: `opencode-glm-5p3-flash`; `twitter-primary`: `opencode-glm-5p3-flash`; `twitter-primary-repair`: `opencode-glm-5p3-flash`._
 
 <!-- END GENERATED BACKEND MATRIX -->
 

--- a/scripts/test_backend_matrix.py
+++ b/scripts/test_backend_matrix.py
@@ -386,28 +386,40 @@ class RoutingInvariants(unittest.TestCase):
         self.assertEqual(len(chain), len(set(chain)), "chain has duplicates")
         self.assertTrue(self.fallback["native_model"])
 
-    def test_local_digest_has_the_only_cross_adapter_lane_override(self):
+    def test_local_content_lanes_have_cross_adapter_overrides(self):
         overrides = {
             key: lane["fallback_chain"]
             for key, lane in self.lanes.items() if lane.get("fallback_chain")
         }
         self.assertEqual(
-            {"digest-synthesis-fallback": ["opencode-glm-5p3-flash"]},
+            {
+                "digest-synthesis-fallback": ["opencode-glm-5p3-flash"],
+                "twitter-primary": ["opencode-glm-5p3-flash"],
+                "twitter-primary-repair": ["opencode-glm-5p3-flash"],
+            },
             overrides,
         )
         # The lane override replaces this global chain; it never appends Z.ai
         # as a third provenance hop.
         self.assertEqual(["claude", "zai-glm-5p2"], self.fallback["chain"])
 
-        local_step = next(
-            step for step in self.obs["daily-digest.yml"].agent_run
-            if step.lane == "digest-synthesis-fallback"
-        )
-        self.assertEqual("OPENCODE_API_KEY",
-                         local_step.secrets["opencode-api-key"])
+        isolated_lanes = {
+            "digest-synthesis-fallback",
+            "twitter-primary",
+            "twitter-primary-repair",
+        }
+        local_steps = [
+            step for obs in self.obs.values() for step in obs.agent_run
+            if step.lane in isolated_lanes
+        ]
+        self.assertEqual(isolated_lanes, {step.lane for step in local_steps})
+        self.assertTrue(all(
+            step.secrets["opencode-api-key"] == "OPENCODE_API_KEY"
+            for step in local_steps
+        ))
         other_steps = [
             step for obs in self.obs.values() for step in obs.agent_run
-            if step.lane != "digest-synthesis-fallback"
+            if step.lane not in isolated_lanes
         ]
         self.assertTrue(all(not step.secrets.get("opencode-api-key")
                             for step in other_steps))

--- a/scripts/test_select_backend.py
+++ b/scripts/test_select_backend.py
@@ -105,6 +105,33 @@ class SelectBackendTest(unittest.TestCase):
         self.assertEqual(out["used-fallback"], "true")
         self.assertIn("rate limited for this run", log)
 
+    def test_twitter_primary_and_repair_use_opencode_on_claude_429(self):
+        lanes = {
+            lane: {
+                "workflow": "hourly-twitter.yml",
+                "harness": "agent-run",
+                "backend": "claude",
+                "fallback_chain": ["opencode-glm-5p3-flash"],
+            }
+            for lane in ("twitter-primary", "twitter-primary-repair")
+        }
+        self.set_availability(zai=True, **{"opencode-go": True})
+        with unittest.mock.patch.dict(
+                os.environ, {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-oat01-test"}), \
+                unittest.mock.patch.object(
+                    select_backend, "request_oauth_preflight",
+                    return_value=(429, '{"error":{"message":"rate limit exceeded"}}')):
+            for lane in lanes:
+                with self.subTest(lane=lane):
+                    code, out, log = self.run_select(
+                        "--lane", lane,
+                        chain=("claude", "zai-glm-5p2"), lanes=lanes)
+                    self.assertEqual(code, 0)
+                    self.assertEqual(out["backend"], "opencode-glm-5p3-flash")
+                    self.assertEqual(out["provider"], "opencode-go")
+                    self.assertEqual(out["used-fallback"], "true")
+                    self.assertIn("rate limited for this run", log)
+
     def test_claude_429_does_not_cross_strict_lane_boundary(self):
         lanes = {
             "digest": {"workflow": "daily-digest.yml", "harness": "agent-run",


### PR DESCRIPTION
What changed:
- give twitter-primary and twitter-primary-repair explicit isolated OpenCode GLM 5.3 Flash fallback chains
- pass OPENCODE_API_KEY to both compatible agent-run calls
- regenerate the backend matrix and lock the route and secret contract in tests

Why:
Liveness run 33262929157 correctly found Twitter stale. The upstream producer selected Claude even though its OAuth preflight returned HTTP 429, then both primary and repair failed and only a recovery heartbeat was committed. Main already classifies 429 as unavailable; this change gives the Twitter content lanes the requested compatible secondary instead of the global Z.ai route or deterministic recovery.

Verification:
- 135 routing, matrix, and freshness tests passed
- generated backend matrix check passed
- git diff check passed

Review note:
Independent Claude CLI and agy review attempts did not produce a usable review due to timeout or read permission denial. OpenCode GLM 5.3 Flash plan mode read the complete diff but timed out before a verdict. Local routing and matrix tests are green.