### PR TITLE
Twitter registry: Cohere renamed its handle to @cohere

### DIFF
--- a/data/sources/twitter_accounts.json
+++ b/data/sources/twitter_accounts.json
@@ -36,7 +36,7 @@
           "notes": "Real Meta AI account; @MetaAI is largely inactive."
         },
         {
-          "handle": "CohereAI",
+          "handle": "cohere",
           "name": "Cohere"
         },
         {


### PR DESCRIPTION
@CohereAI returns `User not found` on every hourly-twitter multi-fetch since the account was renamed; `@cohere` serves the same account (verified with `birdy user-tweets cohere -n 1` on 2026-09-06). Found while auditing birdy multi-fetch failures. `curate_twitter_accounts.py validate` and its tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2FYb2zupuW9VBdnTFjz3Y