### PR TITLE
Pin birdy v1.2.2: one unreadable timeline post no longer drops a whole account

### DIFF
--- a/.github/actions/install-birdy/action.yml
+++ b/.github/actions/install-birdy/action.yml
@@ -19,7 +19,7 @@ inputs:
       Audited release tag to install. The default is pinned in
       data/toolchain-pins.json; an override must also provide sha256.
     required: false
-    default: v1.2.1
+    default: v1.2.2
   sha256:
     description: Optional SHA-256 for a non-default version override.
     required: false

--- a/.github/actions/run-cursor-container/action.yml
+++ b/.github/actions/run-cursor-container/action.yml
@@ -606,11 +606,11 @@ runs:
         RUN set -eux; \
           arch="$(dpkg --print-architecture)"; \
           case "$arch" in \
-            amd64) a=amd64; sha=abc3b49dbf35357bae40eaff268c3e33159dce873f09a7ca864bb5a6f506b15a ;; \
-            arm64) a=arm64; sha=6ee0140cff9925ed880ed2a332741721d6ab1838d51a672a37d938e043b4192d ;; \
+            amd64) a=amd64; sha=4758fc21d2d1e0c639f57c3c9d264c803ce829759d9ca24df69d260c4a680516 ;; \
+            arm64) a=arm64; sha=9c3a71712c28e9cb6ea5d09c9b2ace91c21af318277930bf358dd05165840121 ;; \
             *) echo "unsupported arch $arch" >&2; exit 1 ;; \
           esac; \
-          curl -fsSL "https://github.com/guzus/birdy/releases/download/v1.2.1/birdy_linux_${a}.tar.gz" -o /tmp/birdy.tgz; \
+          curl -fsSL "https://github.com/guzus/birdy/releases/download/v1.2.2/birdy_linux_${a}.tar.gz" -o /tmp/birdy.tgz; \
           echo "$sha  /tmp/birdy.tgz" | sha256sum -c -; \
           tar -xzf /tmp/birdy.tgz -C /tmp; \
           install -m 755 /tmp/birdy /usr/local/bin/birdy; \

--- a/.github/actions/run-opencode-container/action.yml
+++ b/.github/actions/run-opencode-container/action.yml
@@ -606,11 +606,11 @@ runs:
         RUN set -eux; \
           arch="$(dpkg --print-architecture)"; \
           case "$arch" in \
-            amd64) a=amd64; sha=abc3b49dbf35357bae40eaff268c3e33159dce873f09a7ca864bb5a6f506b15a ;; \
-            arm64) a=arm64; sha=6ee0140cff9925ed880ed2a332741721d6ab1838d51a672a37d938e043b4192d ;; \
+            amd64) a=amd64; sha=4758fc21d2d1e0c639f57c3c9d264c803ce829759d9ca24df69d260c4a680516 ;; \
+            arm64) a=arm64; sha=9c3a71712c28e9cb6ea5d09c9b2ace91c21af318277930bf358dd05165840121 ;; \
             *) echo "unsupported arch $arch" >&2; exit 1 ;; \
           esac; \
-          curl -fsSL "https://github.com/guzus/birdy/releases/download/v1.2.1/birdy_linux_${a}.tar.gz" -o /tmp/birdy.tgz; \
+          curl -fsSL "https://github.com/guzus/birdy/releases/download/v1.2.2/birdy_linux_${a}.tar.gz" -o /tmp/birdy.tgz; \
           echo "$sha  /tmp/birdy.tgz" | sha256sum -c -; \
           tar -xzf /tmp/birdy.tgz -C /tmp; \
           install -m 755 /tmp/birdy /usr/local/bin/birdy; \

--- a/.github/actions/run-pi-container/action.yml
+++ b/.github/actions/run-pi-container/action.yml
@@ -78,11 +78,11 @@ runs:
         RUN set -eux; \
           arch="$(dpkg --print-architecture)"; \
           case "$arch" in \
-            amd64) a=amd64; sha=abc3b49dbf35357bae40eaff268c3e33159dce873f09a7ca864bb5a6f506b15a ;; \
-            arm64) a=arm64; sha=6ee0140cff9925ed880ed2a332741721d6ab1838d51a672a37d938e043b4192d ;; \
+            amd64) a=amd64; sha=4758fc21d2d1e0c639f57c3c9d264c803ce829759d9ca24df69d260c4a680516 ;; \
+            arm64) a=arm64; sha=9c3a71712c28e9cb6ea5d09c9b2ace91c21af318277930bf358dd05165840121 ;; \
             *) echo "unsupported arch $arch" >&2; exit 1 ;; \
           esac; \
