### PR TITLE
Suppress cross-cycle Twitter rebroadcasts

### DIFF
--- a/docs/headline-dedupe.md
+++ b/docs/headline-dedupe.md
@@ -137,6 +137,13 @@ never re-tokenizes history.
    never a swallowed headline. (Whole-file JSON corruption still fails
    **closed** — `load_json_list` raises `SystemExit`.)
 
+4. **Pass 1d has no separate recency window.** Within the retained 3,000-row
+   alert ledger, an external status ID or normalized URL is durable identity:
+   re-headlining it later does not make it a new alert. This deliberately favors
+   duplicate prevention over repeat coverage. A publisher that reuses one
+   canonical URL for genuinely different stories can therefore be suppressed;
+   producers should emit story-specific canonical URLs when available.
+
 **In-batch behavior:** `filter_headlines` appends each accepted item back into
 `history` (stamped with the run `now`) as it iterates, so two paraphrases of
 the same story *in the same cycle* from different accounts collapse to one —

--- a/docs/headline-dedupe.md
+++ b/docs/headline-dedupe.md
@@ -43,7 +43,8 @@ Two `dedupe_headline_alerts.py` subcommands bracket the send:
 The ledger (`research/summaries/twitter-announced-history.json`) is committed
 back to `main` each cycle, so the next run sees the updated history. Each
 record is `{headline, source, url, category, delivered_at}` where
-`delivered_at` is `"YYYY-MM-DD HH:MM UTC"`.
+`delivered_at` is the workflow's current `"YYYY-MM-DD HH:MM:SS UTC"` format;
+legacy `"YYYY-MM-DD HH:MM UTC"` records remain parseable.
 
 ## The decision: `duplicate_reason(item, history, history_keys, now)`
 
@@ -66,7 +67,9 @@ flowchart TD
     G -->|yes| R2([duplicate_headline]):::supp
     G -->|no| H{"Any record with the SAME url<br/>and max-containment/Jaccard ≥ 0.62?"}
     H -->|yes| R3([duplicate_source_similar_headline]):::supp
-    H -->|no| Q
+    H -->|no| I{"now provided and same external key<br/>was delivered strictly before now?"}
+    I -->|yes| R3D([duplicate_rebroadcast]):::supp
+    I -->|no| Q
 
     %% Gate: cross-source pass only runs when a reference time is supplied
     Q{now provided?} -->|"no — legacy / test caller"| SEND
