### PR TITLE
Pin birdy v1.2.1: underscore-prefixed handles are valid op ids again

### DIFF
--- a/.github/actions/install-birdy/action.yml
+++ b/.github/actions/install-birdy/action.yml
@@ -19,7 +19,7 @@ inputs:
       Audited release tag to install. The default is pinned in
       data/toolchain-pins.json; an override must also provide sha256.
     required: false
-    default: v1.2.0
+    default: v1.2.1
   sha256:
     description: Optional SHA-256 for a non-default version override.
     required: false

--- a/.github/actions/run-cursor-container/action.yml
+++ b/.github/actions/run-cursor-container/action.yml
@@ -606,11 +606,11 @@ runs:
         RUN set -eux; \
           arch="$(dpkg --print-architecture)"; \
           case "$arch" in \
-            amd64) a=amd64; sha=e6ba33c9b0934d7d0fe26fd2bca02b25f713614b40770f611e4de6c17b05ba41 ;; \
-            arm64) a=arm64; sha=e8a19d16aefc8c83b929ce10d389b0cee93cadc23629f635c695c10a01ec35c9 ;; \
+            amd64) a=amd64; sha=abc3b49dbf35357bae40eaff268c3e33159dce873f09a7ca864bb5a6f506b15a ;; \
+            arm64) a=arm64; sha=6ee0140cff9925ed880ed2a332741721d6ab1838d51a672a37d938e043b4192d ;; \
             *) echo "unsupported arch $arch" >&2; exit 1 ;; \
           esac; \
-          curl -fsSL "https://github.com/guzus/birdy/releases/download/v1.2.0/birdy_linux_${a}.tar.gz" -o /tmp/birdy.tgz; \
+          curl -fsSL "https://github.com/guzus/birdy/releases/download/v1.2.1/birdy_linux_${a}.tar.gz" -o /tmp/birdy.tgz; \
           echo "$sha  /tmp/birdy.tgz" | sha256sum -c -; \
           tar -xzf /tmp/birdy.tgz -C /tmp; \
           install -m 755 /tmp/birdy /usr/local/bin/birdy; \

--- a/.github/actions/run-opencode-container/action.yml
+++ b/.github/actions/run-opencode-container/action.yml
@@ -606,11 +606,11 @@ runs:
         RUN set -eux; \
           arch="$(dpkg --print-architecture)"; \
           case "$arch" in \
-            amd64) a=amd64; sha=e6ba33c9b0934d7d0fe26fd2bca02b25f713614b40770f611e4de6c17b05ba41 ;; \
-            arm64) a=arm64; sha=e8a19d16aefc8c83b929ce10d389b0cee93cadc23629f635c695c10a01ec35c9 ;; \
+            amd64) a=amd64; sha=abc3b49dbf35357bae40eaff268c3e33159dce873f09a7ca864bb5a6f506b15a ;; \
+            arm64) a=arm64; sha=6ee0140cff9925ed880ed2a332741721d6ab1838d51a672a37d938e043b4192d ;; \
             *) echo "unsupported arch $arch" >&2; exit 1 ;; \
           esac; \
-          curl -fsSL "https://github.com/guzus/birdy/releases/download/v1.2.0/birdy_linux_${a}.tar.gz" -o /tmp/birdy.tgz; \
+          curl -fsSL "https://github.com/guzus/birdy/releases/download/v1.2.1/birdy_linux_${a}.tar.gz" -o /tmp/birdy.tgz; \
           echo "$sha  /tmp/birdy.tgz" | sha256sum -c -; \
           tar -xzf /tmp/birdy.tgz -C /tmp; \
           install -m 755 /tmp/birdy /usr/local/bin/birdy; \

--- a/.github/actions/run-pi-container/action.yml
+++ b/.github/actions/run-pi-container/action.yml
@@ -78,11 +78,11 @@ runs:
         RUN set -eux; \
           arch="$(dpkg --print-architecture)"; \
           case "$arch" in \
-            amd64) a=amd64; sha=e6ba33c9b0934d7d0fe26fd2bca02b25f713614b40770f611e4de6c17b05ba41 ;; \
-            arm64) a=arm64; sha=e8a19d16aefc8c83b929ce10d389b0cee93cadc23629f635c695c10a01ec35c9 ;; \
+            amd64) a=amd64; sha=abc3b49dbf35357bae40eaff268c3e33159dce873f09a7ca864bb5a6f506b15a ;; \
+            arm64) a=arm64; sha=6ee0140cff9925ed880ed2a332741721d6ab1838d51a672a37d938e043b4192d ;; \
             *) echo "unsupported arch $arch" >&2; exit 1 ;; \
           esac; \
-          curl -fsSL "https://github.com/guzus/birdy/releases/download/v1.2.0/birdy_linux_${a}.tar.gz" -o /tmp/birdy.tgz; \
+          curl -fsSL "https://github.com/guzus/birdy/releases/download/v1.2.1/birdy_linux_${a}.tar.gz" -o /tmp/birdy.tgz; \
           echo "$sha  /tmp/birdy.tgz" | sha256sum -c -; \
           tar -xzf /tmp/birdy.tgz -C /tmp; \
           install -m 755 /tmp/birdy /usr/local/bin/birdy; \