-          curl -fsSL "https://github.com/guzus/birdy/releases/download/v1.2.1/birdy_linux_${a}.tar.gz" -o /tmp/birdy.tgz; \
+          curl -fsSL "https://github.com/guzus/birdy/releases/download/v1.2.2/birdy_linux_${a}.tar.gz" -o /tmp/birdy.tgz; \
           echo "$sha  /tmp/birdy.tgz" | sha256sum -c -; \
           tar -xzf /tmp/birdy.tgz -C /tmp; \
           install -m 755 /tmp/birdy /usr/local/bin/birdy; \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -575,7 +575,7 @@ output or break the pipeline. Read them before editing.
    looked self-sufficient and were not), and birdy falls back to `bird` when
    its native path fails — with bird absent that surfaces as
    `bird CLI not found` where the real cause is usually a rate limit.
-   **Since birdy v1.2.1 (pinned 2026-09-06) `multi-fetch` runs every op
+   **Since birdy v1.2.2 (pinned 2026-09-06) `multi-fetch` runs every op
    natively in-process** — it no longer needs a bird binary at all — retries
    a rate-limited op once on a non-cooling account, and writes
    `<output-dir>/_report.json` (per-op `status`: ok | rate_limited |

--- a/data/toolchain-pins.json
+++ b/data/toolchain-pins.json
@@ -14,12 +14,12 @@
     "anthropics/claude-code-action": {"version": "v1", "sha": "a874e9ecd7bb36efdad65429c6b35815f5a08f10"}
   },
   "birdy": {
-    "version": "v1.2.1",
+    "version": "v1.2.2",
     "sha256": {
-      "darwin_amd64": "b6d491ee93a6af1b105f7068562d6f6258bcf89c267b112fdebb6e95b94aadd9",
-      "darwin_arm64": "6b428040dda2728e7ccf80a33a326d7e3b05a3167bdfef2c2ef98dc977bc65af",
-      "linux_amd64": "abc3b49dbf35357bae40eaff268c3e33159dce873f09a7ca864bb5a6f506b15a",
-      "linux_arm64": "6ee0140cff9925ed880ed2a332741721d6ab1838d51a672a37d938e043b4192d"
+      "darwin_amd64": "ecb076a73926882fa775be678823066ea272b9f456a05d4e2f46cc0002840d5d",
+      "darwin_arm64": "659a73849fd581b4230736caf07e5e08856430f1026751397cccd580e0eff142",
+      "linux_amd64": "4758fc21d2d1e0c639f57c3c9d264c803ce829759d9ca24df69d260c4a680516",
+      "linux_arm64": "9c3a71712c28e9cb6ea5d09c9b2ace91c21af318277930bf358dd05165840121"
     }
   },
   "cursor_agent": {

--- a/docs/toolchain-pins.md
+++ b/docs/toolchain-pins.md
@@ -7,7 +7,7 @@ The JSON is the reviewable update manifest; CI verifies every trusted build call
 |---|---|---|
 | Node agent base | `node:22-bookworm-slim@sha256:83f487e0a63425e5b4d146fb5e5be574bcbe1b7b843d3ebafdd95eaf7767a7e5` | OCI index digest |
 | uv copy image | `ghcr.io/astral-sh/uv:0.9.7@sha256:ba4857bf2a068e9bc0e64eed8563b065908a4cd6bfb66b531a9c424c8e25e142` | OCI index digest |
-| Birdy | `v1.2.1` | SHA-256 per OS/architecture |
+| Birdy | `v1.2.2` | SHA-256 per OS/architecture |
 | Cursor Agent | `2026.08.25-3e8eec8` | SHA-256 per Linux architecture |
 | OpenCode | `1.18.3` | `sha512-HnItl/+uhSpj7JV9x6ITiE0XFq4b/PKF5OM03TIyiFoFiLw3MQoJOAXZFTEzC7IOgAIYcysRQBBmCmlXILkxww==` |
 | Pi coding agent | `0.73.1` | `sha512-gXQh3SaZmWTfVMc4Ao5+LGbVeKvzyO7tolok0nLsZgq9nGjZx/EEU3NM8C+qUnB4Nvs2rswG5qOVgLzQkq0fHQ==` |


### PR DESCRIPTION
Run 34021220976 (birdy 1.2.1) lost two whole accounts because X served one tweet-typed entry the strict parser could not read. birdy v1.2.2's CLI reads skip such an entry with a `[birdy] warning` on stderr (library monitoring reads stay strict; both modes tested upstream). SHA-256s verified against the release checksums manifest; `check_toolchain_pins.py --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)