### PR TITLE
Give Twitter GLM fallback its input and repair contract

### DIFF
--- a/.github/actions/agent-run/action.yml
+++ b/.github/actions/agent-run/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: OpenCode Go key. Passed only to a lane-explicit isolated OpenCode fallback.
     required: false
     default: ""
+  opencode-mode:
+    description: Isolated OpenCode contract/input mode. Use twitter only for callers that stage .twitter-input; all other agent-run lanes remain editorial.
+    required: false
+    default: editorial
   fireworks-fallback:
     description: Fallback policy. claude (default) = walk the lane fallback_chain override when declared, otherwise the global fallback.chain; none = strict, requested backend only.
     required: false
@@ -177,7 +181,7 @@ runs:
       if: steps.select.outputs.provider == 'opencode-go'
       uses: ./.github/actions/run-opencode-container
       with:
-        mode: editorial
+        mode: ${{ inputs.opencode-mode }}
         lane: ${{ inputs.lane }}
         allowed-paths: ${{ steps.isolated-contract.outputs.paths }}
         model: ${{ steps.select.outputs.provider }}/${{ steps.select.outputs.model-id }}

--- a/.github/actions/render-twitter-prompt/action.yml
+++ b/.github/actions/render-twitter-prompt/action.yml
@@ -270,7 +270,7 @@ runs:
             f"--summary-file {summaries_dir}/{date}-{summary_slug}-{hour}h-summary.txt "
             f"--headlines-file {summaries_dir}/{date}-{summary_slug}-{hour}h-headlines.json "
             f"--date {date} --hour {hour} --generated-at \"{ts}\" "
-            f"--run-id {run_id} --run-attempt {run_attempt}\n"
+            f"--run-id {run_id} --run-attempt {run_attempt} --reject-recovery\n"
             "A published section must contain this exact line:\n"
             "**Cycle summary**: <1-2 sentences>\n"
             "`**Cycle Summary**:` (capital S) or a missing line fails the host validator."

--- a/.github/workflows/hourly-twitter.yml
+++ b/.github/workflows/hourly-twitter.yml
@@ -511,22 +511,66 @@ jobs:
           fireworks-api-key: ${{ secrets.FIREWORKS_API_KEY }}
           zai-api-key: ${{ secrets.ZAI_API_KEY }}
           opencode-api-key: ${{ secrets.OPENCODE_API_KEY }}
+          opencode-mode: twitter
           claude-args: |
             --model opus --allowedTools "Read,Write,Edit,MultiEdit,Bash(git:*),Bash(birdy-fast:*),Bash(curl:*),Bash(jq:*),Bash(python3:*),Bash(python:*),Bash(node:*),Bash(ls:*),Bash(cat:*),Bash(head:*),Bash(test:*),Bash(wc:*),Bash(mkdir:*),Bash(sed:*),Bash(rg:*),Bash(printf:*),Bash(touch:*)"
           expected-paths: |
             ${{ steps.const.outputs.status_file }}
           allowed-paths: |
-            research/twitter/
-            research/summaries/
+            ${{ steps.const.outputs.digest_file }}
+            ${{ steps.const.outputs.status_file }}
+            ${{ steps.const.outputs.summary_file }}
+            ${{ steps.const.outputs.headlines_file }}
           label: Twitter primary Claude processor
           prompt: ${{ steps.render.outputs.prompt }}
