### PR TITLE
Fix recurring unpublished deep-link 404s

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -3,7 +3,7 @@
 	encode zstd gzip
 
 	@html {
-		path / /index.html /today /today/* /twitter /twitter/* /models /models/* /frontpage /frontpage/* /research /research/* /wiki /wiki/* /agents /agents/ /design/*
+		path / /index.html /today /today/* /twitter /twitter/* /models /models/* /frontpage /frontpage/* /research /research/* /wiki /wiki/* /agents /agents/ /design/* /pricing /pricing/
 		not path *.js *.css *.json *.xml *.txt *.png *.jpg *.jpeg *.webp *.gif *.svg *.ico *.avif *.woff *.woff2
 	}
 	header @html Cache-Control "public, max-age=0, must-revalidate"
@@ -38,8 +38,35 @@
 		Referrer-Policy "strict-origin-when-cross-origin"
 	}
 
-	# Every legitimate public SPA route has a generated HTML entry point. Return
-	# a real 404 for unknown/missing routes instead of a homepage soft-404.
-	try_files {path} {path}/index.html =404
-	file_server
+	# Generated HTML is authoritative and wins first. /pricing is the one
+	# interactive-only shell route. A syntactically valid dated route can also be
+	# opened before that artifact reaches the current Railway image; redirect it
+	# temporarily to the generated section alias instead of publishing a soft-404
+	# shell under a false date. Every malformed route, unknown slug, and missing
+	# asset remains a real 404.
+	@pricingShell path /pricing /pricing/
+	@datedShell {
+		path_regexp datedShell ^/(today|twitter|frontpage|models)/[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])/?$
+		not file {path}/index.html
+	}
+	route {
+		try_files {path} {path}/index.html
+
+		handle @pricingShell {
+			header X-Robots-Tag "noindex, nofollow"
+			rewrite * /index.html
+			file_server
+		}
+
+		handle @datedShell {
+			header Cache-Control "no-store"
+			header CDN-Cache-Control "no-store"
+			redir * /{re.datedShell.1} 307
+		}
+
+		handle {
+			try_files {path} =404
+			file_server
+		}
+	}
 }

--- a/dashboard/scripts/date-routing.test.mjs
+++ b/dashboard/scripts/date-routing.test.mjs
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { resolvePublishedDate } from '../src/date-routing.ts';
+
+test('Today uses the latest actual publication when the local day is ahead', () => {
+  assert.equal(
+    resolvePublishedDate(['2026-08-27', '2026-08-28', '2026-08-29'], '2026-08-30'),
+    '2026-08-29',
+  );
+});
+
+test('published dates remain stable and gaps resolve backward', () => {
+  const dates = ['2026-08-29', '2026-08-27', '2026-08-29'];
+  assert.equal(resolvePublishedDate(dates, '2026-08-29'), '2026-08-29');
+  assert.equal(resolvePublishedDate(dates, '2026-08-28'), '2026-08-27');
+});
+
+test('requests before retained history have no truthful fallback', () => {
+  assert.equal(resolvePublishedDate(['2026-08-28', '2026-08-29'], '2020-01-01'), null);
+  assert.equal(resolvePublishedDate([], '2026-08-30'), null);
+});

--- a/dashboard/src/date-routing.ts
+++ b/dashboard/src/date-routing.ts
@@ -1,0 +1,19 @@
+/** Resolve a requested calendar day to a date that was actually published.
+ *
+ * The browser's local day can be ahead of the UTC publication pipeline. A
+ * Today URL must never claim that older fallback content belongs to that newer
+ * day, so missing days resolve to the nearest earlier publication. If no
+ * earlier publication exists, there is no truthful fallback.
+ */
+export function resolvePublishedDate(dates: string[], requested: string): string | null {
+  const published = Array.from(new Set(dates)).sort();
+  if (published.length === 0) return null;
+  if (published.includes(requested)) return requested;
+
+  let previous: string | null = null;
+  for (const date of published) {
+    if (date > requested) break;
+    previous = date;
+  }
+  return previous;
+}

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -57,6 +57,7 @@ import {
   openAraFigureModal,
   scrollToHashIfPresent,
 } from './ara-enhance';
+import { resolvePublishedDate } from './date-routing';
 
 // Sanitizer-level guarantee: any sanitized anchor keeping target="_blank"
 // MUST carry rel="noopener noreferrer". Sanitized content is adversarial /
@@ -904,7 +905,15 @@ function displayDate(d: Date): string {
 
 function shiftDate(days: number): void {
   latestAliasRequested = null;
-  currentDate.setDate(currentDate.getDate() + days);
+  const requested = new Date(currentDate);
+  requested.setDate(requested.getDate() + days);
+  if (activeTab === 'today' && manifest) {
+    const published = resolvePublishedDate(manifest.today, fmtDate(requested));
+    if (!published) return;
+    currentDate = ymdToDate(published);
+  } else {
+    currentDate = requested;
+  }
   const newMonth = new Date(currentDate.getFullYear(), currentDate.getMonth(), 1);
   if (newMonth.getTime() !== calendarMonth.getTime()) {
     calendarMonth = newMonth;
@@ -1332,7 +1341,12 @@ function handleCalendarClick(e: Event): void {
   const dayEl = target.closest('.cal-day') as HTMLElement | null;
   if (dayEl && dayEl.dataset.date) {
     latestAliasRequested = null;
-    const parts = dayEl.dataset.date.split('-');
+    const requestedDate = dayEl.dataset.date;
+    const published = manifest
+      ? resolvePublishedDate(manifest.today, requestedDate)
+      : requestedDate;
+    if (!published) return;
+    const parts = published.split('-');
     currentDate = new Date(+parts[0], +parts[1] - 1, +parts[2]);
     activeTab = 'today';                 // picking a date opens that day's view
     syncTabUi();
@@ -2080,6 +2094,18 @@ function findMostRecentAvailable(tab: DateTab, targetDateStr: string): string | 
     else break;
   }
   return best;
+}
+
+/** Keep Today state, labels, canonical metadata, and URL on a real publication.
+ * The KST browser day advances nine hours before the UTC digest date; using
+ * that local day while rendering the previous digest creates a false dated
+ * page and a refresh-only 404. */
+function normalizeTodayPublicationDate(): void {
+  if (activeTab !== 'today' || !manifest) return;
+  const published = resolvePublishedDate(manifest.today, fmtDate(currentDate));
+  if (!published || published === fmtDate(currentDate)) return;
+  currentDate = ymdToDate(published);
+  calendarMonth = new Date(currentDate.getFullYear(), currentDate.getMonth(), 1);
 }
 
 function offsetDateStr(dateStr: string, days: number): string {
@@ -6247,7 +6273,7 @@ function renderFocusReader(data: FocusReaderData): void {
 
 // ── Main load ─────────────────────────────────────────
 async function load(): Promise<void> {
-  const dateStr = fmtDate(currentDate);
+  let dateStr = fmtDate(currentDate);
   const requestId = ++loadRequestId;
   if (activeLoadController) activeLoadController.abort();
   const controller = new AbortController();
@@ -6270,10 +6296,19 @@ async function load(): Promise<void> {
   // dispatch; renderResearchIndex re-adds it when it actually paints the shelf.
   document.body.classList.remove('research-shelf');
 
-  updateRoute();
-  showLoading();
-
   try {
+    // Root, /today, Go to today, calendar clicks, T, and adjacent-date
+    // shortcuts all converge here. Wait for the publication manifest before
+    // emitting a dated Today URL or painting a date label.
+    if (activeTab === 'today' && !manifest) {
+      await loadManifest();
+      if (requestId !== loadRequestId) return;
+    }
+    normalizeTodayPublicationDate();
+    dateStr = fmtDate(currentDate);
+    updateRoute();
+    showLoading();
+
     if (activeTab === 'pricing') {
       const pricing = await withTimeout(
         Promise.all([loadModelPricing(controller.signal), loadGpuSpot(controller.signal)]),

--- a/scripts/check_production_surface.py
+++ b/scripts/check_production_surface.py
@@ -23,7 +23,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import asdict, dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Callable, Iterable, Optional
 
 
@@ -74,13 +74,32 @@ HTML_HEADERS = (
     ("cache-control", "max-age=0"),
 )
 
+KST_TODAY = datetime.now(timezone(timedelta(hours=9))).date().isoformat()
+
 ROUTE_PROBES: tuple[Probe, ...] = (
     Probe("home", "/", content_type_prefix="text/html", body_contains="<title", required_headers=HTML_HEADERS),
     Probe("today", "/today", content_type_prefix="text/html", body_contains="<title", required_headers=HTML_HEADERS),
+    # Follows the temporary section-alias redirect when KST has advanced ahead
+    # of the deployed UTC digest; either way the user must reach HTML, not 404.
+    Probe("today-kst-current", f"/today/{KST_TODAY}", content_type_prefix="text/html", body_contains="<title", required_headers=HTML_HEADERS),
     Probe("twitter", "/twitter", content_type_prefix="text/html", body_contains="<title", required_headers=HTML_HEADERS),
     Probe("models", "/models", content_type_prefix="text/html", body_contains="<title", required_headers=HTML_HEADERS),
     Probe("research", "/research", content_type_prefix="text/html", body_contains="<title", required_headers=HTML_HEADERS),
     Probe("wiki", "/wiki", content_type_prefix="text/html", body_contains="<title", required_headers=HTML_HEADERS),
+    Probe(
+        "pricing",
+        "/pricing",
+        content_type_prefix="text/html",
+        body_contains="<title",
+        required_headers=HTML_HEADERS + (("x-robots-tag", "noindex, nofollow"),),
+    ),
+    Probe(
+        "pricing-trailing-slash",
+        "/pricing/",
+        content_type_prefix="text/html",
+        body_contains="<title",
+        required_headers=HTML_HEADERS + (("x-robots-tag", "noindex, nofollow"),),
+    ),
     Probe("manifest", "/research/manifest.json", content_type_prefix="application/json", body_contains='"generatedAt"'),
     Probe(
         "evidence-search-contract",
@@ -101,6 +120,8 @@ ROUTE_PROBES: tuple[Probe, ...] = (
     Probe("feed", "/feed.xml", content_type_prefix="text/xml", body_contains="<rss"),
     Probe("llms", "/llms.txt", content_type_prefix="text/plain", body_contains="#"),
     Probe("real-404", "/__ara_synthetic_missing__", expected_status=404),
+    Probe("malformed-today-404", "/today/not-a-date", expected_status=404),
+    Probe("missing-asset-404", "/assets/__ara_synthetic_missing__.js", expected_status=404),
 )
 
 # Cloudflare policy observed and documented in CLAUDE.md rule 3.  These are

--- a/scripts/smoke_production_container.sh
+++ b/scripts/smoke_production_container.sh
@@ -33,7 +33,7 @@ for attempt in {1..30}; do
   sleep 1
 done
 
-for route in / /today /twitter /models /research /wiki; do
+for route in / /today /twitter /models /research /wiki /pricing /pricing/; do
   headers="$(mktemp)"
   body="$(mktemp)"
   curl -fsS --max-time 10 -D "$headers" -o "$body" "$base$route"
@@ -44,12 +44,45 @@ for route in / /today /twitter /models /research /wiki; do
   rm -f "$headers" "$body"
 done
 
+for route in /pricing /pricing/; do
+  pricing_headers="$(mktemp)"
+  curl -fsS --max-time 10 -D "$pricing_headers" -o /dev/null "$base$route"
+  grep -Eiq '^x-robots-tag: noindex, nofollow' "$pricing_headers"
+  rm -f "$pricing_headers"
+done
+
 manifest_headers="$(mktemp)"
 manifest_body="$(mktemp)"
 curl -fsS --max-time 10 -D "$manifest_headers" -o "$manifest_body" "$base/research/manifest.json"
 grep -Eiq '^content-type: application/json' "$manifest_headers"
 grep -q '"generatedAt"' "$manifest_body"
+
+# A generated dated page must win over the temporary missing-date redirect.
+latest_today="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["today"][-1])' "$manifest_body")"
 rm -f "$manifest_headers" "$manifest_body"
+generated_headers="$(mktemp)"
+generated_body="$(mktemp)"
+curl -fsS --max-time 10 -D "$generated_headers" -o "$generated_body" "$base/today/$latest_today"
+grep -Eiq '^content-type: text/html' "$generated_headers"
+grep -Fq "$latest_today" "$generated_body"
+if grep -Eiq '^location:' "$generated_headers"; then
+  echo "generated Today page redirected unexpectedly" >&2
+  exit 1
+fi
+rm -f "$generated_headers" "$generated_body"
+
+status="$(curl -sS --max-time 10 -o /dev/null -w '%{http_code}' "$base/today/$latest_today/")"
+test "$status" = 200
+
+# A valid but unpublished date redirects temporarily to the generated alias;
+# no-store ensures the future artifact can take over without a cached redirect.
+missing_headers="$(mktemp)"
+status="$(curl -sS --max-time 10 -D "$missing_headers" -o /dev/null -w '%{http_code}' "$base/today/2999-12-31")"
+test "$status" = 307
+grep -Eiq '^location: /today' "$missing_headers"
+grep -Eiq '^cache-control: no-store' "$missing_headers"
+grep -Eiq '^cdn-cache-control: no-store' "$missing_headers"
+rm -f "$missing_headers"
 
 for route in /robots.txt /sitemap.xml /feed.xml /llms.txt; do
   curl -fsS --max-time 10 "$base$route" >/dev/null
@@ -57,5 +90,10 @@ done
 
 status="$(curl -sS --max-time 10 -o /dev/null -w '%{http_code}' "$base/__ara_smoke_missing__")"
 test "$status" = 404
+
+for route in /today/not-a-date /assets/__ara_smoke_missing__.js; do
+  status="$(curl -sS --max-time 10 -o /dev/null -w '%{http_code}' "$base$route")"
+  test "$status" = 404
+done
 
 echo "production Docker/Caddy smoke passed at $base"

--- a/scripts/test_check_production_surface.py
+++ b/scripts/test_check_production_surface.py
@@ -118,8 +118,9 @@ class EvaluateTest(unittest.TestCase):
 
     def test_default_matrix_covers_routes_discovery_404_and_user_agents(self):
         names = {probe.name for probe in cps.DEFAULT_PROBES}
-        self.assertTrue({"home", "today", "twitter", "models", "research", "wiki"} <= names)
+        self.assertTrue({"home", "today", "today-kst-current", "twitter", "models", "research", "wiki", "pricing", "pricing-trailing-slash"} <= names)
         self.assertTrue({"manifest", "robots", "sitemap", "feed", "llms", "real-404"} <= names)
+        self.assertTrue({"malformed-today-404", "missing-asset-404"} <= names)
         self.assertTrue({"evidence-search-contract", "public-claims-contract"} <= names)
         self.assertTrue({"ua-googlebot", "ua-perplexity", "ua-claudebot-policy", "ua-gptbot-policy", "ua-ccbot-policy"} <= names)
 


### PR DESCRIPTION
## Root cause
KST advances to the next calendar date nine hours before the UTC digest job. The SPA used the viewer-local date in routes and labels, then silently rendered the prior digest, while Caddy correctly had no generated HTML for that future date. Reloading the URL returned 404. The route contract also omitted direct /pricing loads.

## Fix
- normalize Today state to an actually published manifest date before emitting URL, canonical metadata, labels, or fetches
- serve exact /pricing and /pricing/ as a noindex app-shell route
- temporarily redirect missing date-shaped section routes to the generated section alias with no-store, while letting generated dated pages win
- preserve real 404s for malformed paths, arbitrary routes, and missing assets
- add dashboard, production synthetic, and exact Docker/Caddy smoke coverage, including the KST current date

## Verification
- dashboard: 39 tests pass
- TypeScript: tsc --noEmit passes
- full Vite build + SEO postbuild passes
- production-surface unit tests: 11 pass
- pinned Caddy 2.11.4 config validation passes
- local Docker daemon was unavailable; PR production-image CI exercises the exact Dockerfile/Caddy container

## Review
Independent researcher and reviewer reproduced the 9-hour timezone gap and verified the hard-404/SEO constraints. Grok and Claude CLIs returned no usable review output; OpenCode GLM execution was blocked by the local execution policy, so none were counted as reviews.