### PR TITLE
Align Twitter liveness with recovery contract

### DIFF
--- a/data/artifact-slos.json
+++ b/data/artifact-slos.json
@@ -50,6 +50,17 @@
         "path": "research/twitter/status/[0-9]*.json",
         "selectors": [
           "recovery"
+        ],
+        "absent_means_false": true,
+        "required_selectors": [
+          "schema_version",
+          "date",
+          "hour",
+          "generated_at",
+          "run_id",
+          "run_attempt",
+          "status",
+          "public_items"
         ]
       },
       "content": {

--- a/data/sources/ai_blogs.json
+++ b/data/sources/ai_blogs.json
@@ -177,7 +177,8 @@
     "cadence": "weekly",
     "tags": ["academic-research", "robotics", "inference", "world-models"],
     "include_in_digest": true,
-    "notes": "Berkeley AI Research primary context on academic AI work."
+    "enabled": false,
+    "notes": "Temporarily disabled 2026-08-29: the official feed and site repeatedly time out from the production runner. Re-enable after the endpoint responds reliably."
   },
   {
     "id": "microsoft-research",

--- a/scripts/artifact_slos.py
+++ b/scripts/artifact_slos.py
@@ -92,6 +92,27 @@ def load_registry(path: Path | str = DEFAULT_REGISTRY) -> list[dict[str, Any]]:
                     raise ValueError(
                         f"{source}: {artifact_id} json_boolean_any signal needs selectors[]"
                     )
+                absent_means_false = signal.get("absent_means_false")
+                if absent_means_false is not None and not isinstance(absent_means_false, bool):
+                    raise ValueError(
+                        f"{source}: {artifact_id} json_boolean_any "
+                        "absent_means_false must be boolean"
+                    )
+                if absent_means_false is True and any("*" in value for value in selectors):
+                    raise ValueError(
+                        f"{source}: {artifact_id} json_boolean_any "
+                        "absent_means_false cannot be used with wildcard selectors"
+                    )
+                required_selectors = signal.get("required_selectors")
+                if required_selectors is not None and (
+                    not isinstance(required_selectors, list)
+                    or not required_selectors
+                    or not all(isinstance(value, str) and value for value in required_selectors)
+                ):
+                    raise ValueError(
+                        f"{source}: {artifact_id} json_boolean_any "
+                        "required_selectors must be a non-empty string list"
+                    )
         cadence = entry.get("cadence")
         if not isinstance(cadence, dict) or cadence.get("kind") not in CADENCE_KINDS:
             raise ValueError(f"{source}: {artifact_id} has invalid cadence")

--- a/scripts/check_lane_freshness.py
+++ b/scripts/check_lane_freshness.py
@@ -204,6 +204,9 @@ def lane_producer_health(lane: str, repo_root: str) -> tuple[str, Optional[str]]
                 payload = json.load(handle)
         except (OSError, json.JSONDecodeError) as exc:
             return UNKNOWN, f"{label}: cannot read {display_path}: {type(exc).__name__}"
+        for selector in signal.get("required_selectors", []):
+            if not _select_values(payload, str(selector)):
+                return UNKNOWN, f"{label}: {display_path} missing required {selector}"
         observed = False
         for selector in signal["selectors"]:  # validated by artifact_slos
             values = _select_values(payload, str(selector))
@@ -215,6 +218,8 @@ def lane_producer_health(lane: str, repo_root: str) -> tuple[str, Optional[str]]
             if any(value is True for value in values):
                 return DEGRADED, f"{label}: {display_path} {selector}=true"
         if not observed:
+            if signal.get("absent_means_false") is True:
+                return HEALTHY, None
             return UNKNOWN, f"{label}: {display_path} selectors matched no values"
         return HEALTHY, None
     if kind == "text_regex":

--- a/scripts/fetch_ai_blogs.py
+++ b/scripts/fetch_ai_blogs.py
@@ -123,6 +123,7 @@ class Source:
     tags: tuple[str, ...]
     include_in_digest: bool
     notes: str = ""
+    enabled: bool = True
 
 
 @dataclasses.dataclass(frozen=True)
@@ -224,6 +225,7 @@ def load_sources(path: Path) -> list[Source]:
             tags=tuple(row.get("tags", [])),
             include_in_digest=bool(row.get("include_in_digest", True)),
             notes=row.get("notes", ""),
+            enabled=row.get("enabled", True),
         )
         if src.id in seen_ids:
             raise ValueError(f"duplicate source id: {src.id}")