@@ -90,6 +93,7 @@ flowchart TD
 | 1a | `duplicate_story_key` | same non-empty `story_key` | explicit story grouping (**inert today** — the agent's schema emits no `story_key`; kept for when it does) |
 | 1b | `duplicate_headline` | identical **normalized** headline, **any** source | verbatim re-posts / cross-account copies |
 | 1c | `duplicate_source_similar_headline` | **same URL** + `max(containment, jaccard) ≥ 0.62` | one author rephrasing their own tweet |
+| 1d | `duplicate_rebroadcast` | same external key + parseable `delivered_at < now` | a prior-run tweet/status or normalized URL re-headlined at any wording overlap |
 | 2 | `duplicate_cross_source_similar_headline` | **different URL** + in 14-day window + `≥ 4` shared tokens + `Jaccard ≥ 0.5` | **the same story from a different account, paraphrased** (the leak this layer was added to close) |
 
 **Normalization** (`normalize_headline`): NFKC, uppercase, strip URLs, drop
@@ -118,17 +122,20 @@ never re-tokenizes history.
    gap (0.375 there), letting genuine "more details" updates through. Pass 1c
    keeps the looser `max()` because an identical URL already proves same source.
 
-2. **Pass 2 is inert without `now`.** The recency window needs a reference
-   time. When `duplicate_reason` is called with no `now` (the 2-arg legacy/test
-   signature), Pass 2 is skipped entirely — existing callers are byte-for-byte
-   unchanged. `filter_headlines` derives `now` from the run `--timestamp`; if
-   that is malformed, Pass 2 simply doesn't run (no crash).
+2. **Passes 1d and 2 are inert without `now`.** Both need a trusted run
+   boundary. When `duplicate_reason` is called with no `now` (the 2-arg
+   legacy/test signature), both are skipped. `filter_headlines` derives `now`
+   from the run `--timestamp`; if that is malformed, both passes simply do not
+   run (no crash). Pass 1d uses strict `delivered_at < now`, not `<=`: accepted
+   same-cycle items are appended to in-memory history at exactly `now`, and one
+   thread may legitimately yield multiple distinct claims in that cycle.
 
 3. **Per-record timestamps fail OPEN.** A history record whose `delivered_at`
-   is missing or unparseable is treated as **outside** the window → it cannot
-   suppress an incoming alert. The cost of a parse bug is at worst one
-   duplicate, never a swallowed headline. (Whole-file JSON corruption still
-   fails **closed** — `load_json_list` raises `SystemExit`.)
+   is missing, unparseable, equal to the current run, or in the future cannot
+   trigger Pass 1d. Missing/unparseable timestamps are also treated as outside
+   the Pass-2 window. The cost of a timestamp bug is at worst one duplicate,
+   never a swallowed headline. (Whole-file JSON corruption still fails
+   **closed** — `load_json_list` raises `SystemExit`.)
 
 **In-batch behavior:** `filter_headlines` appends each accepted item back into
 `history` (stamped with the run `now`) as it iterates, so two paraphrases of

--- a/scripts/dedupe_headline_alerts.py
+++ b/scripts/dedupe_headline_alerts.py
@@ -11,6 +11,10 @@ Full contract + flow diagrams (incl. the downstream agent gate in
 Dedupe layers (see `duplicate_reason`), in priority order:
   1. shared story_key, exact normalized headline (any source), and same-source
      (same URL) paraphrase — time-independent, highest precision.
+  1d. same-source rebroadcast — the SAME tweet/status id (or normalized
+      external URL) that alerted in an EARLIER run, regardless of wording.
+      Records stamped by the current run do not qualify, preserving
+      same-cycle multi-claim extraction. Gated on a reference time like layer 2.
   2. cross-source semantic duplicate — the SAME story reported by a DIFFERENT
      account (different tweet URL) with paraphrased wording. This catches the
      re-reports the same-URL check structurally cannot see. It is gated on a
@@ -207,11 +211,14 @@ def external_key(url: str) -> str:
 
 
 def parse_delivered_at(value: Any) -> datetime | None:
-    """Parse a ledger ``delivered_at`` ("YYYY-MM-DD HH:MM UTC"); None if unparseable."""
-    try:
-        return datetime.strptime(str(value or "").strip(), "%Y-%m-%d %H:%M UTC")
-    except (TypeError, ValueError):
-        return None
+    """Parse legacy minute or current second precision; None if unparseable."""
+    raw = str(value or "").strip()
+    for fmt in ("%Y-%m-%d %H:%M:%S UTC", "%Y-%m-%d %H:%M UTC"):
+        try:
+            return datetime.strptime(raw, fmt)
+        except (TypeError, ValueError):
+            continue
+    return None
 
 
 def within_cross_source_window(delivered_at: Any, now: datetime, window_days: int) -> bool:
@@ -289,6 +296,21 @@ def duplicate_reason(
             similarity = headline_similarity(headline, record_headline)
             if similarity >= URL_SIMILARITY_THRESHOLD:
                 return "duplicate_source_similar_headline"
+
+    # Pass 1d — same external item, earlier cycle (rebroadcast). A status id or
+    # normalized external URL that already alerted is the same alert even when
+    # a later model rewrites its headline with zero token overlap. The strict
+    # timestamp comparison is load-bearing: records appended during this run
+    # have delivered_at == now and may represent distinct claims extracted from
+    # one thread, so they remain deliverable. Missing/unparseable timestamps
+    # fail open and cannot suppress an item.
+    if now is not None and keys.external_key:
+        for record, record_keys in zip(history, history_keys):
+            if record_keys.external_key != keys.external_key:
+                continue
+            delivered = parse_delivered_at(record.get("delivered_at"))
+            if delivered is not None and delivered < now:
+                return "duplicate_rebroadcast"
 
     # Pass 2 — cross-source semantic duplicate: same story, DIFFERENT account
     # (different tweet URL), paraphrased. Inert unless a reference time `now` is

--- a/scripts/test_dedupe_headline_alerts.py
+++ b/scripts/test_dedupe_headline_alerts.py
@@ -11,6 +11,121 @@ import dedupe_headline_alerts as dedupe
 
 
 class DedupeHeadlineAlertsTest(unittest.TestCase):
+    def test_same_tweet_earlier_run_is_rebroadcast_even_with_zero_overlap(self):
+        history = [
+            dedupe.make_record(
+                {
+                    "headline": "GPT-5.6 POSTPONED AGAIN; NEXT MOVE FRAMED AS SONNET 5",
+                    "url": "https://x.com/apples_jimmy/status/2071000000000000001",
+                },
+                "2026-06-24 01:06 UTC",
+            )
+        ]
+        item = {
+            "headline": "COMPLETELY DIFFERENT WORDING ABOUT A MID-JULY SLIP",
+            "url": "https://twitter.com/another_handle/status/2071000000000000001?s=20",
+        }
+        now = dedupe.parse_delivered_at("2026-06-24 03:54 UTC")
+        self.assertEqual(
+            dedupe.duplicate_reason(item, history, None, now),
+            "duplicate_rebroadcast",
+        )
+
+    def test_same_normalized_external_url_earlier_run_is_rebroadcast(self):
+        history = [
+            dedupe.make_record(
+                {
+                    "headline": "ORIGINAL PRODUCT ANNOUNCEMENT",
+                    "url": "https://example.com/launch?utm_source=x&edition=global",
+                },
+                "2026-06-24 01:06 UTC",
+            )
+        ]
+        item = {
+            "headline": "ZERO-OVERLAP REWRITE OF THE ANNOUNCEMENT",
+            "url": "https://www.example.com/launch?edition=global&utm_medium=social",
+        }
+        now = dedupe.parse_delivered_at("2026-06-24 03:54 UTC")
+        self.assertEqual(
+            dedupe.duplicate_reason(item, history, None, now),
+            "duplicate_rebroadcast",
+        )
+
+    def test_same_tweet_same_run_multi_claim_still_delivers(self):
+        now_text = "2026-06-29 03:36:27 UTC"
+        history = [
+            dedupe.make_record(
+                {
+                    "headline": "ELON MUSK ANNOUNCES GROK 4.5 IN PRIVATE BETA",
+                    "url": "https://x.com/elonmusk/status/2071184354756477041",
+                },
+                now_text,
+            )
+        ]
+        item = {
+            "headline": "SPACEX TO RELEASE FROM-SCRATCH AI MODELS EVERY MONTH THIS YEAR",
+            "url": "https://x.com/elonmusk/status/2071184354756477041",
+        }
+        now = dedupe.parse_delivered_at(now_text)
+        self.assertEqual(dedupe.duplicate_reason(item, history, None, now), "")
+
+    def test_rebroadcast_layer_is_inert_without_reference_time(self):
+        history = [
+            dedupe.make_record(
+                {
+                    "headline": "ORIGINAL WORDING OF SOME STORY",
+                    "url": "https://x.com/a/status/777",
+                },
+                "2026-06-24 01:06 UTC",
+            )
+        ]
+        item = {
+            "headline": "TOTALLY REWORDED TAKE WITH NO SHARED TOKENS AT ALL",
+            "url": "https://x.com/a/status/777",
+        }
+        self.assertEqual(dedupe.duplicate_reason(item, history), "")
+
+    def test_rebroadcast_fails_open_on_unparseable_history_timestamp(self):
+        history = [
+            dedupe.make_record(
+                {
+                    "headline": "ORIGINAL WORDING OF SOME STORY",
+                    "url": "https://x.com/a/status/888",
+                },
+                "not-a-timestamp",
+            )
+        ]
+        item = {
+            "headline": "TOTALLY REWORDED TAKE WITH NO SHARED TOKENS AT ALL",
+            "url": "https://x.com/a/status/888",
+        }
+        now = dedupe.parse_delivered_at("2026-06-24 03:54 UTC")
+        self.assertEqual(dedupe.duplicate_reason(item, history, None, now), "")
+
+    def test_rebroadcast_fails_open_on_future_history_timestamp(self):
+        history = [
+            dedupe.make_record(
+                {
+                    "headline": "ORIGINAL WORDING OF SOME STORY",
+                    "url": "https://x.com/a/status/999",
+                },
+                "2026-06-24 05:00 UTC",
+            )
+        ]
+        item = {
+            "headline": "TOTALLY REWORDED TAKE WITH NO SHARED TOKENS AT ALL",
+            "url": "https://x.com/a/status/999",
+        }
+        now = dedupe.parse_delivered_at("2026-06-24 03:54 UTC")
+        self.assertEqual(dedupe.duplicate_reason(item, history, None, now), "")
+
+    def test_delivered_at_parser_accepts_current_seconds_and_legacy_minutes(self):
+        seconds = dedupe.parse_delivered_at("2026-08-29 17:19:04 UTC")
+        minutes = dedupe.parse_delivered_at("2026-07-31 17:19 UTC")
+        self.assertEqual(seconds, dedupe.datetime(2026, 8, 29, 17, 19, 4))
+        self.assertEqual(minutes, dedupe.datetime(2026, 7, 31, 17, 19))
+        self.assertIsNone(dedupe.parse_delivered_at("2026-08-29T17:19:04Z"))
+
     def test_normalize_url_twitter_variants(self):
         left = "http://www.twitter.com/OpenAI/status/123?s=20&utm_source=x"
         right = "https://x.com/OpenAI/status/123/"
@@ -132,6 +247,41 @@ class DedupeHeadlineAlertsTest(unittest.TestCase):
                     }
                 ],
             )
