### PR TITLE
Refresh verified Polymarket ticket mappings

### DIFF
--- a/research/models/tickets/moonshot-kimi-k3.md
+++ b/research/models/tickets/moonshot-kimi-k3.md
@@ -77,8 +77,14 @@ sources:
   - "@rohanpaul_ai"
   - "@EpochAIResearch"
   - "@theinformation"
+polymarket:
+  - event_slug: moonshot-publishes-kimi-k3-weights-by-july-27-20260717164254847
+    market_id: "2962189"
+    token_id: "75115059341633093064218172577665054472726102773501095008666040339558881159279"
+    question: "Moonshot publishes Kimi K3 weights by July 27?"
+    outcome: "Jul 27 2026"
 created_at: 2026-07-16
-updated_at: 2026-08-23
+updated_at: 2026-08-30
 closed_at: 2026-08-23
 closed_reason: released-and-aged
 history:
@@ -94,6 +100,8 @@ history:
     change: "License, pricing, and rank detail. Licensing clarified as a bespoke 'Kimi K3 License' (>$20M/12mo-revenue MaaS providers need a separate Moonshot agreement; must display the 'Kimi K3' name) rather than plain Modified MIT. API pricing published: $0.30/$3/$15 per Mtok. Artificial Analysis Intelligence Index: 57, #1 open-weight (ahead of GLM-5.2 at 51, DeepSeek V4 Pro at 44). Day-0 hosting confirmed: Baseten, Nebius, Vercel AI Gateway, Dell on-prem. Status stays released; verification stays confirmed."
   - ts: 2026-08-23
     change: "Closed — released-and-aged. Kimi K3 shipped in mid-July and had licensing, pricing ($0.30/$3/$15 per Mtok), Artificial Analysis Intelligence Index 57 (#1 open-weight at the time) and day-0 hosting all resolved by the 2026-07-28 update; @teortaxesTex (2026-08-23) refers to it as having been 'released 5 weeks ago,' putting it past the >=4-week trigger. It remains an active reference point rather than a forgotten model — @emollick benchmarks the unattributed [[stealth-ox-alpha-model-2026-08]] against it and rates K3 higher on his shader test — but that is normal coverage. The successor signal is a separate artifact: @kimmonismus (2026-08-21) relays that 'Kimi k3.1 also incoming,' which is a zero-artifact single-relay claim and will get its own ticket when an artifact appears. Moonshot's other open tickets ([[moonshot-funding-2026-06]], [[moonshot-claude-distillation-us-scrutiny-2026-07]]) are unaffected. History preserved."
+  - ts: 2026-08-30
+    change: "Linked the resolved Polymarket market 'Moonshot publishes Kimi K3 weights by July 27?' (event moonshot-publishes-kimi-k3-weights-by-july-27-20260717164254847, market 2962189, final outcome Yes). Its criterion requires the complete official K3 weights to be publicly downloadable by July 27 — API access, partial, converted, or third-party weights do not count — so it matches this ticket's full-weights milestone rather than the earlier app/API release. Event, market, question, and Yes-token identity revalidated against the Gamma record; ticket lifecycle remains closed."
 ---
 
 **Moonshot AI's** next flagship coding/reasoning model, **Kimi K3**, is

--- a/research/models/tickets/openai-us-govt-stake-2026-06.md
+++ b/research/models/tickets/openai-us-govt-stake-2026-06.md
@@ -74,8 +74,14 @@ sources:
   - "@Sharity"
   - "@rohanpaul_ai"
   - "@_StockMlKTNewz"
+polymarket:
+  - event_slug: which-companies-will-the-us-take-a-stake-in
+    market_id: "1323318"
+    token_id: "105746726493182224982615892012481143192604366292256699612958741853324716128080"
+    question: "Will the US federal government take a stake in OpenAI?"
+    outcome: "Dec 31 2026"
 created_at: 2026-06-07
-updated_at: 2026-07-04
+updated_at: 2026-08-30
 closed_at: null
 closed_reason: null
 history:
@@ -89,6 +95,8 @@ history:
     change: "Polymarket odds data point (~73% implied) on the government taking a stake (@_StockMlKTNewz); TechCrunch/Ars Technica reiterate Altman's ~5% donation proposal. Continuing thread, no new fact confirmation. Status stays confirmed; verification stays partial."
   - ts: 2026-07-04
     change: "Viral backlash (Digg: 1M+ views, 79.5% negative across 472 comments) plus the first on-record presidential reaction: in a CNBC interview, Trump declined to confirm or deny the 5% stake, instead citing the government's ~10% Intel stake ('$60 or $70B' paper gain in 8 months) as the operating precedent and calling it 'very American' — reproduced verbatim across 4+ independent accounts, so on-record but non-committal. CNBC follow-up: the concept has circulated over a year, Altman first pitched it to Trump in early 2025. Ars Technica-sourced relay: the 5% figure is 'far below' Sanders' ask. Status stays confirmed; verification stays partial (no OpenAI/WH confirmation of terms)."
