### PR TITLE
Add isolated Cursor fallbacks for failing workflows

### DIFF
--- a/.github/actions/agent-run/action.yml
+++ b/.github/actions/agent-run/action.yml
@@ -1,5 +1,5 @@
 name: ARA agent run
-description: Run an agent through native Claude, Fireworks, Z.ai, or an explicitly compatible isolated OpenCode lane fallback and optionally require committed output.
+description: Run an agent through native Claude, Fireworks, Z.ai, or an explicitly compatible isolated adapter fallback and optionally require committed output.
 
 inputs:
   lane:
@@ -27,6 +27,14 @@ inputs:
     default: ""
   opencode-mode:
     description: Isolated OpenCode contract/input mode. Use twitter only for callers that stage .twitter-input; all other agent-run lanes remain editorial.
+    required: false
+    default: editorial
+  cursor-api-key:
+    description: Cursor API key. Passed only to a lane-explicit isolated Cursor fallback.
+    required: false
+    default: ""
+  cursor-mode:
+    description: Isolated Cursor contract/input mode. Use twitter only for callers that stage .twitter-input; all other agent-run lanes remain editorial.
     required: false
     default: editorial
   fireworks-fallback:
@@ -83,7 +91,7 @@ outputs:
     description: Resolved native Claude model (what the `--model opus` alias serves on the native path — the native-model input, else the SSOT's global fallback.native_model).
     value: ${{ steps.select.outputs.native-model }}
   execution-file:
-    description: Path to the Claude Code execution transcript JSON reported by a Claude-compatible child (intentionally empty for isolated OpenCode). Callers that need it after a later agent-run call in the same job must copy it immediately.
+    description: Path to the Claude Code execution transcript JSON reported by a Claude-compatible child (intentionally empty for isolated adapters). Callers that need it after a later agent-run call in the same job must copy it immediately.
     value: ${{ steps.run-claude.outputs.execution_file || steps.run-claude-bots.outputs.execution_file || steps.run-fireworks.outputs.execution_file || steps.run-fireworks-bots.outputs.execution_file || steps.run-zai.outputs.execution_file || steps.run-zai-bots.outputs.execution_file }}
   changed:
     description: "true when expected-paths were provided and changed"
@@ -123,6 +131,7 @@ runs:
         FIREWORKS_API_KEY: ${{ inputs.fireworks-api-key }}
         ZAI_API_KEY: ${{ inputs.zai-api-key }}
         OPENCODE_API_KEY: ${{ inputs.opencode-api-key }}
+        CURSOR_API_KEY: ${{ inputs.cursor-api-key }}
         # The Claude OAuth preflight marks 401/403 auth rejection and a 429
         # run-scoped rate limit unavailable (non-strict → walk the chain).
         # Without the token the native path is also unavailable.
@@ -148,7 +157,7 @@ runs:
 
     - name: Resolve isolated editorial path contract
       id: isolated-contract
-      if: steps.select.outputs.provider == 'opencode-go'
+      if: steps.select.outputs.adapter == 'opencode' || steps.select.outputs.adapter == 'cursor'
       shell: bash
       env:
         EXPECTED_PATHS: ${{ inputs.expected-paths }}
@@ -160,7 +169,7 @@ runs:
           paths="$EXPECTED_PATHS"
         fi
         if [ -z "$paths" ]; then
-          echo "::error::An isolated OpenCode fallback requires expected-paths or allowed-paths."
+          echo "::error::An isolated adapter fallback requires expected-paths or allowed-paths."
           exit 1
         fi
         {
@@ -170,7 +179,7 @@ runs:
         } >> "$GITHUB_OUTPUT"
 
     - name: Setup Claude sandbox
-      if: steps.select.outputs.provider != 'opencode-go'
+      if: steps.select.outputs.adapter == 'agent-run'
       uses: ./.github/actions/setup-claude-sandbox
 
     # Cross-adapter fallback is opt-in per lane in the routing SSOT. The
@@ -178,7 +187,7 @@ runs:
     # and imports only one validated commit back into the host checkout.
     - name: Run agent with isolated OpenCode
       id: run-opencode
-      if: steps.select.outputs.provider == 'opencode-go'
+      if: steps.select.outputs.adapter == 'opencode'
       uses: ./.github/actions/run-opencode-container
       with:
         mode: ${{ inputs.opencode-mode }}
@@ -186,6 +195,18 @@ runs:
         allowed-paths: ${{ steps.isolated-contract.outputs.paths }}
         model: ${{ steps.select.outputs.provider }}/${{ steps.select.outputs.model-id }}
         opencode-api-key: ${{ inputs.opencode-api-key }}
+        prompt-text: ${{ inputs.prompt }}
+
+    - name: Run agent with isolated Cursor
+      id: run-cursor
+      if: steps.select.outputs.adapter == 'cursor'
+      uses: ./.github/actions/run-cursor-container
+      with:
+        mode: ${{ inputs.cursor-mode }}
+        lane: ${{ inputs.lane }}
+        allowed-paths: ${{ steps.isolated-contract.outputs.paths }}
+        model: ${{ steps.select.outputs.provider }}/${{ steps.select.outputs.model-id }}
+        cursor-api-key: ${{ inputs.cursor-api-key }}
         prompt-text: ${{ inputs.prompt }}
 
     # Native-Claude runs (requested backend=claude or Fireworks fallback)

--- a/.github/workflows/ai-news-research.yml
+++ b/.github/workflows/ai-news-research.yml
@@ -105,6 +105,7 @@ jobs:
           [ "${{ steps.check-keys.outputs.has_perplexity }}" = "true" ] && echo "perplexity"
 
       - name: Setup Claude sandbox
+        if: steps.check-keys.outputs.has_exa == 'true' || steps.check-keys.outputs.has_perplexity == 'true'
         uses: ./.github/actions/setup-claude-sandbox
 
       - name: Run AI News Research with Claude (with MCP)
@@ -184,13 +185,27 @@ jobs:
 
             CRITICAL: Write REAL news with actual sources. No placeholder content. NO DUPLICATES from previous reports.
 
-      - name: Run AI News Research with Claude (without MCP)
+      - name: Run AI News Research with SSOT-routed agent (without MCP)
         if: steps.check-keys.outputs.has_exa != 'true' && steps.check-keys.outputs.has_perplexity != 'true'
-        uses: anthropics/claude-code-action@a874e9ecd7bb36efdad65429c6b35815f5a08f10 # v1
+        uses: ./.github/actions/agent-run
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: |
-            --model claude-sonnet-5 --allowedTools "Read,Write,Edit,Bash(git:*),WebSearch"
+          lane: ai-news-research
+          native-model: claude-sonnet-5
+          claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          fireworks-api-key: ${{ secrets.FIREWORKS_API_KEY }}
+          zai-api-key: ${{ secrets.ZAI_API_KEY }}
+          opencode-api-key: ${{ secrets.OPENCODE_API_KEY }}
+          cursor-api-key: ${{ secrets.CURSOR_API_KEY }}
+          cursor-mode: editorial
+          claude-args: |
+            --model opus --allowedTools "Read,Write,Edit,Bash(git:*),Bash(curl:*),Bash(uv:*),Bash(python3:*),WebFetch"
+          expected-paths: |
+            research/${{ steps.date.outputs.date }}-ai-news.md
+            research/summaries/${{ steps.date.outputs.date }}-summary.txt
+          allowed-paths: |
+            research/${{ steps.date.outputs.date }}-ai-news.md
+            research/summaries/${{ steps.date.outputs.date }}-summary.txt
+          label: AI news research (portable discovery)
           prompt: |
             You are an AI news research agent. Find BREAKING NEWS and RECENT ANNOUNCEMENTS only.
 
@@ -206,16 +221,17 @@ jobs:
             Make a mental note of ALL stories already covered. DO NOT include any story that was already reported.
 
             STEP 2 - SEARCH FOR NEW NEWS:
-            Do multiple specific searches to find REAL NEWS from TODAY (${{ steps.date.outputs.date }}) or YESTERDAY (${{ steps.date.outputs.yesterday }}):
-            - "OpenAI announcement ${{ steps.date.outputs.date }}"
-            - "Anthropic Claude news ${{ steps.date.outputs.date }}"
-            - "Google Gemini update ${{ steps.date.outputs.date }}"
-            - "AI startup funding ${{ steps.date.outputs.date }}"
-            - "AI model release today"
-            - "AI news today ${{ steps.date.outputs.date }}"
-
-            Also try yesterday's date if today has few results:
-            - "AI breaking news ${{ steps.date.outputs.yesterday }}"
+            This no-MCP lane must use a provider-portable discovery contract.
+            Do NOT call WebSearch or MCP tools. Start with the repo's stdlib
+            search wrappers, running several focused commands such as:
+            - uv run python scripts/research_search.py gdelt "OpenAI OR Anthropic OR Gemini" --limit 10
+            - uv run python scripts/research_search.py arxiv "large language model OR AI agent" --limit 8
+            - uv run python scripts/research_search.py github "AI agent created:>${{ steps.date.outputs.yesterday }}" --limit 8
+            Use curl or WebFetch to open promising result URLs and verify each
+            claim against the publisher page or an official company source.
+            You may use `uv run python scripts/source_cache.py get <url>` for a
+            source that needs a stable local copy. If a source cannot be
+            fetched or dated, omit it.
 
             STRICT RECENCY FILTER - Today is ${{ steps.date.outputs.date }}. ONLY include news that:
             - Was published on ${{ steps.date.outputs.date }} or ${{ steps.date.outputs.yesterday }} (LAST 24-48 HOURS ONLY)

--- a/.github/workflows/daily-digest.yml
+++ b/.github/workflows/daily-digest.yml
@@ -336,8 +336,10 @@ jobs:
           fireworks-api-key: ${{ secrets.FIREWORKS_API_KEY }}
           zai-api-key: ${{ secrets.ZAI_API_KEY }}
           # Lane-scoped authorization: only this compatibility-tested digest
-          # call can select the isolated OpenCode fallback.
+          # call can select the isolated Cursor fallback.
           opencode-api-key: ${{ secrets.OPENCODE_API_KEY }}
+          cursor-api-key: ${{ secrets.CURSOR_API_KEY }}
+          cursor-mode: editorial
           claude-args: |
             --model opus --allowedTools "Glob,Read,Write,Edit,Bash(git:*),Bash(jq:*),Bash(python3:*),Bash(test:*),Bash(ls:*),Bash(cat:*),Bash(head:*),Bash(wc:*),Bash(mkdir:*),Bash(rg:*),Bash(printf:*),Bash(touch:*)"
           expected-paths: |

--- a/.github/workflows/hourly-twitter.yml
+++ b/.github/workflows/hourly-twitter.yml
@@ -511,7 +511,8 @@ jobs:
           fireworks-api-key: ${{ secrets.FIREWORKS_API_KEY }}
           zai-api-key: ${{ secrets.ZAI_API_KEY }}
           opencode-api-key: ${{ secrets.OPENCODE_API_KEY }}
-          opencode-mode: twitter
+          cursor-api-key: ${{ secrets.CURSOR_API_KEY }}
+          cursor-mode: twitter
           claude-args: |
             --model opus --allowedTools "Read,Write,Edit,MultiEdit,Bash(git:*),Bash(birdy-fast:*),Bash(curl:*),Bash(jq:*),Bash(python3:*),Bash(python:*),Bash(node:*),Bash(ls:*),Bash(cat:*),Bash(head:*),Bash(test:*),Bash(wc:*),Bash(mkdir:*),Bash(sed:*),Bash(rg:*),Bash(printf:*),Bash(touch:*)"
           expected-paths: |
@@ -582,7 +583,8 @@ jobs:
           fireworks-api-key: ${{ secrets.FIREWORKS_API_KEY }}
           zai-api-key: ${{ secrets.ZAI_API_KEY }}
           opencode-api-key: ${{ secrets.OPENCODE_API_KEY }}
-          opencode-mode: twitter
+          cursor-api-key: ${{ secrets.CURSOR_API_KEY }}
+          cursor-mode: twitter
           claude-args: |
             --model opus --max-turns 40 --allowedTools "Read,Write,Edit,MultiEdit,Bash(git:*),Bash(jq:*),Bash(python3:*),Bash(python:*),Bash(node:*),Bash(test:*),Bash(ls:*),Bash(cat:*),Bash(head:*),Bash(wc:*),Bash(mkdir:*),Bash(sed:*),Bash(rg:*),Bash(printf:*),Bash(touch:*)"
           expected-paths: |

--- a/.github/workflows/opencode-deepseek-canary.yml
+++ b/.github/workflows/opencode-deepseek-canary.yml
@@ -268,20 +268,31 @@ jobs:
           opencode-config: .github/opencode/opencode-canary.json
           timeout-minutes: '10'
 
-      # Keep this model dynamic: production editorial routing is owned by the
-      # SSOT, and a canary literal can silently drift away from that route.
-      - name: Resolve production editorial OpenCode model
+      # Resolve the registered editorial profile directly. During an emergency
+      # route switch RSS no longer points at OpenCode; this independent probe
+      # is the evidence required before moving research-editorial back.
+      - name: Resolve registered editorial OpenCode model
         id: glm_route
         run: |
           set -euo pipefail
-          python3 scripts/resolve_agent_route.py rss --github-output "$GITHUB_OUTPUT"
-          if [ "$(python3 scripts/resolve_agent_route.py rss --field backend)" \
-            != "opencode-glm-5p3-flash" ]; then
-            echo "::error::research-editorial is not routed to the expected GLM 5.3 Flash profile."
-            exit 1
-          fi
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          from pathlib import Path
 
-      - name: Run production editorial GLM canary
+          profile = json.loads(Path("data/agent-backends.json").read_text())["backends"].get(
+              "opencode-glm-5p3-flash"
+          )
+          if not isinstance(profile, dict):
+              raise SystemExit("registered OpenCode editorial profile is missing")
+          if profile.get("adapter") != "opencode" or profile.get("provider") != "opencode-go":
+              raise SystemExit("registered OpenCode editorial profile has an invalid adapter/provider")
+          model = profile.get("model")
+          if not isinstance(model, str) or not model:
+              raise SystemExit("registered OpenCode editorial profile has no model")
+          print(f"model_ref=opencode-go/{model}")
+          PY
+
+      - name: Run registered editorial GLM canary
         uses: ./.github/actions/run-opencode-container
         with:
           mode: canary

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,14 +13,14 @@ short pointer plus the few genuinely agent-specific notes.
 
 - **Scheduled model workflows** use the Claude-harness `.github/actions/agent-run`
   directly or, for RSS, community, arXiv, Bluesky, and wiki, the trusted
-  `.github/actions/agent-dispatch`. RSS/community/Bluesky reference the
-  `research-editorial` OpenCode route; arXiv/wiki reference the
-  `research-editorial-secondary` Cursor route. Both select only registered
-  isolated editorial adapters. Two registered
-  compatible adapters are selected in production: strict OpenCode Go and
-  Cursor CLI (`cursor-grok-4p6-fast`, Grok 4.6 Fast). Host-checkout
-  `agent-run` is deliberately capability-incompatible and rejected. The split
-  bounds one provider key/cap failure to its assigned subset. Direct
+  `.github/actions/agent-dispatch`. RSS/community/Bluesky reference
+  `research-editorial`; arXiv/wiki reference `research-editorial-secondary`.
+  Both temporarily select the registered Cursor CLI adapter
+  (`cursor-grok-4p6-fast`, Grok 4.6 Fast) because the OpenCode Go monthly plan
+  is exhausted. Host-checkout `agent-run` is deliberately
+  capability-incompatible and rejected. This emergency convergence restores
+  the three actively failing lanes but temporarily expands one Cursor failure
+  domain across all five editorial lanes. Direct
   Claude workflows may still use
   `anthropics/claude-code-action@v1`; when they do, pass the model via
   `claude_args`, never as a separate `model:` input:
@@ -36,18 +36,19 @@ short pointer plus the few genuinely agent-specific notes.
   Reference: https://code.claude.com/docs/en/github-actions
   (action repo: https://github.com/anthropics/claude-code-action)
 
-- **GLM-5.2 is the default fallback for Claude-harness content lanes.** The
-  editorial dispatcher uses two strict isolated routes: OpenCode
-  `opencode-go/glm-5.3-flash` for RSS/community/Bluesky and Cursor Grok 4.6 Fast
-  for arXiv/wiki. Known
+- **GLM-5.2 is the default fallback for ordinary Claude-harness lanes.** The
+  editorial dispatcher temporarily serves both strict routes with Cursor Grok
+  4.6 Fast while the OpenCode Go monthly plan is exhausted. Known
   credential slots are prewired for a future isolated adapter, but the current
   host-checkout `agent-run` profiles cannot be selected by this route. `agent-run`
   probes the requested provider and walks the ordered `fallback.chain` from
   `data/agent-backends.json` when it is unavailable (currently native Claude →
-  Z.ai GLM). The local-source `digest-synthesis-fallback` lane is the explicit
-  exception: its lane-local chain replaces the global chain with isolated
-  OpenCode `opencode-go/glm-5.3-flash`, and Claude HTTP 429 selects that
-  adapter before execution. Lanes marked `"strict": true` and `fireworks-fallback:
+  Z.ai GLM). Compatibility-tested local digest, primary Twitter/repair, and
+  no-MCP AI-news lanes are explicit exceptions: their lane-local chains replace
+  the currently unusable global secondary with isolated Cursor. Claude remains
+  primary and currently healthy; these Cursor paths are standby fallbacks.
+  The MCP AI-news path stays direct native Claude because Cursor denies MCP.
+  Lanes marked `"strict": true` and `fireworks-fallback:
   none` runs never fall back. Set `expected-paths` in `agent-run`, or call
   `.github/actions/require-output` after deterministic commit steps, so green
   no-op runs do not leave the freshness watchdog stale. RSS, HN/Reddit
@@ -94,25 +95,31 @@ short pointer plus the few genuinely agent-specific notes.
   ChatGPT/Codex subscription.
 
 - **OpenCode Go runs** use the opencode CLI (pinned `opencode-ai@1.18.3`)
-  with plain env-var auth. The production editorial route prioritizes
+  with plain env-var auth. The registered editorial profile uses
   `glm-5.3-flash`; explicit generative-research, Twitter comparison, and canary
   paths remain pinned to `deepseek-v4-flash`. A single secret is the whole login;
   there is no `opencode auth login` step and no auth-file seeding. The workflow
   resolves the route exclusively through `OPENCODE_API_KEY` (OpenCode Go subscription — sign in
   at https://opencode.ai/auth, subscribe, copy the key). The Go plan caps are
-  $12/5h, $30/week, and $60/month; exhaustion affects RSS/community/Bluesky,
-  while arXiv/wiki use the independent Cursor route.
+  $12/5h, $30/week, and $60/month. It is temporarily absent from production
+  routing because the monthly cap is exhausted. Revert only after
+  `opencode-deepseek-canary.yml`'s registered editorial GLM probe succeeds:
+  point only `routes.research-editorial.backend` back to
+  `opencode-glm-5p3-flash`, regenerate the matrix, and redispatch
+  RSS/community/Bluesky.
   Moonshot is not a provider for either pinned model and is not a fallback.
   Store the key with `gh secret set OPENCODE_API_KEY`; the retained
   `opencode-deepseek-canary.yml` validates both the explicit DeepSeek path and
-  the dynamically resolved production GLM route before dispatching
+  the registered editorial GLM profile before dispatching
   `generative-research.yml backend=opencode-deepseek-v4-flash`.
 
-- **Cursor CLI + Grok 4.6 Fast** is a second isolated editorial adapter
+- **Cursor CLI + Grok 4.6 Fast** is an isolated editorial adapter
   (`run-cursor-container`, official `agent` binary, `CURSOR_API_KEY`).
   It is selectable via SSOT / `generative-research.yml
   backend=cursor-grok-4p6-fast` / `hourly-twitter.yml
-  backend=cursor-grok-4p6-fast` and is **not** the production default.
+  backend=cursor-grok-4p6-fast` and temporarily serves both production
+  editorial routes plus lane-local standby fallbacks for compatible local
+  digest/Twitter/no-MCP AI-news contracts. It is never in the global chain.
   Store the key with `gh secret set CURSOR_API_KEY`, then validate
   cheaply with `cursor-cli-canary.yml`. Korean translation currently
   selects this profile via `routes.generative-translation`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,12 +166,13 @@ deleted on purpose.
 
 **Scheduled agent lanes use `.github/actions/agent-run` or the trusted
 `.github/actions/agent-dispatch`,** not `anthropics/claude-code-action@v1`
-directly. RSS, community, and Bluesky use the strict containerized OpenCode
-`research-editorial` route; arXiv and wiki use the strict Cursor-backed
-`research-editorial-secondary` route. The split prevents one provider key or
-plan cap from staling all five editorial lanes. The adapter registry requires both `isolated_workspace`
+directly. RSS, community, and Bluesky use `research-editorial`; arXiv and wiki
+use `research-editorial-secondary`. Both strict routes temporarily select
+Cursor because the OpenCode Go monthly plan is exhausted. This restores the
+three actively failing lanes while deliberately expanding one Cursor failure
+domain across all five editorial lanes. The adapter registry requires both `isolated_workspace`
 and `editorial_contract`; current host-checkout `agent-run` is explicitly
-incompatible and rejected. The selected OpenCode action uses a disposable
+incompatible and rejected. The selected isolated action uses a disposable
 checkout and imports only validated output.
 `agent-run` resolves its backend from
 the SSOT (see Backends), sets up the sandbox centrally, and enforces two
@@ -333,9 +334,11 @@ false `deploy-stale` alerts. Do not "fix" any of these omissions.
 `agent-run` remaps that alias to whatever the resolved backend serves —
 the Fireworks or Z.ai profile model, or `native-model` (default
 **`claude-opus-5`** since 2026-08-01 — was `claude-sonnet-5`) on the
-native path. Direct Claude workflows are NOT covered by that default:
+native path. A caller can preserve a cheaper native model while retaining a
+lane-compatible fallback by setting `native-model` (no-MCP AI news pins Sonnet
+5 this way). Direct Claude workflows are NOT covered by that default:
 the mirror lanes (`claude.yml`, `claude-code-review.yml`,
-`ai-news-research.yml`, `daily-improve.yml`, `research-issue.yml`,
+the MCP variant of `ai-news-research.yml`, `daily-improve.yml`, `research-issue.yml`,
 `twitter-account-explorer.yml`) still pin `--model claude-sonnet-5`
 literally via `claude_args`, and the README diagram's `native` node is
 where that split is visible. Read the workflow file rather than assuming
@@ -365,9 +368,9 @@ derivable from the SSOT.
 | **GLM 5.2 (via Z.ai Coding Plan)** | Second link in the fallback chain; `agent-run backend=zai-glm-5p2`; default manual `hourly-twitter.yml` backend; `zai-claude-code-canary.yml` | `ZAI_API_KEY` | Anthropic-compatible Claude Code endpoint `https://api.z.ai/api/anthropic`, model `glm-5.2`, `CLAUDE_CODE_AUTO_COMPACT_WINDOW=1000000`. The `glm-5.2[1m]` alias was rejected as `Unknown Model` (canary run `28751367808`) — keep the endpoint-valid id unless a raw probe proves otherwise. Because it shares the harness and sandbox but not the credential, **the canary is the fastest way to tell a dead Claude token from a broken runner**. Selectors: `zai-glm-5p2`, `zai-glm-5.2`, `zai-glm52`, `zai`. |
 | **GLM 5.2 (via Fireworks)** | `generative-research backend=glm-5p2` | `FIREWORKS_API_KEY` | Model `accounts/fireworks/models/glm-5p2`. Selectors: `fireworks-glm-5p2`, `glm-5p2`, `glm`. In `generative-research.yml` the workflow-level `fireworks_fallback` input falls back to native Claude by default. |
 | **DeepSeek V4 Flash (via Fireworks)** | Low-cost/comparison: `generative-research backend=deepseek-v4-flash`; `hourly-twitter.yml` DeepSeek tiers | `FIREWORKS_API_KEY` | Endpoint `https://api.fireworks.ai/inference` (base URL omits `/v1`; the client appends `/v1/messages`), model `accounts/fireworks/models/deepseek-v4-flash`. Overrides `ANTHROPIC_BASE_URL`/`AUTH_TOKEN`/`MODEL` so the Claude action transparently calls Fireworks. The direct DeepSeek API is retired (billing). Scheduled DeepSeek lanes are STRICT comparison tiers that never fall back. |
-| **GLM 5.3 Flash (via OpenCode)** | Primary `research-editorial` route for RSS, community, and Bluesky | `OPENCODE_API_KEY` (Go plan) | Strict containerized opencode profile `opencode-glm-5p3-flash`, using the official `opencode-go/glm-5.3-flash` model id. The trusted action injects the selected SSOT `provider/model` into an ephemeral read-only config. This failure domain is independent from the Cursor-backed arXiv/wiki route. |
+| **GLM 5.3 Flash (via OpenCode)** | Registered editorial profile; explicit generative/Twitter selector and canary | `OPENCODE_API_KEY` (Go plan) | Strict containerized profile `opencode-glm-5p3-flash`, using `opencode-go/glm-5.3-flash`. Temporarily removed from production routes while its monthly plan is exhausted. The independent registered-profile probe in `opencode-deepseek-canary.yml` is the exact reversion signal. |
 | **DeepSeek V4 Flash (via opencode)** | Explicit `generative-research` and `hourly-twitter` selector; and `opencode-deepseek-canary.yml` | `OPENCODE_API_KEY` (Go plan) | Retained comparison/diagnostic profile pinned to `opencode-go/deepseek-v4-flash` — the **2026-07-31** release. 1M ctx, $0.07/$0.14 per Mtok on the $10/mo Go plan (caps $12/5h, $30/wk, $60/mo). It is no longer the production editorial priority. Moonshot serves Kimi only and is not a fallback. |
-| **Grok 4.6 Fast (via Cursor CLI)** | Secondary `research-editorial-secondary` route for arXiv/wiki; explicit generative/Twitter selector; `cursor-cli-canary.yml`; `generative-translation` route | `CURSOR_API_KEY` | Official Cursor Agent CLI (`agent`) inside `run-cursor-container`, same isolation contract as OpenCode. Model **`cursor-grok-4.6-high-fast`** (the CLI id for Grok 4.6 Fast; replaced `composer-2.5`). Nested sandbox disabled (container is the boundary). Not on `fallback.chain`; the secondary route fails closed. Selectors: `cursor`, `cursor-cli`, `cursor-agent`, `grok-4.6-fast`, `grok`. `cursor-composer-2p5` remains a compatibility alias. Validate with `cursor-cli-canary.yml`. |
+| **Grok 4.6 Fast (via Cursor CLI)** | Both strict editorial routes during the OpenCode incident; lane-local standby for compatible local digest/Twitter/no-MCP AI-news; explicit generative/Twitter selector; canary; translation | `CURSOR_API_KEY` | Official Cursor Agent CLI (`agent`) inside `run-cursor-container`, same isolation contract as OpenCode. Model **`cursor-grok-4.6-high-fast`**. Nested sandbox disabled (container is the boundary). Never on global `fallback.chain`: only named lane-local chains may cross into Cursor, and exact path/mode contracts apply. MCP AI-news is excluded because Cursor policy denies MCP. Validate with `cursor-cli-canary.yml`. |
 | **Opus 5 (native)** | **The `generative-research` default** plus explicit `generative-research` `backend=opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | Native Anthropic on **`claude-opus-5`**. Not the Fireworks-unavailable fallback target. The resolved model pins `--model`, every `ANTHROPIC_DEFAULT_*` alias, and `CLAUDE_CODE_SUBAGENT_MODEL`; a pre-push gate verifies provenance. Selectors: `opus-5`, `opus5`, `claude-opus-5`. |
 | **Codex** | `generative-research backend=codex` | `CODEX_AUTH_JSON` | Codex CLI with ChatGPT-managed file auth (`auth.json` from `codex login`), so usage bills against the ChatGPT/Codex subscription, not the API. |
 | **Fireworks pi** | `hourly-twitter.yml backend=fireworks-pi` manual comparison lane | `FIREWORKS_API_KEY` | Uses pi's built-in Fireworks provider with `accounts/fireworks/models/kimi-k2p7`; writes `research/twitter-fireworks-pi/` plus a Telegram summary. |
@@ -465,8 +468,8 @@ Secrets are configured in GitHub Actions. None are committed.
 | `CLAUDE_CODE_OAUTH_TOKEN` | Claude-harness `agent-run` lanes, direct-Claude workflows, and a reserved dispatcher credential slot | Required by `claude-code-action@v1`; agent-run call sites carry it alongside alternate-provider keys for runtime routing. Expiry can take down the Claude-harness failure domain, but current host-checkout agent-run is rejected by `research-editorial` and never receives this reserved dispatcher slot. Log signature: `is_error: true`, `num_turns: 1`, `total_cost_usd: 0`, `duration_ms` < ~2000, zero permission denials — the agent dies before doing any work. Re-mint with `claude setup-token` → `gh secret set CLAUDE_CODE_OAUTH_TOKEN`; dispatch `zai-claude-code-canary.yml` to separate a dead credential from a broken runner/sandbox. Last expiry 2026-07-24; see rule 14. |
 | `ZAI_API_KEY` | Fallback chain link 2; `agent-run backend=zai-glm-5p2`; `zai-claude-code-canary.yml` | Z.ai Coding Plan key. Now load-bearing for outage resilience, not just comparison. |
 | `FIREWORKS_API_KEY` | Fireworks generative/comparison lanes and a reserved dispatcher credential slot | Covers GLM and DeepSeek Fireworks profiles. The prewired dispatcher slot is for a future isolated adapter; current agent-run profiles are not selectable by `research-editorial`. **The account is SUSPENDED as of 2026-08-01** — probes return `HTTP 412: Account getclarito-5mege6wpl is suspended, possibly due to reaching the monthly spending limit or failure to pay past invoices` (run `30641250660`). The strict `twitter-deepseek` cron had hard-failed 4×/day since ~2026-07-05 and was dropped 2026-08-01; it remains dispatch-only until billing is settled at https://fireworks.ai/account/billing. Check the job name before attributing those historical failures to a primary lane. |
-| `OPENCODE_API_KEY` | OpenCode profiles, direct comparison/canary paths, and the dispatcher credential set | OpenCode Go key: https://opencode.ai/auth; caps are $12/5h, $30/week, $60/month. It backs RSS, community, and Bluesky; arXiv/wiki are deliberately outside this failure domain. `MOONSHOT_API_KEY` serves neither pinned OpenCode Go model. `opencode-deepseek-canary.yml` validates both the retained explicit DeepSeek path and the dynamically resolved primary editorial route. |
-| `CURSOR_API_KEY` | Cursor CLI profiles, arXiv/wiki, translation, direct comparison/canary paths, and the dispatcher credential set | Cursor dashboard API key. It backs the secondary editorial failure domain plus translation. Validate with `cursor-cli-canary.yml`. |
+| `OPENCODE_API_KEY` | OpenCode profiles, direct comparison/canary paths, and the dispatcher credential set | OpenCode Go key: https://opencode.ai/auth; caps are $12/5h, $30/week, $60/month. The monthly cap is currently exhausted, so production editorial routing is temporarily off OpenCode. `opencode-deepseek-canary.yml` independently probes the registered editorial profile. When that probe succeeds, restore only `routes.research-editorial.backend`, regenerate docs, and redispatch RSS/community/Bluesky. |
+| `CURSOR_API_KEY` | Cursor CLI profiles, all five editorial lanes during the incident, translation, direct comparison/canary paths, and four lane-local agent-run fallbacks | Cursor dashboard API key. It temporarily carries a larger failure domain: RSS/community/Bluesky plus arXiv/wiki, with standby fallback authorization for local digest, primary Twitter/repair, and no-MCP AI-news. Cursor is never a global fallback. Validate with `cursor-cli-canary.yml`. |
 | `CODEX_AUTH_JSON` | `generative-research backend=codex` | The file-backed `~/.codex/auth.json` from `codex login`. Treat like a password; one auth file per serialized runner stream. |
 | `BIRD_AUTH_TOKEN`, `BIRD_CT0` | birdy workflows (`hourly-twitter*`, `24h-model-timeline`, `twitter-account-explorer`, `generative-research`) | X/Twitter cookies; they expire — see rule 6. The env-var names keep the `BIRD_` prefix because that is what birdy reads. |
 | `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID` | `blog-subscriptions`, `daily-digest`, `liveness-check` | Blog alerts, digest delivery, liveness escalation. |
@@ -678,10 +681,14 @@ output or break the pipeline. Read them before editing.
 
 14. **No single credential may be able to take down the whole agent fleet.**
     The remaining `agent-run` production lanes use a provider-spanning global
-    `fallback.chain`. The isolated editorial fleet is split across two strict
-    route failure domains: OpenCode backs RSS/community/Bluesky, while Cursor
-    backs arXiv/wiki. Neither silently changes provider; the split bounds each
-    credential's blast radius. On
+    `fallback.chain`. The isolated editorial fleet normally splits across two
+    strict route failure domains. During the current OpenCode monthly-cap
+    incident, Cursor temporarily backs all five editorial lanes, increasing
+    blast radius in exchange for restoring RSS/community/Bluesky. Restore the
+    split only after `opencode-deepseek-canary.yml`'s registered editorial GLM
+    probe succeeds: change only `routes.research-editorial.backend` back to
+    `opencode-glm-5p3-flash`, regenerate the matrix, then redispatch the three
+    lanes. On
     2026-07-24 it wasn't: the chain was `["claude"]` and `probe_claude()`
     hardcoded "always available", so an expired `CLAUDE_CODE_OAUTH_TOKEN`
     killed every lane at once (then including digest, RSS, community, Twitter,
@@ -693,10 +700,13 @@ output or break the pipeline. Read them before editing.
     (it is what the prompts are tuned against); it must not also terminate.
     (b) **`probe_claude()` is a narrow run-availability preflight** — down
     on 401/403 auth rejection and on HTTP 429. A 429 proves the subscription
-    token is alive but also proves Claude cannot serve this run. The local-source
-    digest lane has an explicit compatibility-tested `fallback_chain` override,
-    so it runs the same prompt through isolated OpenCode GLM 5.3 Flash; if that
-    adapter is unavailable it fails into the existing deterministic recovery.
+    token is alive but also proves Claude cannot serve this run. Local digest,
+    primary Twitter/repair, and no-MCP AI-news have explicit
+    compatibility-tested `fallback_chain` overrides to isolated Cursor. These
+    are standby paths while Claude is healthy, replace rather than append the
+    global chain, and keep exact path/mode contracts. MCP AI-news remains direct
+    Claude because Cursor denies MCP. If Cursor is unavailable, digest/Twitter
+    continue into their existing deterministic recovery where applicable.
     Unrelated non-strict agent-run lanes retain the global Z.ai secondary.
     HTTP 400, 5xx, and network faults remain fail-open because this
     tiny probe does not mechanically prove the full Claude Code path is down.

--- a/README.md
+++ b/README.md
@@ -152,17 +152,16 @@ the SSOT so it cannot drift. Full per-lane matrix:
 ```mermaid
 flowchart LR
     subgraph runtime["⚙️ Runtime-routed lanes — lane: → data/agent-backends.json"]
-        lanes0["digest-audio-script · digest-synthesis · digest-synthesis-fallback<br/>model-timeline · twitter-autoresearch · twitter-judge<br/>twitter-primary · twitter-primary-repair<br/><i>8 lanes</i>"]
+        lanes0["ai-news-research · digest-audio-script · digest-synthesis<br/>digest-synthesis-fallback · model-timeline · twitter-autoresearch<br/>twitter-judge · twitter-primary · twitter-primary-repair<br/><i>9 lanes</i>"]
         strict0["🔒 twitter-ab-claude · twitter-ab-judge · twitter-ab-judge-swapped<br/><i>strict — never falls back</i>"]
-        strict1["🔒 arxiv · generative-research-ko · wiki-ingest<br/><i>strict — never falls back</i>"]
+        strict1["🔒 arxiv · bluesky · community<br/>generative-research-ko · rss · wiki-ingest<br/><i>strict — never falls back</i>"]
         strict2["🔒 twitter-deepseek<br/><i>strict — never falls back</i>"]
-        strict3["🔒 bluesky · community · rss<br/><i>strict — never falls back</i>"]
-        strict4["🔒 twitter-ab-zai · twitter-zai · zai-canary<br/><i>strict — never falls back</i>"]
+        strict3["🔒 twitter-ab-zai · twitter-zai · zai-canary<br/><i>strict — never falls back</i>"]
         gendef["generative-research-default<br/><i>dispatch default</i>"]
     end
     subgraph mirrors["🪞 CI-enforced mirrors — literal in workflow, equality-gated"]
         pi["twitter-deepseek-pi · twitter-fireworks-pi"]
-        native["ai-news-research · claude-code-review · claude-interactive<br/>daily-improve · generative-research-claude · research-issue<br/>twitter-account-explorer"]
+        native["ai-news-research-mcp · claude-code-review · claude-interactive<br/>daily-improve · generative-research-claude · research-issue<br/>twitter-account-explorer"]
     end
     subgraph providers["🏭 Token providers"]
         FW["🎆 Fireworks"]
@@ -176,8 +175,7 @@ flowchart LR
     strict0 -->|"claude-opus-5"| ANT
     strict1 -->|"cursor-grok-4.6-high-fast"| CUR
     strict2 -->|"deepseek-v4-flash"| FW
-    strict3 -->|"glm-5.3-flash"| OC
-    strict4 -->|"glm-5.2"| ZAI
+    strict3 -->|"glm-5.2"| ZAI
     gendef -->|"claude-opus-5"| ANT
     pi -->|"deepseek-v4-flash · kimi-k2p7"| FW
     native -->|"claude-sonnet-5"| ANT

--- a/data/agent-backends.json
+++ b/data/agent-backends.json
@@ -41,7 +41,7 @@
       "model": "",
       "display_name": "Claude",
       "aliases": [],
-      "notes": "Native Anthropic through claude-code-action OAuth; the served model is fallback.native_model (the --model opus alias resolves to it). The preflight marks 401/403 auth rejection and HTTP 429 rate limiting unavailable for the current run. Ordinary non-strict lanes continue to the global Z.ai secondary; digest-synthesis-fallback uses its explicit isolated OpenCode lane override."
+      "notes": "Native Anthropic through claude-code-action OAuth; the served model is fallback.native_model (the --model opus alias resolves to it). The preflight marks 401/403 auth rejection and HTTP 429 rate limiting unavailable for the current run. Ordinary non-strict lanes continue to the global Z.ai secondary; compatibility-tested local content lanes can replace that chain with an explicit isolated Cursor fallback."
     },
     "claude-opus-5": {
       "adapter": "dispatch-default",
@@ -96,7 +96,7 @@
         "opencode-glm",
         "glm-5.3-flash-opencode"
       ],
-      "notes": "OpenCode CLI inside run-opencode-container, authenticated by OPENCODE_API_KEY and pinned to the official opencode-go/glm-5.3-flash model id. Primary strict profile for the shared research-editorial route and the explicit isolated fallback for digest-synthesis-fallback; it is never a member of the global host-checkout fallback chain."
+      "notes": "OpenCode CLI inside run-opencode-container, authenticated by OPENCODE_API_KEY and pinned to the official opencode-go/glm-5.3-flash model id. Retained as a registered compatible editorial profile, but not selected by production routes while the OpenCode Go monthly plan is exhausted; it is never a member of the global host-checkout fallback chain."
     },
     "zai-glm-5p2": {
       "adapter": "agent-run",
@@ -124,15 +124,15 @@
         "cursor-composer-2p5",
         "composer-2.5"
       ],
