### PR TITLE
Pin birdy v1.2.0; surface multi-fetch _report.json in all.json meta

### DIFF
--- a/.github/actions/install-birdy/action.yml
+++ b/.github/actions/install-birdy/action.yml
@@ -19,7 +19,7 @@ inputs:
       Audited release tag to install. The default is pinned in
       data/toolchain-pins.json; an override must also provide sha256.
     required: false
-    default: v1.1.0
+    default: v1.2.0
   sha256:
     description: Optional SHA-256 for a non-default version override.
     required: false

--- a/.github/actions/run-cursor-container/action.yml
+++ b/.github/actions/run-cursor-container/action.yml
@@ -606,11 +606,11 @@ runs:
         RUN set -eux; \
           arch="$(dpkg --print-architecture)"; \
           case "$arch" in \
-            amd64) a=amd64; sha=001763ea3c9063f97980a912afa8d2b43ca2a949ea9cf3ab323b4d0f21421fb4 ;; \
-            arm64) a=arm64; sha=ac0f68274aa8a76ee0b015c776b0922303c03fe29c691477b49eb10e97231c94 ;; \
+            amd64) a=amd64; sha=e6ba33c9b0934d7d0fe26fd2bca02b25f713614b40770f611e4de6c17b05ba41 ;; \
+            arm64) a=arm64; sha=e8a19d16aefc8c83b929ce10d389b0cee93cadc23629f635c695c10a01ec35c9 ;; \
             *) echo "unsupported arch $arch" >&2; exit 1 ;; \
           esac; \
-          curl -fsSL "https://github.com/guzus/birdy/releases/download/v1.1.0/birdy_linux_${a}.tar.gz" -o /tmp/birdy.tgz; \
+          curl -fsSL "https://github.com/guzus/birdy/releases/download/v1.2.0/birdy_linux_${a}.tar.gz" -o /tmp/birdy.tgz; \
           echo "$sha  /tmp/birdy.tgz" | sha256sum -c -; \
           tar -xzf /tmp/birdy.tgz -C /tmp; \
           install -m 755 /tmp/birdy /usr/local/bin/birdy; \

--- a/.github/actions/run-opencode-container/action.yml
+++ b/.github/actions/run-opencode-container/action.yml
@@ -606,11 +606,11 @@ runs:
         RUN set -eux; \
           arch="$(dpkg --print-architecture)"; \
           case "$arch" in \
-            amd64) a=amd64; sha=001763ea3c9063f97980a912afa8d2b43ca2a949ea9cf3ab323b4d0f21421fb4 ;; \
-            arm64) a=arm64; sha=ac0f68274aa8a76ee0b015c776b0922303c03fe29c691477b49eb10e97231c94 ;; \
+            amd64) a=amd64; sha=e6ba33c9b0934d7d0fe26fd2bca02b25f713614b40770f611e4de6c17b05ba41 ;; \
+            arm64) a=arm64; sha=e8a19d16aefc8c83b929ce10d389b0cee93cadc23629f635c695c10a01ec35c9 ;; \
             *) echo "unsupported arch $arch" >&2; exit 1 ;; \
           esac; \
-          curl -fsSL "https://github.com/guzus/birdy/releases/download/v1.1.0/birdy_linux_${a}.tar.gz" -o /tmp/birdy.tgz; \
+          curl -fsSL "https://github.com/guzus/birdy/releases/download/v1.2.0/birdy_linux_${a}.tar.gz" -o /tmp/birdy.tgz; \
           echo "$sha  /tmp/birdy.tgz" | sha256sum -c -; \
           tar -xzf /tmp/birdy.tgz -C /tmp; \
           install -m 755 /tmp/birdy /usr/local/bin/birdy; \

--- a/.github/actions/run-pi-container/action.yml
+++ b/.github/actions/run-pi-container/action.yml
@@ -78,11 +78,11 @@ runs:
         RUN set -eux; \
           arch="$(dpkg --print-architecture)"; \
           case "$arch" in \
-            amd64) a=amd64; sha=001763ea3c9063f97980a912afa8d2b43ca2a949ea9cf3ab323b4d0f21421fb4 ;; \
-            arm64) a=arm64; sha=ac0f68274aa8a76ee0b015c776b0922303c03fe29c691477b49eb10e97231c94 ;; \
+            amd64) a=amd64; sha=e6ba33c9b0934d7d0fe26fd2bca02b25f713614b40770f611e4de6c17b05ba41 ;; \
+            arm64) a=arm64; sha=e8a19d16aefc8c83b929ce10d389b0cee93cadc23629f635c695c10a01ec35c9 ;; \
             *) echo "unsupported arch $arch" >&2; exit 1 ;; \
           esac; \