+
+      # agent-run's expected-path guard proves that the per-run heartbeat
+      # changed; it deliberately cannot prove the multi-file editorial
+      # contract. Check the canonical contract here so a syntactically fresh
+      # but incomplete model result gets one model repair turn before the
+      # deterministic last resort.
+      - name: Check Claude primary editorial contract
+        id: check_claude_primary
+        if: >-
+          steps.backend.outputs.name == 'claude'
+          && (steps.twitter-claude-agent.outcome == 'success' || steps.twitter-claude-agent.outcome == 'failure')
+          && !(github.event_name == 'workflow_dispatch' && inputs.dry_run == true)
+        env:
+          DATE: ${{ steps.datetime.outputs.date }}
+          HOUR: ${{ steps.datetime.outputs.hour }}
+          TIMESTAMP: ${{ steps.datetime.outputs.timestamp }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          DIGEST_FILE: ${{ steps.const.outputs.digest_file }}
+          STATUS_FILE: ${{ steps.const.outputs.status_file }}
+          SUMMARY_FILE: ${{ steps.const.outputs.summary_file }}
+          HEADLINES_FILE: ${{ steps.const.outputs.headlines_file }}
+        run: |
+          set -euo pipefail
+          if uv run python scripts/validate_twitter_public_output.py \
+            --backend claude \
+            --status-file "$STATUS_FILE" \
+            --digest-file "$DIGEST_FILE" \
+            --summary-file "$SUMMARY_FILE" \
+            --headlines-file "$HEADLINES_FILE" \
+            --date "$DATE" \
+            --hour "$HOUR" \
+            --generated-at "$TIMESTAMP" \
+            --run-id "$RUN_ID" \
+            --run-attempt "$RUN_ATTEMPT" \
+            --reject-recovery; then
+            echo "valid=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Primary model output failed the editorial contract; running one model repair turn"
+          fi
 
       - name: Repair missing Twitter output with Claude (primary tier)
         id: twitter-claude-repair
         continue-on-error: true
         if: >-
           steps.backend.outputs.name == 'claude'
-          && steps.twitter-claude-agent.outcome == 'failure'
+          && steps.check_claude_primary.outputs.valid != 'true'
           && !(github.event_name == 'workflow_dispatch' && inputs.dry_run == true)
         uses: ./.github/actions/agent-run
         env:
@@ -538,17 +582,20 @@ jobs:
           fireworks-api-key: ${{ secrets.FIREWORKS_API_KEY }}
           zai-api-key: ${{ secrets.ZAI_API_KEY }}
           opencode-api-key: ${{ secrets.OPENCODE_API_KEY }}
+          opencode-mode: twitter
           claude-args: |
             --model opus --max-turns 40 --allowedTools "Read,Write,Edit,MultiEdit,Bash(git:*),Bash(jq:*),Bash(python3:*),Bash(python:*),Bash(node:*),Bash(test:*),Bash(ls:*),Bash(cat:*),Bash(head:*),Bash(wc:*),Bash(mkdir:*),Bash(sed:*),Bash(rg:*),Bash(printf:*),Bash(touch:*)"
           expected-paths: |
             ${{ steps.const.outputs.status_file }}
           allowed-paths: |
-            research/twitter/
-            research/summaries/
+            ${{ steps.const.outputs.digest_file }}
+            ${{ steps.const.outputs.status_file }}
+            ${{ steps.const.outputs.summary_file }}
+            ${{ steps.const.outputs.headlines_file }}
           label: Twitter primary Claude repair writer
           prompt: |
-            The primary Claude Twitter/X monitor returned without writing
-            its required files. Repair that now using only local files.
+            The primary Twitter/X model output failed its complete editorial
+            contract. Repair that now using only local files.
             Reason from first principles: for each candidate tweet, decide
             whether the underlying event is actually AI-specific and
             publication-worthy, not merely viral or from an AI-adjacent
@@ -569,6 +616,9 @@ jobs:
             HARD RULES
               - This is still the production Claude lane. Do not write a
                 deterministic quick-hit dump.
+              - Never copy or preserve a `recovery: true` status. Recovery
+                heartbeats belong only to the deterministic last resort and
+                are invalid model output.
               - Use tool calls to read the raw input and write the required
                 run artifacts. Do not merely respond in chat.
               - If any tool call is denied, retry with an allowed tool
@@ -613,8 +663,10 @@ jobs:
                  Use `status: "no_update"` and `public_items: 0` only when the
                  public same-hour section is absent. Count `public_items` as
                  Top Story `twitter-story` cards plus linked bullets under
-                 `### Quick hits`; it must equal the rendered count.
+                 `### Quick hits`; it must equal the rendered count. Do not
+                 include a `recovery` field in model-authored status.
               5. Commit exactly those outputs:
+                   uv run python scripts/validate_twitter_public_output.py --backend claude --status-file "${{ steps.const.outputs.status_file }}" --digest-file "${{ steps.const.outputs.digest_file }}" --summary-file "${{ steps.const.outputs.summary_file }}" --headlines-file "${{ steps.const.outputs.headlines_file }}" --date "${{ steps.datetime.outputs.date }}" --hour "${{ steps.datetime.outputs.hour }}" --generated-at "${{ steps.datetime.outputs.timestamp }}" --run-id "${{ github.run_id }}" --run-attempt "${{ github.run_attempt }}" --reject-recovery
                    git add "${{ steps.const.outputs.output_dir }}/" "${{ steps.const.outputs.summary_file }}" "${{ steps.const.outputs.headlines_file }}"
                    git commit -m "Twitter Claude repair ${{ steps.datetime.outputs.timestamp }}" || echo "No changes"
 

--- a/scripts/test_backend_matrix.py
+++ b/scripts/test_backend_matrix.py
@@ -435,7 +435,8 @@ class RoutingInvariants(unittest.TestCase):
         )
         self.assertEqual("steps.select.outputs.provider == 'opencode-go'",
                          child.get("if"))
