### PR TITLE
Stop treating steady-state OAuth 429 as Claude down; fall back post-agent

### DIFF
--- a/.github/actions/agent-run/action.yml
+++ b/.github/actions/agent-run/action.yml
@@ -270,6 +270,9 @@ runs:
         STEP_OUTCOME: ${{ inputs.allowed-bots == '' && steps.run-claude.outcome || steps.run-claude-bots.outcome }}
         EXEC_FILE: ${{ steps.run-claude.outputs.execution_file || steps.run-claude-bots.outputs.execution_file }}
         LABEL: ${{ inputs.label }}
+        PRE_SHA: ${{ steps.pre.outputs.sha }}
+        EXPECTED_PATHS: ${{ inputs.expected-paths }}
+        ALLOWED_PATHS: ${{ inputs.allowed-paths }}
       run: |
         set -euo pipefail
         if [ "$STEP_OUTCOME" = "success" ]; then
@@ -282,6 +285,32 @@ runs:
         reason="$(sed -n 's/^reason=//p' "$verdict_file" | head -n1)"
         rm -f "$verdict_file"
         if [ "$outcome" = "dead-start" ]; then
+          # Belt and braces: the transcript says nothing was written; prove it
+          # against the checkout too. HEAD must still be the pre-run SHA and
+          # no tracked or untracked file under the output contract may have
+          # changed — otherwise a fallback runner's import plus the later
+          # "Commit expected-path changes" step could merge two models' work.
+          leftovers=""
+          if [ "$(git rev-parse HEAD)" != "$PRE_SHA" ]; then
+            leftovers="HEAD moved from ${PRE_SHA}"
+          fi
+          paths="$ALLOWED_PATHS"
+          [ -z "$paths" ] && paths="$EXPECTED_PATHS"
+          pathspecs=()
+          while IFS= read -r pathspec; do
+            pathspec="${pathspec#"${pathspec%%[![:space:]]*}"}"
+            pathspec="${pathspec%"${pathspec##*[![:space:]]}"}"
+            [ -z "$pathspec" ] && continue
+            pathspecs+=("$pathspec")
+          done <<< "$paths"
+          if [ "${#pathspecs[@]}" -gt 0 ] && [ -n "$(git status --porcelain -- "${pathspecs[@]}")" ]; then
+            leftovers="${leftovers:+$leftovers; }uncommitted changes under the output contract"
+          fi
+          if [ -n "$leftovers" ]; then
+            echo "dead-start=false" >> "$GITHUB_OUTPUT"
+            echo "::error::${LABEL}: transcript looks like a Claude dead-start (${reason}) but the checkout is not clean (${leftovers}). Refusing the post-agent fallback so two models' work cannot be merged."
+            exit 1
+          fi
           echo "::warning::${LABEL}: native Claude died before doing work — ${reason}. Re-walking the lane fallback chain post-agent."
           echo "dead-start=true" >> "$GITHUB_OUTPUT"
           exit 0

--- a/.github/actions/agent-run/action.yml
+++ b/.github/actions/agent-run/action.yml
@@ -94,8 +94,8 @@ outputs:
     description: Resolved native Claude model (what the `--model opus` alias serves on the native path — the native-model input, else the SSOT's global fallback.native_model).
     value: ${{ steps.select.outputs.native-model }}
   execution-file:
-    description: Path to the Claude Code execution transcript JSON reported by a Claude-compatible child (intentionally empty for isolated adapters). Callers that need it after a later agent-run call in the same job must copy it immediately.
-    value: ${{ steps.run-zai-fallback.outputs.execution_file || steps.run-zai-fallback-bots.outputs.execution_file || steps.run-claude.outputs.execution_file || steps.run-claude-bots.outputs.execution_file || steps.run-fireworks.outputs.execution_file || steps.run-fireworks-bots.outputs.execution_file || steps.run-zai.outputs.execution_file || steps.run-zai-bots.outputs.execution_file }}
+    description: Path to the Claude Code execution transcript JSON reported by a Claude-compatible child (intentionally empty for isolated adapters — including when an isolated adapter served the run as the post-agent fallback after a Claude dead-start, whose failed transcript must not be reported as the run's transcript). Callers that need it after a later agent-run call in the same job must copy it immediately.
+    value: ${{ steps.reselect.outputs.adapter != 'opencode' && steps.reselect.outputs.adapter != 'cursor' && (steps.run-zai-fallback.outputs.execution_file || steps.run-zai-fallback-bots.outputs.execution_file || steps.run-claude.outputs.execution_file || steps.run-claude-bots.outputs.execution_file || steps.run-fireworks.outputs.execution_file || steps.run-fireworks-bots.outputs.execution_file || steps.run-zai.outputs.execution_file || steps.run-zai-bots.outputs.execution_file) || '' }}
   changed:
     description: "true when expected-paths were provided and changed"
     value: ${{ steps.guard.outputs.changed }}

--- a/.github/actions/agent-run/action.yml
+++ b/.github/actions/agent-run/action.yml
@@ -79,20 +79,23 @@ outputs:
     description: Normalized requested backend selector.
     value: ${{ steps.select.outputs.requested-backend }}
   effective-backend:
-    description: Backend actually used after walking the SSOT fallback chain.
-    value: ${{ steps.select.outputs.backend }}
+    description: Backend actually used after walking the SSOT fallback chain (pre-agent probe OR post-agent reselection after a Claude dead-start).
+    value: ${{ steps.reselect.outputs.backend || steps.select.outputs.backend }}
   used-fallback:
-    description: "true when the requested backend was unavailable and a chain candidate was selected"
-    value: ${{ steps.select.outputs.used-fallback }}
+    description: "true when the requested backend was unavailable (or died at agent time) and a chain candidate was selected"
+    value: ${{ steps.reselect.outputs.used-fallback || steps.select.outputs.used-fallback }}
+  claude-dead-start:
+    description: "true when native Claude was selected but died before doing any work (is_error, <=1 turn, $0 — throttle or rejected credential) and the lane chain was re-walked post-agent"
+    value: ${{ steps.claude-outcome.outputs.dead-start == 'true' }}
   model-id:
     description: Provider model id of the EFFECTIVE backend (empty on the native path — see native-model resolution).
-    value: ${{ steps.select.outputs.model-id }}
+    value: ${{ steps.reselect.outputs.model-id || steps.select.outputs.model-id }}
   native-model:
     description: Resolved native Claude model (what the `--model opus` alias serves on the native path — the native-model input, else the SSOT's global fallback.native_model).
     value: ${{ steps.select.outputs.native-model }}
   execution-file:
     description: Path to the Claude Code execution transcript JSON reported by a Claude-compatible child (intentionally empty for isolated adapters). Callers that need it after a later agent-run call in the same job must copy it immediately.
-    value: ${{ steps.run-claude.outputs.execution_file || steps.run-claude-bots.outputs.execution_file || steps.run-fireworks.outputs.execution_file || steps.run-fireworks-bots.outputs.execution_file || steps.run-zai.outputs.execution_file || steps.run-zai-bots.outputs.execution_file }}
+    value: ${{ steps.run-zai-fallback.outputs.execution_file || steps.run-zai-fallback-bots.outputs.execution_file || steps.run-claude.outputs.execution_file || steps.run-claude-bots.outputs.execution_file || steps.run-fireworks.outputs.execution_file || steps.run-fireworks-bots.outputs.execution_file || steps.run-zai.outputs.execution_file || steps.run-zai-bots.outputs.execution_file }}
   changed:
     description: "true when expected-paths were provided and changed"
     value: ${{ steps.guard.outputs.changed }}
@@ -132,8 +135,11 @@ runs:
         ZAI_API_KEY: ${{ inputs.zai-api-key }}
         OPENCODE_API_KEY: ${{ inputs.opencode-api-key }}
         CURSOR_API_KEY: ${{ inputs.cursor-api-key }}
-        # The Claude OAuth preflight marks 401/403 auth rejection and a 429
-        # run-scoped rate limit unavailable (non-strict → walk the chain).
+        # The Claude OAuth preflight is AUTH-ONLY: 401/403 = unavailable
+        # (non-strict → walk the chain); 429 is the steady-state answer a
+        # healthy OAuth token gives this raw ping and therefore UP. A real
+        # throttle is detected after the Claude step (see "Classify native
+        # Claude outcome" below) and re-walks the same chain post-agent.
         # Without the token the native path is also unavailable.
         CLAUDE_CODE_OAUTH_TOKEN: ${{ inputs.claude-code-oauth-token }}
       run: |
@@ -218,6 +224,9 @@ runs:
     - name: Run agent with Claude
       id: run-claude
       if: steps.select.outputs.provider == 'claude' && inputs.allowed-bots == ''
+      # continue-on-error so the step below can classify HOW it ended. A
+      # non-dead-start failure is re-raised there, so this is not a swallow.
+      continue-on-error: true
       uses: anthropics/claude-code-action@a874e9ecd7bb36efdad65429c6b35815f5a08f10 # v1
       env:
         ANTHROPIC_MODEL: ${{ steps.select.outputs.native-model }}
@@ -232,12 +241,188 @@ runs:
     - name: Run agent with Claude
       id: run-claude-bots
       if: steps.select.outputs.provider == 'claude' && inputs.allowed-bots != ''
+      continue-on-error: true
       uses: anthropics/claude-code-action@a874e9ecd7bb36efdad65429c6b35815f5a08f10 # v1
       env:
         ANTHROPIC_MODEL: ${{ steps.select.outputs.native-model }}
         ANTHROPIC_DEFAULT_OPUS_MODEL: ${{ steps.select.outputs.native-model }}
         ARA_AGENT_BACKEND: claude
         ARA_AGENT_MODEL_ID: ${{ steps.select.outputs.native-model }}
+      with:
+        claude_code_oauth_token: ${{ inputs.claude-code-oauth-token }}
+        allowed_bots: ${{ inputs.allowed-bots }}
+        claude_args: ${{ inputs.claude-args }}
+        prompt: ${{ inputs.prompt }}
+
+    # POST-AGENT THROTTLE FALLBACK. The pre-agent OAuth probe cannot see a
+    # real throttle (a healthy token answers the raw ping 429 unconditionally),
+    # so the Claude step runs first and its transcript is classified here.
+    # Only a DEAD-START — is_error with <=1 turn and $0, the signature of a
+    # throttled or rejected credential — may hand the SAME prompt to the next
+    # chain candidate: nothing was written, so a clean re-run is safe. A
+    # failure after real work is re-raised: partial edits may sit in the
+    # checkout and a second model must never silently finish another's job.
+    - name: Classify native Claude outcome
+      id: claude-outcome
+      if: steps.select.outputs.provider == 'claude'
+      shell: bash
+      env:
+        STEP_OUTCOME: ${{ inputs.allowed-bots == '' && steps.run-claude.outcome || steps.run-claude-bots.outcome }}
+        EXEC_FILE: ${{ steps.run-claude.outputs.execution_file || steps.run-claude-bots.outputs.execution_file }}
+        LABEL: ${{ inputs.label }}
+      run: |
+        set -euo pipefail
+        if [ "$STEP_OUTCOME" = "success" ]; then
+          echo "dead-start=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        verdict_file="$(mktemp)"
+        python3 scripts/classify_claude_execution.py ${EXEC_FILE:+"$EXEC_FILE"} --github-output "$verdict_file"
+        outcome="$(sed -n 's/^outcome=//p' "$verdict_file" | head -n1)"
+        reason="$(sed -n 's/^reason=//p' "$verdict_file" | head -n1)"
+        rm -f "$verdict_file"
+        if [ "$outcome" = "dead-start" ]; then
+          echo "::warning::${LABEL}: native Claude died before doing work — ${reason}. Re-walking the lane fallback chain post-agent."
+          echo "dead-start=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        echo "dead-start=false" >> "$GITHUB_OUTPUT"
+        echo "::error::${LABEL}: native Claude step failed (${outcome}) — ${reason}. Not a dead-start, so no fallback is attempted."
+        exit 1
+
+    # Same selector, same lane/global chain, same strictness and eligibility
+    # rules — with Claude marked unavailable. A strict lane or an exhausted
+    # chain exits 1 here and the run stays red (fail-closed, as before).
+    - name: Re-select backend after Claude dead-start
+      id: reselect
+      if: steps.claude-outcome.outputs.dead-start == 'true'
+      shell: bash
+      env:
+        LANE: ${{ inputs.lane }}
+        BACKEND_OVERRIDE: ${{ inputs.backend }}
+        NATIVE_MODEL_OVERRIDE: ${{ inputs.native-model }}
+        FALLBACK_POLICY: ${{ inputs.fireworks-fallback }}
+        FIREWORKS_API_KEY: ${{ inputs.fireworks-api-key }}
+        ZAI_API_KEY: ${{ inputs.zai-api-key }}
+        OPENCODE_API_KEY: ${{ inputs.opencode-api-key }}
+        CURSOR_API_KEY: ${{ inputs.cursor-api-key }}
+        CLAUDE_CODE_OAUTH_TOKEN: ${{ inputs.claude-code-oauth-token }}
+      run: |
+        set -euo pipefail
+        args=(--github-output "$GITHUB_OUTPUT" --fallback-policy "${FALLBACK_POLICY:-claude}" --exclude-backend claude)
+        if [ -n "$BACKEND_OVERRIDE" ]; then
+          args+=(--backend "$BACKEND_OVERRIDE")
+        else
+          args+=(--lane "$LANE")
+        fi
+        if [ -n "$NATIVE_MODEL_OVERRIDE" ]; then
+          args+=(--native-model-override "$NATIVE_MODEL_OVERRIDE")
+        fi
+        python3 scripts/select_backend.py "${args[@]}"
+
+    - name: Resolve isolated editorial path contract (post-agent fallback)
+      id: isolated-contract-fallback
+      if: steps.reselect.outputs.adapter == 'opencode' || steps.reselect.outputs.adapter == 'cursor'
+      shell: bash
+      env:
+        EXPECTED_PATHS: ${{ inputs.expected-paths }}
+        ALLOWED_PATHS: ${{ inputs.allowed-paths }}
+      run: |
+        set -euo pipefail
+        paths="$ALLOWED_PATHS"
+        if [ -z "$paths" ]; then
+          paths="$EXPECTED_PATHS"
+        fi
+        if [ -z "$paths" ]; then
+          echo "::error::An isolated adapter fallback requires expected-paths or allowed-paths."
+          exit 1
+        fi
+        {
+          echo "paths<<__ISOLATED_ALLOWED_PATHS__"
+          echo "$paths"
+          echo "__ISOLATED_ALLOWED_PATHS__"
+        } >> "$GITHUB_OUTPUT"
+
+    # Only the providers that appear in a lane or global chain have a
+    # post-agent runner. Anything else is a hard error rather than a silent
+    # no-op that the output guard would report as a confusing "no output".
+    - name: Verify the reselected backend has a post-agent runner
+      if: steps.reselect.outcome == 'success'
+      shell: bash
+      env:
+        ADAPTER: ${{ steps.reselect.outputs.adapter }}
+        PROVIDER: ${{ steps.reselect.outputs.provider }}
+        BACKEND: ${{ steps.reselect.outputs.backend }}
+      run: |
+        set -euo pipefail
+        case "${ADAPTER}/${PROVIDER}" in
+          opencode/*|cursor/*|agent-run/zai) ;;
+          *) echo "::error::post-agent fallback selected '${BACKEND}' (adapter=${ADAPTER}, provider=${PROVIDER}) but agent-run has no post-agent runner for it."; exit 1 ;;
+        esac
+
+    - name: Run agent with isolated OpenCode (post-agent fallback)
+      id: run-opencode-fallback
+      if: steps.reselect.outputs.adapter == 'opencode'
+      uses: ./.github/actions/run-opencode-container
+      with:
+        mode: ${{ inputs.opencode-mode }}
+        lane: ${{ inputs.lane }}
+        allowed-paths: ${{ steps.isolated-contract-fallback.outputs.paths }}
+        model: ${{ steps.reselect.outputs.provider }}/${{ steps.reselect.outputs.model-id }}
+        opencode-api-key: ${{ inputs.opencode-api-key }}
+        prompt-text: ${{ inputs.prompt }}
+
+    - name: Run agent with isolated Cursor (post-agent fallback)
+      id: run-cursor-fallback
+      if: steps.reselect.outputs.adapter == 'cursor'
+      uses: ./.github/actions/run-cursor-container
+      with:
+        mode: ${{ inputs.cursor-mode }}
+        lane: ${{ inputs.lane }}
+        allowed-paths: ${{ steps.isolated-contract-fallback.outputs.paths }}
+        model: ${{ steps.reselect.outputs.provider }}/${{ steps.reselect.outputs.model-id }}
+        cursor-api-key: ${{ inputs.cursor-api-key }}
+        prompt-text: ${{ inputs.prompt }}
+
+    - name: Run agent with Z.ai (post-agent fallback)
+      id: run-zai-fallback
+      if: steps.reselect.outputs.provider == 'zai' && inputs.allowed-bots == ''
+      uses: anthropics/claude-code-action@a874e9ecd7bb36efdad65429c6b35815f5a08f10 # v1
+      env:
+        ANTHROPIC_BASE_URL: https://api.z.ai/api/anthropic
+        ANTHROPIC_AUTH_TOKEN: ${{ inputs.zai-api-key }}
+        ANTHROPIC_MODEL: ${{ steps.reselect.outputs.model-id }}
+        ANTHROPIC_DEFAULT_OPUS_MODEL: ${{ steps.reselect.outputs.model-id }}
+        ANTHROPIC_DEFAULT_SONNET_MODEL: ${{ steps.reselect.outputs.model-id }}
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: ${{ steps.reselect.outputs.model-id }}
+        CLAUDE_CODE_SUBAGENT_MODEL: ${{ steps.reselect.outputs.model-id }}
+        CLAUDE_CODE_EFFORT_LEVEL: max
+        CLAUDE_CODE_AUTO_COMPACT_WINDOW: "1000000"
+        API_TIMEOUT_MS: "3000000"
+        ARA_AGENT_BACKEND: ${{ steps.reselect.outputs.backend }}
+        ARA_AGENT_MODEL_ID: ${{ steps.reselect.outputs.model-id }}
+      with:
+        claude_code_oauth_token: ${{ inputs.claude-code-oauth-token }}
+        claude_args: ${{ inputs.claude-args }}
+        prompt: ${{ inputs.prompt }}
+
+    - name: Run agent with Z.ai (post-agent fallback)
+      id: run-zai-fallback-bots
+      if: steps.reselect.outputs.provider == 'zai' && inputs.allowed-bots != ''
+      uses: anthropics/claude-code-action@a874e9ecd7bb36efdad65429c6b35815f5a08f10 # v1
+      env:
+        ANTHROPIC_BASE_URL: https://api.z.ai/api/anthropic
+        ANTHROPIC_AUTH_TOKEN: ${{ inputs.zai-api-key }}
+        ANTHROPIC_MODEL: ${{ steps.reselect.outputs.model-id }}
+        ANTHROPIC_DEFAULT_OPUS_MODEL: ${{ steps.reselect.outputs.model-id }}
+        ANTHROPIC_DEFAULT_SONNET_MODEL: ${{ steps.reselect.outputs.model-id }}
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: ${{ steps.reselect.outputs.model-id }}
+        CLAUDE_CODE_SUBAGENT_MODEL: ${{ steps.reselect.outputs.model-id }}
+        CLAUDE_CODE_EFFORT_LEVEL: max
+        CLAUDE_CODE_AUTO_COMPACT_WINDOW: "1000000"
+        API_TIMEOUT_MS: "3000000"
+        ARA_AGENT_BACKEND: ${{ steps.reselect.outputs.backend }}
+        ARA_AGENT_MODEL_ID: ${{ steps.reselect.outputs.model-id }}
       with:
         claude_code_oauth_token: ${{ inputs.claude-code-oauth-token }}
         allowed_bots: ${{ inputs.allowed-bots }}

--- a/.github/workflows/hourly-twitter.yml
+++ b/.github/workflows/hourly-twitter.yml
@@ -76,6 +76,17 @@ on:
         required: false
         default: false
         type: boolean
+      native_model:
+        description: >-
+          Claude tier only — native Anthropic model id served by the
+          `--model opus` alias for this run (e.g. claude-fable-5-1,
+          claude-opus-5). Empty = the SSOT fallback.native_model. Rejected
+          for any other backend so a requested model is never silently
+          ignored. Premium models bill the shared subscription window —
+          use for deliberate one-off comparisons, not as a standing default.
+        required: false
+        default: ""
+        type: string
 
 # Per-backend concurrency groups: each tier serializes against itself
 # (cron-driven and manually-dispatched runs of the same backend land
@@ -149,6 +160,7 @@ jobs:
           ACTUAL_SCHEDULE: ${{ github.event.schedule }}
           MATRIX_BACKEND: ${{ matrix.backend }}
           INPUT_BACKEND: ${{ inputs.backend }}
+          INPUT_NATIVE_MODEL: ${{ inputs.native_model }}
         run: |
           set -euo pipefail
 
@@ -176,11 +188,28 @@ jobs:
             claude|deepseek-claude-code|zai-glm-5p2|deepseek-pi|fireworks-pi|opencode-deepseek-v4-flash|cursor-grok-4p6-fast) ;;
             *) echo "::error::Unknown backend '$BACKEND'"; exit 1 ;;
           esac
+          # Optional native-model override (dispatch only). Honored solely on
+          # the Claude tier: agent-run maps it onto the `--model opus` alias.
+          # Any other tier serves a fixed provider model, so a requested id
+          # there would be a silent no-op — reject it instead.
+          NATIVE_MODEL=""
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "${INPUT_NATIVE_MODEL:-}" ]; then
+            if [ "$BACKEND" != "claude" ]; then
+              echo "::error::native_model='${INPUT_NATIVE_MODEL}' is only honored with backend=claude (got '${BACKEND}')."
+              exit 1
+            fi
+            if ! [[ "$INPUT_NATIVE_MODEL" =~ ^claude-[a-z0-9][a-z0-9.-]*$ ]]; then
+              echo "::error::native_model='${INPUT_NATIVE_MODEL}' is not a native Anthropic model id (expected claude-<family>-<version>, e.g. claude-fable-5-1)."
+              exit 1
+            fi
+            NATIVE_MODEL="$INPUT_NATIVE_MODEL"
+          fi
           {
             echo "skip=false"
             echo "name=${BACKEND}"
+            echo "native_model=${NATIVE_MODEL}"
           } >> "$GITHUB_OUTPUT"
-          echo "Resolved backend: ${BACKEND}"
+          echo "Resolved backend: ${BACKEND}${NATIVE_MODEL:+ (native model override: ${NATIVE_MODEL})}"
 
       - name: Quarantine stale self-hosted workspace
         if: steps.backend.outputs.skip != 'true'
@@ -507,6 +536,7 @@ jobs:
           BIRDY_TOOL_LOG_PATH: ${{ github.workspace }}/.twitter-input/birdy-tool-log.jsonl
         with:
           lane: twitter-primary
+          native-model: ${{ steps.backend.outputs.native_model }}
           claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           fireworks-api-key: ${{ secrets.FIREWORKS_API_KEY }}
           zai-api-key: ${{ secrets.ZAI_API_KEY }}
@@ -579,6 +609,7 @@ jobs:
           BIRDY_TOOL_LOG_PATH: ${{ github.workspace }}/.twitter-input/birdy-tool-log.jsonl
         with:
           lane: twitter-primary-repair
+          native-model: ${{ steps.backend.outputs.native_model }}
           claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           fireworks-api-key: ${{ secrets.FIREWORKS_API_KEY }}
           zai-api-key: ${{ secrets.ZAI_API_KEY }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -466,7 +466,7 @@ Secrets are configured in GitHub Actions. None are committed.
 
 | Secret | Used by | Notes |
 |---|---|---|
-| `CLAUDE_CODE_OAUTH_TOKEN` | Claude-harness `agent-run` lanes, direct-Claude workflows, and a reserved dispatcher credential slot | Required by `claude-code-action@v1`; agent-run call sites carry it alongside alternate-provider keys for runtime routing. Expiry can take down the Claude-harness failure domain, but current host-checkout agent-run is rejected by `research-editorial` and never receives this reserved dispatcher slot. Log signature: `is_error: true`, `num_turns: 1`, `total_cost_usd: 0`, `duration_ms` < ~2000, zero permission denials — the agent dies before doing any work. Re-mint with `claude setup-token` → `gh secret set CLAUDE_CODE_OAUTH_TOKEN`; dispatch `zai-claude-code-canary.yml` to separate a dead credential from a broken runner/sandbox. Last expiry 2026-07-24; see rule 14. |
+| `CLAUDE_CODE_OAUTH_TOKEN` | Claude-harness `agent-run` lanes, direct-Claude workflows, and a reserved dispatcher credential slot | Required by `claude-code-action@v1`; agent-run call sites carry it alongside alternate-provider keys for runtime routing. Expiry can take down the Claude-harness failure domain, but current host-checkout agent-run is rejected by `research-editorial` and never receives this reserved dispatcher slot. Log signature: `is_error: true`, `num_turns: 1`, `total_cost_usd: 0`, `duration_ms` < ~2000, zero permission denials — the agent dies before doing any work. `agent-run` now classifies exactly this shape as a **dead-start** and re-walks the lane chain post-agent (rule 14b), so the lane survives; the run log carries the `died before doing work` warning. Re-mint with `claude setup-token` → `gh secret set CLAUDE_CODE_OAUTH_TOKEN`; dispatch `zai-claude-code-canary.yml` to separate a dead credential from a broken runner/sandbox. Last expiry 2026-07-24; see rule 14. |
 | `ZAI_API_KEY` | Fallback chain link 2; `agent-run backend=zai-glm-5p2`; `zai-claude-code-canary.yml` | Z.ai Coding Plan key. Now load-bearing for outage resilience, not just comparison. |
 | `FIREWORKS_API_KEY` | Fireworks generative/comparison lanes and a reserved dispatcher credential slot | Covers GLM and DeepSeek Fireworks profiles. The prewired dispatcher slot is for a future isolated adapter; current agent-run profiles are not selectable by `research-editorial`. **The account is SUSPENDED as of 2026-08-01** — probes return `HTTP 412: Account getclarito-5mege6wpl is suspended, possibly due to reaching the monthly spending limit or failure to pay past invoices` (run `30641250660`). The strict `twitter-deepseek` cron had hard-failed 4×/day since ~2026-07-05 and was dropped 2026-08-01; it remains dispatch-only until billing is settled at https://fireworks.ai/account/billing. Check the job name before attributing those historical failures to a primary lane. |
 | `OPENCODE_API_KEY` | OpenCode profiles, direct comparison/canary paths, and the dispatcher credential set | OpenCode Go key: https://opencode.ai/auth; caps are $12/5h, $30/week, $60/month. The monthly cap is currently exhausted, so production editorial routing is temporarily off OpenCode. `opencode-deepseek-canary.yml` independently probes the registered editorial profile. When that probe succeeds, restore only `routes.research-editorial.backend`, regenerate docs, and redispatch RSS/community/Bluesky. |
@@ -699,18 +699,33 @@ output or break the pipeline. Read them before editing.
     (a) **`fallback.chain` spans ≥2 providers** — CI-enforced by
     `test_backend_matrix.test_global_fallback_chain_shape`. Claude leads
     (it is what the prompts are tuned against); it must not also terminate.
-    (b) **`probe_claude()` is a narrow run-availability preflight** — down
-    on 401/403 auth rejection and on HTTP 429. A 429 proves the subscription
-    token is alive but also proves Claude cannot serve this run. Local digest,
-    primary Twitter/repair, and no-MCP AI-news have explicit
-    compatibility-tested `fallback_chain` overrides to isolated Cursor. These
-    are standby paths while Claude is healthy, replace rather than append the
-    global chain, and keep exact path/mode contracts. MCP AI-news remains direct
-    Claude because Cursor denies MCP. If Cursor is unavailable, digest/Twitter
-    continue into their existing deterministic recovery where applicable.
-    Unrelated non-strict agent-run lanes retain the global Z.ai secondary.
-    HTTP 400, 5xx, and network faults remain fail-open because this
-    tiny probe does not mechanically prove the full Claude Code path is down.
+    (b) **`probe_claude()` is auth-only, and HTTP 429 is UP.** Down only
+    on 401/403. A healthy Claude Code OAuth token answers the probe's raw
+    1-token ping with `429 rate_limit_error "Error"` **every time** — it is
+    the steady-state answer, not a throttle signal (re-verified 2026-09-06
+    against a Max token that was serving real runs at that moment). PR #3333
+    (2026-08-30) classified 429 as down and the entire Claude fleet silently
+    ran on Cursor Grok for a week — green runs, fresh files, no alert —
+    while the model-timeline lane, whose only other candidate is the
+    out-of-balance Z.ai key, published six days of "No change today"
+    fallbacks. **Do not reintroduce 429-as-down.** A real throttle looks
+    identical at the probe, so it is detected AFTER the agent step instead:
+    `agent-run` runs the Claude step with `continue-on-error`, classifies the
+    transcript with `scripts/classify_claude_execution.py`, and only on a
+    **dead-start** (is_error, ≤1 turn, $0 — the 2026-07-24 and 2026-08-28
+    signature) re-runs `select_backend.py --exclude-backend claude` over the
+    SAME lane/global chain and hands the same prompt to that candidate from
+    the clean checkout. A Claude failure after real work is re-raised, never
+    retried elsewhere. Local digest, primary Twitter/repair, and no-MCP
+    AI-news have explicit compatibility-tested `fallback_chain` overrides to
+    isolated Cursor; these replace rather than append the global chain and
+    keep exact path/mode contracts. MCP AI-news remains direct Claude because
+    Cursor denies MCP. Unrelated non-strict agent-run lanes retain the global
+    Z.ai secondary. HTTP 400, 5xx, and network faults remain fail-open
+    because the tiny probe does not prove the full Claude Code path is down.
+    **Reading a run:** `candidate claude (claude): available — ... probe HTTP
+    429` is normal; a fallback shows up as the `::warning::... died before
+    doing work` line plus `Re-select backend after Claude dead-start`.
     It must send
     `authorization: Bearer` + the oauth beta header and **never**
     `x-api-key` (which makes the API reject a *good* OAuth token with

--- a/data/agent-backends.json
+++ b/data/agent-backends.json
@@ -50,7 +50,7 @@
         "protocol": "native-claude",
         "preflight_path": "harness"
       },
-      "notes": "Native Anthropic through claude-code-action OAuth; the served model is fallback.native_model (the --model opus alias resolves to it). The preflight marks 401/403 auth rejection and HTTP 429 rate limiting unavailable for the current run. Ordinary non-strict lanes continue to the global Z.ai secondary; compatibility-tested local content lanes can replace that chain with an explicit isolated Cursor fallback."
+      "notes": "Native Anthropic through claude-code-action OAuth; the served model is fallback.native_model (the --model opus alias resolves to it; agent-run's native-model input overrides it per call \u2014 hourly-twitter exposes that as the native_model dispatch input). The preflight is AUTH-ONLY: 401/403 = unavailable; HTTP 429 is UP because a healthy OAuth token answers the raw 1-token ping 429 unconditionally (2026-08-30..09-06: classifying it as down ran the whole fleet on Cursor for a week). A real throttle is detected AFTER the agent step \u2014 dead-start = is_error, <=1 turn, $0 (scripts/classify_claude_execution.py) \u2014 and agent-run then re-runs the selector with --exclude-backend claude over the SAME chain: ordinary non-strict lanes continue to the global Z.ai secondary; compatibility-tested local content lanes replace that chain with their explicit isolated Cursor fallback. A Claude failure after real work is never retried elsewhere."
     },
     "claude-opus-5": {
       "adapter": "dispatch-default",
@@ -263,7 +263,7 @@
       "zai-glm-5p2"
     ],
     "native_model": "claude-opus-5",
-    "notes": "ORDERED fallback chain, applied to non-strict agent-run lanes that do not declare a lane.fallback_chain override. Native Claude leads and serves `native_model`; Z.ai GLM-5.2 is the global secondary. Cross-adapter fallbacks are never inferred globally: only lanes with an explicit compatibility-tested fallback_chain may enter an isolated adapter, and that lane chain replaces rather than extends the global chain. The intentionally narrow Claude 400/5xx/network fail-open behavior is unchanged. Strict lanes never walk either chain."
+    "notes": "ORDERED fallback chain, applied to non-strict agent-run lanes that do not declare a lane.fallback_chain override. Native Claude leads and serves `native_model`; Z.ai GLM-5.2 is the global secondary. Cross-adapter fallbacks are never inferred globally: only lanes with an explicit compatibility-tested fallback_chain may enter an isolated adapter, and that lane chain replaces rather than extends the global chain. The Claude probe is auth-only (401/403 down; 429, 400, 5xx and network faults stay UP \u2014 429 is the steady-state answer for a live OAuth token). The chain is walked twice at most: pre-agent on a probe failure, and post-agent with --exclude-backend claude when the Claude step dead-starts (is_error, <=1 turn, $0). Strict lanes never walk either chain."
   },
   "lanes": {
     "rss": {

--- a/docs/backend-matrix.md
+++ b/docs/backend-matrix.md
@@ -33,8 +33,12 @@ lists backend selectors tried in order. At run time `scripts/select_backend.py`
 walks `[lane's backend] + chain` (deduplicated — a failed primary isn't
 retried from the chain), probes each candidate's provider (fireworks =
 preflight request, zai = Z.ai endpoint probe, claude = OAuth preflight),
-and runs the first available candidate. Claude 401/403 auth rejection or
-HTTP 429 rate limiting advances ordinary non-strict callers to Z.ai; the
+and runs the first available candidate. The Claude probe is auth-only:
+401/403 advances ordinary non-strict callers to Z.ai, while HTTP 429 keeps
+Claude selected (a healthy OAuth token answers the raw ping 429
+unconditionally — it is not a throttle signal). A real throttle surfaces as a
+Claude dead-start (is_error, ≤1 turn, $0) and `agent-run` then re-runs the
+selector with `--exclude-backend claude` over the same chain post-agent. The
 local digest, primary Twitter/repair, and no-MCP AI-news lanes explicitly
 override that chain with isolated Cursor because their inputs and exact commit
 contracts are adapter-compatible. Each lane declares `fallback_mode`; CI
@@ -111,8 +115,8 @@ Reading notes:
 | twitter-deepseek-pi (tier:deepseek-pi) | `hourly-twitter.yml` | pi · run-pi-container (CI-enforced mirror) | fireworks (pi built-in) | `accounts/fireworks/models/deepseek-v4-flash` | `FIREWORKS_API_KEY` | — |
 | twitter-fireworks-pi (tier:fireworks-pi) | `hourly-twitter.yml` | pi · run-pi-container (CI-enforced mirror) | fireworks (pi built-in) | `accounts/fireworks/models/kimi-k2p7` | `FIREWORKS_API_KEY` | — |
 | twitter-judge (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `zai-glm-5p2` |
-| twitter-primary (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `cursor-grok-4p6-fast`; then `deterministic_twitter_digest.py` |
-| twitter-primary-repair (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `claude-opus-5` | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `cursor-grok-4p6-fast` |
+| twitter-primary (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `${{ steps.backend.outputs.native_model }}` (workflow `native-model` override) | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `cursor-grok-4p6-fast`; then `deterministic_twitter_digest.py` |
+| twitter-primary-repair (tier:claude) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | Claude | `${{ steps.backend.outputs.native_model }}` (workflow `native-model` override) | `CLAUDE_CODE_OAUTH_TOKEN` | chain: `cursor-grok-4p6-fast` |
 | twitter-zai (tier:zai-glm-5p2) | `hourly-twitter.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Z.ai | `glm-5.2` | `ZAI_API_KEY` | hard fail (strict — never walks the chain) |
 | wiki-ingest (route:research-editorial-secondary) | `wiki-ingest.yml` | agent-dispatch → Cursor CLI (runtime SSOT) | Grok 4.6 Fast via Cursor CLI | `cursor-grok-4.6-high-fast` | `CURSOR_API_KEY` | hard fail (route fallback=none) |
 | zai-canary · PINNED | `zai-claude-code-canary.yml` | Claude Code · agent-run (runtime SSOT) | GLM 5.2 via Z.ai | `glm-5.2` | `ZAI_API_KEY` | hard fail (strict — never walks the chain) |

--- a/scripts/classify_claude_execution.py
+++ b/scripts/classify_claude_execution.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Classify how a native Claude Code agent step ended, for post-agent fallback.
+
+`.github/actions/agent-run` cannot learn from the pre-agent OAuth probe
+whether Claude can serve a run: a healthy Claude Code OAuth token answers
+the raw 1-token ping with HTTP 429 unconditionally, so 429 there carries no
+information (see scripts/select_backend.py). The reliable signal is the
+agent step itself. This helper reads the claude-code-action execution
+transcript and answers one question: did Claude die BEFORE doing any work?
+
+Outcomes
+  success    a `result` object with is_error false.
+  dead-start is_error true AND num_turns <= 1 AND total_cost_usd == 0 —
+             the signature of a throttled or rejected credential (the
+             2026-07-24 expired-token outage and the 2026-08-28 usage-limit
+             hits both look exactly like this). Nothing was written, so the
+             caller may hand the SAME prompt to the next backend in the
+             chain from a clean checkout.
+  failed     is_error true after real work (turns > 1 or cost > 0). The
+             checkout may hold partial edits; NOT safe to re-run elsewhere.
+  unknown    no `result` object (transcript missing/empty/truncated).
+
+Only `dead-start` is a fallback trigger. `failed` and `unknown` are surfaced
+as errors so a real agent failure stays red instead of being papered over
+by a fallback that would double-spend and could mix two models' output.
+
+STDLIB ONLY — runs on bare python3 on the runner. Exit code is always 0
+(classification is data; the action decides), except 2 for bad arguments.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from summarize_claude_execution import parse_objects, redact, summarize  # noqa: E402
+
+DEAD_START_MAX_TURNS = 1
+MAX_REASON_CHARS = 400
+
+
+def _as_int(value: Any, default: int) -> int:
+    if isinstance(value, bool):
+        return default
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    if isinstance(value, str) and value.strip().isdigit():
+        return int(value.strip())
+    return default
+
+
+def _as_float(value: Any, default: float) -> float:
+    if isinstance(value, bool):
+        return default
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value.strip())
+        except ValueError:
+            return default
+    return default
+
+
+def classify(objects: list[dict[str, Any]]) -> dict[str, Any]:
+    result_obj = None
+    for obj in objects:
+        if obj.get("type") == "result":
+            result_obj = obj  # keep the LAST result object
+    if result_obj is None:
+        return {"outcome": "unknown", "reason": "no result object in transcript",
+                "num_turns": None, "total_cost_usd": None, "error_status": None}
+
+    is_error = result_obj.get("is_error") is True
+    num_turns = _as_int(result_obj.get("num_turns"), default=0)
+    cost = _as_float(result_obj.get("total_cost_usd"), default=0.0)
+    summary = summarize(objects)
+    status = summary.get("status")
+    message = summary.get("message") or ""
+    if not message and isinstance(result_obj.get("result"), str):
+        message = redact(result_obj["result"])
+    if len(message) > MAX_REASON_CHARS:
+        message = message[: MAX_REASON_CHARS - 1] + "..."
+
+    if not is_error:
+        outcome, reason = "success", f"{num_turns} turn(s), ${cost:.4f}"
+    elif num_turns <= DEAD_START_MAX_TURNS and cost == 0:
+        outcome = "dead-start"
+        reason = (f"Claude died before doing work (is_error, {num_turns} turn(s), $0"
+                  + (f", API status {status}" if status else "") + ")"
+                  + (f": {message}" if message else ""))
+    else:
+        outcome = "failed"
+        reason = (f"Claude failed after real work ({num_turns} turn(s), ${cost:.4f}"
+                  + (f", API status {status}" if status else "") + ")"
+                  + (f": {message}" if message else ""))
+    return {"outcome": outcome, "reason": reason, "num_turns": num_turns,
+            "total_cost_usd": cost, "error_status": status}
+
+
+def classify_file(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {"outcome": "unknown", "reason": f"execution transcript not found: {path}",
+                "num_turns": None, "total_cost_usd": None, "error_status": None}
+    try:
+        text = path.read_text(errors="replace")
+    except OSError as exc:
+        return {"outcome": "unknown", "reason": f"cannot read transcript: {exc}",
+                "num_turns": None, "total_cost_usd": None, "error_status": None}
+    return classify(parse_objects(text))
+
+
+def write_github_output(path: Path, verdict: dict[str, Any]) -> None:
+    def one_line(value: Any) -> str:
+        return " ".join(str(value if value is not None else "").splitlines())
+    with path.open("a") as handle:
+        handle.write(f"outcome={one_line(verdict['outcome'])}\n")
+        handle.write(f"reason={one_line(verdict['reason'])}\n")
+        handle.write(f"num_turns={one_line(verdict['num_turns'])}\n")
+        handle.write(f"total_cost_usd={one_line(verdict['total_cost_usd'])}\n")
+        handle.write(f"error_status={one_line(verdict['error_status'])}\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("execution_file", type=Path, nargs="?",
+                        help="claude-code-action execution transcript (JSONL / JSON)")
+    parser.add_argument("--github-output", type=Path)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.execution_file is None:
+        verdict = {"outcome": "unknown", "reason": "no execution transcript path given",
+                   "num_turns": None, "total_cost_usd": None, "error_status": None}
+    else:
+        verdict = classify_file(args.execution_file)
+
+    if args.github_output:
+        write_github_output(args.github_output, verdict)
+    if args.json:
+        print(json.dumps(verdict, separators=(",", ":")))
+    else:
+        print(f"claude outcome: {verdict['outcome']} — {verdict['reason']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/select_backend.py
+++ b/scripts/select_backend.py
@@ -14,8 +14,8 @@ cross-adapter fallback; the global chain remains agent-run-native.
 Probes: fireworks → tiny /v1/messages preflight (reuses
 check_fireworks_backend); zai → same-shape probe against the Z.ai
 Anthropic-compatible endpoint; claude → OAuth-token preflight against
-api.anthropic.com that is UNAVAILABLE on an explicit credential rejection
-(401/403) or a run-scoped rate limit (429), and available on anything else;
+api.anthropic.com that is UNAVAILABLE only on an explicit credential
+rejection (401/403) and available on anything else — INCLUDING 429;
 opencode-go and Cursor are available when their isolated-adapter credentials
 are configured; their containers own the runtime provider call.
 
@@ -23,13 +23,28 @@ Why the claude probe is auth-only (2026-07-24 incident): this probe used
 to hardcode "always available", so when CLAUDE_CODE_OAUTH_TOKEN expired
 every agent lane in the fleet died instantly (is_error, 1 turn, $0) with
 no route out — the chain could not move past a backend it always believed
-was up. A 429 proves the credential is alive but also proves Claude cannot
-serve this run, so compatibility-tested local-content lanes can continue
-through an explicit isolated-adapter override. Other lanes retain the global
-chain. The probe remains
-deliberately narrow for 400, 5xx, and network faults: those inconclusive
-responses keep the existing fail-open behavior rather than broadening the
-reroute policy.
+was up.
+
+Why 429 is NOT "down" (2026-08-30..09-06 incident): a healthy Claude Code
+OAuth subscription token answers this raw 1-token /v1/messages ping with
+`429 rate_limit_error "Error"` EVERY time — it is the steady-state answer,
+not a throttle signal. PR #3333 classified it as unavailable and the whole
+Claude fleet silently ran on the Cursor fallback for a week while the same
+token served 121-turn generative-research runs. A real throttle looks
+identical here, so this preflight cannot tell them apart; instead
+`.github/actions/agent-run` lets the Claude step run, classifies a
+dead-start failure (is_error, ≤1 turn, $0) with
+`scripts/classify_claude_execution.py`, and re-invokes this selector with
+`--exclude-backend claude` to walk the SAME lane/global chain post-agent.
+The probe remains deliberately narrow for 400, 5xx, and network faults:
+those inconclusive responses keep the fail-open behavior rather than
+broadening the reroute policy.
+
+`--exclude-backend <selector>` (repeatable) marks a candidate unavailable
+without probing — the post-agent reselection path. Chain order, strictness,
+lane-override and production-eligibility rules are identical to the first
+selection, so a strict lane still fails closed and a lane override still
+never continues into the global chain.
 
 Strictness: `--fallback-policy none` or a lane with `"strict": true`
 disables the chain — the requested backend is the only candidate and its
@@ -126,7 +141,7 @@ def probe_zai(model: str) -> tuple[bool, str]:
 
 
 def probe_claude(model: str) -> tuple[bool, str]:
-    """Report Claude down on auth rejection or a run-scoped rate limit.
+    """Report Claude down ONLY on an explicit credential rejection.
 
     The Claude Code OAuth token authenticates with `authorization: Bearer`
     plus the oauth beta header. It must NOT be sent as `x-api-key` — the
@@ -135,11 +150,15 @@ def probe_claude(model: str) -> tuple[bool, str]:
     how a naive reuse of request_preflight() would strand the whole fleet
     on the fallback backend. Hence a dedicated request here.
 
-    A 429 means the credential is alive, but availability is the ability to
-    serve this run, not merely authenticate. Non-strict callers should walk
-    to Z.ai instead of selecting a Claude path known to be throttled. Only
-    401/403 and 429 are classified unavailable; 400, 5xx, and network faults
-    retain the existing fail-open behavior because this narrow preflight does
+    HTTP 429 is UP. A healthy subscription token answers this raw ping with
+    `429 rate_limit_error` unconditionally (verified 2026-08-28 and
+    2026-09-06 against tokens that were serving real runs at the same
+    moment), so 429 carries no information about whether Claude can serve
+    the run. Treating it as down reroutes a healthy fleet off Claude
+    permanently (the 2026-08-30..09-06 incident). Real throttles are
+    detected AFTER the agent step by scripts/classify_claude_execution.py
+    and handled by re-running this selector with `--exclude-backend claude`.
+    400, 5xx, and network faults also stay fail-open: this preflight does
     not prove the full Claude Code path is unavailable in those cases.
     """
     token = os.environ.get("CLAUDE_CODE_OAUTH_TOKEN", "").strip()
@@ -155,7 +174,10 @@ def probe_claude(model: str) -> tuple[bool, str]:
     if status in (401, 403):
         return False, f"HTTP {status}: {extract_message(status, body)}"
     if status == 429:
-        return False, f"HTTP 429: rate limited for this run: {extract_message(status, body)}"
+        # Steady-state answer for a healthy OAuth token — NOT a throttle
+        # signal (see docstring). Real throttles surface post-agent.
+        return True, ("native path (claude-code-action OAuth; probe HTTP 429 is the "
+                      "steady-state answer for a live OAuth token, not a throttle)")
     return True, f"native path (claude-code-action OAuth; probe HTTP {status})"
 
 
@@ -224,6 +246,11 @@ def main_with_args(argv: list[str] | None = None) -> int:
                         choices=["claude", "none"],
                         help="claude = walk the SSOT fallback chain; none = strict")
     parser.add_argument("--native-model-override", default="")
+    parser.add_argument("--exclude-backend", action="append", default=[],
+                        metavar="SELECTOR",
+                        help="mark this backend unavailable without probing "
+                             "(post-agent reselection after an agent-time failure); "
+                             "repeatable")
     parser.add_argument("--file", type=Path, default=DEFAULT_FILE)
     parser.add_argument("--github-output", type=Path)
     args = parser.parse_args(argv)
@@ -350,6 +377,13 @@ def main_with_args(argv: list[str] | None = None) -> int:
                 f"binding for provider '{provider}'"
             )
 
+    excluded: set[str] = set()
+    for selector in args.exclude_backend:
+        key = normalize(str(selector), backends)
+        if key is None:
+            return config_error(f"--exclude-backend '{selector}' is not in the backends table")
+        excluded.add(key)
+
     chosen = None
     for key in candidates:
         spec = backends[key]
@@ -357,7 +391,11 @@ def main_with_args(argv: list[str] | None = None) -> int:
         probe = PROBES.get(provider)
         if probe is None:
             return config_error(f"backend '{key}' has unknown provider '{provider}'")
-        available, reason = probe(str(spec.get("model", "")))
+        if key in excluded:
+            available, reason = False, ("excluded: failed at agent time "
+                                        "(post-agent reselection)")
+        else:
+            available, reason = probe(str(spec.get("model", "")))
         marker = "available" if available else "UNAVAILABLE"
         print(f"candidate {key} ({provider}): {marker} — {reason}")
         if available:
@@ -378,7 +416,8 @@ def main_with_args(argv: list[str] | None = None) -> int:
         return config_error("fallback.native_model is not set in data/agent-backends.json")
     used_fallback = chosen != requested
     if used_fallback:
-        print(f"::warning::requested backend '{requested}' unavailable; "
+        how = ("failed at agent time" if requested in excluded else "unavailable")
+        print(f"::warning::requested backend '{requested}' {how}; "
               f"selected '{chosen}' from the SSOT fallback chain.")
 
     write_outputs(args.github_output, {
@@ -390,6 +429,7 @@ def main_with_args(argv: list[str] | None = None) -> int:
         "display-name": str(spec.get("display_name", chosen)),
         "native-model": native_model,
         "used-fallback": str(used_fallback).lower(),
+        "reselected": str(bool(excluded)).lower(),
     })
     print(f"Selected backend: {spec.get('display_name', chosen)} "
           f"(requested {requested}{', fell back' if used_fallback else ''})")

--- a/scripts/summarize_claude_execution.py
+++ b/scripts/summarize_claude_execution.py
@@ -23,7 +23,14 @@ MAX_MESSAGE_CHARS = 500
 
 
 def parse_objects(text: str) -> list[dict[str, Any]]:
-    """Parse JSONL or concatenated JSON objects."""
+    """Parse the claude-code-action execution transcript.
+
+    The pinned action writes ONE pretty-printed JSON array
+    (`JSON.stringify(messages, null, 2)` in base-action/src/execution-file.ts),
+    so a top-level list is expanded into its dict elements. JSONL and
+    concatenated JSON objects are accepted too, because older transcripts and
+    hand-written fixtures use those shapes. Anything else is skipped.
+    """
     objects: list[dict[str, Any]] = []
     decoder = json.JSONDecoder()
     pos = 0
@@ -42,6 +49,8 @@ def parse_objects(text: str) -> list[dict[str, Any]]:
             continue
         if isinstance(obj, dict):
             objects.append(obj)
+        elif isinstance(obj, list):
+            objects.extend(item for item in obj if isinstance(item, dict))
         pos = end
     return objects
 

--- a/scripts/test_backend_matrix.py
+++ b/scripts/test_backend_matrix.py
@@ -502,6 +502,98 @@ class RoutingInvariants(unittest.TestCase):
         self.assertNotIn("run-opencode", execution_output)
         self.assertNotIn("run-cursor", execution_output)
 
+    def test_agent_run_post_agent_dead_start_fallback_contract(self):
+        """The 2026-08-30..09-06 incident fix: 429 no longer reroutes at the
+        probe, so a REAL throttle must be caught after the Claude step and
+        re-walk the same chain. Four invariants keep that from becoming a
+        swallow or a secret leak; preserve them if you edit agent-run."""
+        action = yaml.safe_load(
+            (REPO_ROOT / ".github/actions/agent-run/action.yml").read_text()
+        )
+        steps = action["runs"]["steps"]
+        by_id = {step.get("id"): step for step in steps if step.get("id")}
+
+        # (1) Both Claude steps are continue-on-error, else the classifier
+        # never runs; and the classifier re-raises anything but a dead-start.
+        for step_id in ("run-claude", "run-claude-bots"):
+            self.assertIs(True, by_id[step_id].get("continue-on-error"), step_id)
+        outcome = by_id["claude-outcome"]
+        self.assertEqual("steps.select.outputs.provider == 'claude'", outcome["if"])
+        self.assertIn("classify_claude_execution.py", outcome["run"])
+        self.assertIn('if [ "$outcome" = "dead-start" ]', outcome["run"])
+        self.assertIn("exit 1", outcome["run"],
+                      "a non-dead-start Claude failure must stay red")
+
+        # (2) Reselection is the SAME selector with claude excluded — same
+        # lane/global chain, strictness and eligibility rules — and it
+        # only fires on a dead-start.
+        reselect = by_id["reselect"]
+        self.assertEqual("steps.claude-outcome.outputs.dead-start == 'true'",
+                         reselect["if"])
+        self.assertIn("select_backend.py", reselect["run"])
+        self.assertIn("--exclude-backend claude", reselect["run"])
+        self.assertEqual("${{ inputs.fireworks-fallback }}",
+                         reselect["env"]["FALLBACK_POLICY"])
+
+        # (3) Fallback children are keyed on the RESELECT outputs and carry
+        # the same secret scoping as the primary isolated children.
+        opencode = by_id["run-opencode-fallback"]
+        cursor = by_id["run-cursor-fallback"]
+        self.assertEqual("./.github/actions/run-opencode-container", opencode["uses"])
+        self.assertEqual("./.github/actions/run-cursor-container", cursor["uses"])
+        self.assertEqual("steps.reselect.outputs.adapter == 'opencode'", opencode["if"])
+        self.assertEqual("steps.reselect.outputs.adapter == 'cursor'", cursor["if"])
+        for child in (opencode, cursor):
+            self.assertEqual("${{ inputs.prompt }}", child["with"]["prompt-text"])
+            self.assertEqual("${{ steps.isolated-contract-fallback.outputs.paths }}",
+                             child["with"]["allowed-paths"])
+            self.assertIn("steps.reselect.outputs.model-id", child["with"]["model"])
+            rendered = json.dumps(child, sort_keys=True)
+            for secret_input in ("claude-code-oauth-token", "fireworks-api-key",
+                                 "zai-api-key"):
+                self.assertNotIn(secret_input, rendered)
+        self.assertNotIn("cursor-api-key", json.dumps(opencode, sort_keys=True))
+        self.assertNotIn("opencode-api-key", json.dumps(cursor, sort_keys=True))
+        for step_id in ("run-zai-fallback", "run-zai-fallback-bots"):
+            zai = by_id[step_id]
+            self.assertIn("steps.reselect.outputs.provider == 'zai'", zai["if"])
+            self.assertEqual("${{ steps.reselect.outputs.model-id }}",
+                             zai["env"]["ANTHROPIC_MODEL"])
+
+        # (4) Outputs report the EFFECTIVE backend after reselection, and the
+        # execution-file output still never points at an isolated child.
+        outputs = action["outputs"]
+        for key in ("effective-backend", "used-fallback", "model-id"):
+            self.assertIn("steps.reselect.outputs", outputs[key]["value"], key)
+        self.assertIn("claude-dead-start", outputs)
+        execution_output = outputs["execution-file"]["value"]
+        self.assertIn("run-zai-fallback", execution_output)
+        self.assertNotIn("run-opencode", execution_output)
+        self.assertNotIn("run-cursor", execution_output)
+
+    def test_twitter_native_model_dispatch_input_reaches_agent_run(self):
+        """hourly-twitter's `native_model` input is the one-off model switch
+        (e.g. claude-fable-5-1). It must reach BOTH twitter-primary agent-run
+        calls, be validated, and be rejected off the Claude tier."""
+        workflow_path = REPO_ROOT / ".github/workflows/hourly-twitter.yml"
+        text = workflow_path.read_text()
+        workflow = yaml.safe_load(text)
+        inputs = workflow[True]["workflow_dispatch"]["inputs"]
+        self.assertEqual("", inputs["native_model"]["default"])
+        self.assertEqual("string", inputs["native_model"]["type"])
+        job = next(iter(workflow["jobs"].values()))
+        agent_runs = [step for step in job["steps"]
+                      if step.get("uses") == "./.github/actions/agent-run"
+                      and str((step.get("with") or {}).get("lane", "")).startswith("twitter-primary")]
+        self.assertEqual(2, len(agent_runs))
+        for step in agent_runs:
+            self.assertEqual("${{ steps.backend.outputs.native_model }}",
+                             step["with"]["native-model"], step["with"]["lane"])
+        resolve = next(step for step in job["steps"] if step.get("id") == "backend")
+        self.assertIn('[ "$BACKEND" != "claude" ]', resolve["run"])
+        self.assertIn("^claude-[a-z0-9][a-z0-9.-]*$", resolve["run"])
+        self.assertIn('echo "native_model=${NATIVE_MODEL}"', resolve["run"])
+
     def test_ai_news_mcp_cannot_select_cursor(self):
         mcp = self.lanes["ai-news-research-mcp"]
         self.assertEqual("claude-code-action", mcp["harness"])

--- a/scripts/test_backend_matrix.py
+++ b/scripts/test_backend_matrix.py
@@ -570,6 +570,15 @@ class RoutingInvariants(unittest.TestCase):
         self.assertIn("run-zai-fallback", execution_output)
         self.assertNotIn("run-opencode", execution_output)
         self.assertNotIn("run-cursor", execution_output)
+        # After a dead-start the failed Claude transcript still exists; when an
+        # ISOLATED adapter then served the run the output must be empty, not
+        # that stale path (review finding on PR #3698). The guard must precede
+        # the step chain so the whole `||` chain is short-circuited to ''.
+        guard = ("steps.reselect.outputs.adapter != 'opencode' && "
+                 "steps.reselect.outputs.adapter != 'cursor' && (")
+        self.assertTrue(execution_output.strip().startswith("${{ " + guard),
+                        execution_output)
+        self.assertTrue(execution_output.rstrip().endswith(") || '' }}"), execution_output)
 
     def test_twitter_native_model_dispatch_input_reaches_agent_run(self):
         """hourly-twitter's `native_model` input is the one-off model switch

--- a/scripts/test_classify_claude_execution.py
+++ b/scripts/test_classify_claude_execution.py
@@ -1,0 +1,93 @@
+"""Tests for scripts/classify_claude_execution.py — the post-agent signal
+that decides whether agent-run may hand the prompt to the next backend."""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import classify_claude_execution as cce
+
+
+def transcript(*objects):
+    return "\n".join(json.dumps(o) for o in objects)
+
+
+def result(**kw):
+    base = {"type": "result", "subtype": "success", "is_error": False,
+            "num_turns": 12, "total_cost_usd": 1.23, "result": "done"}
+    base.update(kw)
+    return base
+
+
+class ClassifyTest(unittest.TestCase):
+    def classify_text(self, text):
+        return cce.classify(cce.parse_objects(text))
+
+    def test_success(self):
+        v = self.classify_text(transcript({"type": "system"}, result()))
+        self.assertEqual("success", v["outcome"])
+        self.assertEqual(12, v["num_turns"])
+
+    def test_dead_start_signature_is_the_only_fallback_trigger(self):
+        # The 2026-07-24 expired-token and 2026-08-28 usage-limit shapes.
+        for turns in (0, 1):
+            with self.subTest(turns=turns):
+                v = self.classify_text(transcript(result(
+                    is_error=True, num_turns=turns, total_cost_usd=0,
+                    result="API Error: 429 rate limit")))
+                self.assertEqual("dead-start", v["outcome"])
+                self.assertEqual(429, v["error_status"])
+                self.assertIn("429", v["reason"])
+
+    def test_failure_after_real_work_is_not_dead_start(self):
+        # Partial edits may sit in the checkout: a fallback here would
+        # double-spend and could mix two models' output.
+        for kw in ({"num_turns": 5, "total_cost_usd": 0},
+                   {"num_turns": 1, "total_cost_usd": 0.02},
+                   {"num_turns": 121, "total_cost_usd": 15.76}):
+            with self.subTest(**kw):
+                v = self.classify_text(transcript(result(is_error=True, **kw)))
+                self.assertEqual("failed", v["outcome"])
+
+    def test_missing_result_object_is_unknown(self):
+        v = self.classify_text(transcript({"type": "system"}, {"type": "assistant"}))
+        self.assertEqual("unknown", v["outcome"])
+        v = self.classify_text("")
+        self.assertEqual("unknown", v["outcome"])
+
+    def test_last_result_object_wins(self):
+        v = self.classify_text(transcript(
+            result(is_error=True, num_turns=1, total_cost_usd=0), result()))
+        self.assertEqual("success", v["outcome"])
+
+    def test_missing_file_is_unknown_not_crash(self):
+        v = cce.classify_file(Path("/nonexistent/exec.json"))
+        self.assertEqual("unknown", v["outcome"])
+
+    def test_string_numbers_and_redaction(self):
+        v = self.classify_text(transcript(result(
+            is_error=True, num_turns="1", total_cost_usd="0",
+            result="Bearer abcdefghijklmnopqrstuvwxyz0123 rejected")))
+        self.assertEqual("dead-start", v["outcome"])
+        self.assertNotIn("abcdefghijklmnop", v["reason"])
+
+    def test_github_output_is_single_line_per_key(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            exec_file = Path(tmp) / "exec.jsonl"
+            exec_file.write_text(transcript(result(
+                is_error=True, num_turns=1, total_cost_usd=0,
+                result="line one\nline two")))
+            out = Path(tmp) / "out.txt"
+            out.write_text("")
+            self.assertEqual(0, cce.main([str(exec_file), "--github-output", str(out)]))
+            lines = out.read_text().splitlines()
+            keys = [line.split("=", 1)[0] for line in lines]
+            self.assertEqual(["outcome", "reason", "num_turns", "total_cost_usd",
+                              "error_status"], keys)
+            self.assertEqual("outcome=dead-start", lines[0])
+            self.assertNotIn("\n", lines[1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_classify_claude_execution.py
+++ b/scripts/test_classify_claude_execution.py
@@ -56,6 +56,21 @@ class ClassifyTest(unittest.TestCase):
         v = self.classify_text("")
         self.assertEqual("unknown", v["outcome"])
 
+    def test_real_action_transcript_is_a_pretty_printed_json_array(self):
+        """claude-code-action@a874e9e writes JSON.stringify(messages, null, 2):
+        ONE top-level array, not JSONL. A parser that only reads top-level
+        objects returns nothing and every dead-start becomes `unknown`, so
+        the fallback never fires (caught in review of PR #3698)."""
+        transcript_array = json.dumps([
+            {"type": "system", "subtype": "init"},
+            result(is_error=True, num_turns=1, total_cost_usd=0,
+                   result="API Error: 429 rate limit"),
+        ], indent=2)
+        v = self.classify_text(transcript_array)
+        self.assertEqual("dead-start", v["outcome"])
+        v = self.classify_text(json.dumps([{"type": "system"}, result()], indent=2))
+        self.assertEqual("success", v["outcome"])
+
     def test_last_result_object_wins(self):
         v = self.classify_text(transcript(
             result(is_error=True, num_turns=1, total_cost_usd=0), result()))

--- a/scripts/test_select_backend.py
+++ b/scripts/test_select_backend.py
@@ -118,7 +118,11 @@ class SelectBackendTest(unittest.TestCase):
         self.assertEqual(out["provider"], "zai")
         self.assertEqual(out["used-fallback"], "true")
 
-    def test_claude_429_uses_lane_local_cursor_instead_of_global_zai(self):
+    def test_claude_429_probe_keeps_claude_selected(self):
+        """Regression for the 2026-08-30..09-06 incident: a healthy OAuth
+        token answers the raw ping 429 unconditionally, so 429 must NOT
+        reroute — PR #3333 did, and the whole fleet ran on Cursor for a
+        week while the same token served real runs."""
         lanes = {
             "digest": {"workflow": "daily-digest.yml", "harness": "agent-run",
                        "backend": "claude",
@@ -129,16 +133,59 @@ class SelectBackendTest(unittest.TestCase):
                 os.environ, {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-oat01-test"}), \
                 unittest.mock.patch.object(
                     select_backend, "request_oauth_preflight",
-                    return_value=(429, '{"error":{"message":"rate limit exceeded"}}')):
+                    return_value=(429, '{"type":"error","error":{"type":"rate_limit_error","message":"Error"}}')):
             code, out, log = self.run_select(
                 "--lane", "digest", chain=("claude", "zai-glm-5p2"), lanes=lanes)
+
+        self.assertEqual(code, 0)
+        self.assertEqual(out["backend"], "claude")
+        self.assertEqual(out["used-fallback"], "false")
+        self.assertEqual(out["reselected"], "false")
+        self.assertIn("probe HTTP 429", log)
+        self.assertNotIn("candidate cursor-grok-4p6-fast", log)
+
+    def test_post_agent_exclude_uses_lane_local_cursor_instead_of_global_zai(self):
+        """The post-agent path: agent-run saw Claude dead-start and re-runs
+        the selector with --exclude-backend claude. Same chain semantics as
+        a probe failure — the lane override wins over the global chain."""
+        lanes = {
+            "digest": {"workflow": "daily-digest.yml", "harness": "agent-run",
+                       "backend": "claude",
+                       "fallback_chain": ["cursor-grok-4p6-fast"]},
+        }
+        self.set_availability(zai=True, cursor=True, claude=True)
+        code, out, log = self.run_select(
+            "--lane", "digest", "--exclude-backend", "claude",
+            chain=("claude", "zai-glm-5p2"), lanes=lanes)
 
         self.assertEqual(code, 0)
         self.assertEqual(out["backend"], "cursor-grok-4p6-fast")
         self.assertEqual(out["provider"], "cursor")
         self.assertEqual(out["adapter"], "cursor")
         self.assertEqual(out["used-fallback"], "true")
-        self.assertIn("rate limited for this run", log)
+        self.assertEqual(out["reselected"], "true")
+        self.assertIn("candidate claude (claude): UNAVAILABLE — excluded", log)
+        self.assertIn("failed at agent time", log)
+        self.assertNotIn("candidate zai-glm-5p2", log)
+
+    def test_exclude_never_probes_the_excluded_backend(self):
+        calls = []
+        select_backend.PROBES["claude"] = lambda model: calls.append(model) or (True, "x")
+        self.set_availability(zai=True)
+        code, out, _ = self.run_select(
+            "--lane", "rss", "--exclude-backend", "claude",
+            chain=("claude", "zai-glm-5p2"),
+            lanes={"rss": {"workflow": "hourly-rss.yml", "harness": "agent-run",
+                           "backend": "claude"}})
+        self.assertEqual(code, 0)
+        self.assertEqual(out["backend"], "zai-glm-5p2")
+        self.assertEqual(calls, [], "an excluded backend must not be probed")
+
+    def test_exclude_unknown_selector_is_config_error(self):
+        code, out, log = self.run_select("--lane", "rss", "--exclude-backend", "nope")
+        self.assertEqual(code, 2)
+        self.assertNotIn("backend", out)
+        self.assertIn("--exclude-backend 'nope'", log)
 
     def test_automated_lane_rejects_restricted_fallback_at_runtime(self):
         lanes = {
@@ -159,7 +206,7 @@ class SelectBackendTest(unittest.TestCase):
         self.assertIn("not production-eligible", log)
         self.assertIn("manual_only", log)
 
-    def test_twitter_primary_and_repair_use_cursor_on_claude_429(self):
+    def test_twitter_primary_and_repair_use_cursor_on_claude_dead_start(self):
         lanes = {
             lane: {
                 "workflow": "hourly-twitter.yml",
@@ -169,42 +216,32 @@ class SelectBackendTest(unittest.TestCase):
             }
             for lane in ("twitter-primary", "twitter-primary-repair")
         }
-        self.set_availability(zai=True, cursor=True)
-        with unittest.mock.patch.dict(
-                os.environ, {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-oat01-test"}), \
-                unittest.mock.patch.object(
-                    select_backend, "request_oauth_preflight",
-                    return_value=(429, '{"error":{"message":"rate limit exceeded"}}')):
-            for lane in lanes:
-                with self.subTest(lane=lane):
-                    code, out, log = self.run_select(
-                        "--lane", lane,
-                        chain=("claude", "zai-glm-5p2"), lanes=lanes)
-                    self.assertEqual(code, 0)
-                    self.assertEqual(out["backend"], "cursor-grok-4p6-fast")
-                    self.assertEqual(out["provider"], "cursor")
-                    self.assertEqual(out["used-fallback"], "true")
-                    self.assertIn("rate limited for this run", log)
+        self.set_availability(zai=True, cursor=True, claude=True)
+        for lane in lanes:
+            with self.subTest(lane=lane):
+                code, out, log = self.run_select(
+                    "--lane", lane, "--exclude-backend", "claude",
+                    chain=("claude", "zai-glm-5p2"), lanes=lanes)
+                self.assertEqual(code, 0)
+                self.assertEqual(out["backend"], "cursor-grok-4p6-fast")
+                self.assertEqual(out["provider"], "cursor")
+                self.assertEqual(out["used-fallback"], "true")
+                self.assertIn("failed at agent time", log)
 
-    def test_claude_429_does_not_cross_strict_lane_boundary(self):
+    def test_claude_dead_start_does_not_cross_strict_lane_boundary(self):
         lanes = {
             "digest": {"workflow": "daily-digest.yml", "harness": "agent-run",
                        "backend": "claude",
                        "fallback_chain": ["cursor-grok-4p6-fast"]},
         }
-        self.set_availability(zai=True, cursor=True)
-        with unittest.mock.patch.dict(
-                os.environ, {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-oat01-test"}), \
-                unittest.mock.patch.object(
-                    select_backend, "request_oauth_preflight",
-                    return_value=(429, '{"error":{"message":"rate limit exceeded"}}')):
-            code, out, log = self.run_select(
-                "--lane", "digest", "--fallback-policy", "none",
-                chain=("claude", "zai-glm-5p2"), lanes=lanes)
+        self.set_availability(zai=True, cursor=True, claude=True)
+        code, out, log = self.run_select(
+            "--lane", "digest", "--fallback-policy", "none", "--exclude-backend", "claude",
+            chain=("claude", "zai-glm-5p2"), lanes=lanes)
 
         self.assertEqual(code, 1)
         self.assertNotIn("backend", out)
-        self.assertIn("rate limited for this run", log)
+        self.assertIn("excluded", log)
         self.assertNotIn("candidate cursor-grok-4p6-fast", log)
         self.assertNotIn("candidate zai-glm-5p2", log)
 
@@ -214,13 +251,10 @@ class SelectBackendTest(unittest.TestCase):
                        "backend": "claude",
                        "fallback_chain": ["cursor-grok-4p6-fast"]},
         }
-        self.set_availability(zai=True, cursor=False)
-        with unittest.mock.patch.dict(
-                os.environ, {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-oat01-test"}), \
-                unittest.mock.patch.object(
-                    select_backend, "request_oauth_preflight", return_value=(429, "{}")):
-            code, out, log = self.run_select(
-                "--lane", "digest", chain=("claude", "zai-glm-5p2"), lanes=lanes)
+        self.set_availability(zai=True, cursor=False, claude=True)
+        code, out, log = self.run_select(
+            "--lane", "digest", "--exclude-backend", "claude",
+            chain=("claude", "zai-glm-5p2"), lanes=lanes)
 
         self.assertEqual(code, 1)
         self.assertNotIn("backend", out)
@@ -322,8 +356,10 @@ class ProbeClaudeTest(unittest.TestCase):
     probe_claude used to hardcode "always available", so an expired
     CLAUDE_CODE_OAUTH_TOKEN killed every agent lane with no route out.
     The replacement must be sharp in BOTH directions: down on a real
-    credential rejection or a run-scoped 429, without broadening other
-    inconclusive failures into reroutes.
+    credential rejection, up on everything else — INCLUDING 429, which is
+    the steady-state answer a healthy OAuth token gives this raw ping
+    (2026-08-30..09-06 incident: classifying it as down rerouted the whole
+    fleet). Real throttles are detected post-agent, not here.
     """
 
     def setUp(self):
@@ -345,11 +381,14 @@ class ProbeClaudeTest(unittest.TestCase):
                 self.assertFalse(available)
                 self.assertIn(str(status), reason)
 
-    def test_rate_limit_marks_claude_unavailable_for_this_run(self):
-        self.stub(429, '{"error":{"message":"rate limit exceeded"}}')
+    def test_steady_state_429_keeps_claude_up(self):
+        # Exact body a live Max-plan token returned on 2026-09-06 while it
+        # was serving real runs. Down here == fleet permanently off Claude.
+        self.stub(429, '{"type":"error","error":{"type":"rate_limit_error","message":"Error"}}')
         available, reason = select_backend.probe_claude("claude-sonnet-5")
-        self.assertFalse(available)
-        self.assertIn("rate limited for this run", reason)
+        self.assertTrue(available, "429 is not evidence Claude cannot serve the run")
+        self.assertIn("429", reason)
+        self.assertIn("steady-state", reason)
 
     def test_healthy_and_inconclusive_non_auth_failures_keep_claude_up(self):
         # Preserve the old narrow behavior for shapes this preflight cannot


### PR DESCRIPTION
## Problem

Since #3333 (2026-08-30) `probe_claude` classified HTTP 429 as unavailable. A healthy Claude Code OAuth token answers the probe's raw 1-token `/v1/messages` ping with `429 rate_limit_error "Error"` **every time** (reproduced 2026-09-06 with a Max token that was serving a live session; the same repo token ran a 121-turn / $15.76 generative-research job on 09-04 while the probe said 429). Result: every agent-run lane rerouted to `cursor-grok-4p6-fast` for a week with green runs and fresh files; `24h-model-timeline` had no backend at all (Z.ai `Insufficient balance`) and published six days of "No change today" fallbacks.

## Change

- **Probe is auth-only again.** 401/403 = down; 429 = up, with an explicit steady-state reason in the log.
- **Real throttles are caught after the agent step.** `agent-run` runs the Claude step with `continue-on-error`, classifies the transcript with the new `scripts/classify_claude_execution.py`, and only on a **dead-start** (`is_error`, ≤1 turn, $0 — the 2026-07-24 / 2026-08-28 signature) re-runs `select_backend.py --exclude-backend claude` over the *same* lane/global chain and hands the same prompt to that candidate (Cursor / OpenCode / Z.ai runners). A failure after real work is re-raised, never retried elsewhere. Strict lanes still fail closed. New outputs: `claude-dead-start`; `effective-backend` / `used-fallback` / `model-id` reflect the reselection.
- **`hourly-twitter.yml` gets a `native_model` dispatch input** (Claude tier only, regex-validated, rejected on other tiers) wired to `agent-run`'s `native-model` on both `twitter-primary*` calls — a one-off `claude-fable-5-1` patrol needs no routing edit.
- SSOT notes, `docs/backend-matrix.md`, CLAUDE.md rule 14(b) updated; tests for all of the above.

## Verification

- `uv run python -m unittest discover -s scripts -p 'test_*.py'` — 1042 passed, 6 skipped
- `uv run python scripts/build_backend_matrix.py --check` — in sync
- `actionlint` — only pre-existing shellcheck infos in untouched files
- Follow-up after merge: dispatch `hourly-twitter.yml` with `backend=claude native_model=claude-fable-5-1` and report cost/quality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2FYb2zupuW9VBdnTFjz3Y