-      "notes": "Cursor Agent CLI inside run-cursor-container, authenticated by CURSOR_API_KEY and pinned to cursor-grok-4.6-high-fast (the CLI id for Grok 4.6 Fast; grok-4.6-fast is not a valid --model). Replaces composer-2.5. Runtime-selectable by agent-dispatch; not selectable by agent-run. Production editorial defaults stay on OpenCode until this profile is chosen in a route. cursor-composer-2p5 remains a compatibility alias."
+      "notes": "Cursor Agent CLI inside run-cursor-container, authenticated by CURSOR_API_KEY and pinned to cursor-grok-4.6-high-fast (the CLI id for Grok 4.6 Fast; grok-4.6-fast is not a valid --model). Replaces composer-2.5. Runtime-selectable by agent-dispatch and by agent-run only through a lane-local compatibility override. It temporarily serves both production editorial routes while the OpenCode Go monthly plan is exhausted. cursor-composer-2p5 remains a compatibility alias."
     }
   },
   "routes": {
     "research-editorial": {
       "contract": "research-editorial",
-      "backend": "opencode-glm-5p3-flash",
+      "backend": "cursor-grok-4p6-fast",
       "fallback": "none",
-      "notes": "Primary isolated editorial route for RSS, Bluesky, and community. The arXiv and wiki lanes deliberately use research-editorial-secondary so one provider credential or plan cap cannot stale all five scheduled editorial lanes. Incompatible host-checkout adapters are rejected before execution; this route is fail-closed with no cross-adapter fallback."
+      "notes": "Primary isolated editorial route for RSS, Bluesky, and community. It temporarily shares Cursor with research-editorial-secondary while the OpenCode Go monthly plan is exhausted, increasing the Cursor failure domain across all five scheduled editorial lanes. Revert this route to opencode-glm-5p3-flash only after the OpenCode canary proves the plan is usable again. Incompatible host-checkout adapters are rejected before execution; this route is fail-closed with no cross-adapter fallback."
     },
     "research-editorial-secondary": {
       "contract": "research-editorial",
@@ -188,9 +188,10 @@
       "harness": "agent-run",
       "backend": "claude",
       "fallback_chain": [
-        "opencode-glm-5p3-flash"
+        "cursor-grok-4p6-fast"
       ],
-      "notes": "Local-source digest synthesis when MCP keys are absent. Its committed research/digest/ + research/summaries/ contract and local-only prompt are compatible with isolated OpenCode editorial mode, so Claude unavailability uses OpenCode GLM 5.3 Flash instead of the global Z.ai chain."
+      "fallback_mode": "editorial",
+      "notes": "Local-source digest synthesis when MCP keys are absent. Its exact local write contract is compatible with isolated Cursor editorial mode, so this lane-local chain replaces the unavailable global Claude -> Z.ai chain during the provider incident."
     },
     "digest-audio-script": {
       "workflow": "daily-digest.yml",
@@ -220,9 +221,10 @@
       "harness": "agent-run",
       "backend": "claude",
       "fallback_chain": [
-        "opencode-glm-5p3-flash"
+        "cursor-grok-4p6-fast"
       ],
-      "notes": "Primary 3h Twitter/X processor (tier slot named 'claude' for historical reasons). Its local snapshot prompt and research/twitter/ + research/summaries/ write contract are compatible with isolated OpenCode editorial mode, so Claude unavailability uses OpenCode GLM 5.3 Flash instead of publishing a deterministic recovery heartbeat."
+      "fallback_mode": "twitter",
+      "notes": "Primary 3h Twitter/X processor (tier slot named 'claude' for historical reasons). Its staged snapshot and exact output contract are compatible with isolated Cursor twitter mode; if native Claude and Cursor are unavailable, the workflow publishes its deterministic recovery heartbeat."
     },
     "twitter-primary-repair": {
       "workflow": "hourly-twitter.yml",
@@ -230,9 +232,10 @@
       "harness": "agent-run",
       "backend": "claude",
       "fallback_chain": [
-        "opencode-glm-5p3-flash"
+        "cursor-grok-4p6-fast"
       ],
-      "notes": "Repair writer for the primary Twitter/X tier when the first pass returns without required files. It shares the primary lane's isolated OpenCode GLM 5.3 Flash fallback and exact output contract."
+      "fallback_mode": "twitter",
+      "notes": "Repair writer for the primary Twitter/X tier when the first pass returns without required files. It shares the primary lane's isolated Cursor twitter-mode fallback and exact output contract."
     },
     "twitter-judge": {
       "workflow": "hourly-twitter.yml",
@@ -339,9 +342,20 @@
     },
     "ai-news-research": {
       "workflow": "ai-news-research.yml",
+      "harness": "agent-run",
+      "backend": "claude",
+      "fallback_chain": [
+        "cursor-grok-4p6-fast"
+      ],
+      "fallback_mode": "editorial",
+      "notes": "Twice-daily broad news sweep without external MCP search keys. Native Claude remains Sonnet 5 via the workflow override; the prompt uses a portable curl/WebFetch discovery contract so the lane-local Cursor editorial fallback can preserve the same exact output paths."
+    },
+    "ai-news-research-mcp": {
+      "workflow": "ai-news-research.yml",
       "harness": "claude-code-action",
       "model": "claude-sonnet-5",
-      "notes": "Twice-daily broad news sweep (MCP and no-MCP variants share the lane). MIRROR: CI enforces equality."
+      "strict": true,
+      "notes": "Twice-daily broad news sweep with configured Exa/Perplexity MCP search. It remains pinned to native Claude Sonnet 5 because the isolated Cursor adapter intentionally denies MCP tools; the lane fails honestly rather than silently changing its search contract. MIRROR: CI enforces equality."
     },
     "research-issue": {
       "workflow": "research-issue.yml",

--- a/docs/backend-matrix.md
+++ b/docs/backend-matrix.md
@@ -11,12 +11,12 @@ slots, endpoints, selector tokens) live in `CLAUDE.md` → "Backends" and
 
 | Harness | What it means |
 |---|---|
-| Claude Code · agent-run | `anthropics/claude-code-action@v1` wrapped by `.github/actions/agent-run`: resolves the lane from the SSOT, selects provider env (Fireworks / Z.ai Anthropic-compatible endpoints, or native), preflights Fireworks with native-Claude fallback, then enforces `expected-paths` / `allowed-paths`. |
+| Claude Code · agent-run | `anthropics/claude-code-action@v1` wrapped by `.github/actions/agent-run`: resolves the lane from the SSOT, probes the requested provider, walks either the global chain or a lane-local compatibility override, and enforces `expected-paths` / `allowed-paths`. Explicit isolated OpenCode/Cursor candidates run in their container action; only the selected child receives its credential. |
 | Claude Code · claude-code-action | The action invoked directly. Native Anthropic unless the step's `env` reroutes `ANTHROPIC_BASE_URL` (generative-research does this on its Fireworks paths). |
 | pi · run-pi-container | The pi coding-agent harness in a container with pi's own provider config. Twitter comparison tiers only. |
 | Codex CLI | `codex exec` with ChatGPT-managed file auth (subscription entitlement, not API billing). |
-| opencode CLI | `opencode run` **inside a Docker container** (`.github/actions/run-opencode-container`: `--cap-drop ALL`, `no-new-privileges`, non-root, throwaway HOME, disposable clone). The trusted action injects the selected profile's validated `provider/model` into an ephemeral read-only config. Missing Docker is a hard failure. RSS, community, and Bluesky use this strict route; host-checkout agent-run is explicitly incompatible. |
-| Cursor CLI | `agent -p` **inside a Docker container** (`.github/actions/run-cursor-container`: same isolation contract as OpenCode). Authenticated by `CURSOR_API_KEY`; model selected by `agent --model` (canonical `cursor-grok-4.6-high-fast`). Nested sandbox is disabled because the container is the boundary. Missing Docker is a hard failure. arXiv and wiki use this second strict failure domain, so no one provider key/cap can stale all five editorial lanes. Validate with `cursor-cli-canary.yml`. |
+| opencode CLI | `opencode run` **inside a Docker container** (`.github/actions/run-opencode-container`: `--cap-drop ALL`, `no-new-privileges`, non-root, throwaway HOME, disposable clone). The registered editorial profile is temporarily off production routes while the monthly plan is exhausted; its independent canary is the reversion signal. |
+| Cursor CLI | `agent -p` **inside a Docker container** (`.github/actions/run-cursor-container`: same isolation contract as OpenCode). Authenticated by `CURSOR_API_KEY`; model selected by `agent --model` (canonical `cursor-grok-4.6-high-fast`). Cursor temporarily serves both strict editorial routes and four named lane-local fallback contracts; it is never on the global chain. Missing Docker is a hard failure. Validate with `cursor-cli-canary.yml`. |
 | dispatch default | Not an agent itself: the SSOT-resolved default backend a dispatch/issue run uses when none is specified. |
 
 ## How routing consumption works
@@ -35,11 +35,13 @@ retried from the chain), probes each candidate's provider (fireworks =
 preflight request, zai = Z.ai endpoint probe, claude = OAuth preflight),
 and runs the first available candidate. Claude 401/403 auth rejection or
 HTTP 429 rate limiting advances ordinary non-strict callers to Z.ai; the