-        self.assertEqual("editorial", child["with"]["mode"])
+        self.assertEqual("editorial", action["inputs"]["opencode-mode"]["default"])
+        self.assertEqual("${{ inputs.opencode-mode }}", child["with"]["mode"])
         self.assertEqual("${{ inputs.prompt }}", child["with"]["prompt-text"])
         self.assertEqual("${{ steps.isolated-contract.outputs.paths }}",
                          child["with"]["allowed-paths"])

--- a/scripts/test_deterministic_twitter_digest.py
+++ b/scripts/test_deterministic_twitter_digest.py
@@ -5,6 +5,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
+import yaml
+
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from deterministic_twitter_digest import main
@@ -250,6 +252,44 @@ class DeterministicTwitterDigestTest(unittest.TestCase):
         fail_step = workflow[fail_index : workflow.index("\n      - name:", fail_index + 1)]
         self.assertIn("steps.recover_claude.outputs.recovered == 'true'", fail_step)
         self.assertIn("exit 1", fail_step)
+
+    def test_workflow_repairs_invalid_model_output_before_recovery(self) -> None:
+        workflow_path = (
+            Path(__file__).resolve().parent.parent / ".github" / "workflows" / "hourly-twitter.yml"
+        )
+        workflow = workflow_path.read_text(encoding="utf-8")
+
+        check_index = workflow.index("      - name: Check Claude primary editorial contract")
+        repair_index = workflow.index("      - name: Repair missing Twitter output with Claude")
+        recovery_index = workflow.index("      - name: Validate or recover Claude primary output")
+        self.assertLess(check_index, repair_index)
+        self.assertLess(repair_index, recovery_index)
+
+        check_step = workflow[check_index:repair_index]
+        self.assertIn("validate_twitter_public_output.py", check_step)
+        self.assertIn("--reject-recovery", check_step)
+        repair_step = workflow[repair_index:recovery_index]
+        self.assertIn("steps.check_claude_primary.outputs.valid != 'true'", repair_step)
+        self.assertNotIn("steps.twitter-claude-agent.outcome == 'failure'", repair_step)
+
+        doc = yaml.safe_load(workflow)
+        steps = doc["jobs"]["twitter"]["steps"]
+        primary = next(step for step in steps if step.get("id") == "twitter-claude-agent")
+        repair = next(step for step in steps if step.get("id") == "twitter-claude-repair")
+        self.assertEqual("twitter", primary["with"]["opencode-mode"])
+        self.assertEqual("twitter", repair["with"]["opencode-mode"])
+
+    def test_agent_run_preserves_editorial_default_but_forwards_explicit_twitter_mode(self) -> None:
+        action_path = (
+            Path(__file__).resolve().parent.parent / ".github" / "actions" / "agent-run" / "action.yml"
+        )
+        action = yaml.safe_load(action_path.read_text(encoding="utf-8"))
+        self.assertEqual("editorial", action["inputs"]["opencode-mode"]["default"])
+        isolated = next(
+            step for step in action["runs"]["steps"]
+            if step.get("id") == "run-opencode"
+        )
+        self.assertEqual("${{ inputs.opencode-mode }}", isolated["with"]["mode"])
 
 
 if __name__ == "__main__":