-          curl -fsSL "https://github.com/guzus/birdy/releases/download/v1.1.0/birdy_linux_${a}.tar.gz" -o /tmp/birdy.tgz; \
+          curl -fsSL "https://github.com/guzus/birdy/releases/download/v1.2.0/birdy_linux_${a}.tar.gz" -o /tmp/birdy.tgz; \
           echo "$sha  /tmp/birdy.tgz" | sha256sum -c -; \
           tar -xzf /tmp/birdy.tgz -C /tmp; \
           install -m 755 /tmp/birdy /usr/local/bin/birdy; \

--- a/.github/actions/twitter-fetch/action.yml
+++ b/.github/actions/twitter-fetch/action.yml
@@ -247,8 +247,19 @@ runs:
         total = 0
         non_empty_accounts = 0
 
+        # birdy >= 1.2 writes <output-dir>/_report.json (per-op status) beside
+        # the op files; it is metadata, never an account. Surface it so the
+        # agent can tell "quiet handle" from "not fetched (429 / dead handle)".
+        fetch_report = None
+        report_path = bird / "_report.json"
+        if report_path.exists():
+            try:
+                fetch_report = json.loads(report_path.read_text())
+            except Exception as exc:
+                print(f"warning: unreadable _report.json: {exc}")
+
         for f in sorted(bird.glob("*.json")):
-            if f.name in ("all.json", "manifest.json"):
+            if f.name in ("all.json", "manifest.json") or f.name.startswith("_"):
                 continue
             try:
                 data = json.loads(f.read_text() or "[]")
@@ -282,10 +293,35 @@ runs:
                 "generated_at": datetime.now(timezone.utc).isoformat(),
             },
         }
+        if isinstance(fetch_report, dict):
+            ops = fetch_report.get("ops") or []
+            by_status = {}
+            for op in ops:
+                if isinstance(op, dict) and op.get("status") and op.get("status") != "ok":
+                    by_status.setdefault(op["status"], []).append(op.get("id"))
+            out["meta"]["fetch"] = {
+                "summary": fetch_report.get("summary") or {},
+                # Handles that were NOT read this run. An empty array under
+                # accounts[<handle>] for one of these means "unfetched", not
+                # "posted nothing" — the agent must not treat it as silence.
+                "unfetched_accounts": sorted(
+                    op.get("id") for op in ops
+                    if isinstance(op, dict) and not op.get("ok")
+                    and not str(op.get("id", "")).startswith("search-")
+                    and op.get("id") != "news"
+                ),
+                "ops_by_status": {k: sorted(v) for k, v in sorted(by_status.items())},
+            }
         (bird / "all.json").write_text(json.dumps(out, separators=(",", ":")))
+        fetch_note = ""
+        if "fetch" in out["meta"]:
+            fs = out["meta"]["fetch"]["summary"]
+            fetch_note = (f"; fetch: {fs.get('failed', 0)} failed "
+                          f"({fs.get('rate_limited', 0)} rate_limited, {fs.get('not_found', 0)} not_found), "
+                          f"{fs.get('retried', 0)} retried")
         print(f"Aggregated: {len(accounts)} accounts ({non_empty_accounts} non-empty), "
               f"{len(searches)} searches, {len(news)} news items, "
-              f"{total} tweets total")
+              f"{total} tweets total{fetch_note}")
         '
         echo "all.json size: $(wc -c < /tmp/bird/all.json) bytes"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -575,6 +575,16 @@ output or break the pipeline. Read them before editing.
    looked self-sufficient and were not), and birdy falls back to `bird` when
    its native path fails — with bird absent that surfaces as
    `bird CLI not found` where the real cause is usually a rate limit.
+   **Since birdy v1.2.0 (pinned 2026-09-06) `multi-fetch` runs every op
+   natively in-process** — it no longer needs a bird binary at all — retries
+   a rate-limited op once on a non-cooling account, and writes
+   `<output-dir>/_report.json` (per-op `status`: ok | rate_limited |
+   not_found | timeout | error). `twitter-fetch` folds that into
+   `all.json` as `meta.fetch` (`summary`, `unfetched_accounts`,
+   `ops_by_status`): an empty `accounts[<handle>]` listed under
+   `unfetched_accounts` means "not read this run", never "posted nothing".
+   Before 1.2.0 every run silently lost 7-42 of 127 ops to X 429s (the same
+   ~13 tail handles each time) with a green job.
 
 7. **Improvement logs belong in `docs/archive/YYYY-MM-DD-improvements.md`,**
    not repo root. The improve loop runs weekly on Mondays and auto-closes