-local-source digest lane explicitly overrides that chain with isolated
-OpenCode GLM 5.3 Flash because its local prompt and exact two-file commit
-contract are adapter-compatible. A lane override replaces the global chain,
-so OpenCode failure reaches the existing deterministic digest recovery rather
-than silently changing provenance again. HTTP 400, 5xx, and network faults
+local digest, primary Twitter/repair, and no-MCP AI-news lanes explicitly
+override that chain with isolated Cursor because their inputs and exact commit
+contracts are adapter-compatible. Each lane declares `fallback_mode`; CI
+checks `twitter` for the staged Twitter snapshot and `editorial` elsewhere.
+A lane override replaces the global chain, so Cursor failure never silently
+continues into Z.ai. MCP AI-news remains direct native Claude because Cursor
+denies MCP tools. HTTP 400, 5xx, and network faults
 retain the narrow fail-open behavior. Lanes marked
 `"strict": true` (zai-canary)
 and runs with `fireworks-fallback: none` never walk the chain: requested
@@ -60,8 +62,9 @@ uv run python scripts/build_backend_matrix.py --check
 Reading notes:
 
 - **Token secret** is the secret that pays for tokens on the lane's current
-  route. agent-run lanes always carry all three secrets (see above); the
-  unused ones are inert.
+  route. agent-run callers preserve the standard provider-key plumbing and
+  add isolated-adapter keys only where the lane contract permits them; only
+  the selected child receives its credential.
 - **`--model opus` in `claude_args` is an alias**, not a provider model:
   agent-run remaps it to the effective profile's model id (Fireworks/Z.ai)
   or to the SSOT's global `fallback.native_model` on the native path.