+  - ts: 2026-08-30
+    change: "Linked the active Polymarket market 'Will the US federal government take a stake in OpenAI?' (event which-companies-will-the-us-take-a-stake-in, market 1323318, deadline December 31, 2026). The market requires direct federal equity or a binding agreement to acquire it; speculation, proposals, and non-equity instruments do not count. That is the same unresolved consummation criterion this ticket tracks, not merely the already-confirmed existence of talks. Event, market, question, and Yes-token identity revalidated against the Gamma record; no status or verification change."
 ---
 
 Per **NOTUS, TechCrunch, and The Decoder** (2026-06-06), the **Trump

--- a/research/models/tickets/reliance-intelligence-2026-06.md
+++ b/research/models/tickets/reliance-intelligence-2026-06.md
@@ -33,13 +33,31 @@ sources:
   - https://x.com/investor1397/status/2068230147606475240
   - "@gaze_observer"
   - "@investor1397"
+polymarket:
+  - event_slug: jio-platforms-ipo-byptptpt-20260629175823569
+    market_id: "2734707"
+    token_id: "78791224576670745293172582717415121152419990078489841207969233298036502966175"
+    question: "Will Jio Platforms IPO by September 30, 2026?"
+    outcome: "Sep 30 2026"
+  - event_slug: jio-platforms-ipo-byptptpt-20260629175823569
+    market_id: "2734708"
+    token_id: "87218132281162226192564134544957766898701908105269167897566982880770950467378"
+    question: "Will Jio Platforms IPO by December 31, 2026?"
+    outcome: "Dec 31 2026"
+  - event_slug: jio-platforms-ipo-byptptpt-20260629175823569
+    market_id: "2734705"
+    token_id: "106288975322599844817998715240962735449402266747474973473213248062206417629461"
+    question: "Will Jio Platforms IPO by July 31, 2026?"
+    outcome: "Jul 31 2026"
 created_at: 2026-06-20
-updated_at: 2026-06-20
+updated_at: 2026-08-30
 closed_at: null
 closed_reason: null
 history:
   - ts: 2026-06-20
     change: "Created — at Reliance's 49th AGM (2026-06-19) Mukesh Ambani moved Reliance Intelligence to execution: first 120 MW of Jamnagar AI compute by end-2026 (NVIDIA GB300 first phase, ~75k H100-equiv; scalable to >200k H100-equiv; Kutch solar-powered), free Google AI Pro (Gemini) for hundreds of millions of Jio users, a Meta/Llama JV, and a 22-language AI app suite. Same day, Jio Platforms filed a DRHP for a potential India-record IPO (~₹40,000 cr fresh issue; ~$120-150B est. valuation). Sourced from detailed secondary AGM recaps (no captured Reliance primary handle in-window) → status confirmed (official AGM event, multi-account corroboration), verification partial. @gaze_observer 2068232851724947827, @investor1397 2068230147606475240."
+  - ts: 2026-08-30
+    change: "Linked three exact Polymarket horizons for this ticket's Jio Platforms IPO leg: September 30 (market 2734707, primary/nearest decision-useful active horizon), December 31 (2734708, active year-end horizon), and the resolved July 31 market (2734705, final outcome No) for historical odds. Every leg requires Jio's first public stock sale on a recognized exchange, matching the ticket's pending IPO milestone rather than its separate AI-compute and partnership claims. Event, market, question, and Yes-token identities were revalidated against the Gamma record. The near-expiry August 31 sibling was omitted under the three-mapping cap in favor of the next live horizon, year-end horizon, and resolved history; no status or verification change."
 ---
 
 At **Reliance Industries' 49th AGM on 2026-06-19**, Mukesh Ambani declared


### PR DESCRIPTION
## Summary

- rebuild stale draft #961 on current `main` without carrying its conflicting ticket snapshots forward
- preserve every current lifecycle and history entry, then append dated mapping updates
- link exact, revalidated Kimi K3 and OpenAI stake markets
- use Jio’s three slots for the next decision-useful live horizon, year-end horizon, and resolved July history

## Identity and semantic verification

Exact Gamma records were re-read on 2026-08-30. For every mapping, the event slug, market ID, question, and first `clobTokenIds` entry (Yes token) match the committed values. Resolution text was checked against the ticket milestone:

- Kimi: complete official downloadable weights by July 27; excludes API-only, partial, converted, and third-party weights. Resolved Yes.
- OpenAI: direct federal equity or a binding acquisition agreement by December 31; excludes proposals, speculation, and non-equity instruments. Active.
- Jio: first public stock sale on a recognized exchange by the named date. September and December are active; July resolved No. The near-expiry August sibling is omitted under the max-3 contract.

## Validation

- `uv run python scripts/check_model_tickets.py` — 246 tickets valid
- `python -m unittest test_check_model_tickets` from `scripts/` — 12 passed
- `node --test dashboard/scripts/forecast-seo.test.mjs` — 3 passed
- `bun run build` in `dashboard/` — typecheck, Vite build, and SEO postbuild passed; generated 4 verified forecast pages including Kimi
- generated prebuild index retained all three tickets and exact mapping values
- `git diff --check`

Full `bun test` also ran: 33 passed; 2 unrelated publication-contract fixture tests fail on current `main` because the 2026-08-29 digest is now editorial rather than the older deterministic fallback those tests still expect.

Supersedes #961.