@@ -231,8 +233,11 @@ def load_sources(path: Path) -> list[Source]:
             raise ValueError(f"{src.id}: invalid priority {src.priority!r}")
         if src.type not in TYPE_WEIGHT:
             raise ValueError(f"{src.id}: invalid type {src.type!r}")
+        if not isinstance(src.enabled, bool):
+            raise ValueError(f"{src.id}: enabled must be boolean")
         seen_ids.add(src.id)
-        sources.append(src)
+        if src.enabled:
+            sources.append(src)
     return sources
 
 

--- a/scripts/test_artifact_slos.py
+++ b/scripts/test_artifact_slos.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+import json
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -49,6 +51,53 @@ class ArtifactSloRegistryTest(unittest.TestCase):
                     artifact_slos.DEGRADED_SIGNAL_KINDS,
                     entry["id"],
                 )
+
+    def test_json_signal_optional_fields_are_typed(self):
+        base = {
+            "schema_version": 1,
+            "artifacts": [
+                {
+                    "id": "test",
+                    "producer": "workflow.yml",
+                    "artifacts": ["artifact.json"],
+                    "freshness_paths": ["artifact.json"],
+                    "validators": ["validator.py"],
+                    "degraded_policy": "per-symbol-stale-carry-forward",
+                    "degraded_signal": {
+                        "kind": "json_boolean_any",
+                        "label": "stale",
+                        "path": "artifact.json",
+                        "selectors": ["stale"],
+                    },
+                    "cadence": {
+                        "kind": "interval",
+                        "hours": 1,
+                        "freshness_slo_hours": 3,
+                    },
+                }
+            ],
+        }
+        for key, value, message in (
+            ("absent_means_false", "false", "must be boolean"),
+            ("required_selectors", [], "non-empty string list"),
+        ):
+            payload = json.loads(json.dumps(base))
+            payload["artifacts"][0]["degraded_signal"][key] = value
+            with tempfile.TemporaryDirectory() as tmp:
+                registry = Path(tmp) / "artifact-slos.json"
+                registry.write_text(json.dumps(payload), encoding="utf-8")
+                with self.assertRaisesRegex(ValueError, message):
+                    artifact_slos.load_registry(registry)
+
+        payload = json.loads(json.dumps(base))
+        signal = payload["artifacts"][0]["degraded_signal"]
+        signal["selectors"] = ["rows.*.stale"]
+        signal["absent_means_false"] = True
+        with tempfile.TemporaryDirectory() as tmp:
+            registry = Path(tmp) / "artifact-slos.json"
+            registry.write_text(json.dumps(payload), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "cannot be used with wildcard"):
+                artifact_slos.load_registry(registry)
 
 
 if __name__ == "__main__":

--- a/scripts/test_check_lane_freshness.py
+++ b/scripts/test_check_lane_freshness.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import json
 import os
 import shutil
 import subprocess
@@ -174,6 +175,59 @@ class ProducerSignalTest(unittest.TestCase):
                 path.write_text('{"stale":"false"}')
                 self.assertEqual(clf.lane_producer_health("test", tmp)[0], clf.UNKNOWN)
 