@@ -81,22 +84,23 @@ Reading notes:
 
 | Lane | Workflow | Harness | Provider | Model | Token secret | Fallback |
 |---|---|---|---|---|---|---|
-| ai-news-research (×2 step variants) | `ai-news-research.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
+| ai-news-research | `ai-news-research.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-sonnet-5` (workflow `native-model` override) | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `cursor-grok-4p6-fast` |
+| ai-news-research-mcp | `ai-news-research.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
 | arxiv (route:research-editorial-secondary) | `daily-arxiv.yml` | agent-dispatch → Cursor CLI (runtime SSOT) | Grok 4.6 Fast via Cursor CLI | `cursor-grok-4.6-high-fast` | `CURSOR_API_KEY` | hard fail (route fallback=none) |
-| bluesky (route:research-editorial) | `2h-bluesky.yml` | agent-dispatch → opencode CLI (runtime SSOT) | GLM 5.3 Flash via OpenCode Go | `glm-5.3-flash` | `OPENCODE_API_KEY` | hard fail (route fallback=none) |
+| bluesky (route:research-editorial) | `2h-bluesky.yml` | agent-dispatch → Cursor CLI (runtime SSOT) | Grok 4.6 Fast via Cursor CLI | `cursor-grok-4.6-high-fast` | `CURSOR_API_KEY` | hard fail (route fallback=none) |
 | claude-code-review | `claude-code-review.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
 | claude-interactive | `claude.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