--- a/.github/actions/twitter-fetch/action.yml
+++ b/.github/actions/twitter-fetch/action.yml
@@ -259,7 +259,9 @@ runs:
                 print(f"warning: unreadable _report.json: {exc}")
 
         for f in sorted(bird.glob("*.json")):
-            if f.name in ("all.json", "manifest.json") or f.name.startswith("_"):
+            # Exact names only: X handles may start with "_" (e.g. @_cpatonn),
+            # and the op file for such a handle is data, not metadata.
+            if f.name in ("all.json", "manifest.json", "_report.json"):
                 continue
             try:
                 data = json.loads(f.read_text() or "[]")

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -575,7 +575,7 @@ output or break the pipeline. Read them before editing.
    looked self-sufficient and were not), and birdy falls back to `bird` when
    its native path fails — with bird absent that surfaces as
    `bird CLI not found` where the real cause is usually a rate limit.
-   **Since birdy v1.2.0 (pinned 2026-09-06) `multi-fetch` runs every op
+   **Since birdy v1.2.1 (pinned 2026-09-06) `multi-fetch` runs every op
    natively in-process** — it no longer needs a bird binary at all — retries
    a rate-limited op once on a non-cooling account, and writes
    `<output-dir>/_report.json` (per-op `status`: ok | rate_limited |

--- a/data/toolchain-pins.json
+++ b/data/toolchain-pins.json
@@ -14,12 +14,12 @@
     "anthropics/claude-code-action": {"version": "v1", "sha": "a874e9ecd7bb36efdad65429c6b35815f5a08f10"}
   },
   "birdy": {
-    "version": "v1.2.0",
+    "version": "v1.2.1",
     "sha256": {
-      "darwin_amd64": "a3b16873aba5bd576d6e7b670a613f3a86c76fe168384a471a7016604a0277e6",
-      "darwin_arm64": "d920dc782a4ba24761729619b6849120009c958e48b19979c41944ed59bb1c86",
-      "linux_amd64": "e6ba33c9b0934d7d0fe26fd2bca02b25f713614b40770f611e4de6c17b05ba41",
-      "linux_arm64": "e8a19d16aefc8c83b929ce10d389b0cee93cadc23629f635c695c10a01ec35c9"
+      "darwin_amd64": "b6d491ee93a6af1b105f7068562d6f6258bcf89c267b112fdebb6e95b94aadd9",
+      "darwin_arm64": "6b428040dda2728e7ccf80a33a326d7e3b05a3167bdfef2c2ef98dc977bc65af",
+      "linux_amd64": "abc3b49dbf35357bae40eaff268c3e33159dce873f09a7ca864bb5a6f506b15a",
+      "linux_arm64": "6ee0140cff9925ed880ed2a332741721d6ab1838d51a672a37d938e043b4192d"
     }
   },
   "cursor_agent": {

--- a/docs/toolchain-pins.md
+++ b/docs/toolchain-pins.md
@@ -7,7 +7,7 @@ The JSON is the reviewable update manifest; CI verifies every trusted build call
 |---|---|---|
 | Node agent base | `node:22-bookworm-slim@sha256:83f487e0a63425e5b4d146fb5e5be574bcbe1b7b843d3ebafdd95eaf7767a7e5` | OCI index digest |
 | uv copy image | `ghcr.io/astral-sh/uv:0.9.7@sha256:ba4857bf2a068e9bc0e64eed8563b065908a4cd6bfb66b531a9c424c8e25e142` | OCI index digest |
-| Birdy | `v1.2.0` | SHA-256 per OS/architecture |
+| Birdy | `v1.2.1` | SHA-256 per OS/architecture |
 | Cursor Agent | `2026.08.25-3e8eec8` | SHA-256 per Linux architecture |
 | OpenCode | `1.18.3` | `sha512-HnItl/+uhSpj7JV9x6ITiE0XFq4b/PKF5OM03TIyiFoFiLw3MQoJOAXZFTEzC7IOgAIYcysRQBBmCmlXILkxww==` |
 | Pi coding agent | `0.73.1` | `sha512-gXQh3SaZmWTfVMc4Ao5+LGbVeKvzyO7tolok0nLsZgq9nGjZx/EEU3NM8C+qUnB4Nvs2rswG5qOVgLzQkq0fHQ==` |


### PR DESCRIPTION
v1.2.0's `multi-fetch` reserved every `_`-prefixed op id for its report file and rejected the production manifest at `@_cpatonn` (run 34020799468, the first run after #3703). birdy v1.2.1 reserves only the exact `_report` id (regression test added upstream); the `twitter-fetch` aggregator likewise skips only `_report.json` instead of `_*.json`. SHA-256s verified against the release checksums manifest; `check_toolchain_pins.py --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)