+    def test_optional_positive_json_marker_can_be_absent_when_contract_is_complete(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "status.json"
+            base = {
+                "schema_version": 1,
+                "date": "2026-08-29",
+                "status": "published",
+            }
+            signal = {
+                "kind": "json_boolean_any",
+                "label": "restore-baseline",
+                "path": "status.json",
+                "selectors": ["recovery"],
+                "absent_means_false": True,
+                "required_selectors": ["schema_version", "date", "status"],
+            }
+            with mock.patch.dict(clf.LANE_DEGRADED_SIGNALS, {"test": signal}, clear=True):
+                path.write_text(json.dumps(base), encoding="utf-8")
+                self.assertEqual(clf.lane_producer_health("test", tmp), (clf.HEALTHY, None))
+
+                path.write_text(json.dumps({**base, "recovery": False}), encoding="utf-8")
+                self.assertEqual(clf.lane_producer_health("test", tmp), (clf.HEALTHY, None))
+
+                path.write_text(json.dumps({**base, "recovery": True}), encoding="utf-8")
+                self.assertEqual(clf.lane_producer_health("test", tmp)[0], clf.DEGRADED)
+
+                path.write_text(json.dumps({**base, "recovery": "false"}), encoding="utf-8")
+                self.assertEqual(clf.lane_producer_health("test", tmp)[0], clf.UNKNOWN)
+
+                for invalid in (None, 0):
+                    path.write_text(json.dumps({**base, "recovery": invalid}), encoding="utf-8")
+                    self.assertEqual(clf.lane_producer_health("test", tmp)[0], clf.UNKNOWN)
+
+                path.write_text("{}", encoding="utf-8")
+                state, reason = clf.lane_producer_health("test", tmp)
+                self.assertEqual(state, clf.UNKNOWN)
+                self.assertIn("missing required schema_version", reason)
+
+                path.write_text("[]", encoding="utf-8")
+                self.assertEqual(clf.lane_producer_health("test", tmp)[0], clf.UNKNOWN)
+
+    def test_json_marker_absence_stays_unknown_without_explicit_default(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "artifact.json").write_text("{}", encoding="utf-8")
+            signal = {
+                "kind": "json_boolean_any",
+                "label": "carry-forward",
+                "path": "artifact.json",
+                "selectors": ["stale"],
+            }
+            with mock.patch.dict(clf.LANE_DEGRADED_SIGNALS, {"test": signal}, clear=True):
+                self.assertEqual(clf.lane_producer_health("test", tmp)[0], clf.UNKNOWN)
+
     def test_text_regex_reads_latest_labelled_artifact_only(self):
         with tempfile.TemporaryDirectory() as tmp:
             lane = Path(tmp, "lane")
@@ -330,7 +384,22 @@ class GitIntegrationTest(unittest.TestCase):
     def test_twitter_recovery_status_survives_unrelated_public_path_commit(self):
         status = Path(self.repo, "research", "twitter", "status", "2026-05-28-06h.json")
         status.parent.mkdir(parents=True)
-        status.write_text('{"recovery":true}', encoding="utf-8")
+        status.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "date": "2026-05-28",
+                    "hour": "06:00 UTC",
+                    "generated_at": "2026-05-28 06:00:00 UTC",
+                    "run_id": "42",
+                    "run_attempt": 1,
+                    "status": "no_update",
+                    "public_items": 0,
+                    "recovery": True,
+                }
+            ),
+            encoding="utf-8",
+        )
         self._git("add", "-A")
         self._git("commit", "-q", "-m", "Twitter deterministic fallback 2026-05-28 06:00 UTC")
         self.assertEqual(clf.lane_producer_health("twitter", self.repo)[0], clf.DEGRADED)

--- a/scripts/test_fetch_ai_blogs.py
+++ b/scripts/test_fetch_ai_blogs.py
@@ -245,6 +245,7 @@ class ShippedRegistryTest(unittest.TestCase):
 
     def test_registry_loads_and_is_non_trivial(self):
         self.assertGreaterEqual(len(self.sources), 25)
+        self.assertNotIn("bair", {source.id for source in self.sources})
 
     def test_feed_urls_are_https_and_unique(self):
         feeds = [s.feed_url for s in self.sources]


### PR DESCRIPTION
## Why

A valid model-published Twitter status omits the optional positive-only `recovery` marker. The liveness checker incorrectly treated that omission as unknown, so the lane stayed red after GLM 5.3 Flash successfully published.

## What changed

- make missing `recovery` mean false only for the Twitter signal
- require all normal Twitter status identity fields before applying that default
- preserve UNKNOWN for malformed, partial, non-boolean, and missing artifacts
- preserve strict missing-selector behavior for market carry-forward signals
- validate the new registry options and reject wildcard defaults
- quarantine the BAIR source with `enabled: false` after three producer timeouts and direct HTTP/HTTPS probes timed out; source metadata stays in place for easy reactivation

## Verification

- `UV_CACHE_DIR=/tmp/ara-uv-cache uv run python -m unittest test_artifact_slos test_check_lane_freshness test_validate_twitter_public_output test_fetch_ai_blogs` from `scripts/` (61 passed)
- local liveness now reports Twitter healthy while retaining the genuine blogs and digest degradation alerts
- independent reviewer confirmed the canonical validator intentionally treats missing `recovery` as false