-| community (route:research-editorial) | `4h-community.yml` | agent-dispatch → opencode CLI (runtime SSOT) | GLM 5.3 Flash via OpenCode Go | `glm-5.3-flash` | `OPENCODE_API_KEY` | hard fail (route fallback=none) |
+| community (route:research-editorial) | `4h-community.yml` | agent-dispatch → Cursor CLI (runtime SSOT) | Grok 4.6 Fast via Cursor CLI | `cursor-grok-4.6-high-fast` | `CURSOR_API_KEY` | hard fail (route fallback=none) |
 | daily-improve | `daily-improve.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
 | digest-audio-script | `daily-digest.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2`; then `deterministic_daily_digest.py` |
 | digest-synthesis | `daily-digest.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2`; then `deterministic_daily_digest.py` |
-| digest-synthesis-fallback | `daily-digest.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `opencode-glm-5p3-flash`; then `deterministic_daily_digest.py` |
+| digest-synthesis-fallback | `daily-digest.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `cursor-grok-4p6-fast`; then `deterministic_daily_digest.py` |
 | generative-research-claude (+1 retry step) | `generative-research.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
 | generative-research-default | `generative-research.yml` | dispatch default (runtime SSOT) | (per chosen backend) | default: `claude-opus-5` | (per chosen backend) | workflow-level `fireworks_fallback` input (default `claude`) |
 | generative-research-ko (route:generative-translation) | `translate-generative-research.yml` | agent-dispatch → Cursor CLI (runtime SSOT) | Grok 4.6 Fast via Cursor CLI | `cursor-grok-4.6-high-fast` | `CURSOR_API_KEY` | hard fail (route fallback=none) |
 | model-timeline | `24h-model-timeline.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2` |
 | research-issue (×2 step variants) | `research-issue.yml` | Claude Code · claude-code-action (CI-enforced mirror) | Anthropic (native) | `claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` | — |
-| rss (route:research-editorial) | `hourly-rss.yml` | agent-dispatch → opencode CLI (runtime SSOT) | GLM 5.3 Flash via OpenCode Go | `glm-5.3-flash` | `OPENCODE_API_KEY` | hard fail (route fallback=none) |
+| rss (route:research-editorial) | `hourly-rss.yml` | agent-dispatch → Cursor CLI (runtime SSOT) | Grok 4.6 Fast via Cursor CLI | `cursor-grok-4.6-high-fast` | `CURSOR_API_KEY` | hard fail (route fallback=none) |
 | twitter-ab-claude · PINNED | `twitter-model-ab.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (strict — never walks the chain) |
 | twitter-ab-judge · PINNED | `twitter-model-ab.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-4-8` (workflow `native-model` override) | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (strict — never walks the chain) |
 | twitter-ab-judge-swapped · PINNED | `twitter-model-ab.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-4-8` (workflow `native-model` override) | `CLAUDE_CODE_OAUTH_TOKEN` | hard fail (strict — never walks the chain) |
@@ -107,8 +111,8 @@ Reading notes:
 | twitter-deepseek-pi (tier:deepseek-pi) | `hourly-twitter.yml` | pi · run-pi-container (CI-enforced mirror) | fireworks (pi built-in) | `accounts/fireworks/models/deepseek-v4-flash` | `FIREWORKS_API_KEY` | — |
 | twitter-fireworks-pi (tier:fireworks-pi) | `hourly-twitter.yml` | pi · run-pi-container (CI-enforced mirror) | fireworks (pi built-in) | `accounts/fireworks/models/kimi-k2p7` | `FIREWORKS_API_KEY` | — |
 | twitter-judge (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2` |