--- a/scripts/test_validate_twitter_public_output.py
+++ b/scripts/test_validate_twitter_public_output.py
@@ -47,7 +47,7 @@ class ValidateTwitterPublicOutputTest(unittest.TestCase):
             encoding="utf-8",
         )
 
-    def validate(self) -> None:
+    def validate(self, *, reject_recovery: bool = False) -> None:
         validate(
             backend="claude",
             status_file=self.status,
@@ -59,6 +59,7 @@ class ValidateTwitterPublicOutputTest(unittest.TestCase):
             generated_at="2026-07-10 10:07:09 UTC",
             run_id="1234",
             run_attempt=2,
+            reject_recovery=reject_recovery,
         )
 
     def test_accepts_concrete_published_section(self) -> None:
@@ -189,6 +190,12 @@ class ValidateTwitterPublicOutputTest(unittest.TestCase):
             encoding="utf-8",
         )
         self.validate()
+
+    def test_model_validation_rejects_recovery_heartbeat(self) -> None:
+        self.write_status("no_update", 0, recovery=True)
+        self.summary.write_text("", encoding="utf-8")
+        with self.assertRaisesRegex(ContractError, "must not be a recovery heartbeat"):
+            self.validate(reject_recovery=True)
 
     def test_rejects_stale_run_identity(self) -> None:
         self.write_status("no_update", 0, generated_at="2026-07-10 10:07:00 UTC")

--- a/scripts/validate_twitter_public_output.py
+++ b/scripts/validate_twitter_public_output.py
@@ -141,6 +141,7 @@ def validate(
     run_id: str,
     run_attempt: int,
     headlines_file: Path | None = None,
+    reject_recovery: bool = False,
 ) -> None:
     status = load_json(status_file)
     if not isinstance(status, dict):
@@ -169,6 +170,8 @@ def validate(
         raise ContractError("public_items must be a non-negative integer")
     if not isinstance(recovery, bool):
         raise ContractError("recovery must be a boolean when present")
+    if reject_recovery and recovery:
+        raise ContractError("model output must not be a recovery heartbeat")
     if not summary_file.exists():
         raise ContractError(f"missing summary artifact: {summary_file}")
 
@@ -241,6 +244,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--generated-at", required=True)
     parser.add_argument("--run-id", required=True)
     parser.add_argument("--run-attempt", type=int, required=True)
+    parser.add_argument(
+        "--reject-recovery",
+        action="store_true",
+        help="reject deterministic recovery heartbeats when validating model output",
+    )
     args = parser.parse_args(argv)
 
     try:
@@ -255,6 +263,7 @@ def main(argv: list[str] | None = None) -> int:
             generated_at=args.generated_at,
             run_id=args.run_id,
             run_attempt=args.run_attempt,
+            reject_recovery=args.reject_recovery,
         )
     except ContractError as exc:
         parser.error(str(exc))


### PR DESCRIPTION
Fixes the live Twitter liveness failure exposed by run 33264185662.

Root cause:
- Claude 429 correctly selected OpenCode GLM 5.3 Flash.
- agent-run invoked the isolated adapter in editorial mode, so the gitignored .twitter-input snapshot was not copied into the container.
- status-only output checks accepted a refreshed recovery heartbeat and skipped the model repair turn.

Changes:
- opt Twitter primary and repair fallbacks into isolated twitter mode so GLM receives .twitter-input/bird/all.json;
- validate the complete model-authored output contract before deciding whether repair is needed;
- reject recovery heartbeats as model output;
- run one model repair before deterministic recovery;
- narrow allowed changes to the exact cycle artifacts;
- add regression coverage.

Verification:
- 48 targeted unit/invariant tests pass;
- backend SSOT generator check passes;
- git diff --check passes.

Independent review:
- two read-only agents independently confirmed the missing input boundary and contract-gating bug;
- Cursor Grok 4.6 Fast was invoked for an external review but did not return within five minutes and was stopped, so no finding from that leg was treated as evidence.