--- a/data/toolchain-pins.json
+++ b/data/toolchain-pins.json
@@ -14,12 +14,12 @@
     "anthropics/claude-code-action": {"version": "v1", "sha": "a874e9ecd7bb36efdad65429c6b35815f5a08f10"}
   },
   "birdy": {
-    "version": "v1.1.0",
+    "version": "v1.2.0",
     "sha256": {
-      "darwin_amd64": "350c50306fa30705c01141ba195df1805021821e9e60a2a01bb9e162576282cf",
-      "darwin_arm64": "64708f03ef3ade019784a20328b4a8c8ac5a80325538f584d945e2e64d3181aa",
-      "linux_amd64": "001763ea3c9063f97980a912afa8d2b43ca2a949ea9cf3ab323b4d0f21421fb4",
-      "linux_arm64": "ac0f68274aa8a76ee0b015c776b0922303c03fe29c691477b49eb10e97231c94"
+      "darwin_amd64": "a3b16873aba5bd576d6e7b670a613f3a86c76fe168384a471a7016604a0277e6",
+      "darwin_arm64": "d920dc782a4ba24761729619b6849120009c958e48b19979c41944ed59bb1c86",
+      "linux_amd64": "e6ba33c9b0934d7d0fe26fd2bca02b25f713614b40770f611e4de6c17b05ba41",
+      "linux_arm64": "e8a19d16aefc8c83b929ce10d389b0cee93cadc23629f635c695c10a01ec35c9"
     }
   },
   "cursor_agent": {

--- a/docs/toolchain-pins.md
+++ b/docs/toolchain-pins.md
@@ -7,7 +7,7 @@ The JSON is the reviewable update manifest; CI verifies every trusted build call
 |---|---|---|
 | Node agent base | `node:22-bookworm-slim@sha256:83f487e0a63425e5b4d146fb5e5be574bcbe1b7b843d3ebafdd95eaf7767a7e5` | OCI index digest |
 | uv copy image | `ghcr.io/astral-sh/uv:0.9.7@sha256:ba4857bf2a068e9bc0e64eed8563b065908a4cd6bfb66b531a9c424c8e25e142` | OCI index digest |
-| Birdy | `v1.1.0` | SHA-256 per OS/architecture |
+| Birdy | `v1.2.0` | SHA-256 per OS/architecture |
 | Cursor Agent | `2026.08.25-3e8eec8` | SHA-256 per Linux architecture |
 | OpenCode | `1.18.3` | `sha512-HnItl/+uhSpj7JV9x6ITiE0XFq4b/PKF5OM03TIyiFoFiLw3MQoJOAXZFTEzC7IOgAIYcysRQBBmCmlXILkxww==` |
 | Pi coding agent | `0.73.1` | `sha512-gXQh3SaZmWTfVMc4Ao5+LGbVeKvzyO7tolok0nLsZgq9nGjZx/EEU3NM8C+qUnB4Nvs2rswG5qOVgLzQkq0fHQ==` |


### PR DESCRIPTION
## Why
birdy v1.2.0 (guzus/birdy #47, #48, #49) makes `multi-fetch` run natively in-process, retry rate-limited ops on a non-cooling account, and write `<output-dir>/_report.json` with a per-op `status`. Before this, every hourly Twitter run silently lost 7–42 of 127 ops (the same ~13 tail handles each time) to X 429s while the job stayed green, and the agent could not distinguish a quiet handle from an unfetched one.

## Change
- `data/toolchain-pins.json` and the four audited call sites pin **v1.2.0**; SHA-256s verified against the release's `birdy_1.2.0_checksums.txt` and the binary smoke-tested locally. `check_toolchain_pins.py --check` passes; `docs/toolchain-pins.md` regenerated.
- `twitter-fetch` aggregator skips `_*.json` metadata (a `_report.json` would otherwise be ingested as an account named `_report`) and adds `meta.fetch` = `{summary, unfetched_accounts, ops_by_status}` to `all.json`. Simulated against a fixture.
- CLAUDE.md rule 6 documents the contract.

## Verification
- `check_toolchain_pins.py --check`, `test_check_toolchain_pins`, `test_backend_matrix`, `test_curate_twitter_accounts` — pass
- First scheduled Twitter run after merge should log `multi-fetch: 127 ops, … (N rate_limited, …), M retried` and `Aggregated: … fetch: …`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