-| twitter-primary (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `opencode-glm-5p3-flash`; then `deterministic_twitter_digest.py` |
-| twitter-primary-repair (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `opencode-glm-5p3-flash` |
+| twitter-primary (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `cursor-grok-4p6-fast`; then `deterministic_twitter_digest.py` |
+| twitter-primary-repair (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `cursor-grok-4p6-fast` |
 | twitter-zai (tier:zai-glm-5p2) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Z.ai | `glm-5.2` | `ZAI_API_KEY` | hard fail (strict — never walks the chain) |
 | wiki-ingest (route:research-editorial-secondary) | `wiki-ingest.yml` | agent-dispatch → Cursor CLI (runtime SSOT) | Grok 4.6 Fast via Cursor CLI | `cursor-grok-4.6-high-fast` | `CURSOR_API_KEY` | hard fail (route fallback=none) |
 | zai-canary · PINNED | `zai-claude-code-canary.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Z.ai | `glm-5.2` | `ZAI_API_KEY` | hard fail (strict — never walks the chain) |
@@ -140,9 +144,9 @@ Reading notes:
 - `model-pricing.yml`
 - `production-synthetic.yml`
 
-_Global ordered fallback chain (SSOT `fallback.chain`): `claude` → `zai-glm-5p2`; native path serves `claude-opus-5`. 31 SSOT lanes (+10 dispatch execution paths) across 34 workflows; 14 workflows run no model._
+_Global ordered fallback chain (SSOT `fallback.chain`): `claude` → `zai-glm-5p2`; native path serves `claude-opus-5`. 32 SSOT lanes (+10 dispatch execution paths) across 34 workflows; 14 workflows run no model._
 
-_Explicit lane fallback overrides (replace, never extend, the global chain): `digest-synthesis-fallback`: `opencode-glm-5p3-flash`; `twitter-primary`: `opencode-glm-5p3-flash`; `twitter-primary-repair`: `opencode-glm-5p3-flash`._
+_Explicit lane fallback overrides (replace, never extend, the global chain): `ai-news-research`: `cursor-grok-4p6-fast`; `digest-synthesis-fallback`: `cursor-grok-4p6-fast`; `twitter-primary`: `cursor-grok-4p6-fast`; `twitter-primary-repair`: `cursor-grok-4p6-fast`._
 
 <!-- END GENERATED BACKEND MATRIX -->
 

--- a/scripts/build_backend_matrix.py
+++ b/scripts/build_backend_matrix.py
@@ -166,6 +166,7 @@ REQUIRED_AGENT_RUN_SECRETS = {
 }
 OPTIONAL_AGENT_RUN_SECRETS = {
     "opencode-api-key": "OPENCODE_API_KEY",
+    "cursor-api-key": "CURSOR_API_KEY",
 }
 AGENT_RUN_SECRET_INPUTS = {
     **REQUIRED_AGENT_RUN_SECRETS,
@@ -203,6 +204,7 @@ class AgentRunStep:
     secrets: dict[str, str]
     fireworks_fallback: str
     native_model_override: str
+    cursor_mode: str
     is_retry: bool
 
 
@@ -498,6 +500,7 @@ def observe_workflow(wf_path: Path) -> Observation:
                     secrets=secrets,
                     fireworks_fallback=str(with_block.get("fireworks-fallback", "")).strip(),
                     native_model_override=str(with_block.get("native-model", "")).strip(),
+                    cursor_mode=str(with_block.get("cursor-mode", "editorial")).strip(),
                     is_retry=is_retry,
                 ))
 
@@ -746,6 +749,7 @@ def cross_check(lanes: dict[str, dict], observations: dict[str, Observation],
             if lane.get("strict") and lane_chain:
                 errors.append(f"lane '{step.lane}': strict lanes cannot declare fallback_chain")
             seen_lane_fallbacks: set[str] = set()
+            has_cursor_fallback = False
             for candidate in lane_chain:
                 candidate_profile = profiles.get(str(candidate))
                 if candidate_profile is None:
@@ -756,7 +760,7 @@ def cross_check(lanes: dict[str, dict], observations: dict[str, Observation],
                     errors.append(f"lane '{step.lane}': fallback_chain entry '{candidate}' "
                                   "duplicates an earlier candidate")
                 seen_lane_fallbacks.add(candidate_profile.normalized)
-                if candidate_profile.adapter not in {"agent-run", "opencode"}:
+                if candidate_profile.adapter not in {"agent-run", "opencode", "cursor"}:
                     errors.append(f"lane '{step.lane}': fallback backend '{candidate}' uses "
                                   f"unsupported adapter '{candidate_profile.adapter}'")
                 if candidate_profile.adapter == "opencode":
@@ -769,6 +773,29 @@ def cross_check(lanes: dict[str, dict], observations: dict[str, Observation],
                     if step.secrets.get("opencode-api-key") != expected:
                         errors.append(f"{label}: lane fallback requires opencode-api-key: "
                                       f"secrets.{expected}")
+                if candidate_profile.adapter == "cursor":
+                    has_cursor_fallback = True
+                    adapter = adapters.get("cursor", {})
+                    if adapter.get("isolated_workspace") is not True \
+                      or adapter.get("editorial_contract") is not True:
+                        errors.append(f"lane '{step.lane}': Cursor fallback lacks the "
+                                      "isolated editorial capability contract")
+                    expected = OPTIONAL_AGENT_RUN_SECRETS["cursor-api-key"]
+                    if step.secrets.get("cursor-api-key") != expected:
+                        errors.append(f"{label}: lane fallback requires cursor-api-key: "
+                                      f"secrets.{expected}")
+            fallback_mode = lane.get("fallback_mode")
+            if has_cursor_fallback:
+                if fallback_mode not in {"editorial", "twitter"}:
+                    errors.append(f"lane '{step.lane}': Cursor fallback requires "
+                                  "fallback_mode editorial or twitter")
+                elif step.cursor_mode != fallback_mode:
+                    errors.append(f"{label}: lane '{step.lane}' declares fallback_mode "
+                                  f"'{fallback_mode}' but the step passes cursor-mode "
+                                  f"'{step.cursor_mode}'")
+            elif fallback_mode is not None:
+                errors.append(f"lane '{step.lane}': fallback_mode is only valid with a "
+                              "Cursor fallback_chain entry")
             for input_name, expected in REQUIRED_AGENT_RUN_SECRETS.items():
                 if step.secrets.get(input_name) != expected:
                     errors.append(f"{label}: must pass {input_name}: secrets.{expected} — "

--- a/scripts/select_backend.py
+++ b/scripts/select_backend.py
@@ -16,15 +16,17 @@ check_fireworks_backend); zai → same-shape probe against the Z.ai
 Anthropic-compatible endpoint; claude → OAuth-token preflight against
 api.anthropic.com that is UNAVAILABLE on an explicit credential rejection
 (401/403) or a run-scoped rate limit (429), and available on anything else;
-opencode-go is available when its isolated-adapter credential is configured.
+opencode-go and Cursor are available when their isolated-adapter credentials
+are configured; their containers own the runtime provider call.
 
 Why the claude probe is auth-only (2026-07-24 incident): this probe used
 to hardcode "always available", so when CLAUDE_CODE_OAUTH_TOKEN expired
 every agent lane in the fleet died instantly (is_error, 1 turn, $0) with
 no route out — the chain could not move past a backend it always believed
 was up. A 429 proves the credential is alive but also proves Claude cannot
-serve this run, so the compatible local-source digest lane first continues to
-isolated OpenCode GLM 5.3 Flash. Other lanes retain the global Z.ai chain. The probe remains
+serve this run, so compatibility-tested local-content lanes can continue
+through an explicit isolated-adapter override. Other lanes retain the global
+chain. The probe remains
 deliberately narrow for 400, 5xx, and network faults: those inconclusive
 responses keep the existing fail-open behavior rather than broadening the
 reroute policy.
@@ -171,11 +173,25 @@ def probe_opencode(model: str) -> tuple[bool, str]:
     return True, "isolated OpenCode credential configured"
 
 
+def probe_cursor(model: str) -> tuple[bool, str]:
+    """Check whether the isolated Cursor adapter credential is configured.
+
+    The scheduled canary is the authoritative live provider probe. Selection
+    keeps the key scoped to run-cursor-container and lets that action surface
+    provider/model failures without exposing the key to another adapter.
+    """
+    api_key = os.environ.get("CURSOR_API_KEY", "").strip()
+    if not api_key:
+        return False, "CURSOR_API_KEY is not configured"
+    return True, "isolated Cursor credential configured"
+
+
 PROBES = {
     "fireworks": probe_fireworks,
     "zai": probe_zai,
     "claude": probe_claude,
     "opencode-go": probe_opencode,
+    "cursor": probe_cursor,
 }
 
 
@@ -218,6 +234,7 @@ def main_with_args(argv: list[str] | None = None) -> int:
         return config_error(f"cannot read {args.file}: {exc}")
 
     backends = data.get("backends") or {}
+    adapters = data.get("adapters") or {}
     fallback = data.get("fallback") or {}
     lanes = data.get("lanes") or {}
     if not backends:
@@ -248,6 +265,13 @@ def main_with_args(argv: list[str] | None = None) -> int:
         if requested is None:
             return config_error(f"lane '{args.lane}' backend '{lane.get('backend')}' is not "
                                 "in the backends table")
+        requested_adapter = str(backends[requested].get("adapter", "agent-run"))
+        if requested_adapter != "agent-run":
+            return config_error(
+                f"lane '{args.lane}' primary backend '{requested}' uses adapter "
+                f"'{requested_adapter}'; agent-run permits isolated adapters only "
+                "as explicit lane fallback_chain candidates"
+            )
         if lane.get("strict"):
             strict = True
         raw_lane_chain = lane.get("fallback_chain", [])
@@ -274,6 +298,37 @@ def main_with_args(argv: list[str] | None = None) -> int:
             return config_error(f"fallback chain entry '{selector}' is not in the backends table")
         if key not in candidates:
             candidates.append(key)
+
+    isolated_candidates = {
+        normalize(selector, backends) for selector in lane_fallback_chain
+    }
+    for key in candidates:
+        spec = backends[key]
+        adapter_name = str(spec.get("adapter", "agent-run"))
+        if adapter_name == "agent-run":
+            continue
+        if key not in isolated_candidates or adapter_name not in {"opencode", "cursor"}:
+            return config_error(
+                f"backend '{key}' uses unsupported agent-run adapter '{adapter_name}'"
+            )
+        adapter_spec = adapters.get(adapter_name)
+        if not isinstance(adapter_spec, dict):
+            return config_error(
+                f"backend '{key}' references unknown adapter '{adapter_name}'"
+            )
+        for capability in ("isolated_workspace", "editorial_contract"):
+            if adapter_spec.get(capability) is not True:
+                return config_error(
+                    f"backend '{key}' adapter '{adapter_name}' lacks required "
+                    f"capability '{capability}'"
+                )
+        credential_map = adapter_spec.get("provider_credentials")
+        provider = str(spec.get("provider", ""))
+        if not isinstance(credential_map, dict) or not credential_map.get(provider):
+            return config_error(
+                f"backend '{key}' adapter '{adapter_name}' has no credential "
+                f"binding for provider '{provider}'"
+            )
 
     chosen = None
     for key in candidates:
@@ -310,6 +365,7 @@ def main_with_args(argv: list[str] | None = None) -> int:
         "requested-backend": requested,
         "backend": chosen,
         "provider": str(spec.get("provider", "")),
+        "adapter": str(spec.get("adapter", "agent-run")),
         "model-id": str(spec.get("model", "")),
         "display-name": str(spec.get("display_name", chosen)),
         "native-model": native_model,

--- a/scripts/test_backend_matrix.py
+++ b/scripts/test_backend_matrix.py
@@ -72,15 +72,15 @@ class RoutingInvariants(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "isolated_workspace"):
                 resolve_route(config, lane)
 
-    def test_research_editorial_prioritizes_opencode_glm_5p3_flash(self):
+    def test_research_editorial_temporarily_uses_cursor(self):
         config = json.loads(LANES_FILE.read_text(encoding="utf-8"))
         route = config["routes"]["research-editorial"]
-        self.assertEqual("opencode-glm-5p3-flash", route["backend"])
+        self.assertEqual("cursor-grok-4p6-fast", route["backend"])
         self.assertIn("opencode-deepseek-v4-flash", config["backends"])
         for lane in ("rss", "bluesky", "community"):
             selected = resolve_route(config, lane)
-            self.assertEqual("opencode", selected.adapter)
-            self.assertEqual("opencode-go/glm-5.3-flash", selected.model_ref)
+            self.assertEqual("cursor", selected.adapter)
+            self.assertEqual("cursor/cursor-grok-4.6-high-fast", selected.model_ref)
         for lane in ("arxiv", "wiki-ingest"):
             selected = resolve_route(config, lane)
             self.assertEqual("cursor", selected.adapter)
@@ -190,6 +190,8 @@ class RoutingInvariants(unittest.TestCase):
             resolve_route(config, "rss")
 
         config = json.loads(LANES_FILE.read_text(encoding="utf-8"))
+        config["routes"]["research-editorial"]["backend"] = \
+            "opencode-glm-5p3-flash"
         config["adapters"]["opencode"]["provider_credentials"]["opencode-go"] = \
             "claude-code-oauth-token"
         with self.assertRaisesRegex(ValueError, "opencode-api-key"):
@@ -393,9 +395,10 @@ class RoutingInvariants(unittest.TestCase):
         }
         self.assertEqual(
             {
-                "digest-synthesis-fallback": ["opencode-glm-5p3-flash"],
-                "twitter-primary": ["opencode-glm-5p3-flash"],
-                "twitter-primary-repair": ["opencode-glm-5p3-flash"],
+                "ai-news-research": ["cursor-grok-4p6-fast"],
+                "digest-synthesis-fallback": ["cursor-grok-4p6-fast"],
+                "twitter-primary": ["cursor-grok-4p6-fast"],
+                "twitter-primary-repair": ["cursor-grok-4p6-fast"],
             },
             overrides,
         )
@@ -405,6 +408,7 @@ class RoutingInvariants(unittest.TestCase):
 
         isolated_lanes = {
             "digest-synthesis-fallback",
+            "ai-news-research",
             "twitter-primary",
             "twitter-primary-repair",
         }
@@ -414,41 +418,95 @@ class RoutingInvariants(unittest.TestCase):
         ]
         self.assertEqual(isolated_lanes, {step.lane for step in local_steps})
         self.assertTrue(all(
-            step.secrets["opencode-api-key"] == "OPENCODE_API_KEY"
+            step.secrets["cursor-api-key"] == "CURSOR_API_KEY"
             for step in local_steps
         ))
         other_steps = [
             step for obs in self.obs.values() for step in obs.agent_run
             if step.lane not in isolated_lanes
         ]
-        self.assertTrue(all(not step.secrets.get("opencode-api-key")
+        self.assertTrue(all(not step.secrets.get("cursor-api-key")
                             for step in other_steps))
+        modes = {step.lane: step.cursor_mode for step in local_steps}
+        self.assertEqual(
+            {
+                "ai-news-research": "editorial",
+                "digest-synthesis-fallback": "editorial",
+                "twitter-primary": "twitter",
+                "twitter-primary-repair": "twitter",
+            },
+            modes,
+        )
 
-    def test_agent_run_scopes_isolated_opencode_child_contract(self):
+    def test_agent_run_scopes_isolated_adapter_child_contracts(self):
         action = yaml.safe_load(
             (REPO_ROOT / ".github/actions/agent-run/action.yml").read_text()
         )
         steps = action["runs"]["steps"]
-        child = next(
+        opencode = next(
             step for step in steps
             if step.get("uses") == "./.github/actions/run-opencode-container"
         )
-        self.assertEqual("steps.select.outputs.provider == 'opencode-go'",
-                         child.get("if"))
+        self.assertEqual("steps.select.outputs.adapter == 'opencode'",
+                         opencode.get("if"))
         self.assertEqual("editorial", action["inputs"]["opencode-mode"]["default"])
-        self.assertEqual("${{ inputs.opencode-mode }}", child["with"]["mode"])
-        self.assertEqual("${{ inputs.prompt }}", child["with"]["prompt-text"])
-        self.assertEqual("${{ steps.isolated-contract.outputs.paths }}",
-                         child["with"]["allowed-paths"])
-        self.assertEqual("${{ inputs.opencode-api-key }}",
-                         child["with"]["opencode-api-key"])
-        rendered = json.dumps(child, sort_keys=True)
-        for secret_input in ("claude-code-oauth-token", "fireworks-api-key",
-                             "zai-api-key"):
-            self.assertNotIn(secret_input, rendered)
+        self.assertEqual("${{ inputs.opencode-mode }}", opencode["with"]["mode"])
+
+        cursor = next(
+            step for step in steps
+            if step.get("uses") == "./.github/actions/run-cursor-container"
+        )
+        self.assertEqual("steps.select.outputs.adapter == 'cursor'", cursor.get("if"))
+        self.assertEqual("editorial", action["inputs"]["cursor-mode"]["default"])
+        self.assertEqual("${{ inputs.cursor-mode }}", cursor["with"]["mode"])
+        self.assertEqual("${{ inputs.cursor-api-key }}",
+                         cursor["with"]["cursor-api-key"])
+
+        for child in (opencode, cursor):
+            self.assertEqual("${{ inputs.prompt }}", child["with"]["prompt-text"])
+            self.assertEqual("${{ steps.isolated-contract.outputs.paths }}",
+                             child["with"]["allowed-paths"])
+            rendered = json.dumps(child, sort_keys=True)
+            for secret_input in ("claude-code-oauth-token", "fireworks-api-key",
+                                 "zai-api-key"):
+                self.assertNotIn(secret_input, rendered)
+        self.assertNotIn("cursor-api-key", json.dumps(opencode, sort_keys=True))
+        self.assertNotIn("opencode-api-key", json.dumps(cursor, sort_keys=True))
 
         execution_output = action["outputs"]["execution-file"]["value"]
         self.assertNotIn("run-opencode", execution_output)
+        self.assertNotIn("run-cursor", execution_output)
+
+    def test_ai_news_mcp_cannot_select_cursor(self):
+        mcp = self.lanes["ai-news-research-mcp"]
+        self.assertEqual("claude-code-action", mcp["harness"])
+        self.assertTrue(mcp["strict"])
+        self.assertNotIn("fallback_chain", mcp)
+        workflow = yaml.safe_load(
+            (REPO_ROOT / ".github/workflows/ai-news-research.yml").read_text()
+        )
+        steps = workflow["jobs"]["ai-news-research"]["steps"]
+        mcp_step = next(step for step in steps if step.get("name") ==
+                        "Run AI News Research with Claude (with MCP)")
+        self.assertIn("anthropics/claude-code-action", mcp_step["uses"])
+        self.assertNotIn("cursor-api-key", mcp_step["with"])
+        cursor_policy = json.loads(
+            (REPO_ROOT / ".github/cursor/cli-config.json").read_text()
+        )
+        self.assertIn("Mcp(*)", cursor_policy["permissions"]["deny"])
+
+        portable = next(step for step in steps if step.get("name") ==
+                        "Run AI News Research with SSOT-routed agent (without MCP)")
+        prompt = portable["with"]["prompt"]
+        self.assertIn("scripts/research_search.py gdelt", prompt)
+        self.assertIn("scripts/research_search.py arxiv", prompt)
+        self.assertIn("scripts/research_search.py github", prompt)
+        self.assertIn("scripts/source_cache.py get", prompt)
+        self.assertIn("Do NOT call WebSearch or MCP tools", prompt)
+        claude_args = portable["with"]["claude-args"]
+        self.assertNotIn("WebSearch", claude_args)
+        self.assertNotIn("mcp__", claude_args)
+        self.assertIn("Bash(uv:*)", claude_args)
 
     def test_local_digest_exact_paths_and_post_recovery_scope_gate(self):
         workflow = yaml.safe_load(
@@ -1005,10 +1063,11 @@ class RoutingInvariants(unittest.TestCase):
             self.assertEqual(
                 "keep\n", (unrelated / "sentinel").read_text(encoding="utf-8"))
 
-    def test_opencode_canary_covers_direct_deepseek_and_editorial_glm(self):
+    def test_opencode_canary_covers_direct_deepseek_and_registered_editorial_glm(self):
         # The raw + first harness probes cover the direct DeepSeek comparison
-        # paths. The second harness probe resolves the production editorial
-        # model dynamically so a route edit cannot leave its canary stale.
+        # paths. The second harness probe resolves the registered editorial
+        # profile independently, so it remains a useful reversion signal while
+        # the production editorial route temporarily points to Cursor.
         model_id = self.assert_single_opencode_model()
         canary = (REPO_ROOT / ".github" / "workflows" /
                   "opencode-deepseek-canary.yml").read_text(encoding="utf-8")
@@ -1018,15 +1077,13 @@ class RoutingInvariants(unittest.TestCase):
         # or the cheap preflight certifies an entitlement the run never uses.
         self.assertIn(f'"model": "{model_id}"', canary)
         self.assertIn(f'{{"model":"{model_id}"', gen)
-        self.assertIn(
-            'python3 scripts/resolve_agent_route.py rss --github-output "$GITHUB_OUTPUT"',
-            canary,
-        )
+        self.assertIn('"opencode-glm-5p3-flash"', canary)
         self.assertIn('model: ${{ steps.glm_route.outputs.model_ref }}', canary)
         config = json.loads(LANES_FILE.read_text(encoding="utf-8"))
-        editorial = resolve_route(config, "rss")
-        self.assertEqual("opencode-glm-5p3-flash", editorial.backend)
-        self.assertEqual("opencode-go/glm-5.3-flash", editorial.model_ref)
+        profile = config["backends"]["opencode-glm-5p3-flash"]
+        self.assertEqual("opencode", profile["adapter"])
+        self.assertEqual("opencode-go", profile["provider"])
+        self.assertEqual("glm-5.3-flash", profile["model"])
         # The production config deliberately carries no static model/default:
         # every action call is authoritative through `opencode run -m`, so a
         # newly registered SSOT profile does not require a config edit.
@@ -3073,6 +3130,12 @@ class RoutingInvariants(unittest.TestCase):
         self.assertIn(self.fallback["native_model"], leg_a[0])
         self.assertNotIn("override", leg_a[0])
 
+        ai_news = [ln for ln in matrix.splitlines()
+                   if ln.startswith("| ai-news-research ")]
+        self.assertEqual(1, len(ai_news), matrix)
+        self.assertIn("claude-sonnet-5", ai_news[0])
+        self.assertIn("native-model` override", ai_news[0])
+
     def test_readme_diagram_generated_and_deterministic(self):
         from build_backend_matrix import build_generated_blocks
         _, diagram1 = build_generated_blocks()
@@ -3102,6 +3165,16 @@ class CrossCheckEnforcement(unittest.TestCase):
         obs["daily-digest.yml"].agent_run[0].secrets["zai-api-key"] = ""
         errors = cross_check(lanes, obs, self.profiles)
         self.assertTrue(any("zai-api-key" in e for e in errors), errors)
+
+    def test_cursor_fallback_mode_mismatch_is_an_error(self):
+        lanes, obs = self.mutated()
+        step = next(
+            step for step in obs["hourly-twitter.yml"].agent_run
+            if step.lane == "twitter-primary"
+        )
+        step.cursor_mode = "editorial"
+        errors = cross_check(lanes, obs, self.profiles)
+        self.assertTrue(any("fallback_mode 'twitter'" in e for e in errors), errors)
 
     def test_explicit_backend_in_workflow_is_an_error(self):
         lanes, obs = self.mutated()

--- a/scripts/test_deterministic_twitter_digest.py
+++ b/scripts/test_deterministic_twitter_digest.py
@@ -276,20 +276,26 @@ class DeterministicTwitterDigestTest(unittest.TestCase):
         steps = doc["jobs"]["twitter"]["steps"]
         primary = next(step for step in steps if step.get("id") == "twitter-claude-agent")
         repair = next(step for step in steps if step.get("id") == "twitter-claude-repair")
-        self.assertEqual("twitter", primary["with"]["opencode-mode"])
-        self.assertEqual("twitter", repair["with"]["opencode-mode"])
+        self.assertEqual("twitter", primary["with"]["cursor-mode"])
+        self.assertEqual("twitter", repair["with"]["cursor-mode"])
 
-    def test_agent_run_preserves_editorial_default_but_forwards_explicit_twitter_mode(self) -> None:
+    def test_agent_run_preserves_isolated_defaults_and_forwards_cursor_twitter_mode(self) -> None:
         action_path = (
             Path(__file__).resolve().parent.parent / ".github" / "actions" / "agent-run" / "action.yml"
         )
         action = yaml.safe_load(action_path.read_text(encoding="utf-8"))
         self.assertEqual("editorial", action["inputs"]["opencode-mode"]["default"])
-        isolated = next(
+        self.assertEqual("editorial", action["inputs"]["cursor-mode"]["default"])
+        opencode = next(
             step for step in action["runs"]["steps"]
             if step.get("id") == "run-opencode"
         )
-        self.assertEqual("${{ inputs.opencode-mode }}", isolated["with"]["mode"])
+        cursor = next(
+            step for step in action["runs"]["steps"]
+            if step.get("id") == "run-cursor"
+        )
+        self.assertEqual("${{ inputs.opencode-mode }}", opencode["with"]["mode"])
+        self.assertEqual("${{ inputs.cursor-mode }}", cursor["with"]["mode"])
 
 
 if __name__ == "__main__":

--- a/scripts/test_select_backend.py
+++ b/scripts/test_select_backend.py
@@ -16,6 +16,27 @@ import select_backend
 
 def fake_data(chain, lanes=None):
     return {
+        "adapters": {
+            "agent-run": {
+                "isolated_workspace": False,
+                "editorial_contract": True,
+                "provider_credentials": {
+                    "claude": "claude-code-oauth-token",
+                    "fireworks": "fireworks-api-key",
+                    "zai": "zai-api-key",
+                },
+            },
+            "opencode": {
+                "isolated_workspace": True,
+                "editorial_contract": True,
+                "provider_credentials": {"opencode-go": "opencode-api-key"},
+            },
+            "cursor": {
+                "isolated_workspace": True,
+                "editorial_contract": True,
+                "provider_credentials": {"cursor": "cursor-api-key"},
+            },
+        },
         "backends": {
             "claude": {"provider": "claude", "model": "", "display_name": "Claude", "aliases": []},
             "fireworks-glm-5p2": {"provider": "fireworks",
@@ -29,6 +50,12 @@ def fake_data(chain, lanes=None):
                 "provider": "opencode-go", "model": "glm-5.3-flash",
                 "display_name": "GLM 5.3 Flash via OpenCode Go",
                 "aliases": ["opencode-glm"],
+            },
+            "cursor-grok-4p6-fast": {
+                "adapter": "cursor",
+                "provider": "cursor", "model": "cursor-grok-4.6-high-fast",
+                "display_name": "Grok 4.6 Fast via Cursor CLI",
+                "aliases": ["cursor"],
             },
         },
         "fallback": {"harness": "agent-run", "chain": chain,
@@ -84,13 +111,13 @@ class SelectBackendTest(unittest.TestCase):
         self.assertEqual(out["provider"], "zai")
         self.assertEqual(out["used-fallback"], "true")
 
-    def test_claude_429_uses_lane_local_opencode_before_global_zai(self):
+    def test_claude_429_uses_lane_local_cursor_instead_of_global_zai(self):
         lanes = {
             "digest": {"workflow": "daily-digest.yml", "harness": "agent-run",
                        "backend": "claude",
-                       "fallback_chain": ["opencode-glm-5p3-flash"]},
+                       "fallback_chain": ["cursor-grok-4p6-fast"]},
         }
-        self.set_availability(zai=True, **{"opencode-go": True})
+        self.set_availability(zai=True, cursor=True)
         with unittest.mock.patch.dict(
                 os.environ, {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-oat01-test"}), \
                 unittest.mock.patch.object(
@@ -100,22 +127,23 @@ class SelectBackendTest(unittest.TestCase):
                 "--lane", "digest", chain=("claude", "zai-glm-5p2"), lanes=lanes)
 
         self.assertEqual(code, 0)
-        self.assertEqual(out["backend"], "opencode-glm-5p3-flash")
-        self.assertEqual(out["provider"], "opencode-go")
+        self.assertEqual(out["backend"], "cursor-grok-4p6-fast")
+        self.assertEqual(out["provider"], "cursor")
+        self.assertEqual(out["adapter"], "cursor")
         self.assertEqual(out["used-fallback"], "true")
         self.assertIn("rate limited for this run", log)
 
-    def test_twitter_primary_and_repair_use_opencode_on_claude_429(self):
+    def test_twitter_primary_and_repair_use_cursor_on_claude_429(self):
         lanes = {
             lane: {
                 "workflow": "hourly-twitter.yml",
                 "harness": "agent-run",
                 "backend": "claude",
-                "fallback_chain": ["opencode-glm-5p3-flash"],
+                "fallback_chain": ["cursor-grok-4p6-fast"],
             }
             for lane in ("twitter-primary", "twitter-primary-repair")
         }
-        self.set_availability(zai=True, **{"opencode-go": True})
+        self.set_availability(zai=True, cursor=True)
         with unittest.mock.patch.dict(
                 os.environ, {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-oat01-test"}), \
                 unittest.mock.patch.object(
@@ -127,8 +155,8 @@ class SelectBackendTest(unittest.TestCase):
                         "--lane", lane,
                         chain=("claude", "zai-glm-5p2"), lanes=lanes)
                     self.assertEqual(code, 0)
-                    self.assertEqual(out["backend"], "opencode-glm-5p3-flash")
-                    self.assertEqual(out["provider"], "opencode-go")
+                    self.assertEqual(out["backend"], "cursor-grok-4p6-fast")
+                    self.assertEqual(out["provider"], "cursor")
                     self.assertEqual(out["used-fallback"], "true")
                     self.assertIn("rate limited for this run", log)
 
@@ -136,9 +164,9 @@ class SelectBackendTest(unittest.TestCase):
         lanes = {
             "digest": {"workflow": "daily-digest.yml", "harness": "agent-run",
                        "backend": "claude",
-                       "fallback_chain": ["opencode-glm-5p3-flash"]},
+                       "fallback_chain": ["cursor-grok-4p6-fast"]},
         }
-        self.set_availability(zai=True, **{"opencode-go": True})
+        self.set_availability(zai=True, cursor=True)
         with unittest.mock.patch.dict(
                 os.environ, {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-oat01-test"}), \
                 unittest.mock.patch.object(
@@ -151,16 +179,16 @@ class SelectBackendTest(unittest.TestCase):
         self.assertEqual(code, 1)
         self.assertNotIn("backend", out)
         self.assertIn("rate limited for this run", log)
-        self.assertNotIn("candidate opencode-glm-5p3-flash", log)
+        self.assertNotIn("candidate cursor-grok-4p6-fast", log)
         self.assertNotIn("candidate zai-glm-5p2", log)
 
     def test_lane_override_does_not_continue_to_global_zai(self):
         lanes = {
             "digest": {"workflow": "daily-digest.yml", "harness": "agent-run",
                        "backend": "claude",
-                       "fallback_chain": ["opencode-glm-5p3-flash"]},
+                       "fallback_chain": ["cursor-grok-4p6-fast"]},
         }
-        self.set_availability(zai=True, **{"opencode-go": False})
+        self.set_availability(zai=True, cursor=False)
         with unittest.mock.patch.dict(
                 os.environ, {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-oat01-test"}), \
                 unittest.mock.patch.object(
@@ -170,7 +198,7 @@ class SelectBackendTest(unittest.TestCase):
 
         self.assertEqual(code, 1)
         self.assertNotIn("backend", out)
-        self.assertIn("candidate opencode-glm-5p3-flash", log)
+        self.assertIn("candidate cursor-grok-4p6-fast", log)
         self.assertNotIn("candidate zai-glm-5p2", log)
 
     def test_explicit_cross_adapter_override_requires_lane_contract(self):
@@ -179,6 +207,26 @@ class SelectBackendTest(unittest.TestCase):
         self.assertEqual(code, 2)
         self.assertNotIn("backend", out)
         self.assertIn("requires a lane fallback_chain contract", log)
+
+    def test_cross_adapter_requires_isolated_editorial_capabilities(self):
+        lanes = {
+            "digest": {"workflow": "daily-digest.yml", "harness": "agent-run",
+                       "backend": "claude",
+                       "fallback_chain": ["cursor-grok-4p6-fast"]},
+        }
+        data = fake_data(["claude", "zai-glm-5p2"], lanes)
+        data["adapters"]["cursor"]["editorial_contract"] = False
+        data_file = Path(self.tmp.name) / "invalid-backends.json"
+        data_file.write_text(json.dumps(data))
+        out_file = Path(self.tmp.name) / "invalid-out.txt"
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stdout):
+            code = select_backend.main_with_args([
+                "--file", str(data_file), "--github-output", str(out_file),
+                "--lane", "digest",
+            ])
+        self.assertEqual(2, code)
+        self.assertIn("lacks required capability 'editorial_contract'", stdout.getvalue())
 
     def test_chain_skips_unavailable_middle_candidate(self):
         self.set_availability(fireworks=False, zai=False, claude=True)
@@ -350,6 +398,23 @@ class ProbeOpenCodeTest(unittest.TestCase):
             available, reason = select_backend.probe_opencode("glm-5.3-flash")
         self.assertTrue(available)
         self.assertIn("isolated OpenCode", reason)
+
+
+class ProbeCursorTest(unittest.TestCase):
+    def test_requires_scoped_credential(self):
+        with unittest.mock.patch.dict(os.environ, {}, clear=True):
+            available, reason = select_backend.probe_cursor(
+                "cursor-grok-4.6-high-fast")
+        self.assertFalse(available)
+        self.assertIn("not configured", reason)
+
+    def test_configured_credential_is_available_without_network_probe(self):
+        with unittest.mock.patch.dict(
+                os.environ, {"CURSOR_API_KEY": "test-key"}, clear=True):
+            available, reason = select_backend.probe_cursor(
+                "cursor-grok-4.6-high-fast")
+        self.assertTrue(available)
+        self.assertIn("isolated Cursor", reason)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- restore RSS, community, and Bluesky by temporarily routing the exhausted OpenCode editorial route to the already-healthy isolated Cursor adapter
- keep Claude primary, while adding lane-scoped Cursor fallbacks for compatible local digest, Twitter primary/repair, and no-MCP AI-news contracts
- preserve the global Claude to Z.ai chain, isolate Cursor credentials, validate per-lane adapter modes, and keep MCP AI news on direct Claude
- decouple the OpenCode editorial canary so a successful registered-profile probe gives an exact signal for restoring the normal split

## Why

Current production evidence shows OpenCode Go failing with monthly usage exhaustion and Z.ai failing with insufficient balance. Cursor is healthy. A fresh direct-Claude AI News run also succeeded, so Claude remains primary rather than being rerouted.

## Verification

- 1,012 Python tests passed; 6 intentional skips
- actionlint passed for all workflow files
- backend SSOT and generated matrix/README diagram are in sync
- git diff hygiene check passed

## Operational follow-through

After merge, redispatch RSS, Community, and Bluesky, then Daily Digest and liveness. Restore only routes.research-editorial.backend to opencode-glm-5p3-flash after the independent registered OpenCode editorial probe succeeds.
