### PR TITLE
Remove What changed from Today

### DIFF
--- a/dashboard/scripts/product-intelligence.test.mjs
+++ b/dashboard/scripts/product-intelligence.test.mjs
@@ -63,6 +63,11 @@ test('What changed DOM exposes reasoning, freshness, honest local highlights, an
   assert.equal((nav.match(/class="tab"/g) || []).length, 6);
 });
 
+test('Today does not mount the What changed decision brief', () => {
+  const source = readFileSync(join(root, 'src/main.ts'), 'utf8');
+  assert.doesNotMatch(source, /void hydrateWhatChanged\(md, dateStr\)/);
+});
+
 test('prebuild search contract preserves claim reuse metadata and refuses unresolved article routes', () => {
   const source = readFileSync(join(root, 'scripts/prebuild.mjs'), 'utf8');
   assert.match(source, /if \(!articleSlug\) continue/);

--- a/dashboard/scripts/publication-contract.test.mjs
+++ b/dashboard/scripts/publication-contract.test.mjs
@@ -41,7 +41,7 @@ test('public projection carries status only and never copies fallback source mat
   assert.doesNotMatch(projected, /Verbatim excerpts|research\/summaries|deterministic_daily_digest/i);
 });
 
-test('historical audio cleanup derives only the six exact fallback-date keys', () => {
+test('historical audio cleanup derives only the seven exact fallback-date keys', () => {
   const cleanup = spawnSync('bash', [join(repoRoot, 'scripts/delete_fallback_audio.sh')], {
     cwd: repoRoot,
     env: { ...process.env, FALLBACK_AUDIO_DRY_RUN: '1' },
@@ -56,6 +56,7 @@ test('historical audio cleanup derives only the six exact fallback-date keys', (
     'audio/2026-08-10-digest.mp3',
     'audio/2026-08-17-digest.mp3',
     'audio/2026-08-28-digest.mp3',
+    'audio/2026-08-30-digest.mp3',
   ]);
 });
 

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -4852,7 +4852,6 @@ function renderToday(md: string, frontPage: FrontPageAsset | null = null): void 
   if (frontPage) enhanceNewspaper();
   syncDigestAudioForDate(dateStr);
   void wikifyContent(content);
-  void hydrateWhatChanged(md, dateStr);
 }
 
 function topicSlugs(text: string): string[] {
@@ -4864,7 +4863,9 @@ function topicSlugs(text: string): string[] {
   return indexed.length ? indexed : [normalizeTopic(text.split(/\s+[—:-]\s+/)[0] || text)].filter(Boolean);
 }
 
-async function hydrateWhatChanged(md: string, dateStr: string): Promise<void> {
+// Kept as an explicit renderer API for any future opt-in surface. The Today
+// route deliberately does not call it; see the product regression test.
+export async function hydrateWhatChanged(md: string, dateStr: string): Promise<void> {
   const [tickets, wiki, pricing, gpu] = await Promise.all([
     loadTickets(),
     loadWikiIndexCached(),


### PR DESCRIPTION
## Outcome
- stop mounting the Decision brief / What changed block on Today
- avoid its follow-up ticket, wiki, pricing, and GPU hydration work
- add a regression test for the Today render path
- refresh the fallback-audio fixture for the newly committed 2026-08-30 fallback digest

## Verification
- bun test: 40 passed, 0 failed
- bun run typecheck
- SKIP_LFS_POINTERS=1 bun run build
- desktop and 390px mobile browser QA
- Today → Twitter → Today navigation QA