+
+    def test_filter_keeps_distinct_same_cycle_claims_from_one_status(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            history_file = root / "history.json"
+            headlines_file = root / "headlines.json"
+            filtered_file = root / "filtered.json"
+            history_file.write_text("[]")
+            items = [
+                {
+                    "headline": "ELON MUSK ANNOUNCES GROK 4.5 IN PRIVATE BETA",
+                    "url": "https://x.com/elonmusk/status/2071184354756477041",
+                },
+                {
+                    "headline": "SPACEX TO RELEASE FROM-SCRATCH AI MODELS EVERY MONTH THIS YEAR",
+                    "url": "https://x.com/elonmusk/status/2071184354756477041",
+                },
+            ]
+            headlines_file.write_text(json.dumps(items))
+            with redirect_stdout(StringIO()):
+                rc = dedupe.main(
+                    [
+                        "filter",
+                        "--headlines-file",
+                        str(headlines_file),
+                        "--history-file",
+                        str(history_file),
+                        "--filtered-file",
+                        str(filtered_file),
+                        "--timestamp",
+                        "2026-06-29 03:36:27 UTC",
+                    ]
+                )
+            self.assertEqual(rc, 0)
+            self.assertEqual(json.loads(filtered_file.read_text()), items)
 
     def test_record_delivered_appends_with_retention(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

- add a deterministic duplicate_rebroadcast pass for an external status ID or normalized URL already delivered in an earlier run
- preserve same-cycle multi-claim extraction with the strict delivered_at < now boundary
- keep missing, malformed, equal-run, and future timestamps fail-open
- accept both the workflow's current second-precision timestamps and legacy minute-precision ledger rows
- document the new layer without changing the current twitter-judge route or dashboard rendering

## Why

The existing same-URL gate still requires headline similarity, so a later model can re-headline the same tweet with zero word overlap and resend it. External identity is stronger evidence than wording for this alert-send ledger.

The live replay also found a pre-existing timestamp contract mismatch: 896 of 3,000 retained rows use the workflow's current YYYY-MM-DD HH:MM:SS UTC format, while the parser accepted only legacy minute precision. Parsing both formats restores evidence for this pass and the existing cross-source window while genuinely malformed values still fail open.

## Verification

- python3 scripts/test_dedupe_headline_alerts.py: 25 tests passed
- python3 scripts/test_headline_judge.py: 15 tests passed; judge behavior and route are untouched
- py_compile passed with a writable temporary bytecode cache
- git diff --check passed

Current 3,000-record ledger replay:

- 103 historical deliveries classify as duplicate_rebroadcast
- 0 timestamps are unparseable after accepting current seconds plus legacy minutes
- 59 same-cycle-only repeated external keys remain deliverable
- 65 total same-cycle repeated external-key records demonstrate that the strict boundary protects a real, not hypothetical, pattern

## Scope

This intentionally ports only the alert-side part of old PR #193. It does not include the obsolete dashboard story-collapse code and does not modify the current model judge contract.
